### PR TITLE
Update message catalogs

### DIFF
--- a/locale/af.po
+++ b/locale/af.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2013-11-04 10:21+0200\n"
 "Last-Translator: F Wolff <friedel@translate.org.za>\n"
 "Language-Team: translate-discuss-af@lists.sourceforge.net\n"
@@ -15,11 +15,11 @@ msgstr ""
 "X-Generator: Virtaal 0.9.0-rc1\n"
 "X-Project-Style: kde\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Alle lêers (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Alle lêers (*)|*"
 
@@ -36,24 +36,21 @@ msgid "Remaining time:"
 msgstr "Oorblywende tyd:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nee"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Goed"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Kanselleer"
@@ -105,7 +102,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Wyser kon nie geskep word nie."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "Druk"
@@ -144,7 +141,7 @@ msgstr "Objek-eienskappe"
 msgid "Printing"
 msgstr "Besig met drukwerk"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simbole"
 
@@ -213,7 +210,7 @@ msgstr "Vo&rige"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Venster"
 
@@ -772,11 +769,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "Wys hierdie hulpboodskap"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "genereer uitgebreide boekstaafboodskappe"
 
@@ -798,84 +795,84 @@ msgstr "Nie-ondersteunde tema '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Spesifikasie '%s' vir vertoonskermmodus is ongeldig."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Gids '%s' kon nie geskep word nie"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Onbekende lang opsie '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Onbekende opsie '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Onverwagte karakters wat volg op opsie '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opsie '%s' vereis 'n waarde."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Skeidingsteken is verwag na die opsie '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' is nie 'n geldige numeriese waarde vir opsie '%s' nie."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opsie '%s': '%s' kan nie na 'n datum omgeskakel word nie."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Onverwagte parameter '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (of %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Die waarde voor die opsie '%s' moet gespesifiseer word."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Die vereiste parameter '%s' is nie gespesifiseer nie."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Gebruik: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "datum"
 
@@ -893,7 +890,7 @@ msgid "Can't &Undo "
 msgstr "Kan nie &ontdoen nie "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Ontdoen"
@@ -903,7 +900,7 @@ msgid "&Redo "
 msgstr "He&rdoen "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "He&rdoen"
@@ -932,12 +929,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' het ekstra '..', geïgnoreer."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -947,103 +944,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "onderstreep"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "vandag"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "gister"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "môre"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "eerste"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "tweede"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "derde"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "vierde"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "vyfde"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sesde"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sewende"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "agtste"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "negende"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "tiende"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "elfde"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "twaalfde"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "dertiende"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "veertiende"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "vyftiende"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "sestiende"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "sewentiende"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "agtiende"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "negentiende"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "twintigste"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "middag"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "middernag"
 
@@ -1111,44 +1108,81 @@ msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 "Die standaard soek/vervang-dialoog kon nie geskep word nie (foutkode %d)"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Stoor as"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Verwerp veranderinge en herlaai die laaste gestoorde weergawe?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "naamloos"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Wil u die veranderinge aan %s stoor?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Stoor"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Moenie stoor nie"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Wil u die veranderinge aan %s stoor?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Die teks kon nie gestoor word nie."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Opening van \"%s\" vir skryfwerk het misluk."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Kon nie dokument stoor na die lêer \"%s\" nie."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Opening van \"%s\" vir leeswerk het misluk."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1157,58 +1191,58 @@ msgstr ""
 "Die lêer '%s' bestaan nie en kon nie oopgemaak word nie.\n"
 "Dit is verwyder van die lys van 'onlangse lêers'."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Opstel van pyp het misluk"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Drukvoorskou"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Gids '%s' kon nie geskep word nie"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "naamloos%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Open Lêer"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Lêerfout"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Jammer, hierdie lêer kon nie oopgemaak word nie."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Jammer, die lêer het 'n onbekende formaat."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Kies 'n dokumentsjabloon"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Sjablone"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Kies 'n dokumentweergawe"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Aansigte"
 
@@ -1242,41 +1276,41 @@ msgstr "Leesfout by lêer '%s'"
 msgid "Write error on file '%s'"
 msgstr "Skryffout by lêer '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "leegmaak van lêer '%s' het misluk"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Soekfout by lêer '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kan nie huidige posisie in lêer '%s' vind nie"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Opstelling van magtigings van tydelyke lêer het misluk"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "kan lêer '%s' nie verwyder nie"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "kan verandering nie deurvoer na lêer '%s' nie"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "kan tydelike lêer '%s' nie verwyder nie"
@@ -1301,27 +1335,27 @@ msgstr "kan nie lees van lêeretiket %d"
 msgid "can't write to file descriptor %d"
 msgstr "kan nie skryf na lêeretiket %d nie"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "kan lêeretiket %d nie leegmaak nie"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "kan nie 'n soekbewerking doen op lêeretiket %d nie"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "kan nie soekposisie verkry by lêeretiket %d nie"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "kan lêerlengte nie vind vir lêeretiket %d nie"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "kan nie bepaal of lêereinde bereik is vir lêeretiket %d nie"
@@ -1345,151 +1379,151 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Fout met lees van konfigurasie-opsies."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Fout met lees van konfigurasie-opsies."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "lêer '%s': onverwagte teken %c in reël %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "lêer '%s', reël %d: '%s' geïgnoreer na groepkopstuk."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "lêer '%s', reël %d: '=' verwag."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "lêer '%s', reël %d: waarde vir onveranderbare sleutel '%s' geïgnoreer."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "lêer '%s', reël %d: sleutel '%s' is eerste gevind op reël %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Naam van konfigurasie-inskrywing mag nie begin met '%c' nie."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "kan gebruikers-konfigurasielêer nie skryf nie."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 #, fuzzy
 msgid "Failed to update user configuration file."
 msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 #, fuzzy
 msgid "Error saving user configuration data."
 msgstr "Fout met lees van konfigurasie-opsies."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "kan lêer met gebruikersopstelling '%s' nie uitvee nie"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "inskrywing '%s' kom meer as één keer voor in groep '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "poging tot wysiging van onveranderbare sleutel '%s' geïgnoreer."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "onverwagte \" op posisie %d in '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kopiëring van lêer '%s' na '%s' het misluk"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Onmoontlik om magtigings vir lêer '%s' te kry"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Onmoontlik om lêer '%s' te oorskryf"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Kopiëring van lêer '%s' na '%s' het misluk"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Onmoontlik om magtigings vir lêer '%s' op te stel"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Gids '%s' kon nie geskep word nie"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Lêer '%s' kon nie verwyd word nie"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Gids '%s' kon nie geskep word nie"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Gids '%s' kon nie geskrap word nie"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kan lêers in gids '%s' nie opsom nie"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Die werkgids kon nie verkry word nie"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Die werkgids kon nie verkry word nie"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, fuzzy, c-format
 msgid "Files (%s)"
 msgstr "Lêers (%s)|%s"
@@ -1516,17 +1550,17 @@ msgstr "'n Tydelyke lêernaam kon nie geskep word nie"
 msgid "Failed to open temporary file."
 msgstr "Opening van tydelyk lêer het misluk."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Verandering van lêertye van '%s' het misluk"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Aanraking van lêer '%s' het misluk"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Verkryging van lêertye vir '%s' het misluk"
@@ -1535,22 +1569,22 @@ msgstr "Verkryging van lêertye vir '%s' het misluk"
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle lêers (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s lêers (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Laai %s-lêer"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Stoor %s-lêer"
@@ -1914,105 +1948,105 @@ msgstr "standaard"
 msgid "unknown-%d"
 msgstr "onbekend-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "onderstreep"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " deurhaal"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " lig"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " lig"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " vetdruk"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " vetdruk"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " vetdruk"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kursief"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "deurhaal"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "lig"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "lig"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normaal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "vet"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "vet"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "vet"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kursief"
 
@@ -2094,7 +2128,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Kon nie FTP-oordragmodus na %s stel nie."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2115,7 +2149,7 @@ msgstr "Die FTP-bediener ondersteun nie passiewe modus nie."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Wyser kon nie geskep word nie."
@@ -2132,7 +2166,7 @@ msgstr "Pasmaak kolomme"
 msgid "&Customize..."
 msgstr "&Pasmaak..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Opening van URL \"%s\" in verstekblaaier het misluk."
@@ -2152,158 +2186,157 @@ msgstr "Laaiing van beeld %d vanuit lêer '%s' het misluk."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Laai van ikoon \"%s\" vanuit hulpbronne het misluk."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: kon nie ongeldige beeld stoor nie"
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage het nie 'n eie wxPalette nie."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: kon nie die lêerkopreëls (Bitmap) skryf nie"
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Kon nie die lêerkopreëls (BitmapInfo) skryf nie."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Kon nie RGB-kleurkaart skryf nie."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: kon nie data skryf nie"
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: kon geen geheue toeken nie."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Opskrif: Beeldbreedte > 32767 pixels in lêer."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Opskrif: Beeldhoogte > 32767 pixels in lêer."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Opskrif: Onbekende bisdiepte in lêer."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Opskrif: Onbekende kodering in lêer."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Opskrif: Kodering kom nie ooreen met bis-diepte nie."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: kon geen geheue toeken nie."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB Opskrif: Beeldbreedte > 32767 pixels in lêer."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB Opskrif: Beeldhoogte > 32767 pixels in lêer."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB Opskrif: Onbekende bisdiepte in lêer."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB Opskrif: Onbekende kodering in lêer."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB Opskrif: Kodering kom nie ooreen met bis-diepte nie."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Fout tydens lees van DIB-beeld."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Fout by inlees van masker DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Beeld is te hoog vir 'n ikoon."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Beeld is te breed vir 'n ikoon."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Fout tydens wegskryf van die beeld!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ongeldige ikoonindeks."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Beeld en masker het verskillende groottes."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 #, fuzzy
 msgid "No unused colour in image being masked."
 msgstr "Daar word geen ongebruikte kleur in die beeld uitgemasker nie"
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Laai van beeld \"%s\" vanuit hulpbronne het misluk."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Laai van ikoon \"%s\" vanuit hulpbronne het misluk."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Laai van beeld vanuit lêer \"%s\" het misluk."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kan beeld nie stoor na lêer '%s': Onbekende uitgang."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Geen hanteerder is gevind vir beeldtipe."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Geen beeldhanteerder is vir die tipe %d gedefinieer nie."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Beeldlêer is nie van die tipe %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "fout in dataformaat."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: dit is nie 'n PCX-lêer nie."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Geen beeldhanteerder is vir die tipe %s gedefinieer nie."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Beeldlêer is nie van die tipe %d."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
@@ -2405,52 +2438,52 @@ msgstr "PNM: lêer lyk afgekap."
 msgid " (in module \"%s\")"
 msgstr " (in module \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: fout by laai van beeld."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Ongeldige TIFF-beeldindeks."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: beeldgrootte is abnormaal groot."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: kon nie geheue reserveer nie."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: fout by lees van beeld."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: fout by stoor van beeld."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: fout by skryf van beeld."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan nie landinstelling na taal \"%s\" stel nie."
@@ -2548,7 +2581,7 @@ msgstr "inpakfout"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "On-afgeslote '{' in mime-tipe %s inskrywing."
@@ -2568,7 +2601,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Boodskap"
 
@@ -3096,7 +3129,7 @@ msgstr "Drukwerkfout"
 msgid "Print"
 msgstr "Druk"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Bladsy-opstelling"
 
@@ -3131,19 +3164,15 @@ msgstr "Druk tans bladsy %d van %d"
 msgid " (copy %d of %d)"
 msgstr " (kopie %d van %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Druk tans "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Eerste bladsy"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Vorige bladsy"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Volgende bladsy"
 
@@ -3187,16 +3216,16 @@ msgstr "Bladsy %d van %d"
 msgid "Page %d"
 msgstr "Bladsy %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "onbekende fout"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ongeldige reëlmatige uitdrukking '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "'%s' kon nie in reëlmatige uitdrukking '%s' gevind word nie"
@@ -3207,21 +3236,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer \"%s\" het onversoenbare weergawe %d.%d en kon nie gelaai word nie."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
@@ -3230,11 +3259,11 @@ msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Stoor"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Moenie stoor nie"
 
@@ -3319,10 +3348,10 @@ msgid "Clear"
 msgstr "Maak skoon"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Maak toe"
 
@@ -3334,7 +3363,7 @@ msgstr "S&kakel om"
 msgid "Convert"
 msgstr "Skakel om"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopieer"
@@ -3343,7 +3372,7 @@ msgstr "&Kopieer"
 msgid "Copy"
 msgstr "Kopieer"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Kn&ip"
@@ -3352,13 +3381,13 @@ msgstr "Kn&ip"
 msgid "Cut"
 msgstr "Knip"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Skrap"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Skrap"
@@ -3449,7 +3478,7 @@ msgstr "Hardeskyf"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Hulp"
 
@@ -3469,7 +3498,7 @@ msgstr "Keep in"
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3538,7 +3567,7 @@ msgstr "&Nuwe"
 msgid "New"
 msgstr "Nuwe"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nee"
 
@@ -3555,12 +3584,12 @@ msgstr "&Open..."
 msgid "Open..."
 msgstr "Open..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Plak"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Plak"
@@ -3590,7 +3619,7 @@ msgid "Print..."
 msgstr "Druk..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Eienskappe"
 
@@ -3625,10 +3654,6 @@ msgstr "Vervang"
 msgid "Revert to Saved"
 msgstr "Keer terug na gestoorde weergawe"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Stoor"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Stoor &as..."
@@ -3638,7 +3663,7 @@ msgstr "Stoor &as..."
 msgid "Save As..."
 msgstr "Stoor &as..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Kies &alles"
@@ -3746,7 +3771,7 @@ msgstr "&Op"
 msgid "Up"
 msgstr "Op"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ja"
 
@@ -3838,43 +3863,43 @@ msgstr "Stoor huidige dokument"
 msgid "Save current document with a different filename"
 msgstr "Stoor huidige dokument met 'n ander lêernaam"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Omskakeling na karakterstel '%s' werk nie."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "onbekend"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3883,7 +3908,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' is waarskynlik 'n binêre buffer."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Lêer kon nie gelaai word nie."
 
@@ -3897,49 +3922,49 @@ msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
 msgid "can't write buffer '%s' to disk."
 msgstr "kan buffer '%s' nie na skyf skryf nie."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Die plaaslike stelseltyd kon nie verkry word nie"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay het misluk."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' is nie 'n geldige boodskapkatalogus."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' is nie 'n geldige boodskapkatalogus."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Kan nie meervoudvorme ontleed nie: `%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "katalogus '%s' van '%s' word gebruik."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' is nie 'n geldige boodskapkatalogus."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Kon uitvoerdraad nie beëindig nie"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Opening van URL \"%s\" in verstekblaaier het misluk."
@@ -3972,7 +3997,7 @@ msgstr "'%s' mag slegs letters bevat."
 msgid "Error: %s (%d)"
 msgstr "Fout: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3981,21 +4006,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Lêer kon nie gelaai word nie."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "String-omskakelings word nie ondersteun nie"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Kon data nie na venster oordra nie"
 
@@ -4047,8 +4072,8 @@ msgstr "Create-parameter nie gevind in die verklaarde RTTI parameters nie"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Ongeldige objekklas (Non-wxEvtHandler) as bron van gebeurtenis"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Tipe moet 'n enum - long omskakeling bevat"
 
@@ -4100,83 +4125,83 @@ msgstr "Objekte moet elkeen 'n id-attribuut hê"
 msgid "Doubly used id : %d"
 msgstr "Dubbelgebruikte id: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Onbekende eienskap %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "'n Nie-leë versameling moet bestaan uit 'element'-nodes"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "verkeerde gebeurtenishanteerder, punt ontbreek"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 #, fuzzy
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Kan nie zlib-afblaasstroom inisialiseer nie."
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 #, fuzzy
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Kan nie zlib-opblaasstroom inisialiseer nie."
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "ongeldig ZIP-lêer"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 #, fuzzy
 msgid "can't find central directory in zip"
 msgstr "Kan nie huidige posisie in lêer '%s' vind nie"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 #, fuzzy
 msgid "error reading zip central directory"
 msgstr "Fout tydens skepping van gids"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4263,32 +4288,32 @@ msgstr "Grafiese kuns deur "
 msgid "Translations by "
 msgstr "Vertalings deur "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Weergawe "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Aangaande %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Lisensie"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Programmeerders"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Dokumentasieskrywers"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Kunstenaars"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Vertalers"
 
@@ -4342,44 +4367,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Vals"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (of %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Voeg kolom by"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4390,8 +4414,7 @@ msgid "Left"
 msgstr "Links"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4479,7 +4502,7 @@ msgid "Home directory"
 msgstr "Tuisgids"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Werkarea"
 
@@ -4492,8 +4515,7 @@ msgstr "Ongeldige gidsnaam."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Fout"
 
@@ -4677,16 +4699,16 @@ msgstr "Wys lêers in detail-aansig"
 msgid "Go to parent directory"
 msgstr "Gaan na moedergids"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Lêer '%s' bestaan al. Moet dit oorskryf word?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Bevestig"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Kies asb. 'n bestaande lêer."
 
@@ -4780,7 +4802,7 @@ msgstr "Die puntgrootte van die lettertipe."
 msgid "Whether the font is underlined."
 msgstr "Of die lettertipe onderstreep word."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Drukvoorskou:"
@@ -4798,48 +4820,47 @@ msgstr "Klik om dei lettertipekeuse te kanselleer."
 msgid "Click to confirm the font selection."
 msgstr "Klik om dei lettertipekeuse te bevestig."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Kies lettertipe"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Hulplêer \"%s\" nie gevind nie."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Geen inskrywings gevind."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Hulpindeks"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevante inskrywings:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Inskrywings gevind"
 
@@ -4944,59 +4965,59 @@ msgstr "Kon nie begin met drukwerk nie."
 msgid "Printing page %d..."
 msgstr "Druk tans bladsy %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Drukker-opsies"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Druk na 'n lêer"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Opstelling..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Drukker:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Almal"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Bladsye"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Drukomvang"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Van:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Aan:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopieë:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript-lêer"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Drukopstelling"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Drukker"
 
@@ -5004,25 +5025,25 @@ msgstr "Drukker"
 msgid "Default printer"
 msgstr "Verstekdrukker"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Papiergrootte"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Regop"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Dwars"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Oriëntasie"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opstellings"
 
@@ -5034,52 +5055,52 @@ msgstr "Druk in kleur"
 msgid "Print spooling"
 msgstr "Drukwerkskedulering"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Drukkerbevel:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Drukkeropsies:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Linkerkantlyn (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Boonste kantlyn (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Regterkantlyn (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Onderste kantlyn (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Drukker..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Slaan oor"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Klaar."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Soek"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Kon nie die etiket vir die id vind nie"
 
@@ -5115,24 +5136,24 @@ msgstr "&Voltooi"
 msgid "< &Back"
 msgstr "< &Terug"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 "Petri Jooste\n"
 "Friedel Wolff"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Kan nie GTK+ inisialiseer nie. Is DISPLAY reg ingestel?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Gids \"%s\" kon nie geskep word nie"
@@ -5158,12 +5179,12 @@ msgstr "Lees van dokument vanuit lêer \"%s\" het misluk."
 msgid "Failed to register font configuration using private fonts."
 msgstr "kan gebruikers-konfigurasielêer nie oopmaak nie."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Fatale fout"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5171,7 +5192,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5179,7 +5200,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI-subvenster"
 
@@ -5195,15 +5216,11 @@ msgstr "Fout tydens drukwerk: "
 msgid "Page Setup"
 msgstr "Bladsy-opstelling"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Kon nie teks in die tekskontrole invoeg nie."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5211,21 +5228,17 @@ msgstr ""
 "Die weergawe van GTK+ wat op dié rekenaar geïnstalleer is, is te oud om "
 "skermsaamstelling te ondersteun. Installeer asb. GTK+ 2.12 of later."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Kies asb. 'n geldige lettertipe."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5324,64 +5337,64 @@ msgstr "Kan inhoudsopgawe-lêer nie oopmaak nie: %s"
 msgid "Cannot open index file: %s"
 msgstr "Kan indekslêer nie oopmaak nie: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "naamloos"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Kan nie HTML-hulplêer oopmaak nie: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(gunstelinge)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Voeg huidige bladsy by gunstelinge"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Verwyder huidige bladsy uit gunstelinge"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Inhoud"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Soek"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Wys alles"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 "Wys alle indeks-items wat die gegewe substring bevat. (Nie kassensitief nie.)"
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Wys alle items in die indeks"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Kassensitief"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Slegs heelwoorde"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5389,147 +5402,147 @@ msgstr ""
 "Soek in inhoudsopgawe van hulplêer(s) vir alle voorkomste van die teks wat "
 "bó getik is"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Wys/verberg navigasiepaneel"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Gaan terug"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Gaan vorentoe"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Gaan een vlak hoër in dokument-hiërargie"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Maak HTML-dokument oop"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Druk hierdie bladsy"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Wys opsies-dialoog"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Kies die bladsy om te vertoon:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Hulponderwerpe"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Soek tans..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Nog geen ooreenstemmende bladsy is gevind nie"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i ooreenkomste gevind"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Help)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d van %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu van %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Soek in alle boeke"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Hulpblaaier-opsies"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normale lettertipe:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Nie-proporsionele lettertipe:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Lettergrootte:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "lettergrootte"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normaal en<br><u>onderstreep</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursief.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Vetdruk.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Vet en kursief.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Vaste lettergrootte.<br> <b>vetdruk</b> <i>kursief</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>vet kursief <u>onderstreep</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Hulpdrukwerk"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Kan nie leë bladsy druk nie."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-lêers (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hulpboeke (*.htb)|*.htb|Hulpboeke (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML-hulpprojek (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Saamgeperste HTML-hulplêer (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i van %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu van %lu"
@@ -5610,32 +5623,6 @@ msgstr ""
 "Daar was 'n probleem tydens bladsy-opstelling: Jy moet dalk 'n "
 "standaarddrukker opstel."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Weergee van HTML-document in %s-kodering het misluk"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets kon vertoonskerm nie oopmaak vir '%s' nie: gaan afsluit."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filter"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Gidse"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Lêers"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Seleksie"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Open van knipbord het misluk."
@@ -5677,59 +5664,59 @@ msgstr "Kleurseleksiedialoog het misluk met fout %0lx."
 msgid "Failed to create cursor."
 msgstr "Wyser kon nie geskep word nie."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Registrasie van DDE-bediener '%s' het misluk"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Deregistrering van DDE-bediener '%s' het misluk"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "'n Verbinding met bediener '%s' vir onderwerp '%s' kon nie gemaak word nie"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE 'poke'-versoek het misluk"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Opstelling van advies-lus met die DDE-server het misluk"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Beëindiging van advies-lus met die DDE-server het misluk"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "DDE-advieskennisgewing kon nie gestuur word nie"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Skepping van DDE-string het misluk"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "geen DDE-fout."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "'n versoek vir 'n sinkrone advies-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "die antwoord op die transaksie het die DDE_FBUSY-bit na 1 gestel."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "'n versoek vir 'n sinkrone data-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5739,7 +5726,7 @@ msgstr ""
 "'n DDEML-funksie is geroep sonder om eers die DdeInitialize-funksie te roep\n"
 "of 'n ongeldige proses-ID is deurgegee aan 'n DDEML-funksie."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5750,44 +5737,44 @@ msgstr ""
 "'n DDE-transaksie uit te voer of 'n toepassing wat as APPCMD_CLIENTONLY \n"
 "begin is, het probeer om 'n bediener-transaksie uit te voer."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "'n versoek vir 'n sinkrone uitvoer-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "'n parameter kon nie deur die DDEML gevalideer word nie."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 "'n DDEML-toepassing het deur 'n wedrentoestand geheuegebrek veroorsaak."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "'n geheuereservering het misluk."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "Kliënt se poging om 'n gesprek te begin, het misluk."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "'n transaksie het misluk."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "'n versoek vir 'n sinkrone 'poke'-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "'n interne oproep van die PostMessage-funksie het misluk."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "probleem met hertoetreding."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5797,16 +5784,16 @@ msgstr ""
 "wat deur die kliënt beëindig is of deur die bediener laat vaar is\n"
 "voordat die transaksie voltooi is."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "'n interne fout het voorgekom in die DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "'n versoek vir beëindiging van 'n advies-transaksie se tyd is verstreke."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5816,12 +5803,12 @@ msgstr ""
 "As die toepassing verdergaan na 'n XTYP_XACT_COMPLETE-callback dan is\n"
 "die transaksie-id vir die callback nie meer geldig nie."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Onbekende DDE-fout %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5829,7 +5816,7 @@ msgstr ""
 "Inbel-funksies is nie beskikbaar nie omdat die afstandtoegangsdiens (RAS) "
 "nie op hierdie masjien geïnstalleer is nie. Installeer dit asb."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5838,65 +5825,65 @@ msgstr ""
 "Die weergawe van die inbelprogrammatuur (RAS) op hierdie masjien is te oud "
 "(die volgende benodigde funksie ontbreek: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Verkryging van teks van inbel-foutmelding het misluk"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "onbekende fout (foutnommer %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kan geen aktiewe inbelverbinding vind nie: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Meer as een aktiewe inbelverbindings gevind, willekeurige keuse is gemaak."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "'n Inbelverbinding kon nie gemaak word nie: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP name %s kon nie verkry word nie"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Verbinding het misluk: geen ISP om te bel."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Kies ISP om te bel"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Kies asb. 'n internetdiensverskaffer om mee te koppel"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Verbinding het misluk: gebruikersnaam/wagwoord ontbreek."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Kan stoorplek van adresboeklêer nie vind nie"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Verbreking van inbelverbinding het misluk: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kan nie neersit nie - geen aktiewe inbelverbinding"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Verbreking van inbelverbinding het misluk: %s"
@@ -5916,18 +5903,17 @@ msgstr "Kon nie %luKb geheue toeken vir bitmap-data nie."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kan lêers in gids '%s' nie opsom nie"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Kon nie gidsnaam kry nie"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (fout %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Kon geen beeld by die lys voeg nie."
 
@@ -5942,7 +5928,7 @@ msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Die standaard soek/vervang-dialoog kon nie geskep word nie (foutkode %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Lêerdialoog het misluk met foutkode %0lx."
@@ -5987,17 +5973,17 @@ msgstr "Aanraking van lêer '%s' het misluk"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan nie veranderinge moniteer aan niebestaande gids \"%s\" nie."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Kon nie 'n tydhouer skep nie"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Inisialisering van OpenGL het misluk."
 
@@ -6005,7 +5991,7 @@ msgstr "Inisialisering van OpenGL het misluk."
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6013,7 +5999,7 @@ msgstr ""
 "MS HTML Help-funksies is nie beskikbaar nie omdat die MS HTML Help-"
 "biblioteek nie op hierdie masjien geïnstalleer is nie. Installeer dit asb."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Inisialisering van MS HTML Help het misluk."
 
@@ -6022,7 +6008,7 @@ msgstr "Inisialisering van MS HTML Help het misluk."
 msgid "Can't delete the INI file '%s'"
 msgstr "Kan INI-lêer '%s' nie uitvee nie"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kon geen inligting oor lys-item %d kry nie."
@@ -6143,7 +6129,7 @@ msgstr "Kon nie knipbord-formaat '%s' registreer nie."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Die knipbord-formaat '%d' bestaan nie."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Slaan oor"
 
@@ -6228,75 +6214,75 @@ msgstr ""
 "as jy dit uitvee word jou stelsel onbruikbaar:\n"
 "bewerking is laat vaar."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kan sleutel '%s' nie skrap nie"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kan waarde '%s' nie uit sleutel '%s' verwyder nie."
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kan waarde van sleutel '%s' nie lees nie"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kan waarde van '%s' nie verstel nie"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kan waarde van '%s' nie lees nie"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kan waarden van sleutel '%s' nie opsom nie"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kan subsleutels van sleutel '%s' nie opsom nie"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, fuzzy, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kan geen waardes van nie-ondersteunde tipe %d kopieer nie."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6304,41 +6290,41 @@ msgstr ""
 "Onmoontlik om Rich Edit beheerelement te skep, gewone teks word gebruik. "
 "Herinstalleer riched32.dll asb."
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kan uitvoerdraad nie laat begin nie: fout met skryf van TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Kan thread-prioriteit nie instellen"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Kan uitvoerdraad nie skep nie"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Kon uitvoerdraad nie beëindig nie"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Kan nie wag vir uitvoerdraad-beëindiging nie"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kan uitvoerdraad %x nie opskort nie"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kan uitvoerdraad %x nie laat voortgaan nie"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Kon nie wyser na die huidige uitvoerdraad verkry nie"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6346,7 +6332,7 @@ msgstr ""
 "Inisialisasie van uitvoerdraadmodule het misluk: onmoontlik om 'n indeks te "
 "reserveer in lokale uitvoerdraad-geheueruimte."
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6377,12 +6363,12 @@ msgstr "Kon nie hulpbron \"%s\" laai nie."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Kon nie hulpbron \"%s\" vassluit nie."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bisweergawe"
 
@@ -6394,47 +6380,47 @@ msgstr "'n Anonieme pyp kon nie geskep word nie"
 msgid "Failed to redirect the child process IO"
 msgstr "Herleiding van toevoer/afvoer van subproses het misluk"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Uitvoering van opdrag '%s' het misluk"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Laai van mpr.dll het misluk."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kan nie die tipenaam van '%s' lees nie!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kan ikoon nie laai van '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Kan thread-prioriteit nie instellen"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Uitvoering van '%s' het misluk\n"
@@ -6468,7 +6454,7 @@ msgid "Check to make the font italic."
 msgstr "Merk om die lettertipe kursief te maak."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Onderstreep"
@@ -6542,17 +6528,32 @@ msgstr "<Enige teletipe>"
 msgid "File type:"
 msgstr "Nie-proporsioneel (Teletype)"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Venster"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hulp"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimaliseer"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zoem in"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6569,488 +6570,488 @@ msgstr "Lêer %s bestaan nie."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Aangaande %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Aangaande"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Voorkeure..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Versteek %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Toepassing"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Versteek ander"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Wys almal"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Sluit %s af"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Toepassing"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Kan vertoonskerm nie inisialiseer nie."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "Lettertipe-grootte:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "Nuwe gids"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 #, fuzzy
 msgid "Style"
 msgstr "Styl"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Gewig"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "lig"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Belyn teks regs."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Kieslys"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Venster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Venster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Venster"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Pasgemaakte grootte"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "MacGreek"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "Herdoen"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "standaard"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "môre"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Regs"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Koeëltjiestyl"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "&Karakterkode:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Lettertipe-grootte:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Belyn regs"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Vraag"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Regs"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Regs"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Maak 'n keuse:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Eienskap"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Waarde"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Gekategoriseerde modus"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alfabetiese modus"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Vals"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Waar"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Nie gespesifiseer nie"
 
@@ -7064,48 +7065,48 @@ msgstr "Drukwerkfout"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Waarde moet %s of meer wees."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Waarde moet tussen %s en %s wees."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Waarde moet %s of minder wees."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Nie %s nie"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Kies 'n gids:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Kies 'n lêer"
 
@@ -7585,119 +7586,119 @@ msgstr "Indeks"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Verander styl"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Verander objekstyl"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Verander eienskappe"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Verander lysstyl"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Hernommeer lys"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Voeg teks in"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Voeg beeld in"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Voeg objek in"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Voeg veld in"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Te veel EndStyle-roepe!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "lêers"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standaard/sirkel"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standaard/sirkelbuitelyn"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standaard/vierkant"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standaard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standaard/driehoek"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Boks-eienskappe"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 #, fuzzy
 msgid "Multiple Cell Properties"
 msgstr "Veelvuldige sel-eienskappe"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Seleienskappe"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Verwyder item"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Skrap ry"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Skrap kolom"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Voeg ry by"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Voeg kolom by"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Tabel-eienskappe"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Prent-eienskappe"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "beeld"
 
@@ -7906,24 +7907,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Sleep"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Skrap teks"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Verwyder koeëltjie"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Die teks kon nie gestoor word nie."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Vervang"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 #, fuzzy
 msgid "&Font:"
 msgstr "Lettertipe-grootte:"
@@ -8924,53 +8925,53 @@ msgstr "Lysstyle"
 msgid "Box styles"
 msgstr "Boksstyle"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Substel:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Wys 'n Unicode-substel."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Karakterkode:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Die karakterkode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Van:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Die omvang om te wys."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Voeg in"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normale teks)"
 
@@ -9164,7 +9165,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Voorbereiding vir speel van \"%s\" het misluk."
@@ -9264,21 +9265,21 @@ msgstr "Klankdata se formaat word nie ondersteun nie."
 msgid "Couldn't open audio: %s"
 msgstr "Kan nie oudio oopmaak nie: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kan nie die uitvoerdraadskeduleringsbeleid verkry nie."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Kan nie die omvang van prioriteite bepaal vir skeduleringsbeleid %d nie."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Uitvoerdraad-prioriteitstelling is geïgnoreer."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9286,62 +9287,62 @@ msgstr ""
 "Aansluiting by 'n uitvoerdraad het misluk, moontlik 'n geheuelekkasie "
 "teëgekom - herbegin die programma asb."
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Opstelling van prioriteit van thread %d het misluk."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Opstelling van prioriteit van thread %d het misluk."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Beëindiging van uitvoerdraad het misluk."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Inisialisasie van uitvoerdraadmodule het misluk: 'n uitvoerdraad-sleutel kon "
 "nie geskep word nie"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Onmoontlik om subproses-toevoer te verkry"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Process %d kon nie doodgemaak word nie"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Uitvoering van '%s' het misluk\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "'Fork' het misluk"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Opstelling van prioriteit van thread %d het misluk."
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Herleiding van toevoer/afvoer van subproses het misluk"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Kan masjiennaam nie vasstel nie"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Kan die amptelike masjiennaam nie vasstel nie."
 
@@ -9359,12 +9360,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "Inlees van PID vanuit slotlêer het misluk."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Ongeldige geometrie-spesifikasie '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets kon vertoonskerm nie oopmaak nie. Gaan dus uit."
 
@@ -9378,30 +9379,59 @@ msgstr "Toemaak van knibord het misluk."
 msgid "Failed to open display \"%s\"."
 msgstr "Opening van '%s' vir %s het misluk"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML-ontledingsfout: '%s' in lyn %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kan hulpbronne nie uit '%s' laai nie."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kan hulpbronlêer '%s' nie laai nie."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kan hulpbronne nie uit lêer '%s' laai nie."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Uitpak van '%s' binne-in '%s' het misluk."
+
+#~ msgid "Printing "
+#~ msgstr "Druk tans "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Kon nie teks in die tekskontrole invoeg nie."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Kies asb. 'n geldige lettertipe."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Weergee van HTML-document in %s-kodering het misluk"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets kon vertoonskerm nie oopmaak vir '%s' nie: gaan afsluit."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Gidse"
+
+#~ msgid "Files"
+#~ msgstr "Lêers"
+
+#~ msgid "Selection"
+#~ msgstr "Seleksie"
 
 #, fuzzy
 #~ msgid "failed to retrieve execution result"
@@ -9548,8 +9578,8 @@ msgstr "Uitpak van '%s' binne-in '%s' het misluk."
 #~ msgstr "Kon nie begin met drukwerk nie."
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/an.po
+++ b/locale/an.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2014-04-13 17:41+0100\n"
 "Last-Translator: Jorge Pérez Pérez <jorgtum@gmail.com>\n"
 "Language-Team: softaragonés\n"
@@ -19,11 +19,11 @@ msgstr ""
 "X-Generator: Poedit 1.6.4\n"
 "X-Poedit-Bookmarks: -1,752,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Totz os fichers (*.*)|*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Totz os fichers (*)|*"
 
@@ -40,24 +40,21 @@ msgid "Remaining time:"
 msgstr "Tiempo restant:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sí"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Acceptar"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
@@ -110,7 +107,7 @@ msgid "Unable to create I/O completion port"
 msgstr "No s'ha puesto creyar o puerto de dentrada/salida de rematanza"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Impresión"
 
@@ -147,7 +144,7 @@ msgstr "Propiedatz d'obchecto"
 msgid "Printing"
 msgstr "Imprentando"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simbolos"
 
@@ -217,7 +214,7 @@ msgstr "&Anterior"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Finestra"
 
@@ -779,11 +776,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Ctrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "amostrar iste mensache d'aduya"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "chenerar mensaches de log explicitos"
 
@@ -805,84 +802,84 @@ msgstr "Tema no suportau '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificación de 'display' no valida: '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "A opción '%s' no puet estar negada"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "O parametro '%s' entero luengo ye desconoixiu"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "O parametro '%s' ye desconoixiu"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracters no asperaus dezaga d'a opción '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A opción '%s' ameneste una valor."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "S'asperaba un separador dimpués d'opción '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' no ye una valor numerica correcta ta lo parametro '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "A opción '%s': '%s' no puet convertir-se en una calendata."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametro '%s' inasperau"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (u %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Cal especificar a valor ta lo parametro '%s'."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "No s'ha especificau o parametro requeriu '%s'."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Uso: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "cad"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "núm"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dople"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "calendata"
 
@@ -900,7 +897,7 @@ msgid "Can't &Undo "
 msgstr "No se puet desfer "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfer"
@@ -910,7 +907,7 @@ msgid "&Redo "
 msgstr "&Refer "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refer"
@@ -940,12 +937,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' tien bell '..' adicional, será ignorau."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -955,103 +952,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "subrayau"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "hue"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "ahiere"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "maitín"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primer"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "segundo"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tercer"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "quatreno"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "cinqueno"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "seiseno"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "seteno"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "uiteno"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "nueno"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "deceno"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "onceno"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "doceno"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "treceno"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "catorceno"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "quinceno"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "setzeno"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "deciseteno"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "deciuiteno"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "decinueno"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vinteno"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "meyodiya"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "meyanueit"
 
@@ -1120,44 +1117,81 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "No s'ha puesto ninviar o reporte de depuración (codigo d'error %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Alzar como"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Descartar os cambeos y recargar a zaguera versión alzada?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "sin nombre"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Quiers alzar os cambeos ta %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Alzar"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "No alzar-lo"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Quiers alzar os cambeos ta %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "No s'ha puesto alzar o texto."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "No s'ha puesto ubrir o fichero \"%s\" ta escribir."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "No s'ha puesto alzar o documento en o fichero \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "No s'ha puesto ubrir o fichero \"%s\" ta leyer."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "No s'ha puesto leyer o documento dende \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1166,57 +1200,57 @@ msgstr ""
 "O fichero '%s' no existe y no puet ubrir-se.\n"
 "Tamién ye estau eliminau d'a lista de fichers recients."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "S'ha produciu una error en creyar l'anvista previa d'impresión."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Anvista previa d'a impresión"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "No s'ha puestodeterminar o formato d'o fichero '%s'."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "sin nombre%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Ubrir un fichero"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Error de fichero"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "No s'ha puesto ubrir iste fichero."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "O formato d'iste fichero ye desconoixiu."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Seleccionar una plantilla de documento"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Plantillas"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Seleccionar una anvista de documento"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Anvistas"
 
@@ -1250,42 +1284,42 @@ msgstr "S'ha produciu una error de lectura en o fichero '%s'"
 msgid "Write error on file '%s'"
 msgstr "S'ha produciu una error d'escritura en o fichero '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "s'ha produciu una error en limpiar o fichero '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Mirar a error en o fichero '%s' (os fichers grans no son suportaus por stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Mirar a error en o fichero '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "No se puet trobar a posición actual en o fichero '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "No s'ha puesto cambiar os permisos d'o fichero temporal"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "no se puet eliminar o fichero '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "no se pueden fer efectivos os cambeos en o fichero '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "no se puet eliminar o fichero temporal '%s'"
@@ -1310,28 +1344,28 @@ msgstr "no se puet leyer dende o descriptor de fichero %d"
 msgid "can't write to file descriptor %d"
 msgstr "no se puet escribir o descriptor de fichero %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "no se puet vuedar o descriptor de fichero %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "no se puet mirar en o descriptor de fichero %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "no se puet aconseguir a posición de busca en o descriptor de fichero %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "no se puet obtener a grandaria d'o fichero con descriptor %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1358,110 +1392,110 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "S'ha produciu una error en leyer as opcions de configuración."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "No s'ha puesto leyer as opcions de configuración."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fichero '%s': caracter %c inasperau en a linia %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "fichero '%s', linia %d: '%s' ignorau dimpués d'o capitero de grupo."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fichero '%s', linia %d: '=' asperau."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "fichero '%s', linia %d: valor ignorada ta la clau immutable '%s'."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "fichero '%s', linia %d: a clau '%s' ye estada trobada por primera vegada en "
 "a linia %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Un nombre de dentrada de configuración no puet empecipiar por '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "no se puet ubrir o fichero de configuración d'usuario."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "no se puet escribir o fichero de configuración de l'usuario."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr ""
 "S'ha produciu una error en alzar os datos de configuración de l'usuario."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "no se puet eliminar o fichero de configuración d'usuario '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a dentrada '%s' amaneix mas d'una vegada en o grupo '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "intento de cambiar clau immutable '%s', ignorau."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "s'ha ignorau a barra inversa sobrant en '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inasperau en a posición %d en '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "S'ha produciu una error en copiar o fichero '%s' ta '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Ye imposible obtener permisos ta lo fichero '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Ye imposible sobrescribir o fichero '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "S'ha produciu una error en copiar o fichero '%s' ta '%s'"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Ye imposible establir permisos ta lo fichero '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1470,40 +1504,40 @@ msgstr ""
 "No s'ha puesto renombrar o fichero '%s' a '%s' porque o fichero de destín ya "
 "existe."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "No s'ha puesto renombrar o fichero '%s' como '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "No s'ha puesto esborrar o fichero '%s'"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "No s'ha puesto creyar o directorio '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "No se puet esborrar o directorio '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "No se pueden enumerar os fichers '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "S'ha produciu una error en obtener o directorio de treballo"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "No s'ha puesto establir o directorio de treballo actual"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Fichers (%s)"
@@ -1530,17 +1564,17 @@ msgstr "S'ha produciu una error en creyar un nombre temporal de fichero"
 msgid "Failed to open temporary file."
 msgstr "No s'ha puesto ubrir o fichero temporal."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "No s'ha puesto modificar as horas d'o fichero ta '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "No s'ha puesto retocar o fichero '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "No s'ha puesto recuperar horas d'o fichero ta '%s'"
@@ -1549,22 +1583,22 @@ msgstr "No s'ha puesto recuperar horas d'o fichero ta '%s'"
 msgid "Browse"
 msgstr "Examinar"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Totz os fichers (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "Fichers %s (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Cargar o fichero %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Alzar o fichero %s"
@@ -1927,105 +1961,105 @@ msgstr "predeterminau"
 msgid "unknown-%d"
 msgstr "desconoixiu-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "subrayau"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " rayau"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " lichera"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " lichera"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " negreta"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " negreta"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " negreta"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "rayau"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "lichera"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "lichera"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "cursiva"
 
@@ -2112,7 +2146,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "No s'ha puesto establir o modo de transferencia FTP a %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2133,7 +2167,7 @@ msgstr "O servidor FTP no suporta o modo pasivo."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Grandaria de marco GIF incorrecta (%u, %d) pa lo marco #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "S'ha produciu una error en asignar a color ta l'OpenGL"
 
@@ -2150,7 +2184,7 @@ msgstr "Columnas personalizadas"
 msgid "&Customize..."
 msgstr "&Personalizar..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "No s'ha puesto ubrir a URL \"%s\" en o navegador predeterminau."
@@ -2170,158 +2204,157 @@ msgstr "No s'ha puesto cargar a imachen %d dende o fluxo."
 msgid "Failed to load icons from resource '%s'."
 msgstr "No s'ha puesto cargar l'icono \"%s\" dende os recursos."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: No s'ha puesto alzar a imachen no valida."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage no tien a suya propia wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: No s'ha puesto escribir o capitero (Bitmap) d'o fichero."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: No s'ha puesto escribir o capitero (BitmapInfo) d'o fichero."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: No s'ha puesto escribir o mapa de color RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: No s'han puesto escribir datos."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: No s'ha puesto reservar memoria."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Capitero DIB: Amplaria d'imachen > 32767 pixels por fichero."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Capitero DIB: Altura d'a imachen > 32767 pixels por fichero."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Capitero DIB: Profundidat de color desconoixida en o fichero."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Capitero DIB: Codificación desconoixida en o fichero."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Capitero DIB: A codificación no coincide con a profundidat de bits."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: No s'ha puesto reservar memoria."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Capitero DIB: Amplaria d'imachen > 32767 pixels por fichero."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Capitero DIB: Altura d'a imachen > 32767 pixels por fichero."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Capitero DIB: Profundidat de color desconoixida en o fichero."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Capitero DIB: Codificación desconoixida en o fichero."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Capitero DIB: A codificación no coincide con a profundidat de bits."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "S'ha produciu una error en leyer a imachen DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Error en leyer a mascareta DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imachen masiau alta ta un icono."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imachen masiau ampla ta un icono."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Error en escribir o fichero d'imachen!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Indiz d'icono no valido."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "A imachen y a mascareta tienen grandarias diferents."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "No bi ha garra color sin usar en a imachen que se ye enmascarando."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "No s'ha puesto cargar o mapa de bits \"%s\" dende os recursos."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "No s'ha puesto cargar l'icono \"%s\" dende os recursos."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "No s'ha puesto cargar a imachen dende o fichero \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "No se puet alzar a imachen en o fichero '%s': a extensión ye desconoixida."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "No s'ha trobau garra maniador ta la mena d'imachen."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "No bi ha definiu garra maniador d'imachen ta la mena %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "O fichero de imachen no ye d'a mena %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "No se puet determinar automaticament o formato d'a imachen a causa d'una "
 "dentrada no localizable."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Formato de datos d'imachen desconoixiu."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Isto no ye un %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "No s'ha definiu garra maniador d'imachen ta la mena %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "A imachen no ye d'a mena %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
@@ -2425,41 +2458,41 @@ msgstr "PNM: O fichero pareix estar truncau."
 msgid " (in module \"%s\")"
 msgstr " (en o modulo \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: S'ha produciu una error en ubrir a imachen."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Indiz d'imachen TIFF no valido."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIF: A grandaria d'a imachen ye anormalment gran."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: No s'ha puesto reservar memoria."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: S'ha produciu una error en leyer a imachen."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unidat de resolución de TIF desconoixida %d ignorada"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: S'ha produciu una error en alzar a imachen."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: S'ha produciu una error en escribir a imachen."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2468,11 +2501,11 @@ msgstr ""
 "No se puet convertir l'argumento %d d'a linia de comandos ta Unicode y será "
 "ignorau."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Ha fallau a inicialización en post init, abortando-la."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "No se puet establir a localización ta l'idioma \"%s\"."
@@ -2570,7 +2603,7 @@ msgstr "s'ha produciu una error de compresión"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Bi ha una '{' no emparellada en una dentrada ta o tipo mime %s."
@@ -2590,7 +2623,7 @@ msgstr "No existe a dependencia \"%s\" d'o modulo \"%s\"."
 msgid "Module \"%s\" initialization failed"
 msgstr "No s'ha puesto inicializar o modulo \"%s\""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Mensache"
 
@@ -3092,7 +3125,7 @@ msgstr "S'ha produciu una error d'impresión"
 msgid "Print"
 msgstr "Imprentar"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Configurar a pachina"
 
@@ -3127,19 +3160,15 @@ msgstr "Imprentando a pachina %d de %d"
 msgid " (copy %d of %d)"
 msgstr " (copiar %d de %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Imprentando "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Primera pachina"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Pachina anterior"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Pachina siguient"
 
@@ -3183,16 +3212,16 @@ msgstr "Pachina %d de %d"
 msgid "Page %d"
 msgstr "Pachina %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "s'ha produciu una error desconoixida"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expresión regular no valida '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
@@ -3205,21 +3234,21 @@ msgstr ""
 "O renderizador \"%s\" tién una versión %d.%d incompatible y no s'ha puesto "
 "ubrir."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
@@ -3228,11 +3257,11 @@ msgstr "Ha fallau a extracción de '%s' en '%s'."
 msgid "Failed to monitor I/O channels"
 msgstr "No s'ha puesto monitorizar as canals de dentrada/salida"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Alzar"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "No alzar-lo"
 
@@ -3316,10 +3345,10 @@ msgid "Clear"
 msgstr "Limpiar"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Zarrar"
 
@@ -3331,7 +3360,7 @@ msgstr "&Convertir"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
@@ -3340,7 +3369,7 @@ msgstr "&Copiar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Tallar"
@@ -3349,13 +3378,13 @@ msgstr "&Tallar"
 msgid "Cut"
 msgstr "Tallar"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Eliminar"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Eliminar"
@@ -3444,7 +3473,7 @@ msgstr "Disco duro"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Aduya"
 
@@ -3464,7 +3493,7 @@ msgstr "Escalonau"
 msgid "&Index"
 msgstr "Ind&iz"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indiz"
 
@@ -3533,7 +3562,7 @@ msgstr "&Nuevo"
 msgid "New"
 msgstr "Nuevo"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&No"
 
@@ -3550,12 +3579,12 @@ msgstr "U&brir..."
 msgid "Open..."
 msgstr "Ubrir..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Apegar"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Apegar"
@@ -3585,7 +3614,7 @@ msgid "Print..."
 msgstr "Imprentar..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Propiedatz"
 
@@ -3619,10 +3648,6 @@ msgstr "Substituir"
 msgid "Revert to Saved"
 msgstr "Recuperar a versión alzada"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Alzar"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Alzar como..."
@@ -3632,7 +3657,7 @@ msgstr "&Alzar como..."
 msgid "Save As..."
 msgstr "&Alzar como..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Seleccionar-lo &Tot"
@@ -3739,7 +3764,7 @@ msgstr "&Alto"
 msgid "Up"
 msgstr "Alto"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Sí"
 
@@ -3830,45 +3855,45 @@ msgstr "Alzar o documento actual"
 msgid "Save current document with a different filename"
 msgstr "Alzar o documento actual con unatro nombre"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "A conversión t'o chuego de caracters '%s' no funciona."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "desconoixiu"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "bloque de capitero incompleto en tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 "s'ha produciu una error de suma de comprebación leyendo lo bloque de "
 "capitero de tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "datos no validos en o capitero de tar extendiu"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "dentrada tar no ubierta"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fin de fichero inasperau"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s no encaixaba en o capitero tar ta la dentrada '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "grandaria incorrecta ta la dentrada de tar"
 
@@ -3877,7 +3902,7 @@ msgstr "grandaria incorrecta ta la dentrada de tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' ye prebablement un fichero binario."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "No s'ha puesto cargar o fichero."
 
@@ -3891,47 +3916,47 @@ msgstr "No s'ha puesto leyer o documento dende \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "no se puet alzar o buffer '%s' en o disco."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "S'ha produciu una error en obtener o sistema horario local"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "Ha fallau o wxGetTimeOfDay."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' no ye un catalogo de mensaches valiu."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catalogo de mensaches invalido."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "No s'ha puesto analisar as formas plurals: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "usando lo catalogo '%s' de '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "O recurso '%s' no ye un catalogo valido de mensaches."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "No s'han puesto enumerar as traduccions"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "No bi ha garra aplicación configurada ta os documentos HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "No s'ha puesto ubrir a URL \"%s\" en o navegador predeterminau."
@@ -3964,7 +3989,7 @@ msgstr "'%s' contién caracters no validos"
 msgid "Error: %s (%d)"
 msgstr "Error: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3973,20 +3998,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "No s'ha puesto inicializar a descripción de columna."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Ista plataforma no suporta a transparencia d'o fondo."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "No se pueden transferir datos ta la finestra"
 
@@ -4041,8 +4066,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Clase d'obchecto (Non-wxEvtHandler) como Event Source ilegal"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "O tipo ha de tener conversión d'enum ta long"
 
@@ -4092,81 +4117,81 @@ msgstr "Os obchectos han a tener un atributo d'identificación"
 msgid "Doubly used id : %d"
 msgstr "Identificador duplicau: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propiedat desconoixida %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una colección no vueda ha de consistir en nodos d'a clase 'elemento'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "cadena d'identificador d'evento incorrecta, i falta o punto"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "no se puet reinicializar o fluxo de compresión de zlib."
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "no se puet reinicializar o fluxo de descompresión de zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "se suposa que ye un fichero zip multiparti concatenau"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "fichero zip no valido"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "no se puet trobar o directorio central en o zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "s'ha produciu una error en leyer o directorio central d'o zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "s'ha produciu una error en leyer o capitero local d'o fichero zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "desplazamiento erronio ta l'elemento d'o fichero zip"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "a longaria d'o fichero almagazenau no ye en o capitero d'o Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "metodo de compresión de Zip no suportau"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "a lo leyer o fluxo de zip (elemento %s): longaria erronia"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "a lo leyer o fluxo de zip (elemento %s): crc erronio"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "s'ha produciu una error en escribir l'elemento de zip '%s': crc u longaria "
 "erronios"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4255,32 +4280,32 @@ msgstr "Graficos por "
 msgid "Translations by "
 msgstr "Traduccions por "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versión "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Arredol de %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licencia"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Desembolicadors"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Escritors de documentos"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Traductors"
 
@@ -4332,44 +4357,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Falso"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (u %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Adhibir unacolumna"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4380,8 +4404,7 @@ msgid "Left"
 msgstr "Cucha"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4477,7 +4500,7 @@ msgid "Home directory"
 msgstr "Directorio prencipal"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Escritorio"
 
@@ -4490,8 +4513,7 @@ msgstr "Nombre de directorio ilegal."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Error"
 
@@ -4675,16 +4697,16 @@ msgstr "Veyer os fichers en anvista de detalle"
 msgid "Go to parent directory"
 msgstr "Ir ta lo directorio pai"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "O fichero '%s' ya existe, realment quiers sobrescribir-lo?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Por favor triga un fichero existent."
 
@@ -4778,7 +4800,7 @@ msgstr "A grandaria d'a fuent en puntos."
 msgid "Whether the font is underlined."
 msgstr "Si a fuent ye subrayada."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Anvista previa:"
@@ -4796,50 +4818,49 @@ msgstr "Fe clic ta cancelar a selección de fuent."
 msgid "Click to confirm the font selection."
 msgstr "Fe clic ta confirmar a selección de fuent."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Trigar a fuent"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Directorio d'aduya \"%s\" no trobau."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Fichero d'aduya \"%s\" no trobau."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "A linia %lu d'o fichero de mapa \"%s\" tien una sintaxi no valida, ye estau "
 "blincau."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "No s'han trobau mapiaus validos en o fichero \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "No s'han trobau dentradas."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indiz de l'Aduya"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Dentradas relevants:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Dentradas trobadas"
 
@@ -4946,59 +4967,59 @@ msgstr "No se puet encetar a impresión."
 msgid "Printing page %d..."
 msgstr "Imprentando a pachina %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opcions d'impresión"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Imprentar-lo en un Fichero"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configuración..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Impresora:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Estau:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tot"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Pachinas"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Rango d'Impresión"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "De:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Dica:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Copias:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Fichero PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Configuración d'Impresión"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Impresora"
 
@@ -5006,25 +5027,25 @@ msgstr "Impresora"
 msgid "Default printer"
 msgstr "Impresora predeterminada"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Grandaria d'o paper"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Vertical"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Horizontal"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientación"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcions"
 
@@ -5036,52 +5057,52 @@ msgstr "Impresión en color"
 msgid "Print spooling"
 msgstr "Coda d'impresión"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Comando d'impresión:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opcions d'impresora:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Marguin cucha (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Marguin superior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Marguin dreita (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Marguin inferior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Impresora..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Privar"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Desconoixiu"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Feito."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Mirar"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "No se puet trobar a pestanya pa l'identificador"
 
@@ -5117,22 +5138,22 @@ msgstr "&Finalizar"
 msgid "< &Back"
 msgstr "< &Dezaga"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "traductor-creditos"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "No s'ha puesto enchegar o GTK+, ye a pantalla bien achustada?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "S'ha produciu una error en creyar o directorio \"%s\""
@@ -5158,12 +5179,12 @@ msgstr "No s'ha puesto leyer o documento dende \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "No s'ha puesto esviellar o fichero de configuración d'usuario."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Error de fichero"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5171,7 +5192,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5179,7 +5200,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Finestra filla MDI"
 
@@ -5195,15 +5216,11 @@ msgstr "S'ha produciu una error en imprentar: "
 msgid "Page Setup"
 msgstr "Configurar a Pachina"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "No s'ha puesto ficar texto en o control."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5211,7 +5228,7 @@ msgstr ""
 "O GTK+ instalau en iste ordinador ye masiau antigo ta suportar a composición "
 "de pantalla, por favor instala o GTK+ 2.12 u superior."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5219,17 +5236,13 @@ msgstr ""
 "A composición no ye suportada por iste sistema, por favor activa-la en o "
 "tuyo administrador de finestras."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Iste programa estió compilau con una versión de GTK+ masiau antiga, por "
 "favor recomplila-lo con o GR+ 2.12 u superior."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Por favor triga una fuent valida."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5328,45 +5341,45 @@ msgstr "No se puet ubrir o fichero de contenius: %s"
 msgid "Cannot open index file: %s"
 msgstr "No se puet ubrir o fichero indiz: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "sin nombre"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "No se puet ubrir o libro d'aduya HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Amuestra l'aduya con o navegador de libros a la cucha."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(marcapachinas)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Adhibir a pachina actual a los marcapachinas"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Eliminar a pachina actual d'os marcapachinas"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Contenius"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Mirar"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Amostrar-lo tot"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5374,19 +5387,19 @@ msgstr ""
 "Amostrar totz os elementos de l'indiz que contiengan a subcadena dada. A "
 "busca ye Insensitiva."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Amostrar totz os datos en l'indiz"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Sensible a las mayusclas y minusclas"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Nomás parolas completas"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5394,147 +5407,147 @@ msgstr ""
 "Mirar contenius d'o(s) libro(s) d'aduya ta todas as aparicions d'o texto que "
 "has escrito mas alto"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Amostrar/amagar o panel de navegación"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Ir ta zaga"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Ir ta debant"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Puyar un libel en a hierarquía d'o documento"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Ubrir un documento HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Imprentar ista pachina"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Amostrar o dialogo d'opcions"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Por favor triga la pachina que quiers presentar:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Temas d'aduya"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Mirando..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Encara no s'ha trobau garra pachina con coincidencias"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Trobadas %i coincidencias"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Aduya)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Mirar en totz os libros"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opcions d'o Navegador de l'Aduya"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Fuent normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fuent fixa:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Grandaria d'a fuent:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "grandaria de fuent"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Nnormal<br>y <u>subrayau</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Negreta.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Negreta cursiva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Monoespaciau.<br> <b>negreta</b> <i>cursiva</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negreta cursiva <u>subrayada</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Aduya d'Impresión"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "No se puet imprentar una pachina vueda."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fichers HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libros d'aduya (*.htb)|*.htb|Libros d'aduya (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Prochecto d'aduya HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fichero d'aduya HTML comprimiu (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i de %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu de %lu"
@@ -5615,33 +5628,6 @@ msgstr ""
 "S'ha produciu un problema en configurar a pachina: s'ameneste una impresora "
 "predeterminada."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr ""
-"S'ha produciu una error en amostrar o documento HTML con codificación %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "o wxWidgets no ha puesto ubrir o 'display' ta '%s': Se'n ye salindo."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtro"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Directorios"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Fichers"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selección"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "No s'ha puesto ubrir o portafuellas."
@@ -5683,59 +5669,59 @@ msgstr "O dialogo de selección de color ha fallau con a error %0lx."
 msgid "Failed to create cursor."
 msgstr "S'ha produciu una error en creyar o cursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "No s'ha puesto rechistrar o servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "No s'ha puesto desrechistrar o servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "S'ha produciu una error en creyar a connexión enta lo servidor '%s' en '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Ha fallau a petición de rastreo DDE"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "S'ha produciu una error en establir un lazo d'aviso con o servidor DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "No s'ha puesto rematar o bucle d'alvertencia con o servidor DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "No s'ha puesto ninviar a notificación d'alvertencia DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "S'ha produciu una error en creyar a cadena DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "sin error DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "una petición ta una transacción sincrona d'alvertencia ha caducau."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a respuesta a la transacción causó que s'activase o bit DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "una petición ta una transacción de datos sincrona ha caducau."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5747,7 +5733,7 @@ msgstr ""
 "u s'ha pasau un identificador d'instancia no valido\n"
 "a una función DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5759,43 +5745,43 @@ msgstr ""
 "u una aplicación inicializada como APPCMD_CLIENTONLY ha\n"
 "prebau a realizar transaccions de servidor."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "una petición ta una transación d'execución sincrona ha caducau."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "ha fallau un parametro a lo validar-se por o DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "una aplicación DDEML ha creyau una condición accelerada prolongada."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "ha fallau a reserva de memoria."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "l'intento d'un client d'estableixer conversación ha fallau."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "ha fallau una transacción."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "una petición ta una transacción sincrona de revisión ha caducau."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ha fallau una clamada interna a la función PostMessage. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5805,16 +5791,16 @@ msgstr ""
 "que estió rematada por o client, u lo servidor\n"
 "remató antes de completar una transacción."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "s'ha produciu una error interna en o DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "una petición ta rematar una transacción sincrona d'alvertencia ha caducau."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5825,12 +5811,12 @@ msgstr ""
 "XTYP_XACT_COMPLETE,\n"
 "l'identificador d'a transacción ta ixa gritada deixa d'estar valido."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "S'ha produciu una error DDE desconoixiu %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5838,7 +5824,7 @@ msgstr ""
 "As funcions de marcau no son disponibles porque os servicios d'acceso remoto "
 "(RAS) no son instalaus en ista maquina. Por favor instala-los."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5848,65 +5834,65 @@ msgstr ""
 "masiau antiga. Por favor, esviella-la (falta la siguient función requiesta: "
 "%s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "No s'ha puesto recuperar o mensache d'error de RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "s'ha produciu una error desconoixida (codigo d'error %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "No se puet trobar a connexión activa: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "S'han trobau quantas connexions activas, se ye trigando una aleatoriament."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "S'ha produciu una error en establir a connexión de marcau: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "S'ha produciu una error en obtener os nombres d'ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "S'ha produciu una error en connectar: no bi ha un ISP a lo que gritar."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Trigar l'ISP a lo que connectar"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Por favor triga l'ISP a lo que te quiers connectar"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "S'ha produciu una error en connectar: falta o nombre d'usuario/clau."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "No se puet trobar o fichero de libreta d'adrezas"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "No s'ha puesto encetar a connexión d'acceso telefonico: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "No se puet penchar - no bi ha connexions activas."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "No s'ha puesto rematar a connexión: %s"
@@ -5927,18 +5913,17 @@ msgstr ""
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "No se pueden enumerar os fichers en a carpeta '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "No s'ha puesto obtener o nombre d'o directorio"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (error %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "No se puet adhibir a imachen a la lista d'imachens."
 
@@ -5954,7 +5939,7 @@ msgstr ""
 "S'ha produciu una error en creyar o dialogo estandar de mirar u "
 "substituir(codigo d'error %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "O dialogo de fichero ha fallau con o codigo d'error %0lx."
@@ -5997,17 +5982,17 @@ msgstr "No s'ha puesto configurar un observador ta '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "No se pueden monitorizar os cambeos d'o directorio no existent \"%s\"."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "No se puet creyar un temporizador"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "No s'ha puesto inicializar l'OpenGL"
 
@@ -6015,7 +6000,7 @@ msgstr "No s'ha puesto inicializar l'OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6023,7 +6008,7 @@ msgstr ""
 "As funcions d'Aduya MS HTML no son disponibles porque a librería d'Aduya MS "
 "HTML no ye instalada. Por favor instala-la."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "S'ha produciu una error en inicializar l'Aduya MS HTML."
 
@@ -6032,7 +6017,7 @@ msgstr "S'ha produciu una error en inicializar l'Aduya MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "No se puet elimininar o fichero INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "No se puet recuperar información sobre l'elemento %d d'a lista."
@@ -6083,8 +6068,8 @@ msgstr "No se puet obtener una instancia activa de \"%s\""
 #, c-format
 msgid "Failed to get OLE automation interface for \"%s\""
 msgstr ""
-"S'ha produciu una error en obtener a interficie OLE d'automatización ta \"%s"
-"\""
+"S'ha produciu una error en obtener a interficie OLE d'automatización ta "
+"\"%s\""
 
 #: ../src/msw/ole/automtn.cpp:622
 msgid "Unknown name or named argument."
@@ -6156,7 +6141,7 @@ msgstr "No se puet rechistrar o formato de portafuellas '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O formato %d d'o portafuellas no existe."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Blincar"
 
@@ -6245,59 +6230,59 @@ msgstr ""
 "si se'n elimina puede deixar o sistema en un estau inestable:\n"
 "operación abortada."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "No se puet eliminar a clau '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "No se puet eliminar a valor '%s' d'a clau '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "No se puet leyer a valor d'a clau '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "No se puet establir a valor de '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "No se puet leyer a valor de '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "No se pueden enumerar as valors d'a clau '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "No se pueden enumerar as subclaus d'a clau '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6305,17 +6290,17 @@ msgstr ""
 "Se ye exportando a clau de rechistro: o fichero \"%s\" ya existe y no se "
 "sobrescribirá."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "No se puet exportar una valura d'un tipo no suportau %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "S'ignorará a valura \"%s\" d'a clau \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6323,43 +6308,43 @@ msgstr ""
 "Ye imposible de creyar o control 'rich edit', s'usará o control de texto "
 "simple. Por favor instala riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 "No se puet empecipiar o filo d'execución: S'ha produciu una error en "
 "escribir TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "No se puet establir a prioridat d'o filo d'execución"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "No se puet creyar o filo d'execución"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "No se puet rematar o filo d'execución"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "No se puet asperar a la finalización d'o filo d'execución"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "No se puet suspender o filo d'execución %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "No se puet reprener o filo d'execución %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "No s'ha puesto obtener o puntero a lo filo d'execución actual"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6367,7 +6352,7 @@ msgstr ""
 "S'ha produciu una error en a inicialización d'o modulo de filos d'execución: "
 "ye imposible reservar l'indiz en l'almagazén local de filos"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6399,12 +6384,12 @@ msgstr "No s'ha puesto cargar o recurso \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "No s'ha puesto blocar o recurso \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "construir %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", edición de 64 bits"
 
@@ -6416,47 +6401,47 @@ msgstr "S'ha produciu una error en creyar una canal anonima"
 msgid "Failed to redirect the child process IO"
 msgstr "No s'ha puesto reendrezar a dentrada/salida d'o proceso fillo"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Ha fallau a execución d'o comando '%s'"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "No s'ha puesto cargar o mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "No se puet leyer o tipo dende '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "No se puet cargar l'icono de '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "No se puet establir a prioridat d'o filo d'execución"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "S'ha produciu una error en executar '%s'\n"
@@ -6490,7 +6475,7 @@ msgid "Check to make the font italic."
 msgstr "Marcar ta fer cursiva la fuent."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subrayau"
@@ -6558,17 +6543,32 @@ msgstr "<Cualsiquier Teletipo>"
 msgid "File type:"
 msgstr "Teletipo"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Finestra"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Aduya"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimizar"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Agrandir"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6585,486 +6585,486 @@ msgstr ": o fichero no existe!"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Arredol de %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Arredol de..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferencias..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Servicios"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Amagar %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Aplicación"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Amagar atros"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Amostrar-lo tot"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Salir de %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Aplicación"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip no ye suportau por ista versión de zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "No s'ha puesto inicializar a descripción de columna."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Grandaria de punto"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nombre d'a fuent"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Peso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Canto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "lichera"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Texto aliniau a la dreita."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Canto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menú"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Grandaria personalizada"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "Mac Griego"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "Examinar"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "Refer"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "predeterminau"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "maitín"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Dreita"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Estilo de vinyeta"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "&Codigo de caracter:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Grandaria de punto"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Aliniar a la dreita"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Pregunta"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Dreita"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Dreita"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Selecciona una opción:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Propiedat"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Modo categorizau"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Modo alfabetico"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Verdadero"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Sin especificar"
 
@@ -7077,12 +7077,12 @@ msgstr "Error de propiedat"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Has introduciu una valor no valida. Preta l'ESC ta cancelar a edición."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "S'ha produciu una error en o recurso: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7091,36 +7091,36 @@ msgstr ""
 "S'ha produciu una error en a operación de tipos \"%s\".: A propiedat "
 "etiquetada \"%s\" ye de tipo \"%s\" y no pas \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "A valor cal estar %s u mas alta."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "A valor cal estar entre %s y %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "A valor cal estar %s u mas baixa."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "No bi ha %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Triga un directorio:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Triga un fichero"
 
@@ -7598,117 +7598,117 @@ msgstr "Interno"
 msgid "Outset"
 msgstr "Externo"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Cambiar o Estilo"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Cambiar o estilo de l'obchecto"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Cambiar as propiedatz"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Cambiar o Estilo de Lista"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renumerar a Lista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Ficar Texto"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Ficar una imachen"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Ficar un obchecto"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Ficar un campo"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Masiadas clamadas EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "fichers"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "estandar/cerclo"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "estandar/cerclo - esquema"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "estandar/quadrau"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "estandar/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "estandar/trianglo"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Propiedatz d'a caixa"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Propiedatz de celda multiple"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Propiedatz de celda"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Establir o estilo de celda"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Eliminar a ringlera"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Eliminar a columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Adhibir una ringlera"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Adhibir unacolumna"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Propiedatz d'a tabla"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Propiedatz d'a imachen"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "imachen"
 
@@ -7916,24 +7916,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Arrocegar"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Eliminar o Texto"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Esborrar a vinyeta"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "No s'ha puesto alzar o texto."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Substituir"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Fuent:"
 
@@ -8902,53 +8902,53 @@ msgstr "Estilos de lista"
 msgid "Box styles"
 msgstr "Estilos de caixa"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "A fuent d'a que prener o simbolo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subconchunto:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Amuestra un subchuego Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Codigo de caracter:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "O codigo de caracter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Dende:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "O rango que amostrar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Ficar"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
@@ -9139,7 +9139,7 @@ msgstr "No s'ha puesto obtener eventos de kqueue"
 msgid "Media playback error: %s"
 msgstr "S'ha produciu una error en a reproducción multimedia: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "No s'ha puesto parar a reproducción \"%s\"."
@@ -9239,21 +9239,21 @@ msgstr "Os datos de son son en un formato no suportau."
 msgid "Couldn't open audio: %s"
 msgstr "No s'ha puesto ubrir l'audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "No se puet recuperar a politica de planificación de filos d'execución."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "No se puet obtener un rango de prioridatz ta la politica de planificación %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "S'ha ignorau a configuración d'a prioridat d'o filo d'execución."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9261,62 +9261,62 @@ msgstr ""
 "No s'ha puesto sincronizar con un filo d'execución, perda potencial de "
 "memoria detectada - por favor reenchega o programa"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "No s'ha puesto establir o libel de concurrencia en %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "No s'ha puesto establir a prioridat d'o filo d'execución %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "No s'ha puesto rematar un filo d'execución."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "S'ha produciu una error en a inicialización d'o modulo de filos d'execución: "
 "error en creyar a clau de filo"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Ye imposible obtener a dentrada d'o proceso fillo"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "No se puet escribir en a dentrada estandar d'o proceso fillo"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "S'ha produciu una error en executar '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "No s'ha puesto a bifurcación d'o proceso"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "No s'ha puesto establir a prioridat d'o proceso"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "No s'ha puesto reendrezar a dentrada/salida d'o proceso fillo"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "No s'ha puesto configurar a canyería sin bloqueyo, o programa puet bloqueyar-"
 "se."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "No se puet obtener o nombre d'a maquina"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "No se puet obtener o nombre oficial d'a maquina"
 
@@ -9335,12 +9335,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "No s'ha puesto leyer d'una tubería de dispertar"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificación de cheometría no valida: '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "Os wxWidgets no ha puesto ubrir o 'display'. Se'n ye salindo."
 
@@ -9354,30 +9354,61 @@ msgstr "S'ha produciu una error en zarrar o display \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "No s'ha puesto ubrir o display \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "S'ha produciu una error d'analisi de XML: '%s' en a linia %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "No se pueden cargar recursos dende '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "No se puet ubrir o fichero de recursos '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "No se pueden cargar os recursos dende o fichero '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Ha fallau a extracción de '%s' en '%s'."
+
+#~ msgid "Printing "
+#~ msgstr "Imprentando "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "No s'ha puesto ficar texto en o control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Por favor triga una fuent valida."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr ""
+#~ "S'ha produciu una error en amostrar o documento HTML con codificación %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr ""
+#~ "o wxWidgets no ha puesto ubrir o 'display' ta '%s': Se'n ye salindo."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Directorios"
+
+#~ msgid "Files"
+#~ msgstr "Fichers"
+
+#~ msgid "Selection"
+#~ msgstr "Selección"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "ha fallau a conversión en codificación de 8 bits"
@@ -9545,8 +9576,8 @@ msgstr "Ha fallau a extracción de '%s' en '%s'."
 #~ "O renderizador de calendata no puet renderizar a valura; tipo de valura: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2012-03-22 18:41+0200\n"
 "Last-Translator: Fatma Mehanna <fatma.mehanna@gmail.com>\n"
 "Language-Team: arabictranslationteam@googlegroups.com\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n>99)?1:(n > 2 && n < 11)?2:0;\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "كل الملفات (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "كل الملفات (*)|*"
 
@@ -42,24 +42,21 @@ msgid "Remaining time:"
 msgstr "الوقت المتبقي:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "نعم"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "لا"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "موافق"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "إلغاء"
@@ -109,7 +106,7 @@ msgid "Unable to create I/O completion port"
 msgstr ""
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "طابعة"
@@ -153,7 +150,7 @@ msgstr "خيارات الطباعة"
 msgid "Printing"
 msgstr "طبع"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "رموز"
 
@@ -222,7 +219,7 @@ msgstr "&سابق"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&نافذة"
 
@@ -783,11 +780,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr ""
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr ""
 
@@ -809,84 +806,84 @@ msgstr ""
 msgid "Invalid display mode specification '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' ليس قيمة رقمية صحيحة للخيار'%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (أو %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "تاريخ"
 
@@ -904,7 +901,7 @@ msgid "Can't &Undo "
 msgstr "لا يمكن ال&تراجع"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&تراجع"
@@ -914,7 +911,7 @@ msgid "&Redo "
 msgstr "&تكرار الفعل"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&تكرار الفعل"
@@ -941,12 +938,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' به مزيد'..', تم تجاهله."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -956,103 +953,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "&غير محدد"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "اليوم"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "أمس"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "غدا"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr ""
 
@@ -1119,103 +1116,139 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 #, fuzzy
 msgid "Save As"
 msgstr "حفظ باسم"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "غير مسمى"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "هل تريد حفظ التغييرات بالملف %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&حفظ"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "لا تحفظ"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "هل تريد حفظ التغييرات بالملف %s?"
+
+#: ../src/common/docview.cpp:560
+msgid "The document must be closed."
+msgstr ""
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "لا يمكن ل wxWidgets فتح الشاشة ل '%s': خروج"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "تعذر حفظ محتوى التقرير بملف."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "تعذر تحميل الملف"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr ""
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr ""
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "فشل معاينة الطباعة"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "معاينة الطباعة"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "غير مسمى %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "فتح ملف"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "خطأ بالملف"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr ""
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr ""
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr ""
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr ""
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr ""
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr ""
 
@@ -1249,41 +1282,41 @@ msgstr ""
 msgid "Write error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "لا يمكن العثور على الموضع الحالي بملف '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr ""
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr ""
@@ -1308,27 +1341,27 @@ msgstr ""
 msgid "can't write to file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1352,148 +1385,148 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "خطأ بقراءة خيارات الإعدادات."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "خطأ بحفظ بيانات إعدادات المستخدم."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "تعذر إعادة إنشاء المجلد '%s' لنفسه"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, fuzzy, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "لا يمكن حصر ملفات '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "تعذر بدأ معاينة المستند."
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "ملفات (%s)"
@@ -1520,17 +1553,17 @@ msgstr ""
 msgid "Failed to open temporary file."
 msgstr ""
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr ""
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr ""
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr ""
@@ -1539,22 +1572,22 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "كل الملفات (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s ملفات(%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "حفظ %s ملف"
@@ -1920,106 +1953,106 @@ msgstr "إفتراضي"
 msgid "unknown-%d"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " يتوسطه خط"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "فاتح"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr "فاتح"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "عريض"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr "عريض"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "عريض"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr "مائل"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 #, fuzzy
 msgid "strikethrough"
 msgstr "&يتوسطه خط"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "فاتح"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "فاتح"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "عادي"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "عريض"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "مائل"
 
@@ -2089,7 +2122,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr ""
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "أسكي"
 
@@ -2110,7 +2143,7 @@ msgstr ""
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr ""
 
@@ -2126,7 +2159,7 @@ msgstr ""
 msgid "&Customize..."
 msgstr ""
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr ""
@@ -2146,156 +2179,155 @@ msgstr ""
 msgid "Failed to load icons from resource '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: لا يمكن حفظ صورة تالفة."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage ليس لديها wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: لا يمكن كتابة الملف (Bitmap) رأس."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: لا يمكن كتابة الملف (BitmapInfo) رأس."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: لا يمكن كتابة خريطة لون RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: لا يمكن كتابة بيانات."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: لا يمكن تحديد الذاكرة."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: لا يمكن تحديد الذاكرة."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr ""
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr ""
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "لا يمكن حفظ الصورة بالملف '%s': الامتداد غير معروف."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "ملف الحركة ليس من نوع %ld."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "نهاية سطر غير معروف"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr ""
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "ملف الحركة ليس من نوع %ld."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
@@ -2397,52 +2429,52 @@ msgstr ""
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr ""
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2540,7 +2572,7 @@ msgstr ""
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr ""
@@ -2560,7 +2592,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "%s رسالة"
@@ -3065,7 +3097,7 @@ msgstr "خطأ في الطباعة"
 msgid "Print"
 msgstr "طبع"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "إعدادات الصفحة"
 
@@ -3101,20 +3133,16 @@ msgstr ""
 msgid " (copy %d of %d)"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "طبع"
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "الصفحة التالية"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "الصفحة السابقة"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "الصفحة التالية"
 
@@ -3159,16 +3187,16 @@ msgstr ""
 msgid "Page %d"
 msgstr ""
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "خطأ غير معروف"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr ""
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
@@ -3178,21 +3206,21 @@ msgstr ""
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "فشل فك '%s' ب '%s'."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "فشل فك '%s' ب '%s'."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "فشل فك '%s' ب '%s'."
@@ -3201,11 +3229,11 @@ msgstr "فشل فك '%s' ب '%s'."
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "حفظ"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "لا تحفظ"
 
@@ -3292,10 +3320,10 @@ msgid "Clear"
 msgstr "&واضح"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "إغلاق"
 
@@ -3309,7 +3337,7 @@ msgstr "محتويات"
 msgid "Convert"
 msgstr "محتويات"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&نسخ"
@@ -3318,7 +3346,7 @@ msgstr "&نسخ"
 msgid "Copy"
 msgstr "نسخ"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "ق&ص"
@@ -3328,13 +3356,13 @@ msgstr "ق&ص"
 msgid "Cut"
 msgstr "ق&ص"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&حذف"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "حذف"
@@ -3430,7 +3458,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&مساعدة"
 
@@ -3450,7 +3478,7 @@ msgstr ""
 msgid "&Index"
 msgstr "&كشاف"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr ""
 
@@ -3524,7 +3552,7 @@ msgstr "&جديد"
 msgid "New"
 msgstr "&جديد"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&لا"
 
@@ -3542,12 +3570,12 @@ msgstr "&فتح..."
 msgid "Open..."
 msgstr "&فتح..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&لصق"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "لصق"
@@ -3581,7 +3609,7 @@ msgid "Print..."
 msgstr "&طباعة..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&الخصائص"
 
@@ -3617,10 +3645,6 @@ msgstr "استبدال"
 msgid "Revert to Saved"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&حفظ"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "حفظ با&سم..."
@@ -3630,7 +3654,7 @@ msgstr "حفظ با&سم..."
 msgid "Save As..."
 msgstr "حفظ با&سم..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "تحديد ال&كل"
@@ -3749,7 +3773,7 @@ msgstr "أ&على"
 msgid "Up"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&نعم"
 
@@ -3839,43 +3863,43 @@ msgstr "حفظ الوثيقة الحالية"
 msgid "Save current document with a different filename"
 msgstr "حفظ الوثيقة الحالية باسم مختلف"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "غير معروف"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s did not fit the tar header for entry '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3884,7 +3908,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' من المحتمل أن تكون ذاكرة ثنائية."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "تعذر تحميل الملف"
 
@@ -3898,49 +3922,49 @@ msgstr "تعذر تحميل المصادر من '%s'."
 msgid "can't write buffer '%s' to disk."
 msgstr ""
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr ""
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr ""
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ليست رسالة صحيحة بالفهرس."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' ليست رسالة صحيحة بالفهرس."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "تعذر تحليل -أشكال- الجمع: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' ليست رسالة صحيحة بالفهرس."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "تعذر إنهاء الموضوع"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr ""
@@ -3973,7 +3997,7 @@ msgstr "'%s' ينبغي أن يحتوي على أحرف أبجدية."
 msgid "Error: %s (%d)"
 msgstr "خطأ:"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3982,20 +4006,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "تعذر تحميل الملف"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "تعذر نقل البيانات إلى النافذة"
 
@@ -4047,8 +4071,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr ""
 
@@ -4098,79 +4122,79 @@ msgstr ""
 msgid "Doubly used id : %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "خاصية غير معروفة %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "نجمع غير فارغ يجب أن يتكون من 'عنصر' فروع"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "طريقة تحويل zip غير معروفة."
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4258,33 +4282,33 @@ msgstr "فن الرسوم بواسطة"
 msgid "Translations by "
 msgstr "الترجمة بمعرفة"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "إصدار"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "حول"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "ترخيص"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "مطورون"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "كتاب ملفات المساعدة"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "فنانون"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "المترجمين"
 
@@ -4335,44 +4359,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "&ملف"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (أو %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4383,8 +4406,7 @@ msgid "Left"
 msgstr "يسار"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4473,7 +4495,7 @@ msgid "Home directory"
 msgstr "مجلد رئيسي"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "سطح المكتب"
 
@@ -4486,8 +4508,7 @@ msgstr ""
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "خطأ"
 
@@ -4668,16 +4689,16 @@ msgstr ""
 msgid "Go to parent directory"
 msgstr "الذهاب للمجلد الحاضن"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "الملف '%s' موجود بالفعل, هل تريد تخطيه؟"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "تأكيد"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr ""
 
@@ -4772,7 +4793,7 @@ msgstr ""
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "معاينة:"
@@ -4790,48 +4811,47 @@ msgstr "انقر لإلغاء تحديد الخط"
 msgid "Click to confirm the font selection."
 msgstr "انقر لتأكيد اختيار الخط"
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "اختر الخط"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "كشاف المساعدة"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "مدخلات متقاربة:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "تم العثور على المدخلات"
 
@@ -4937,59 +4957,59 @@ msgstr "تعذر بدأ الطباعة."
 msgid "Printing page %d..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "خيارات الطباعة"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "إطبع لملف"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "طابعة:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "الكل"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "صفحات"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "ترتيب الطباعة"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "من:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "نُسخ:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "إعدادات الطباعة"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "طابعة"
 
@@ -4997,25 +5017,25 @@ msgstr "طابعة"
 msgid "Default printer"
 msgstr "الطابعة الافتراضية"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "حجم الورقة"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "عرضي"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "طولي"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "خيارات"
 
@@ -5027,52 +5047,52 @@ msgstr "طبع اللون"
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "أمر الطباعة:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "خيارات الطباعة:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "الهامش الأسفل (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "طابعة..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "تم."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "بحث"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr ""
 
@@ -5108,22 +5128,22 @@ msgstr "&إنهاء"
 msgid "< &Back"
 msgstr "< &Back"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr ""
@@ -5148,12 +5168,12 @@ msgstr "تعذر تحميل المصادر من '%s'."
 msgid "Failed to register font configuration using private fonts."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "خطأ فادح"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5161,7 +5181,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5169,7 +5189,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
@@ -5185,34 +5205,26 @@ msgstr ""
 msgid "Page Setup"
 msgstr "إعدادات الصفحة"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr ""
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
-msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
 msgstr ""
 
 #: ../src/html/chm.cpp:138
@@ -5312,209 +5324,209 @@ msgstr "تعذر فتح ملف: المحتويات %s"
 msgid "Cannot open index file: %s"
 msgstr "تعذر فتح ملف التكشيف: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "تعذر فتح كتاب المساعدة بصيغة html: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "يعرض المساعدة أثناء تصفح الكتب على اليسار"
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(إشارات مرجعية)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "أضف الصفحة الحالية لمؤشر الصفحات"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "إزالة الصفحة الحالية من الإشارات المرجعية"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "محتويات"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "بحث"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "عرض الكل"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "حساس لحالة الأحرف"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "رجوع"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "تقدم"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "الصعود لمستوى أعلى في ترتيب الوثيقة"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "إطبع هذه الصفحة"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "عرض محاورة الخيارات"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "مواضيع المساعدة"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "جاري البحث..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(مساعدة)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i من %i"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i من %i"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "بحث في كل الكتب"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "مساعد خيارات المتصفح"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "معالجة الخط:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "مقاس الخط:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Italic face.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Bold face.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Bold italic face.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>bold italic <u>underlined</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "مساعدة الطباعة"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "تعذر طبع صفحة فارغة"
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "ملف مساعدة html مضغوط (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i من %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i من %i"
@@ -5585,32 +5597,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr ""
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "لا يمكن ل wxWidgets فتح الشاشة ل '%s': خروج"
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "تصفية"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "مجلدات"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "ملفات"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "تحديد"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr ""
@@ -5652,58 +5638,58 @@ msgstr ""
 msgid "Failed to create cursor."
 msgstr ""
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5711,7 +5697,7 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5719,140 +5705,140 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
 "old, please upgrade (the following required function is missing: %s)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "تعذر الحصول على محاورة اتصال نشطة: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "اختر isp للاتصال"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "تعذر وجود موقع ملف دفتر العناوين"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "تعذر الحصول على محاورة اتصال نشطة: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "لا يمكن تعليق المكالمة - لا يوجد اتصال هاتفي نشط"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr ""
@@ -5872,18 +5858,17 @@ msgstr ""
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "لا يمكن حصر ملفات المجلد '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr ""
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr "(خطأ %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "تعذر إضافة صورة لقائمة الصور."
 
@@ -5897,7 +5882,7 @@ msgstr ""
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
@@ -5939,17 +5924,17 @@ msgstr ""
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "لم يسطتع إنشاء محول الترميز"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr ""
 
@@ -5957,13 +5942,13 @@ msgstr ""
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr ""
 
@@ -5972,7 +5957,7 @@ msgstr ""
 msgid "Can't delete the INI file '%s'"
 msgstr "لا يمكن حذف الملفini '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6094,7 +6079,7 @@ msgstr "تعذر تسجيل تنسق الحافظة '%s'"
 msgid "The clipboard format '%d' doesn't exist."
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr ""
 
@@ -6176,123 +6161,123 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "لا يمكن حذف المفتاح '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "لا يمكن حذف القيمة '%s' من المفتاح '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "لا يمكن قراءة قيمة المفتاح '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "تعذر تحديد قيمة '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "لا يمكن قراءة قيمة '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "لا يمكن حصر قيم المفتاح '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "لا يمكن حصر المفاتيح الفرعية للمفتاح '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "لا يمكن تصدير النوع الغير مدعوم %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 #, fuzzy
 msgid "Cannot start thread: error writing TLS."
 msgstr "لا يمكن بدأ الموضوع: خطأ بكتابة tls."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "تعذر تحديد أولوية الموضوع"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "لا يمكن إنشاء الموضوع"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "تعذر إنهاء الموضوع"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 #, fuzzy
 msgid "Cannot wait for thread termination"
 msgstr "تعذر الانتظار حتى إنهاء الموضوع"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "لا يمكن توقف الموضوع %x"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "لا يمكن استئناف الموضوع %x"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6321,12 +6306,12 @@ msgstr "تعذر تحميل المصادر من '%s'."
 msgid "Failed to lock resource \"%s\"."
 msgstr ""
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6338,47 +6323,47 @@ msgstr ""
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr ""
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr ""
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "تعذر قراءة اسم النوع من '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "تعذر تحميل الأيقونة من '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "تعذر تحديد أولوية الموضوع"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr ""
 
@@ -6411,7 +6396,7 @@ msgid "Check to make the font italic."
 msgstr "حدد كي تجعل الخط مائلا"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr ""
@@ -6479,16 +6464,31 @@ msgstr "<Any Teletype>"
 msgid "File type:"
 msgstr "خطأ بالملف"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&نافذة"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "مساعدة"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "ت&صغير"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6505,488 +6505,488 @@ msgstr "الملف %s غير موجود."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "حول"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "&نبذة عن..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "&التفضيلات"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "&تفاصيل"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "تحديد"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "عرض الكل"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "&إنهاء"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "تحديد"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "مقاس الخط:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "اسم جديد"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "نمط"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "يمين"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "&عائلة خط:"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "فاتح"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "قائمة"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&نافذة"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&نافذة"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&نافذة"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "&تكرار الفعل"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "إفتراضي"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "غدا"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "يمين"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "إسلوب التنقيط"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "&ترميز الحرف"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "مقاس الخط:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "محاذاة لليمين"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "سؤال"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "يمين"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "يمين"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "حذف إختيار"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "&الخصائص"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 #, fuzzy
 msgid "False"
 msgstr "&ملف"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 #, fuzzy
 msgid "Unspecified"
 msgstr "متوسط"
@@ -7001,49 +7001,49 @@ msgstr "خطأ في الطباعة"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "ادخل رقم صفحة ما بين %d و %d:"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "&ملحوظات:"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "إنشاء مجلد"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "اختر الخط"
@@ -7529,129 +7529,129 @@ msgstr "إدراج"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "تغيير نمط"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 #, fuzzy
 msgid "Change Object Style"
 msgstr "تغيير نمط"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "&الخصائص"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "تغيير إسلوب القائمة"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "إدراج نص"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "إدراج صورة"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "إدراج نص"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "إدراج نص"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "&الخصائص"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 #, fuzzy
 msgid "Multiple Cell Properties"
 msgstr "خيارات الطباعة"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&الخصائص"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "تغيير نمط"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "حذف"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "حذف إختيار"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "&الخصائص"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "خيارات الطباعة"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "صورة"
 
@@ -7859,25 +7859,25 @@ msgstr "~"
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "حذف النص"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "إزالة"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "استبدال"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&خط"
 
@@ -8883,53 +8883,53 @@ msgstr "أساليب القائمة"
 msgid "Box styles"
 msgstr "كل الأنماط"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&فرعي:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&ترميز الحرف"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&من:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "إدراج"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(نص عادي)"
 
@@ -9116,7 +9116,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr ""
@@ -9216,79 +9216,79 @@ msgstr ""
 msgid "Couldn't open audio: %s"
 msgstr "تعذر فتح الملف الصوتي: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "تعذر استرجاع سياسة جدول الموضوع"
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "تعذر الحصول على أولوية ترتيب أولوية سياسة الجدول %d"
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Can't write to deflate stream: %s"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "فشل عند إغلاق الحافظة"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "تعذر الحصول على اسم المضيف"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "تعذر الحصول على اسم المضيف الرسمي"
 
@@ -9304,12 +9304,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr ""
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "لا يمكن ل wxWidgets فتح الشاشة. خروج."
 
@@ -9323,30 +9323,49 @@ msgstr ""
 msgid "Failed to open display \"%s\"."
 msgstr ""
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "تعذر تحميل المصادر من '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "فشل فك '%s' ب '%s'."
+
+#~ msgid "Printing "
+#~ msgstr "طبع"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "لا يمكن ل wxWidgets فتح الشاشة ل '%s': خروج"
+
+#~ msgid "Filter"
+#~ msgstr "تصفية"
+
+#~ msgid "Directories"
+#~ msgstr "مجلدات"
+
+#~ msgid "Files"
+#~ msgstr "ملفات"
+
+#~ msgid "Selection"
+#~ msgstr "تحديد"
 
 #, fuzzy
 #~ msgid "&Save as"

--- a/locale/ca.po
+++ b/locale/ca.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-07-03 20:43+0200\n"
 "Last-Translator: Andriy Byelikov\n"
 "Language-Team: <wx-translators@wxwidgets.org>\n"
@@ -13,11 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Tots els fitxers (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Tots els fitxers (*)|*"
 
@@ -34,24 +34,21 @@ msgid "Remaining time:"
 msgstr "Temps restant:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sí"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "D'acord"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancel·la"
@@ -101,7 +98,7 @@ msgid "Unable to create I/O completion port"
 msgstr "No s'ha pogut crear el port de compleció d'E/S"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Impressió"
 
@@ -138,7 +135,7 @@ msgstr "Propietats de l'objecte"
 msgid "Printing"
 msgstr "S'està imprimint"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Símbols"
 
@@ -207,7 +204,7 @@ msgstr "&Anterior"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Finestra"
 
@@ -736,11 +733,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "mostra aquest missatge d'ajuda"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "genera missatges de registre detallats"
 
@@ -762,84 +759,84 @@ msgstr "Tema no suportat '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificació de mode de pantalla invàlida '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "L'opció '%s' no es pot negar"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opció llarga desconeguda '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opció desconeguda '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Hi ha caràcters inesperats després de l'opció '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L'opció '%s' requereix un valor."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "S'esperava un separador després de l'opció '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' no és valor numèric correcte per a l'opció '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opció '%s': '%s' no es pot convertir a data."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Paràmetre inesperat '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Cal especificar el valor de l'opció '%s'."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "No s'ha especificat el paràmetre necessari '%s'."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Ús: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "núm"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "doble"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -857,7 +854,7 @@ msgid "Can't &Undo "
 msgstr "No es pot &desfer "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfés"
@@ -867,7 +864,7 @@ msgid "&Redo "
 msgstr "&Refés "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refés"
@@ -897,12 +894,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' té '..' extra, s'ha ignorat."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "marcat"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "no marcat"
 
@@ -911,103 +908,103 @@ msgstr "no marcat"
 msgid "undetermined"
 msgstr "indeterminat"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "avui"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "ahir"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "demà"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primer"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "segon"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tercer"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "quart"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "cinquè"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sisè"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "setè"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "vuitè"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "novè"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "desè"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "onzè"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dotzè"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "tretzè"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "catorzè"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "quinzè"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "setzè"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "dissetè"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "divuitè"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "dinovè"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vintè"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "migdia"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "mitjanit"
 
@@ -1075,45 +1072,82 @@ msgstr "No s'ha pogut executar curl, instal·leu-lo al PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "No s'ha pogut pujar l'informe de depuració (codi d'error %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Anomena i desa"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Voleu descartar els canvis i tornar a carregar la darrera versió desada?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "sense nom"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Voleu desar els canvis fets a %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "De&sa"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "No desis"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Voleu desar els canvis fets a %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "No s'ha pogut desar el text."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "No s'ha pogut obrir el fitxer \"%s\" per a escriure-hi."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "No s'ha pogut desar el document al fitxer \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "No s'ha pogut obrir el fitxer \"%s\" per a llegir-lo."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "No s'ha pogut llegir el document del fitxer \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1122,57 +1156,57 @@ msgstr ""
 "El fitxer '%s' no existeix i no s'ha pogut obrir.\n"
 "S'ha suprimit de la llista de fitxers utilitzats més recentment."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "No s'ha pogut crear la previsualització de la impressió."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Previsualització de la impressió"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "No s'ha pogut determinar el format del fitxer '%s'."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "sense nom %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Obre un fitxer"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Error de fitxer"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "No s'ha pogut obrir aquest fitxer."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "El format d'aquest fitxer és desconegut."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Seleccioneu una plantilla de document"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Plantilles"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Seleccioneu una visualització del document"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Visualitzacions"
 
@@ -1206,43 +1240,43 @@ msgstr "S'ha produït un error de lectura al fitxer '%s'"
 msgid "Write error on file '%s'"
 msgstr "S'ha produït un error en escriure al fitxer '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "no s'ha pogut buidar el fitxer '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "S'ha produït un error de cerca al fitxer '%s' (els fitxers grossos no estan "
 "suportats per stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "S'ha produït un error de cerca al fitxer '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "No es pot trobar la posició actual al fitxer '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "No s'ha pogut definir els permisos del fitxer temporal"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "no es pot suprimir el fitxer '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "no es poden publicar els canvis al fitxer '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "no es pot suprimir el fitxer temporal '%s'"
@@ -1267,27 +1301,27 @@ msgstr "no es pot llegir del descriptor de fitxer %d"
 msgid "can't write to file descriptor %d"
 msgstr "no es pot escriure al descriptor de fitxer %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "no es pot buidar el descriptor del fitxer %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "no es pot cercar el descriptor de fitxer %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "no es pot cercar la posició al descriptor de fitxer %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "no es pot trobar la llargada del fitxer al descriptor del fitxer %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1313,111 +1347,111 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "S'ha produït un error en llegir les opcions de configuració."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "No s'han pogut llegir les opcions de la configuració."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fiitxer '%s': caràcter inesperat %c a la línia %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr ""
 "fitxer '%s', línia %zu: s'ha ignorat '%s' després de la capçalera de grup."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fitxer '%s', línia %zu: '=' inesperat."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "fitxer '%s', línia %zu: s'ha ignorat el valor per a clau immutable '%s'."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "fitxer '%s', línia %zu: s'ha trobat la clau '%s' per primer cop a la línia "
 "%d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "El nom d'una entrada de configuració no pot començar amb '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "no es pot obrir el fitxer de configuració de l'usuari."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "no es pot escriure al fitxer de configuració de l'usuari."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "No s'ha pogut actualitzar el fitxer de configuració de l'usuari."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "S'ha produït un error en desar les dades de configuració de l'usuari."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "no es pot suprimir el fitxer de configuració de l'usuari '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "l'entrada '%s' apareix més d'un cop al grup '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "s'ha ignorat l'intent de canviar la clau immutable '%s'."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "s'ha ignorat la barra inversa al final a '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inesperat a la posició %d de '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "No s'ha pogut copiar el fitxer '%s' a '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "No és possible obtenir els permisos del fitxer '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "No és possible sobreescriure el fitxer '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "S'ha produït un error en copiar el fitxer '%s' a '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "No és possible definir els permisos del fitxer '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1426,40 +1460,40 @@ msgstr ""
 "No s'ha pogut canviar el nom del fitxer '%s' a '%s' perquè el fitxer de "
 "destinació ja existeix."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "No s'ha pogut canviar el nom del fitxer '%s' a '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "No s'ha pogut suprimir el fitxer '%s'"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "No s'ha pogut suprimir el directori '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "No es poden enumerar els fitxers '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "No s'ha pogut obtenir el directori de treball"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "No s'ha pogut definir el directori de treball actual"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Fitxers (%s)"
@@ -1486,17 +1520,17 @@ msgstr "No s'ha pogut crear un nom de fitxer temporal"
 msgid "Failed to open temporary file."
 msgstr "No s'ha pogut obrir el fitxer temporal."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "No s'han pogut modificar les hores del fitxer '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "No s'ha pogut fer touch al fitxer '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "No s'han pogut obtenir les hores del fitxer '%s'"
@@ -1505,22 +1539,22 @@ msgstr "No s'han pogut obtenir les hores del fitxer '%s'"
 msgid "Browse"
 msgstr "Navega"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tots els fitxers (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "Fitxers %s (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Carrega el fitxer %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Desa el fitxer %s"
@@ -1883,99 +1917,99 @@ msgstr "per defecte"
 msgid "unknown-%d"
 msgstr "desconegut-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "subratllat"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " ratllat"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " prima"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " extra lleugera"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " lleugera"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " mitjana"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " semi negreta"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " negreta"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " extra negreta"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " pesada"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " extra pesada"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "ratllat"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "prima"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "extralleugera"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "lleugera"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "mitjana"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "seminegreta"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "extranegreta"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "pesada"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "extrapesada"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "cursiva"
 
@@ -2061,7 +2095,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "No s'ha pogut definir el mode de transferència FTP a %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2083,7 +2117,7 @@ msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 "Mida de fotograma de GIF incorrecta (%u, %d) per al fotograma número %u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "No s'ha pogut assignar el color per a l'OpenGL"
 
@@ -2099,7 +2133,7 @@ msgstr "Personalitza les columnes"
 msgid "&Customize..."
 msgstr "&Personalitza..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "No s'ha pogut obrir l'URL \"%s\" al navegador predeterminat"
@@ -2119,158 +2153,157 @@ msgstr "No s'ha pogut carregar la imatge %d del flux."
 msgid "Failed to load icons from resource '%s'."
 msgstr "No s'han pogut carregar les icones del recurs '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: No s'ha pogut desar una imatge invàlida."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage no té una wxPallette pròpia."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: No s'ha pogut escriure el mapa de colors RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: No s'han pogut escriure les dades."
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr "BMP: capçalera té biClrUsed=%d quan biBitCount=%d."
-
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: No s'ha pogut assignar la memòria."
 
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr "Capçalera DIB: Amplada de la imatge > 32767 píxels per fitxer."
 
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr "Capçalera DIB: Alçada de la imatge > 32767 píxels per fitxer."
 
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "Capçalera DIB: Profunditat de bits desconeguda al fitxer."
 
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Capçalera DIB: Codificació desconeguda al fitxer."
 
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 "Capçalera DIB: La codificació no coincideix amb la profunditat de bits."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr "BMP: capçalera té biClrUsed=%d quan biBitCount=%d."
+
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "S'ha produït un error en llegir la imatge DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: S'ha produït un error en llegir la màscara DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imatge massa alta per a una icona."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imatge massa ampla per a una icona."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: S'ha produït un error en escriure el fitxer d'imatge!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índex d'icona invàlid."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "La imatge i la màscara tenen mides diferents."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "No hi ha cap color sense utilitzar a la imatge que voleu emmascarar."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "No s'ha pogut carregar el mapa de bits \"%s\" dels recursos."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "No s'ha pogut carregar la icona \"%s\" dels recursos."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge del fitxer \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "No es pot desar la imatge al fitxer '%s': extensió desconeguda."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "No s'ha trobat cap gestor per al tipus d'imatge."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "No hi ha definit cap gestor d'imatge per al tipus %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "El fitxer d'imatge no és del tipus %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "No es pot determinar automàticament el format d'imatge en una entrada "
 "seqüencial."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Format de dades d'imatge desconegut."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Això no és un %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "No hi ha definit cap gestor d'imatge per al tipus %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "La imatge no és del tipus %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "No s'ha pogut comprovar el format del fitxer d'imatge \"%s\"."
@@ -2373,41 +2406,41 @@ msgstr "PNM: El fitxer sembla truncat."
 msgid " (in module \"%s\")"
 msgstr " (al mòdul \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: S'ha produït un error en carregar la imatge."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Índex d'imatge TIFF invàlid."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: La mida de la imatge és anormalment gran."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: No s'ha pogut assignar la memòria."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: S'ha produït un error en llegir la imatge."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "S'ha ignorat la unitat de resolució TIFF desconeguda %d"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: S'ha produït un error en desar la imatge."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: S'ha produït un error en escriure la imatge."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2416,11 +2449,11 @@ msgstr ""
 "No s'ha pogut convertir a Unicode l'argument %d de la línia d'ordres i "
 "s'ignorarà."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Ha fallat la inicialització a post init, s'està avortant."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "No es pot definir la configuració local a la llengua \"%s\"."
@@ -2514,7 +2547,7 @@ msgstr "Error de compressió LZMA: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Error de compressió LZMA a l'hora de buidar la sortida: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' no tancat en una entrada per a tipus mime %s."
@@ -2534,7 +2567,7 @@ msgstr "La dependència \"%s\" del mòdul \"%s\" no existeix."
 msgid "Module \"%s\" initialization failed"
 msgstr "No s'ha pogut inicialitzar el mòdul \"%s\""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Missatge"
 
@@ -3036,7 +3069,7 @@ msgstr "S'ha produït un error d'impressió"
 msgid "Print"
 msgstr "Imprimeix"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Configuració de la pàgina"
 
@@ -3071,19 +3104,15 @@ msgstr "S'està imprimint la pàgina %d de %d"
 msgid " (copy %d of %d)"
 msgstr " (còpia %d de %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "S'està imprimint "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Primera pàgina"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Pàgina anterior"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Pàgina següent"
 
@@ -3127,16 +3156,16 @@ msgstr "Pàgina %d de %d"
 msgid "Page %d"
 msgstr "Pàgina %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "s'ha produït un error desconegut"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expressió regular invàlida '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "No s'ha pogut trobar cap coincidència per a l'expressió regular: %s"
@@ -3148,21 +3177,21 @@ msgstr ""
 "El renderitzador \"%s\" té la versió incompatible %d.%d i no s'ha pogut "
 "carregar."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "No disponible per aquesta plataforma"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "No s'ha pogut desar la clau d'accés per \"%s\": %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "No s'ha pogut llegir la clau d'accés per \"%s\": %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "No s'ha pogut suprimir la clau d'accés per \"%s\": %s."
@@ -3171,11 +3200,11 @@ msgstr "No s'ha pogut suprimir la clau d'accés per \"%s\": %s."
 msgid "Failed to monitor I/O channels"
 msgstr "No s'han pogut supervisar els canals d'E/S"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Desa"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "No desis"
 
@@ -3256,10 +3285,10 @@ msgid "Clear"
 msgstr "Neteja"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Tanca"
 
@@ -3271,7 +3300,7 @@ msgstr "&Converteix"
 msgid "Convert"
 msgstr "Converteix"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copia"
@@ -3280,7 +3309,7 @@ msgstr "&Copia"
 msgid "Copy"
 msgstr "Copia"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Re&talla"
@@ -3289,13 +3318,13 @@ msgstr "Re&talla"
 msgid "Cut"
 msgstr "Retalla"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Suprimeix"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Suprimeix"
@@ -3382,7 +3411,7 @@ msgstr "Disc dur"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -3402,7 +3431,7 @@ msgstr "Sagnat"
 msgid "&Index"
 msgstr "Í&ndex"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Índex"
 
@@ -3471,7 +3500,7 @@ msgstr "&Nou"
 msgid "New"
 msgstr "Nou"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&No"
 
@@ -3488,12 +3517,12 @@ msgstr "&Obre..."
 msgid "Open..."
 msgstr "Obre..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Enganxa"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Enganxa"
@@ -3523,7 +3552,7 @@ msgid "Print..."
 msgstr "Imprimeix..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Propietats"
 
@@ -3555,10 +3584,6 @@ msgstr "Substitueix..."
 msgid "Revert to Saved"
 msgstr "Reverteix a la versió desada"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "De&sa"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Anomena i desa..."
@@ -3567,7 +3592,7 @@ msgstr "&Anomena i desa..."
 msgid "Save As..."
 msgstr "Anomena i desa..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Seleccion&a-ho tot"
@@ -3674,7 +3699,7 @@ msgstr "Am&unt"
 msgid "Up"
 msgstr "Amunt"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Sí"
 
@@ -3762,44 +3787,44 @@ msgstr "Desa el document actual"
 msgid "Save current document with a different filename"
 msgstr "Desa el document actual amb un nom de fitxer diferent"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "La conversió al joc de caràcters '%s' no funciona."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "desconegut"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "bloc de capçalera incomplet al tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 "ha fallat la suma de verificació en llegir el bloc de la capçalera de tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "dades invàlides a la capçalera estesa del tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "entrada tar no oberta"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "final del fitxer inesperat"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s no s'ajustava a la capçalera tar per a l'entrada '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "s'ha proporcionat una mida incorrecta per a una entrada del tar"
 
@@ -3808,7 +3833,7 @@ msgstr "s'ha proporcionat una mida incorrecta per a una entrada del tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' és probablement memòria intermèdia binària."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "No s'ha pogut carregar el fitxer."
 
@@ -3822,47 +3847,47 @@ msgstr "No s'ha pogut llegir el fitxer de text \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "no es pot escriure la memòria intermèdia '%s' al disc."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "No s'ha pogut obtenir l'hora del sistema local"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay ha fallat."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' no és un missatge de catàleg vàlid."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catàleg de missatges invàlid."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "No s'ha pogut analitzar el Plural-Forms: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "s'utilitzarà el catàleg '%s' de '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "El recurs '%s' no és un catàleg de missatges vàlid."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "No s'han pogut enumerar les traduccions"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "No hi ha configurada cap aplicació per defecte per als fitxers HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "No s'ha pogut obrir l'URL \"%s\" al navegador per defecte."
@@ -3895,7 +3920,7 @@ msgstr "'%s' conté caràcters no permesos"
 msgid "Error: %s (%d)"
 msgstr "Error: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "No hi ha espai suficient al disc per a la descàrrega."
 
@@ -3903,20 +3928,20 @@ msgstr "No hi ha espai suficient al disc per a la descàrrega."
 msgid "libcurl could not be initialized"
 msgstr "no s'ha pogut inicialitzar libcurl"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync no suportat"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Error executant JavaScript: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Aquesta plataforma no suporta la transparència al fons."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "No s'han pogut transferir dades a la finestra"
 
@@ -3972,8 +3997,8 @@ msgstr ""
 "Classe d'objecte invàlida (no és un wxEvtHandler) com a origen de "
 "l'esdeveniment"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "El tipus ha de ser convertir d'enum a long"
 
@@ -4023,82 +4048,82 @@ msgstr "Els objectes han de tenir un atribut d'identificació"
 msgid "Doubly used id : %d"
 msgstr "Identificador utilitzat dues vegades: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propietat desconeguda %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una col·lecció no buida ha de consistir de nodes 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "cadena de manegador d'esdeveniment incorrecte, hi manca un punt"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "no es pot reinicialitzar el flux de deflació de zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "no es pot reinicialitzar el flux d'inflació de zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Ignorant el registre de dades addicionals mal format, el fitxer ZIP pot "
 "estar corromput"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "s'assumeix que això és un zip multipart concatenat"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "fitxer zip invàlid"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "no es pot trobar el directori central al zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "s'ha produït un error en llegir el directori central del zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "s'ha produït un error en llegir la capçalera local del zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "desplaçament a l'entrada del fitxer zip erroni"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "la mida del fitxer emmagatzemat no és a la capçalera del Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "mètode de compressió Zip no suportat"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "en llegir el flux zip (entrada %s): longitud errònia"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "en llegir el flux zip (entrada %s): crc erroni"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "error a l'hora d'escriure l'entrada zip '%s': fitxer massa gran sense ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "error a l'hora d'escriure l'entrada zip '%s': crc o longitud erronis"
@@ -4186,32 +4211,32 @@ msgstr "Art gràfic per "
 msgid "Translations by "
 msgstr "Traduccions de "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versió "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Quant a %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Llicència"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Desenvolupadors"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Redactors de la documentació"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistes"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Traductors"
 
@@ -4262,42 +4287,42 @@ msgid "Password:"
 msgstr "Clau d'accés:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "cert"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "fals"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Fila %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Contrau"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Expandeix"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elements)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Columna %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4308,7 +4333,7 @@ msgid "Left"
 msgstr "Esquerra"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4405,7 +4430,7 @@ msgid "Home directory"
 msgstr "Directori de l'usuari"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -4418,8 +4443,7 @@ msgstr "Nom de directori no permès."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Error"
 
@@ -4603,16 +4627,16 @@ msgstr "Mostra els fitxers en visualització detallada"
 msgid "Go to parent directory"
 msgstr "Vés al directori pare"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "El fitxer '%s' ja existex, esteu segur que el voleu sobreescriure?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirma"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Trieu un fitxer existent."
 
@@ -4706,7 +4730,7 @@ msgstr "La mida en punts del tipus de lletra."
 msgid "Whether the font is underlined."
 msgstr "Si el tipus de lletra està subratllada."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Previsualització:"
@@ -4724,48 +4748,47 @@ msgstr "Feu clic per a cancel·lar la selecció del tipus de lletra."
 msgid "Click to confirm the font selection."
 msgstr "Feu clic per a confirmació la selecció del tipus de lletra."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Trieu el tipus de lletra"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "No es suporta copiar més d'un bloc seleccionat al porta-retalls."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "No s'ha trobat el directori d'ajuda \"%s\"."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "No s'ha trobat el fitxer d'ajuda \"%s\"."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "La línia %lu del fitxer de mapa \"%s\" té sintaxi invàlida, s'ha omès."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "No s'ha trobat cap assignació vàlida al fitxer \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "No s'ha trobat cap entrada."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Índex de l'ajuda"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Entrades rellevants:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Entrades trobades"
 
@@ -4870,59 +4893,59 @@ msgstr "No s'ha pogut iniciar la impressió."
 msgid "Printing page %d..."
 msgstr "S'està imprimint la pàgina %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opcions de la impressora"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Imprimeix a un fitxer"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configura..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Impressora:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Estat:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tot"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Pàgines"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Rang d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "De:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "A:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Còpies:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Fitxer PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Configuració de la impressió"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Impressora"
 
@@ -4930,25 +4953,25 @@ msgstr "Impressora"
 msgid "Default printer"
 msgstr "Impressora per defecte"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Mida del paper"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Vertical"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Apaïsat"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientació"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcions"
 
@@ -4960,52 +4983,52 @@ msgstr "Imprimeix en color"
 msgid "Print spooling"
 msgstr "Cua d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Ordre de la impressora:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opcions de la impressora:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Marge esquerre (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Marge superior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Marge dret (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Marge inferior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Impressora..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Omet"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Desconegut"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Fet."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Cerca"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "No s'ha pogut trobar la pestanya per a l'identificador"
 
@@ -5041,13 +5064,13 @@ msgstr "&Finalitza"
 msgid "< &Back"
 msgstr "< &Endarrere"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 "Eduard Ereza Martínez <eduard@ereza.cat>\n"
 "Andriy Byelikov https://github.com/andriybyelikov"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5057,12 +5080,12 @@ msgstr ""
 "problemes amb la gestió de l'entrada i parpelleig. Consideri desestablir "
 "GTK_IM_MODULE o establir-lo a \"ibus\"."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "No s'ha pogut inicialitzar el GTK+, teniu definit correctament DISPLAY?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "No s'ha pogut canviar el directori actual a \"%s\""
@@ -5090,11 +5113,11 @@ msgstr ""
 "No s'ha pogut registrar la configuració de tipus de lletra utilitzant tipus "
 "de lletra privats."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Error fatal"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5108,7 +5131,7 @@ msgstr ""
 "X11 establint la variable d'entorn GDK_BACKEND=x11 abans d'iniciar el seu\n"
 "programa."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5121,7 +5144,7 @@ msgstr ""
 "el\n"
 "seu programa."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Fill de l'MDI"
 
@@ -5137,17 +5160,13 @@ msgstr "S'ha produït un error en imprimir: "
 msgid "Page Setup"
 msgstr "Configuració de la pàgina"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "No s'ha pogut inserir el text al control."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 "L'obtenció de la sortida d'un script de JavaScript no està suportada amb "
 "WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5155,7 +5174,7 @@ msgstr ""
 "El GTK+ instal·lat en aquest dispositiu és massa antic i no suporta la "
 "composició de pantalla, instal·leu el GTK+ 2.12 o posterior."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5163,17 +5182,13 @@ msgstr ""
 "Aquest sistema no suporta la composició, activeu-la al vostre gestor de "
 "finestres."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Aquest programa s'ha compilat amb una versió massa antiga del GTK+, "
 "recompileu-lo amb el GTK+ 2.12 o posterior."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Trieu un tipus de lletra vàlid."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5272,45 +5287,45 @@ msgstr "No es pot obrir el fitxer de continguts: %s"
 msgid "Cannot open index file: %s"
 msgstr "No es pot obrir el fitxer d'índex: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "sense nom"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "No es pot obrir el llibre d'ajuda HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Mostra l'ajuda mentre navegueu pels llibres de l'esquerra."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(preferits)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Afegeix la pàgina actual als preferits"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Elimina la pàgina actual dels preferits"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Contingut"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Cerca"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Mostra-ho tot"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5318,19 +5333,19 @@ msgstr ""
 "Mostra tots els elements de l'índex que continguin la subcadena donada. La "
 "cerca no distingeix entre majúscules i minúscules."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Mostra tots els elements a l'índex"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Distingeix entre majúscules i minúscules"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Només paraules senceres"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5338,147 +5353,147 @@ msgstr ""
 "Cerca totes les coincidències del text que heu escrit a dalt al contingut "
 "dels llibres d'ajuda"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Mostra/amaga el plafó de navegació"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Vés endarrere"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Vés endavant"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Puja un nivell en la jerarquia del document"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Obre un document HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Imprimeix aquesta pàgina"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Mostra el diàleg d'opcions"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Trieu la pàgina que vulgueu mostrar:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Temes de l'ajuda"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "S'està cercant..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Encara no s'ha trobat cap pàgina que hi coincideixi"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "S'han trobat %i coincidències"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Ajuda)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Cerca a tots els llibres"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opcions del navegador de l'ajuda"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Tipus de lletra normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Tipus de lletra de mida fixa:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Mida de la lletra:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "mida del tipus de lletra"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Text normal<br>i <u>subratllat</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Negreta.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Negreta i cursiva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "De mida fixa.<br> <b>negreta</b> <i>cursiva</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negreta i cursiva <u>subratllada</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Ajuda de la impressió"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "No es pot imprimir una pàgina buida."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fitxers HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Llibres d'ajuda (*.htb)|*.htb|Llibres d'ajuda (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projecte d'ajuda HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fitxer d'ajuda HTML comprimit (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i de %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u de %u"
@@ -5559,32 +5574,6 @@ msgstr ""
 "Hi ha hagut un problema durant la configuració de la pàgina: pot ser que us "
 "calgui establir una impressora per defecte."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "No s'ha pogut mostrar el document HTML amb la codificació %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets no ha pogut obrir la pantalla de '%s': se sortirà."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtre"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Directoris"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Fitxers"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selecció"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "No s'ha pogut obrir el porta-retalls."
@@ -5626,63 +5615,63 @@ msgstr "El diàleg de selecció de color ha fallat amb l'error %0lx."
 msgid "Failed to create cursor."
 msgstr "No s'ha pogut crear el cursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "No s'ha pogut registrar el servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "No s'ha pogut desregistrar el servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "No s'ha pogut crear una connexió al servidor '%s' en el tema '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Ha fallat la petició d'atiar el DDE"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "No s'ha pogut establir un bucle d'avís amb el servidor DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "No s'ha pogut finalitzar el bucle d'avís amb el servidor DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "No s'ha pogut enviar una notificació d'avís DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "No s'ha pogut crear la cadena DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "no hi ha cap error DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a una transacció d'avís "
 "síncrona."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "la resposta a la transacció ha provocat que es defineixi el bit DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a una transacció de dades "
 "síncrona."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5693,7 +5682,7 @@ msgstr ""
 "o s'ha passat un identificador d'instància invàlid\n"
 "a una funció DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5705,47 +5694,47 @@ msgstr ""
 "o bé una aplicació inicialitzada com a APPCMD_CLIENTONLY ha \n"
 "provat d'executar transaccions de servidor."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a una transacció "
 "d'execució síncrona."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "el DDEML no ha pogut validar un paràmetre."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "una aplicació DDEML ha creat una situació de competició prolongada."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "no s'ha pogut fer una assignació de memòria."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "un client no ha pogut establir una conversa."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "no s'ha pogut executar una transacció."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a una transacció poke "
 "síncrona."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ha fallat una crida interna a la funció PostMessage. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5755,17 +5744,17 @@ msgstr ""
 "que ha estat finalitzada pel client, o el servidor\n"
 "ha finalitzat abans de completar una transacció."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "s'ha produït un error intern al DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "s'ha excedit el temps límit d'una sol·licitud per a finalitzar una "
 "transacció d'avís."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5775,12 +5764,12 @@ msgstr ""
 "Un cop que l'aplicació ha retornat d'una crida XTYP_XACT_COMPLETE, \n"
 "l'identificador de transacció d'aquesta crida ja no és vàlid."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Error DDE desconegut %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5788,7 +5777,7 @@ msgstr ""
 "Les funcions de marcatge telefònic no estan disponibles perquè el servei "
 "d'accés remot (RAS) no està instal·lat en aquest dispositiu. Instal·leu-lo."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5797,67 +5786,67 @@ msgstr ""
 "La versió del servei d'accés remot (RAS) instal·lada en aquest dispositiu és "
 "massa antiga, actualitzeu-la (hi manca la següent funció necessària: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "No s'ha pogut recuperar el text del missatge d'error del RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "s'ha produït un error desconegut (codi d'error %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "No es pot trobar cap connexió activa de marcatge telefònic: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "S'han trobat diverses connexions actives de marcatge telefònic, se'n triarà "
 "una aleatòriament."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "No s'ha pogut establir la connexió de marcatge telefònic: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "No s'han pogut obtenir els noms dels proveïdors d'Internet: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 "No s'ha pogut connectar: no hi ha cap proveïdor d'Internet al qual trucar."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Trieu el proveïdor d'Internet a qui voleu trucar"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Trieu a quin proveïdor d'Internet us voleu connectar"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "No s'ha pogut connectar: manca el nom d'usuari o la contrasenya."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "No es pot trobar la ubicació del fitxer de la llibreta d'adreces"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "No s'ha pogut inicialitzar la connexió de marcatge telefònic: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "No es pot penjar - no hi ha cap connexió de marcatge telefònic activa."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "No s'ha pogut finalitzar la connexió de marcatge telefònic: %s"
@@ -5877,18 +5866,17 @@ msgstr "No s'ha pogut assignar %luKb de memòria per a dades de mapa de bits."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "No es poden enumerar els fitxers del directori '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "No s'ha pogut obtenir el nom de la carpeta"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(error %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "No s'ha pogut afegir una imatge a la llista d'imatges."
 
@@ -5904,7 +5892,7 @@ msgstr ""
 "No s'ha pogut crear el diàleg estàndard de cerca/substitueix (codi d'error "
 "%d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "El diàleg de fitxer ha fallat amb el codi d'error %0lx."
@@ -5946,16 +5934,16 @@ msgstr "No s'ha pogut configurar la supervisió de '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "No es pot supervisar si hi ha canvis al directori inexistent \"%s\"."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "El controlador d'OpenGL no suporta OpenGL 3.0 o superior."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "No s'ha pogut crear el context d'OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "No s'ha pogut inicialitzar l'OpenGL"
 
@@ -5965,7 +5953,7 @@ msgstr ""
 "No s'ha pogut enregistrar el carregador personalitzat de tipus de lletra de "
 "DirectWrite."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5973,7 +5961,7 @@ msgstr ""
 "Les funcions de l'ajuda MS HTML no estan disponibles perquè la biblioteca de "
 "l'ajuda MS HTML no està instal·lada en aquest dispositiu. Instal·leu-la."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "No s'ha pogut inicialitzar l'ajuda MS HTML."
 
@@ -5982,7 +5970,7 @@ msgstr "No s'ha pogut inicialitzar l'ajuda MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "No es pot suprimir el fitxer INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6103,7 +6091,7 @@ msgstr "No s'ha pogut registrar el format '%s' del porta-retalls."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "El format del porta-retalls '%d' no existeix."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Omet"
 
@@ -6189,59 +6177,59 @@ msgstr ""
 "si la suprimiu, deixareu el sistema en un estat inservible:\n"
 "s'ha avortat l'operació."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "No es pot suprimir la clau '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "No es pot suprimir el valor '%s' de la clau '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "No es pot llegir el valor de la clau '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "No es pot definir el valor de '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "El valor del registre \"%s\" no és numèric (sinó del tipus %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "El valor del registre \"%s\" no és binari (sinó del tipus %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "El valor del registre \"%s\" no és de text (sinó del tipus %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "No es pot llegir el valor de '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "No es poden enumerar els valors de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "No es poden enumerar les subclaus de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6249,17 +6237,17 @@ msgstr ""
 "Exportació de la clau del registre: el fitxer \"%s\" ja existeix i no se "
 "sobreescriurà."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "No es pot exportar el valor del tipus de no suportat %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "S'ignora el valor \"%s\" de la clau \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6267,43 +6255,43 @@ msgstr ""
 "No és possible crear un control d'edició rica, s'utilitzarà en el seu lloc "
 "un control de text simple. Reinstal·leu riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 "No es pot iniciar el fil d'execució: s'ha produït un error en escriure el "
 "TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "No es pot definir la prioritat del fil d'execució"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "No es pot crear el fil d'execució"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "No s'ha pogut finalitzar el fil d'execució"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "No es pot esperar a la finalització del fil d'execució"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "No es pot suspendre el fil d'execució %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "No es pot reprendre el fil d'execució %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "No s'ha pogut obtenir el punter del fil d'execució actual"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6311,7 +6299,7 @@ msgstr ""
 "No s'ha pogut inicialitzar el mòdul de fils d'execució: no és possible "
 "assignar l'índex a l'emmagatzematge local del fil d'execució"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6343,12 +6331,12 @@ msgstr "No s'ha pogut carregar el recurs \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "No s'ha pogut blocar el recurs \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "compilació %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", edició de 64 bits"
 
@@ -6360,47 +6348,47 @@ msgstr "No s'ha pogut crear una canonada anònima"
 msgid "Failed to redirect the child process IO"
 msgstr "No s'ha pogut redirigir l'E/S del procés fill"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Ha fallat l'execució de l'ordre '%s'"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "No s'ha pogut carregar mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "No es pot llegir el nom del tipus de '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "No es pot carregar la icona de '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "No s'ha pogut trobar el nivell d'emulació de web view al registre"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "No s'ha pogut establir web view a un nivell d'emulació modern"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "No s'ha pogut restablir web view a un nivell d'emulació estàndard"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 "No es pot executar un script de JavaScript sense un document HTML vàlid"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "No es pot obtenir l'objecte de JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "no s'ha pogut evaluar"
 
@@ -6433,7 +6421,7 @@ msgid "Check to make the font italic."
 msgstr "Marqueu-ho per a fer que la lletra sigui cursiva."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subratllat"
@@ -6500,15 +6488,33 @@ msgstr "<Qualsevol Teletip>"
 msgid "File type:"
 msgstr "Tipus de fitxer:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Window"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimitza"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Amplia"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Porta tot al davant"
 
@@ -6531,457 +6537,457 @@ msgstr ""
 "El fitxer de tipus de lletra \"%s\" no es pot utilitzar ja que no es troba "
 "dins el directori de tipus de lletra \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Quant a %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Quant a..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferències..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Serveis"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Amaga %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Amaga l'aplicació"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Amaga els altres"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Mostra-ho tot"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Surt de %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Surt de l'aplicació"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "El control web del sistema no suporta impressió"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "No s'ha pogut inicialitzar l'operació d'impressió"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Mida en punts"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nom del tipus de lletra"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estil"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Pes"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Família"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ButtonText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "GrayText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Highlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menú"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Tooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "TooltipText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Window"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Personalitzat"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Negre"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Marró"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Blau marí"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Porpra"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Xarxet"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Gris"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Verd"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Oliva"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Marró"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Blau"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fúcsia"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Vermell"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Carabassa"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Argent"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Llima"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Cian"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Groc"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Blanc"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Predeterminat"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Fletxa"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Fletxa dreta"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Buit"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Diana"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Caràcter"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Creu"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Mà"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "Perfil en I"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Botó esquerre"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Botó del mig"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Sense entrada"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Pinzell"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Llapis"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Apunta a l'esquerra"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Apunta a la dreta"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Fletxa amb interrogació"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Botó dret"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Redimensionament NE-SO"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Redimensionament N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Redimensionament NO-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Redimensionament O-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Redimensionament"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Esprai"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Espera"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Rellotge"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Fletxa d'espera"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Crea una selecció:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Propietat"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Mode categoritzat"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Mode alfabètic"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Fals"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Cert"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "No especificat"
 
@@ -6994,12 +7000,12 @@ msgstr "Error de propietat"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Heu introduït un valor invàlid. Premeu Esc per a cancel·lar l'edició."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "S'ha produït un error al recurs: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7008,36 +7014,36 @@ msgstr ""
 "L'operació de tipus \"%s\" ha fallat: La propietat etiquetada \"%s\" és del "
 "tipus \"%s\", NO \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Base %d desconeguda. S'utilitzarà la base 10."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "El valor ha de ser més gran o igual que %s."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "El valor ha de ser entre %s i %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "El valor ha de ser més petit o igual que %s."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "No %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Trieu un directori:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Trieu un fitxer"
 
@@ -7504,117 +7510,117 @@ msgstr "Interior"
 msgid "Outset"
 msgstr "Exterior"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Canvia l'estil"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Canvia l'estil d'objecte"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Canvia les propietats"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Canvia l'estil de llista"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Torna a numerar la llista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Insereix text"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Insereix una imatge"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Insereix un objecte"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Insereix un camp"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Massa crides a EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "fitxers"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "estàndard/cercle"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "estàndard/circumferència"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "estàndard/quadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "estàndard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "estàndard/triangle"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Propietats de la caixa"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Propietats de múltiples cel·les"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Propietats de la cel·la"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Defineix l'estil de la cel·la"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Suprimeix la fila"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Suprimeix la columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Afegeix una fila"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Afegeix una columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Propietats de la taula"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Propietats de la imatge"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "imatge"
 
@@ -7822,24 +7828,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Arrossega"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Suprimeix el text"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Suprimeix el pic"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "No s'ha pogut desar el text."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Substitueix"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Tipus de lletra:"
 
@@ -8808,53 +8814,53 @@ msgstr "Estils de llista"
 msgid "Box styles"
 msgstr "Estils de caixa"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "El tipus de lletra del qual prendre el símbol."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subconjunt:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Mostra un subconjunt d'Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Codi de caràcter:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "El codi del caràcter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&De:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "L'interval a mostrar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insereix"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Text normal)"
 
@@ -9040,7 +9046,7 @@ msgstr "No s'han pogut obtenir els esdeveniments de kqueue"
 msgid "Media playback error: %s"
 msgstr "S'ha produït un error en la reproducció del mitjà: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "No s'ha pogut preparar la reproducció de \"%s\"."
@@ -9140,21 +9146,21 @@ msgstr "Les dades del so tenen un format no suportat."
 msgid "Couldn't open audio: %s"
 msgstr "No s'ha pogut obrir l'àudio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "No es pot obtenir la política de planificació de fils d'execució."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "No es pot obtenir el rang de prioritats per a la política de planificació %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "La configuració de prioritat del fil d'execució és ignorada."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9162,63 +9168,63 @@ msgstr ""
 "No s'ha pogut sincronitzar amb un fil d'execució, s'ha detectat una possible "
 "fuita de memòria - reinicieu el programa"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 "No s'ha pogut definir el nivell de concurrència del fil d'execució a %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "No s'ha pogut definir la prioritat del fil d'execució %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "No s'ha pogut finalitzar el fil d'execució."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "No s'ha pogut inicialitzar el mòdul de fils d'execució: no s'ha pogut crear "
 "la clau del fil d'execució"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "No és possible obtenir l'entrada del procés fill"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "No es pot escriure a l'entrada estàndard del procés fill"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "No s'ha pogut executar '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "No s'ha pogut bifurcar"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "No s'ha pogut definir la prioritat del procés"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "No s'ha pogut redirigir l'entrada/sortida del procés fill"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "No s'ha pogut configurar la canonada no blocant, és possible que el programa "
 "es pengi."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "No es pot obtenir el nom del servidor"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "No es pot obtenir el nom oficial del servidor"
 
@@ -9236,12 +9242,12 @@ msgstr "No s'ha pogut canviar la canonada de despertament al mode no blocant"
 msgid "Failed to read from wake-up pipe"
 msgstr "No s'ha pogut llegir la canonada de despertament"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificació de geometria invàlida '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets no ha pogut obrir la pantalla. Se sortirà."
 
@@ -9255,30 +9261,59 @@ msgstr "No s'ha pogut tancar la pantalla \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "No s'ha pogut obrir la pantalla \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "S'ha produït un error d'anàlisi XML: '%s' a la línia %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "No es poden carregar recursos de '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "No es pot obrir el fitxer de recursos '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "No es poden carregar els recursos del fitxer '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "No s'ha pogut crear %s \"%s\"."
+
+#~ msgid "Printing "
+#~ msgstr "S'està imprimint "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "No s'ha pogut inserir el text al control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Trieu un tipus de lletra vàlid."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "No s'ha pogut mostrar el document HTML amb la codificació %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets no ha pogut obrir la pantalla de '%s': se sortirà."
+
+#~ msgid "Filter"
+#~ msgstr "Filtre"
+
+#~ msgid "Directories"
+#~ msgstr "Directoris"
+
+#~ msgid "Files"
+#~ msgstr "Fitxers"
+
+#~ msgid "Selection"
+#~ msgstr "Selecció"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "no s'ha pogut fer la conversió a una codificació de 8 bits"

--- a/locale/ca@valencia.po
+++ b/locale/ca@valencia.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2003-07-22 11:31+0100\n"
 "Last-Translator: Robert Millan <rmh@aybabtu.com>\n"
 "Language-Team: <wx-translators@wxwidgets.org>\n"
@@ -11,11 +11,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Tots els fitxers (*.*) *.*  "
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Tots els fitxers (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "Temps restant :"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sí"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "D'acord"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Anul·la"
@@ -104,7 +101,7 @@ msgid "Unable to create I/O completion port"
 msgstr "No s'ha pogut crear una barra d'estat."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "Imprimix"
@@ -148,7 +145,7 @@ msgstr "&Previ"
 msgid "Printing"
 msgstr "S'està imprimint"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 #, fuzzy
 msgid "Symbols"
 msgstr "Font normal"
@@ -220,7 +217,7 @@ msgstr "&Previ"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Finestra"
 
@@ -787,11 +784,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "control"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "mostra este missatge d'ajuda"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "genera missatges de registre detallats"
 
@@ -813,84 +810,84 @@ msgstr "Tema '%s' no suportat"
 msgid "Invalid display mode specification '%s'."
 msgstr "Mode d'especificació de mostreig '%s' invàlid."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opció llarga desconeguda '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opció '%s' desconeguda"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Paràmetre '%s' no esperat"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L'opció '%s' requerix un valor."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "S'espera un separador després de l'opció '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' no és valor numèric correcte per l'opció '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opció '%s': '%s' no es pot convertir a data."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Paràmetre '%s' no esperat"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "El valor per l'opció '%s' ha d'estar especificat."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "El paràmetre requerit '%s' no ha estat especificat."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Sintaxi: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "núm."
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -908,7 +905,7 @@ msgid "Can't &Undo "
 msgstr "No s'ha pogut &desfer"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfés"
@@ -918,7 +915,7 @@ msgid "&Redo "
 msgstr "&Refés"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refés"
@@ -948,12 +945,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' té '..' extres que han estat ignorats."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -963,103 +960,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "subratllat"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "avui"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "ahir"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "demà"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primer"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "segon"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tercer"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "quart"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "cinquè"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sisè"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "setè"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "vuitè"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "novè"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "desè"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "onzè"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dotzè"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "tretzè"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "catorzé"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "quinzè"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "setzè"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "dissetè"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "divuitè"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "dinovè"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vintè"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "migdia"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "mitja nit"
 
@@ -1125,44 +1122,81 @@ msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 "No s'ha pogut crear el diàleg estàndard de cerca/substituix (codi d'error %d)"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Anomena i Alça"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "sense nom"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Voleu alçar els canvis del document"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+#, fuzzy
+msgid "&Save"
+msgstr "&Desa..."
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+msgid "Do&n't close"
+msgstr ""
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Voleu alçar els canvis del document"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "No s'ha pogut alçar el text."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1171,59 +1205,59 @@ msgstr ""
 "El fitxer '%s' no existix i per tant no pot ser obert.\n"
 "Ha estat extret des de llistat de fitxers utilitzats més recentment."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "No s'ha pogut crear la canonada."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Imprimix previsualització"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "%d sense nom"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Selecciona un Fitxer"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Error de fitxer"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "No s'ha pogut obrir este fitxer."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 #, fuzzy
 msgid "Sorry, the format for this file is unknown."
 msgstr "No s'ha pogut obrir este fitxer."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Seleccioneu una plantilla de document"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Plantilles"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Seleccioneu una vista del document"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Vistes"
 
@@ -1257,41 +1291,41 @@ msgstr "Llig error en el fitxer '%s'"
 msgid "Write error on file '%s'"
 msgstr "Error en el fitxer '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "no s'ha pogut buidar la memòria del fitxer '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Error de recerca en fitxer '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "No es pot trobar la posició actual en el fitxer '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "No s'ha pogut fixar els permisos de fitxer temporals."
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "no s'ha pogut extreure el fitxer '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "no es pot confiar canvis al fitxer '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "no es pot extreure el fitxer temporal '%s'"
@@ -1316,28 +1350,28 @@ msgstr "no es pot llegir des del fitxer descriptor %s"
 msgid "can't write to file descriptor %d"
 msgstr "no es pot escriure en el fitxer descriptiu %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "no es pot buidar el descriptor del fitxer %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "no és pot cercar el fitxer descriptor de %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "no es pot cercar en el descriptor del fitxer %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "no es pot trobar la llargària del fitxer en el descriptor del fitxer %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1363,153 +1397,153 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Error en llegir imatge DIB"
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Error en llegir imatge DIB"
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fiitxer '%s': caràcter inesperat %c a la línia %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "fitxer '%s', línia %d: '%s' ignorada després de la capçalera de grup."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fitxer '%s', línia %d: '=' inesperat."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "fitxer '%s', línia %d: valor per a clau immutable '%s' ignorat."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "fitxer '%s', línia %d: clau '%s' ha estat trobat per primer cop a la línia "
 "%d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "No es pot iniciar un nom d'entrada de configuració per '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "no es pot obrir el fitxer de configuració de l'usuari."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "no es pot escriure el fitxer de configuració de l'usuari"
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 #, fuzzy
 msgid "Failed to update user configuration file."
 msgstr "no es pot obrir el fitxer de configuració de l'usuari."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 #, fuzzy
 msgid "Error saving user configuration data."
 msgstr "Error en llegir imatge DIB"
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "no s'ha pogut eliminar el fitxer de configuració '%s' d'usuari"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "l'entrada '%s' apareix més d'un cop en el grup '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "intent de canviar la clau immutable '%s' ignorat."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "no esperat \" a la posició %d de '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Impossible de copiar el fitxer '%s' a '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "No és possible obtenir permisos per al fitxer '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "És impossible sobrescriure el fitxer '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Impossible de copiar el fitxer '%s' a '%s'"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "És impossible fixar els permisos per al fitxer '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "No s'ha pogut crear el directori '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "No es pot enumerar els fitxers '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "No s'ha pogut obtenir el directori en funcionament"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "No s'ha pogut obtenir el directori en funcionament"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, fuzzy, c-format
 msgid "Files (%s)"
 msgstr "Fitxers (%s)|%s"
@@ -1536,17 +1570,17 @@ msgstr "No s'ha pogut crear un nom d'arxiu temporal"
 msgid "Failed to open temporary file."
 msgstr "No s'ha pogut obrir un fitxer temporal"
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "No s'ha pogut modificar les hores de fitxer de '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "No s'ha pogut posar en contacte amb el fitxer '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "No s'ha pogut recuperar les hores de fitxer de '%s'"
@@ -1555,22 +1589,22 @@ msgstr "No s'ha pogut recuperar les hores de fitxer de '%s'"
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, fuzzy, c-format
 msgid "All files (%s)|%s"
 msgstr "Tots els fitxers (*)|*"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, fuzzy, c-format
 msgid "%s files (%s)|%s"
 msgstr "Fitxers (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Carrega fitxer %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Alça fitxer %s"
@@ -1951,109 +1985,109 @@ msgstr "predeterminat"
 msgid "unknown-%d"
 msgstr "desconegut-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "subratllat"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "clar"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 #, fuzzy
 msgid " light"
 msgstr "clar"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 #, fuzzy
 msgid " bold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 #, fuzzy
 msgid " italic"
 msgstr "cursiva"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "clar"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "clar"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "negreta"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "cursiva"
 
@@ -2137,7 +2171,7 @@ msgstr "El servidor FTP no permet l'ús de mode passiu."
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "No s'ha pogut fixar el mode de transferència FTP a %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2159,7 +2193,7 @@ msgstr "El servidor FTP no permet l'ús de mode passiu."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "No s'ha pogut crear una barra d'estat."
@@ -2178,7 +2212,7 @@ msgstr "Grandària de la font:"
 msgid "&Customize..."
 msgstr "Grandària de la font:"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "No s'ha pogut obrir '%s' per %s"
@@ -2198,159 +2232,158 @@ msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 msgid "Failed to load icons from resource '%s'."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP:No s'ha pogut alçar la imatge invàlida."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP:wxImage no té una wxPallette pròpia."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (Mapa de bits)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: No s'ha pogut escriure la capçalera del fitxer (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: No s'ha pogut escriure el mapa de colors RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: No s'ha pogut escriure la dada."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: No s'ha pogut localitzar la memòria."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Capçalera DIB: Imatge amb amplada  > 32767 píxels per fitxer."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Capçalera DIB: Imatge amb alçada > 32767 píxels per fitxer."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Capçalera DIB: profunditat de bits desconeguda en el fitxer."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Capçalera DIB: codificació desconeguda en el fitxer."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Capçalera DIB: la codificació no coincidix amb la profunditat de bits."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: No s'ha pogut localitzar la memòria."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Capçalera DIB: Imatge amb amplada  > 32767 píxels per fitxer."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Capçalera DIB: Imatge amb alçada > 32767 píxels per fitxer."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Capçalera DIB: profunditat de bits desconeguda en el fitxer."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Capçalera DIB: codificació desconeguda en el fitxer."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Capçalera DIB: la codificació no coincidix amb la profunditat de bits."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Error en llegir imatge DIB"
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Error en llegir la màscara DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imatge massa llarga per a una icona."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO:Imatge massa ampla per poder ser una icona."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Error en llegir el fitxer d'imatge!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índex d'icones invàlid"
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 #, fuzzy
 msgid "Image and mask have different sizes."
 msgstr "La imatge i la màscara tenen diferents grandàries"
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 #, fuzzy
 msgid "No unused colour in image being masked."
 msgstr "Cap color no utilitzat en la imatge està sent emmascarat"
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "No es pot alçar la imatge en el format '%s': extensió desconeguda."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "No s'ha trobat cap manegador per al tipus d'imatge"
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "No hi ha definit cap manegador per al tipus d'imatge %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "El fitxer d'imatge no és del tipus %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "IFF: error en format d'imatge IFF."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: este no és un fitxer PCX ."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "No hi ha definit cap manegador per al tipus d'imatge %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "El fitxer d'imatge no és del tipus %d."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
@@ -2454,52 +2487,52 @@ msgstr "PNM: el fitxer sembla estroncat"
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Error en carregar la imatge."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Index d'imatge TIFF invàlid"
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: No es pot localitzar la memòria"
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Error en llegir la imatge."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Error en alçar la imatge."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Error en escriure la imatge."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2598,7 +2631,7 @@ msgstr ""
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' no tancat per a tipus mime %s."
@@ -2618,7 +2651,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "missatge %s"
@@ -3169,7 +3202,7 @@ msgstr "Error d'impressió"
 msgid "Print"
 msgstr "Imprimix"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 #, fuzzy
 msgid "Page setup"
 msgstr "Configuració de la pàgina"
@@ -3206,20 +3239,16 @@ msgstr "S'està imprimint la pàgina %d..."
 msgid " (copy %d of %d)"
 msgstr "Pàgina %d de %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "S'està imprimint"
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "Pàgina següent"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Pàgina anterior"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Pàgina següent"
 
@@ -3264,16 +3293,16 @@ msgstr "Pàgina %d de %d"
 msgid "Page %d"
 msgstr "Pàgina %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "error desconegut"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expressió regular invàlida '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "No s'ha pogut coincidir '%s' en l'expressió regular: %s"
@@ -3283,21 +3312,21 @@ msgstr "No s'ha pogut coincidir '%s' en l'expressió regular: %s"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "L'execució de l'orde '%s' ha fallit."
@@ -3306,12 +3335,12 @@ msgstr "L'execució de l'orde '%s' ha fallit."
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 #, fuzzy
 msgid "Save"
 msgstr "&Desa..."
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr ""
 
@@ -3399,10 +3428,10 @@ msgid "Clear"
 msgstr "&Neteja"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Tanca"
 
@@ -3416,7 +3445,7 @@ msgstr "Contingut"
 msgid "Convert"
 msgstr "Contingut"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copia"
@@ -3426,7 +3455,7 @@ msgstr "&Copia"
 msgid "Copy"
 msgstr "&Copia"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Re&talla"
@@ -3436,13 +3465,13 @@ msgstr "Re&talla"
 msgid "Cut"
 msgstr "Re&talla"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Elimina"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 #, fuzzy
 msgid "Delete"
@@ -3541,7 +3570,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -3565,7 +3594,7 @@ msgstr "Índex"
 msgid "&Index"
 msgstr "Índex"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Índex"
 
@@ -3642,7 +3671,7 @@ msgstr "&Següent"
 msgid "New"
 msgstr "&Següent"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 #, fuzzy
 msgid "&No"
 msgstr "No"
@@ -3663,12 +3692,12 @@ msgstr "&Desa..."
 msgid "Open..."
 msgstr "&Desa..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Enganxa"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 #, fuzzy
 msgid "Paste"
@@ -3703,7 +3732,7 @@ msgid "Print..."
 msgstr "Imprimix..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 #, fuzzy
 msgid "&Properties"
 msgstr "&Previ"
@@ -3740,11 +3769,6 @@ msgstr "&Substituix"
 msgid "Revert to Saved"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
-#, fuzzy
-msgid "&Save"
-msgstr "&Desa..."
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 #, fuzzy
 msgid "Save &As..."
@@ -3755,7 +3779,7 @@ msgstr "&Desa..."
 msgid "Save As..."
 msgstr "&Desa..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecciona-ho &tot"
@@ -3879,7 +3903,7 @@ msgstr "Amunt"
 msgid "Up"
 msgstr "Amunt"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 #, fuzzy
 msgid "&Yes"
 msgstr "Sí"
@@ -3977,44 +4001,44 @@ msgstr "Seleccioneu una vista del document"
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "La conversió al joc de caràcters '%s' no funciona."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "desconegut"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 #, fuzzy
 msgid "unexpected end of file"
 msgstr "Fi de fitxer inesperat en analitzar el recurs."
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -4023,7 +4047,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' és probablement un búffer binari."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "No s'ha pogut carregar el fitxer."
 
@@ -4037,49 +4061,49 @@ msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 msgid "can't write buffer '%s' to disk."
 msgstr "no es pot escriure el búfer '%s' al disc."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "No s'ha pogut obtenir l'horari local del sistema"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay ha fallat."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' no és un missatge vàlid de catàleg"
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' no és un missatge vàlid de catàleg"
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "No es pot analitzar les coordenades des de '%s'."
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "s'està utilitzant el catàleg '%s' des de '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' no és un missatge vàlid de catàleg"
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "No s'ha acabat la cadena"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "No s'ha pogut obrir '%s' per %s"
@@ -4112,7 +4136,7 @@ msgstr "'%s' només hauria de contenir caràcters alfabètics"
 msgid "Error: %s (%d)"
 msgstr "Error: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4121,20 +4145,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "No s'ha pogut carregar el fitxer."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "No s'ha pogut transferir dades a la finestra"
 
@@ -4186,8 +4210,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr ""
 
@@ -4237,85 +4261,85 @@ msgstr ""
 msgid "Doubly used id : %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Opció '%s' desconeguda"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 #, fuzzy
 msgid "can't re-initialize zlib deflate stream"
 msgstr "No es pot començar a mostrar."
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 #, fuzzy
 msgid "can't re-initialize zlib inflate stream"
 msgstr "No es pot començar a mostrar."
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 #, fuzzy
 msgid "invalid zip file"
 msgstr "Fitxer de bloqueig '%s' invàlid."
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 #, fuzzy
 msgid "can't find central directory in zip"
 msgstr "No es pot trobar la posició actual en el fitxer '%s'"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 #, fuzzy
 msgid "error reading zip central directory"
 msgstr "Error en crear directori"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 #, fuzzy
 msgid "stored file length not in Zip header"
 msgstr "Format no suportat de porta-retalls"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4403,33 +4427,33 @@ msgstr ""
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Permisos"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr ""
 
@@ -4482,44 +4506,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "&Mida"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (o %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4530,8 +4553,7 @@ msgid "Left"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 #, fuzzy
@@ -4623,7 +4645,7 @@ msgid "Home directory"
 msgstr "Crea directori"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr ""
 
@@ -4636,8 +4658,7 @@ msgstr "Nom il·legal de directori"
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Error"
 
@@ -4828,16 +4849,16 @@ msgstr "Mostra els fitxers en vista detallada"
 msgid "Go to parent directory"
 msgstr "Puja un directori "
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, fuzzy, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "El fitxer '%' ja existex, n'esteu segur de voleu rescriure-hi?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirma"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Trieu un fitxer existent."
 
@@ -4936,7 +4957,7 @@ msgstr "Grandària de la font:"
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Previsualització:"
@@ -4954,48 +4975,47 @@ msgstr ""
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Trieu la font"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "no s'ha trobat el fitxer de catàleg per al domini '%s'"
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "No s'ha trobat entrades."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Índex de l'ajuda"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Entrades rellevants:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Entrades trobades:"
 
@@ -5104,61 +5124,61 @@ msgstr "No s'ha pogut iniciar la impressió"
 msgid "Printing page %d..."
 msgstr "S'està imprimint la pàgina %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opcions d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Imprimix al fitxer"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configura..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 #, fuzzy
 msgid "Printer:"
 msgstr "Impressió..."
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 #, fuzzy
 msgid "Status:"
 msgstr "Estat:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tot"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Pàgines"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Rang d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "De:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Per a:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Còpies:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Fitxer PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Paràmetres d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 #, fuzzy
 msgid "Printer"
 msgstr "Imprimix"
@@ -5168,25 +5188,25 @@ msgstr "Imprimix"
 msgid "Default printer"
 msgstr "Codificació predeterminada"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Grandària del paper"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Vertical"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Apaïsat"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientació"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcions"
 
@@ -5198,54 +5218,54 @@ msgstr "Imprimix en color"
 msgid "Print spooling"
 msgstr "Cua d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Orde d'impressió"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opcions d'impressió:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Marge esquerra (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Marge superior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Marge dret (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Marge inferior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Impressió..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 #, fuzzy
 msgid "&Skip"
 msgstr "Script"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 #, fuzzy
 msgid "Unknown"
 msgstr "desconegut"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Fet."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Cerca"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "No es pot trobar la pestanya per a id"
 
@@ -5281,22 +5301,22 @@ msgstr "&Fi"
 msgid "< &Back"
 msgstr "< &Enrere"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "No s'ha pogut crear un directori %s/.gnome."
@@ -5322,12 +5342,12 @@ msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 msgid "Failed to register font configuration using private fonts."
 msgstr "no es pot obrir el fitxer de configuració de l'usuari."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Error fatal"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5335,7 +5355,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5343,7 +5363,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI fill"
 
@@ -5361,36 +5381,27 @@ msgstr "Espereu mentre simprimix\n"
 msgid "Page Setup"
 msgstr "Configuració de la pàgina"
 
-#: ../src/gtk/textctrl.cpp:1273
-#, fuzzy
-msgid "Failed to insert text in the control."
-msgstr "No s'ha pogut obtenir el directori en funcionament"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Trieu una font vàlida"
 
 #: ../src/html/chm.cpp:138
 #, fuzzy, c-format
@@ -5496,45 +5507,45 @@ msgstr "No es pot obrir fitxers de contingut: %s"
 msgid "Cannot open index file: %s"
 msgstr "No es pot obrir el fitxer d'índex: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "sense nom"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "No es pot obrir el llibre d'ajuda HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(preferits)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Afig la pàgina actual a preferits"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Extreu la pàgina actual dels preferits"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Contingut"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Cerca"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Mostra-ho tot"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5542,19 +5553,19 @@ msgstr ""
 "Mostra tots els elements de l'índex que continguin la subcadena donada. La "
 "recerca no distingix majúscules de minúscules."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Mostra tots els elements en el índex"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Distingix entre majúscules i minúscules"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Només paraules senceres"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -5563,150 +5574,150 @@ msgstr ""
 "Cerqueu continguts en llibre(s) d'ajuda per totes les ocurrències del text "
 "escrit"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Mostra/amaga el plafó de navegació"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Vés arrere"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Vés avant"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Puja un nivell de la jerarquia del document."
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Obri document HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Imprimix esta pàgina"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Mostra les opcions del diàleg"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 #, fuzzy
 msgid "Please choose the page to display:"
 msgstr "Trieu un fitxer existent."
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 #, fuzzy
 msgid "Help Topics"
 msgstr "Ajuda: %s"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "S'està cercant..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Encara no s'ha trobat cap pàgina que coincidisca"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "S'han trobat %i coincidències"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Ajuda)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i de %i"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i de %i"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Cerca a tots els llibres"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opcions d'ajuda del navegador"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Font normal"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Font fixada:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Grandària de la font:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 #, fuzzy
 msgid "font size"
 msgstr "Grandària de la font:"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Ajuda de la impressió"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "No es pot imprimir una pàgina buida."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i de %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i de %i"
@@ -5779,36 +5790,6 @@ msgstr ""
 "Hi ha hagut un problema durant l'actualització de la pàgina: potser caldrà "
 "establir la impressora predeterminada."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "No s'ha pogut mostrar el document HTML en codificació %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets no podia obrir l'aplicació per '%s'; s'està eixint."
-
-#: ../src/motif/filedlg.cpp:218
-#, fuzzy
-msgid "Filter"
-msgstr "&Mida"
-
-#: ../src/motif/filedlg.cpp:219
-#, fuzzy
-msgid "Directories"
-msgstr "Decoratiu"
-
-#: ../src/motif/filedlg.cpp:220
-#, fuzzy
-msgid "Files"
-msgstr "&Mida"
-
-#: ../src/motif/filedlg.cpp:220
-#, fuzzy
-msgid "Selection"
-msgstr "Seccions"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "No s'ha pogut obrir el porta-retalls"
@@ -5851,61 +5832,61 @@ msgstr "L'execució de l'orde '%s' ha fallit."
 msgid "Failed to create cursor."
 msgstr "No s'ha pogut crear una barra d'estat."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "No es pot registrar el servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "No s'ha pogut desenregistrar el servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "No s'ha pogut crear una connexió en el servidor '%s' en el tema '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Sol·licitud de DDE poke fallida"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "No s'ha pogut establir un bucle d'avís amb el servidor DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "No s'ha pogut acabar el bucle d'avís amb el servidor DDE."
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "No s'ha pogut enviar una notificació d'avís DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "No s'ha pogut crear una cadena DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "no hi ha error DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "una sol·licitud per a una transacció d'avís síncrona ha excedit el temps"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "la resposta a la transacció causada per la DDE_FBUSY s'ha de fixar una mica."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "una sol·licitud per a una transacció de dades síncrona ha excedit el temps"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5916,7 +5897,7 @@ msgstr ""
 "o un identificador invàlid d'instància\n"
 "ha passat a funció DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5928,45 +5909,45 @@ msgstr ""
 "o bé una aplicació començada com a APPCMD_CLIENTONLY ha \n"
 "intentat fer transaccions de servidor."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "una sol·licitud per a una transacció síncrona per a executar ha excedit el "
 "temps"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "un paràmetre ha fallat per ser validat pel DDEML"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "una aplicació DDEML ha creat una condició estreta prolongada."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "ha fallat una assignació de memòria"
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "Un client que intentava establir una connexió ha fallit."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "ha fallat una transacció"
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "una sol·licitud per a una transacció poke ha excedit el temps"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ha fallat una trucada interna cap a la funció PostMessage"
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5976,17 +5957,17 @@ msgstr ""
 "que ha acabat amb el client, o el servidor\n"
 "abans de completar una transacció."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "Hi ha hagut un error intern en el DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "una sol·licitud per finalitzar un avís de transacció s'ha excedit en el "
 "temps."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5996,12 +5977,12 @@ msgstr ""
 "un cop que l'aplicació ha tornat d'una trucada XTYP_XACT_COMPLETE, \n"
 "l'identificador de transacció d'esta trucada ja no és vàlid."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Error DDE desconegut %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -6010,7 +5991,7 @@ msgstr ""
 "d'accés remot (RAS) no es troba instal·lat en este maquinari. Reinstal·leu-"
 "ho."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -6020,66 +6001,66 @@ msgstr ""
 "\"tooold\", l'hauríeu d'actualitzar (la següent funció sol·licitada s'ha "
 "passat per alt: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "No s'ha pogut recuperar el text del missatge d'error RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "error desconegut (error de codi %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "No es pot trobar connexió activa de marcatge directe: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "S'han triat diverses connexions de marcatge directe, triant-ne una "
 "aleatòriament."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "No s'ha pogut establir la connexió: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "No s'han pogut obtenir els noms ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "No s'ha pogut connectar: no hi ha cap ISP a trucar."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Trieu l'ISP a trucar"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Trieu quin ISP us voleu connectar"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Connexió fallida:  hi manca el nom d'usuari o la contrasenya."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "No es pot localitzar el fitxer del llibre d'adreces"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "No s'ha pogut acabar la connexió de marcatge directe: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "No es pot penjar - no hi ha activa cap connexió de marcatge directe."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "No s'ha pogut acabar la connexió de marcatge directe: %s"
@@ -6099,19 +6080,18 @@ msgstr "No s'ha pogut crear una barra d'estat."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "No es pot enumerar els fitxers en el directori '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "No s'ha pogut crear un temporitzador"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (error %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "No s'ha pogut afegir una imatge al llistat d'imatges."
 
@@ -6126,7 +6106,7 @@ msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "No s'ha pogut crear el diàleg estàndard de cerca/substituix (codi d'error %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "L'execució de l'orde '%s' ha fallit."
@@ -6169,17 +6149,17 @@ msgstr "No s'ha pogut posar en contacte amb el fitxer '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "No s'ha pogut crear un temporitzador"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "No s'ha pogut inicialitzar l'OpenGL"
 
@@ -6187,7 +6167,7 @@ msgstr "No s'ha pogut inicialitzar l'OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6195,7 +6175,7 @@ msgstr ""
 "Les funcions d'ajuda MS HTML no están disponibles perque la llibreria "
 "d'Ajuda MS HTML no està instal·lada en este maquinari. L'heu d'instal·lar.."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "No s'ha pogut inicialitzar l'ajuda MS HTML"
 
@@ -6204,7 +6184,7 @@ msgstr "No s'ha pogut inicialitzar l'ajuda MS HTML"
 msgid "Can't delete the INI file '%s'"
 msgstr "No es pot eliminar el fitxer INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6327,7 +6307,7 @@ msgstr "No s'ha pogut registrar el format '%s' del porta-retalls."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "El format '%s' del porta-retalls no existix."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 #, fuzzy
 msgid "Skip"
 msgstr "Script"
@@ -6414,75 +6394,75 @@ msgstr ""
 "eliminant-los deixarà el vostre sistema en un estat inservible:\n"
 "operació avortada."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "No es pot eliminar la tecla '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "No es pot eliminar el valor '%s' de la clau '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "No es pot llegir el valor de la clau '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "No es pot fixar un valor de '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "No es pot llegir el valor de '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "No es pot enumerar els valors de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "No es poden enumerar subclaus de la clau '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, fuzzy, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "No es pot copiar els valors del tipus %d no suportat."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6490,41 +6470,41 @@ msgstr ""
 "No és possible crear un control d'edició rica, utilitzant en el seu lloc un "
 "control de text simple. Reinstal·leu riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "No es pot iniciar la cadena: error en escriure TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "No es pot fixar la prioritat fils"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "No es pot crear un fil"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "No s'ha acabat la cadena"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "No es pot esperar per a l'acabament de cadena"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "No es pot suspendre en fil %x"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "No es pot enumerar els fitxers en el directori '%s'"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "No es pot obtenir l'actual cadena de punter"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6532,7 +6512,7 @@ msgstr ""
 "La inicialització de mòduls de la cadena ha fallat: no és possible "
 "localitzar l'índex en la cadena emmagatzemada localment"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6563,12 +6543,12 @@ msgstr "No s'ha pogut carregar la imatge %d des del fitxer '%s'."
 msgid "Failed to lock resource \"%s\"."
 msgstr "No s'ha pogut bloquejar el fitxer de bloqueig '%s'"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6580,47 +6560,47 @@ msgstr "Creació fallida d'un conducte anònim."
 msgid "Failed to redirect the child process IO"
 msgstr "No s'ha pogut redireccionar el procés fill d'IO"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "L'execució de l'orde '%s' ha fallit."
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "No s'ha pogut carregar el mpr.dll"
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "No es pot llegir el tipus de nom des de '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "No es pot carregar la icona des de '%s'"
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "No es pot fixar la prioritat fils"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "No s'ha pogut executar '%s'\n"
@@ -6657,7 +6637,7 @@ msgid "Check to make the font italic."
 msgstr ""
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 #, fuzzy
 msgid "Underlined"
@@ -6732,16 +6712,31 @@ msgstr "Teletip"
 msgid "File type:"
 msgstr "Teletip"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Finestra"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimitza"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6758,489 +6753,489 @@ msgstr "El fitxer %s no existix"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Ajuda: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Seccions"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Mostra-ho tot"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "No"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Seccions"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "No es pot començar a mostrar."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "Grandària de la font:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "Nou nom"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "vuitè"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "Grandària de la font:"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "clar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 #, fuzzy
 msgid "Menu"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Finestra"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Grandària de la font:"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "&Refés"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "predeterminat"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "demà"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Clar"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Grandària de la font:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "mitja nit"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Pregunta"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Clar"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Clar"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Seccions"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "&Previ"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 #, fuzzy
 msgid "False"
 msgstr "&Mida"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr ""
 
@@ -7254,49 +7249,49 @@ msgstr "Error d'impressió"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "No"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Crea directori"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "Trieu la font"
@@ -7784,128 +7779,128 @@ msgstr "Índex"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Previ"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "Índex"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "Índex"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 #, fuzzy
 msgid "files"
 msgstr "&Mida"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Previ"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Previ"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "&Elimina"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "&Elimina"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "Seccions"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Previ"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Previ"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 #, fuzzy
 msgid "image"
 msgstr "Temps"
@@ -8116,26 +8111,26 @@ msgstr ""
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 #, fuzzy
 msgid "Delete Text"
 msgstr "&Elimina"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "No s'ha pogut alçar el text."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 #, fuzzy
 msgid "Replace"
 msgstr "&Substituix"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 #, fuzzy
 msgid "&Font:"
 msgstr "Grandària de la font:"
@@ -9175,56 +9170,56 @@ msgstr ""
 msgid "Box styles"
 msgstr "&Següent >"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 #, fuzzy
 msgid "&From:"
 msgstr "De:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 #, fuzzy
 msgid "Unicode"
 msgstr "dinovè"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 #, fuzzy
 msgid "Insert"
 msgstr "Índex"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 #, fuzzy
 msgid "(Normal text)"
 msgstr "Font normal"
@@ -9423,7 +9418,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "No s'ha pogut obrir '%s' per %s"
@@ -9524,21 +9519,21 @@ msgstr ""
 msgid "Couldn't open audio: %s"
 msgstr "No es pot obrir el fitxer '%s'"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "No es pot recuperar la cadena de política de planificació."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "No es pot obtenir un rang de prioritats per la política de planificació %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "La prioritat de paràmetres és ignorada."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9546,62 +9541,62 @@ msgstr ""
 "No s'ha pogut sincronitzar amb un fil, s'ha detectat un potencial de pèrdua "
 "de memòria - reinicieu el programa"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "No s'ha pogut establir la prioritat de la cadena %d"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "No s'ha pogut establir la prioritat de la cadena %d"
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "No s'ha pogut acabar una cadena."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "La inicialització de mòduls de la cadena ha fallat: no s'ha pogut crear una "
 "clau de la cadena."
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "És impossible obtenir l'entrada de procés fill."
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "No s'ha pogut acabar el procés %d"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "No s'ha pogut executar '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "El fork ha fallat!"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "No s'ha pogut establir la prioritat de la cadena %d"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "No s'ha pogut redireccionar el procés fill d'entrada/eixida"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "No es pot obtenir el nom d'hostatger"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "No es pot obtenir el nom oficial de l'hostatger"
 
@@ -9619,12 +9614,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "No s'ha pogut llegir el PID des del fitxer de registre."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificació geomètrica invàlida '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets no podien obrien l'exhibició. S'està eixint."
 
@@ -9638,30 +9633,64 @@ msgstr "No s'ha pogut tancar el porta-retalls"
 msgid "Failed to open display \"%s\"."
 msgstr "No s'ha pogut obrir '%s' per %s"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "error d'anàlisi XML: '%s' a la línia %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "No es pot carregar recursos des del fitxer '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "No es pot carregar recursos des del fitxer '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "No es pot carregar recursos des del fitxer '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "L'execució de l'orde '%s' ha fallit."
+
+#~ msgid "Printing "
+#~ msgstr "S'està imprimint"
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "No s'ha pogut obtenir el directori en funcionament"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Trieu una font vàlida"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "No s'ha pogut mostrar el document HTML en codificació %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets no podia obrir l'aplicació per '%s'; s'està eixint."
+
+#, fuzzy
+#~ msgid "Filter"
+#~ msgstr "&Mida"
+
+#, fuzzy
+#~ msgid "Directories"
+#~ msgstr "Decoratiu"
+
+#, fuzzy
+#~ msgid "Files"
+#~ msgstr "&Mida"
+
+#, fuzzy
+#~ msgid "Selection"
+#~ msgstr "Seccions"
 
 #, fuzzy
 #~ msgid "failed to retrieve execution result"
@@ -9805,8 +9834,8 @@ msgstr "L'execució de l'orde '%s' ha fallit."
 #~ msgstr "No s'ha pogut iniciar la impressió"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/co.po
+++ b/locale/co.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets in Corsican\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-05-13 19:16+0200\n"
 "Last-Translator: Patriccollu di Santa Maria è Sichè <https://github.com/"
 "Patriccollu/Lingua_Corsa-Infurmatica/#readme>\n"
@@ -19,11 +19,11 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Tutti i schedarii (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Tutti i schedarii (*)|*"
 
@@ -40,24 +40,21 @@ msgid "Remaining time:"
 msgstr "Tempu rimanentu :"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sì"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nò"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Vai"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Abbandunà"
@@ -109,7 +106,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Impussibule di creà u portu di cumpiimentu d’E/S"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Stampa"
 
@@ -146,7 +143,7 @@ msgstr "Pruprietà di l’oggettu"
 msgid "Printing"
 msgstr "Stampa"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simbuli"
 
@@ -216,7 +213,7 @@ msgstr "&Precedente"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Finestra"
 
@@ -745,11 +742,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "affissà stu messaghju d’aiutu"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "ingenerà messaghji verbosi di ghjurnale"
 
@@ -771,84 +768,84 @@ msgstr "Tema « %s » micca accettatu."
 msgid "Invalid display mode specification '%s'."
 msgstr "Specificazione di u modu d’affissera « %s » inaccettevule."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "L’ozzione « %s » ùn pò micca esse nigata"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Ozzione longa « %s » scunnisciuta"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Ozzione « %s » scunnisciuta"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caratteri imprevisti dopu l’ozzione « %s »."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L’ozzione « %s » richiede un valore."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Separadore aspettatu dopu l’ozzione « %s »."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "« %s » ùn hè micca un valore numericu currettu per l’ozzione « %s »."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "L’ozzione « %s » : « %s » ùn pò micca esse cunvertita in una data."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametru « %s » imprevistu"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "U valore deve esse specificatu per l’ozzione « %s »."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "U parametru richiestu « %s » ùn hè micca specificatu."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Impiegu : %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "doppiu"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -866,7 +863,7 @@ msgid "Can't &Undo "
 msgstr "Ùn si pò disfà "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Disfà"
@@ -876,7 +873,7 @@ msgid "&Redo "
 msgstr "&Rifà "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Rifà"
@@ -908,12 +905,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "« %s » hà troppu di « .. » ; sò ignurati."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "marcata"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "micca marcata"
 
@@ -922,103 +919,103 @@ msgstr "micca marcata"
 msgid "undetermined"
 msgstr "indeterminata"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "oghje"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "eri"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "dumane"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primu"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "secondu"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "terzu"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "quartu"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "quintu"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sestu"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "settimu"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "ottesimu"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "novesimu"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "decesimu"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "ondecesimu"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dodicesimu"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "tredicesimu"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "quattordicesimu"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "quindecesimu"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "sedecesimu"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "dicessettesimu"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "diciottesimu"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "dicennovesimu"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vintesimu"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "meziornu"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "mezanotte"
 
@@ -1087,44 +1084,81 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Fiascu di l’inviu di u raportu di spannatura (codice di sbagliu %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Arregistrà cù u nome"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Scartà i cambiamenti è ricaricà l’ultima versione arregistrata ?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "senza nome"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vulete arregistrà i cambiamenti ver di %s ?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Arregistrà"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ùn arregistrà micca"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vulete arregistrà i cambiamenti ver di %s ?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "U testu ùn pò micca esse arregistratu."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "U schedariu « %s » ùn pò micca esse apertu in scrittura."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Fiascu à l’arregistramentu di u ducumentu in u schedariu « %s »."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "U schedariu « %s » ùn pò micca esse apertu in lettura."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Fiascu di lettura di u ducumentu in u schedariu « %s »."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1133,57 +1167,57 @@ msgstr ""
 "U schedariu « %s » ùn esiste micca è ùn pò micca esse apertu.\n"
 "Hè statu cacciatu da a lista di i schedarii impiegati pocu fà."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Fiascu di a creazione di a fighjulata nanzu a stampa."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Fighjulata nanzu a stampa"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Ùn si pò determinà u furmatu di u schedariu « %s »."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "senza nome %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Apre un schedariu"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Sbagliu di schedariu"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Per disgrazia, ùn si pò apre stu schedariu."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Per disgrazia, u furmatu di stu schedariu hè scunnisciutu."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Selezziunà un mudellu di ducumentu"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Mudelli"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Selezziunà una vista di u ducumentu"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Viste"
 
@@ -1217,43 +1251,43 @@ msgstr "Sbagliu di lettura nant’à u schedariu « %s »"
 msgid "Write error on file '%s'"
 msgstr "Sbagliu di scrittura nant’à u schedariu « %s »"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "impussibule di sfurzà a scrittura nant’à u discu di u schedariu « %s »"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Sbagliu di ricerca in u schedariu « %s » (i schedarii maiò ùn sò micca "
 "accettati da stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Sbagliu di ricerca in u schedariu « %s »"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Impussibule di truvà a pusizione currente in u schedariu « %s »"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Fiascu di definizione di i permessi di schedariu timpurariu"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ùn si pò caccià u schedariu « %s »"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "ùn si pò accettà i cambiamenti in u schedariu « %s »"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "ùn si pò caccià u schedariu timpurariu « %s »"
@@ -1278,32 +1312,32 @@ msgstr "ùn si pò leghje da u discrittore di schedariu %d"
 msgid "can't write to file descriptor %d"
 msgstr "ùn si pò scrive in u discrittore di schedariu %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 "impussibule di sfurzà a scrittura nant’à u discu di u discrittore di "
 "schedariu %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "ùn si pò circà nant’à u discrittore di schedariu %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "ùn si pò ottene a pusizione di ricerca nant’à u discrittore di schedariu %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "ùn si pò truvà a dimensione di u schedariu nant’à u discrittore di schedariu "
 "%d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1330,113 +1364,113 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Sbagliu durante a lettura di l’ozzioni di cunfigurazione."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Fiascu à a lettura di l’ozzioni di cunfigurazione."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "schedariu « %s » : caratteru %c imprevistu à a linea %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr ""
 "schedariu « %s », linea %zu : « %s » ignuratu dopu l’intestatura di gruppu."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "schedariu « %s », linea %zu : simbulu « = » aspettatu."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "schedariu « %s », linea %zu : valore « %s » ignuratu per u tastu micca "
 "cunfigurevule."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "schedariu « %s », linea %zu : prima occurenza di a chjave « %s » trova à a "
 "linea %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "U nome d’elementu di cunfigurazione ùn pò micca principià cù « %c »."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "ùn si pò apre u schedariu di cunfigurazione di l’utilizatore."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "ùn si pò scrive nant’à u schedariu di cunfigurazione di l’utilizatore."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Fiascu per mudificà u schedariu di cunfigurazione di l’utilizatore."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr ""
 "Sbagliu à l’arregistramentu di i dati di cunfigurazione di l’utilizatore."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "ùn si pò squassà u schedariu di cunfigurazione di l’utilizatore « %s »"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "l’elementu « %s » accade più d’una volta in u gruppu « %s »"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativu ignuratu per cambià u tastu « %s » micca cunfigurevule."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "barra sbieca « \\ » di fine ignurata in « %s »"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "simbulu « \" » imprevistu à a pusizione %d in « %s »."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Fiascu di a copia di u schedariu « %s » versu « %s »."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Impussibule d’ottene i permessi per u schedariu « %s »"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Impussibule di rimpiazzà u schedariu « %s »"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Sbagliu durante a copia di u schedariu « %s » versu « %s »."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Impussibule di definisce i permessi per u schedariu « %s »"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1445,40 +1479,40 @@ msgstr ""
 "Fiascu di a rinuminazione di u schedariu da « %s » à « %s » perchè u "
 "schedariu di destinazione esiste dighjà."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "U schedariu « %s » ùn pò micca esse rinuminatu « %s »"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "U schedariu « %s » ùn pò micca esse cacciatura"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "U cartulare « %s » ùn pò micca esse creatu"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "U cartulare « %s » ùn pò micca esse squassatu"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Ùn si pò micca enumerà i schedarii « %s »"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Fiascu per ottene u cartulare di travagliu"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Ùn si pò micca definisce u cartulare di travagliu attuale"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Schedarii (%s)"
@@ -1505,17 +1539,17 @@ msgstr "Fiascu per creà un nome di schedariu timpurariu"
 msgid "Failed to open temporary file."
 msgstr "Fiascu per apre un schedariu timpurariu."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Fiascu per mudificà a data o l’ora per « %s »"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Fiascu per tuccà u schedariu « %s »"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Fiascu per ricuperà a data o l’ora per « %s »"
@@ -1524,22 +1558,22 @@ msgstr "Fiascu per ricuperà a data o l’ora per « %s »"
 msgid "Browse"
 msgstr "Navigà"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tutti i schedarii (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s schedarii (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Caricà u schedariu %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Arregistrà u schedariu %s"
@@ -1902,99 +1936,99 @@ msgstr "predefinitu"
 msgid "unknown-%d"
 msgstr "%d scunnisciutu"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "sottulineata"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " rigata"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " sdriglia"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " assai chjara"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " chjara"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " mediana"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " semi grassa"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " grassa"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " assai grassa"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " forta"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " assai forta"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "rigata"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "sdriglia"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "assai chjara"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "chjara"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "nurmale"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "mediana"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "semigrassa"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "grassa"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "assai grassa"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "forta"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "assai forta"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "cursiva"
 
@@ -2079,7 +2113,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Fiascu per definisce u modu di trasferimentu FTP à %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2100,7 +2134,7 @@ msgstr "U servitore FTP ùn accetta micca u modu passivu."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Dimensione di fiura GIF incurretta (%u, %d) per a fiura #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Fiascu per attribuisce u culore per OpenGL"
 
@@ -2116,7 +2150,7 @@ msgstr "Persunalizà e culonne"
 msgid "&Customize..."
 msgstr "&Persunalizà…"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Fiascu per apre l’indirizzu web « %s » in u navigatore predefinitu"
@@ -2136,163 +2170,162 @@ msgstr "Fiascu per caricà a fiura %d da u flussu."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Fiascu per caricà l’icone da a risorsa « %s »."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP : Ùn si pò micca arregistrà una fiura inaccettevule."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP : wxImage ùn hà micca a so propia wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP : Ùn si pò micca scrive l’intestatura di u schedariu (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP : Ùn si pò micca scrive l’intestatura di u schedariu (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP : Ùn si pò micca scrive a cartugrafia di i culori RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP : Ùn si pò micca scrive i dati."
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr "BMP : L’intestatura hà biClrUsed=%d quandu biBitCount=%d."
-
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP : Ùn si pò micca riservà memoria."
 
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr ""
 "Intestatura DIB : Larghezza di a fiura > 32767 pizzeli per u schedariu."
 
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr "Intestatura DIB : Altezza di a fiura > 32767 pizzeli per u schedariu."
 
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr ""
 "Intestatura DIB : Numeru di bit à u pizzelu scunnisciutu in u schedariu."
 
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Intestatura DIB : Cudificazione scunnisciuta in u schedariu."
 
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 "Intestatura DIB : A cudificazione ùn currisponde micca à u numeru di bit à u "
 "pizzelu."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr "BMP : L’intestatura hà biClrUsed=%d quandu biBitCount=%d."
+
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Sbagliu à a lettura di a fiura DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO : Sbagliu à a lettura di a maschera DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO : A fiura hè troppu alta per un icona."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO : A fiura hè troppu larga per un icona."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO : Sbagliu à a scrittura di u schedariu di fiura !"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO : Indice d’icona inaccettevule."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "A fiura è a maschera anu dimensioni sfarente."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Alcunu culore inimpiegatu in a fiura in corsu di mascarassi."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Fiascu per caricà a fiura bitmap « %s » da e risorse."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Fiascu per caricà l’icona « %s » da e risorse."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Fiascu per caricà a fiura da u schedariu « %s »."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Ùn si pò micca arregistrà a fiura nant’à u schedariu « %s » : estensione "
 "scunnisciuta."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Nisunu ghjestiunariu trovu per u tipu di fiura."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nisunu ghjestiunariu di fiura definitu per u tipu %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "U schedariu di fiura ùn hè micca di tipu %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Ùn si pò micca determinà autumaticamente u furmatu di a fiura per l’entrata "
 "non pusiziunevule."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Furmatu scunnisciutu di dati di fiura."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Què ùn hè micca un %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nisunu ghjestiunariu di fiura definitu per u tipu %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "A fiura ùn hè micca di tipu %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Fiascu per cuntrollà u furmatu di u schedariu di fiura « %s »."
@@ -2395,41 +2428,41 @@ msgstr "PNM : u schedariu pare truncatu."
 msgid " (in module \"%s\")"
 msgstr " (in u modulu « %s »)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF : Sbagliu à u caricamentu di a fiura."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Indice di fiura TIFF inaccettevule."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF : A dimensione di a fiura hè sprupusitatamente maiò."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF : Ùn si pò micca riservà memoria."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF : Sbagliu à a lettura di a fiura."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unità %d di risuluzione TIFF scunnisciuta è ignurata"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF : Sbagliu à l’arregistramentu di a fiura."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF : Sbagliu à a scrittura di a fiura."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2438,11 +2471,11 @@ msgstr ""
 "U parametru %d di a linea di cumanda ùn pò micca esse cunvertitu in Unicode "
 "è serà ignuratu."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Fiascu di l’iniziu in « post init » ; abbandonu."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Ùn si pò micca definisce « %s » cum’è lingua lucale."
@@ -2538,7 +2571,7 @@ msgstr "Sbagliu di cumpressione LZMA : %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Sbagliu di cumpressione LZMA durante a squassatura di l’esciuta : %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Simbulu « { » micca assurtitu in un elementu per u tipu mime %s."
@@ -2558,7 +2591,7 @@ msgstr "A dipendenza « %s » di u modulu « %s » ùn esiste micca."
 msgid "Module \"%s\" initialization failed"
 msgstr "Fiascu à l’iniziu di u modulu « %s »"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Messaghju"
 
@@ -3060,7 +3093,7 @@ msgstr "Sbagliu di stampa"
 msgid "Print"
 msgstr "Stampà"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Definizione di a pagina"
 
@@ -3095,19 +3128,15 @@ msgstr "Stampa di a pagina %d nant’à %d"
 msgid " (copy %d of %d)"
 msgstr " (copia %d nant’à %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Stampa "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Prima pagina"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Pagina precedente"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Pagina seguente"
 
@@ -3151,16 +3180,16 @@ msgstr "Pagina %d nant’à %d"
 msgid "Page %d"
 msgstr "Pagina %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "sbagliu scunnisciutu"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Espressione regulare « %s » inaccettevule : %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Impussibule di truvà una currispundenza à l’espressione regulare : %s"
@@ -3172,21 +3201,21 @@ msgstr ""
 "U mutore di rinforzu « %s » hà una versione %d.%d incumpatibile è ùn pò "
 "micca esse caricatu."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Micca dispunibule per sta piattaforma"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Arregistramentu di a parolla d’intesa per « %s » fiascatu : %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Lettura di a parolla d’intesa per « %s » fiascata : %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Squassatura di a parolla d’intesa per « %s » fiascata : %s."
@@ -3195,11 +3224,11 @@ msgstr "Squassatura di a parolla d’intesa per « %s » fiascata : %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Fiascu per cuntrollà i canali I/O"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Arregistrà"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Ùn arregistrà micca"
 
@@ -3280,10 +3309,10 @@ msgid "Clear"
 msgstr "Viutà"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Chjode"
 
@@ -3295,7 +3324,7 @@ msgstr "&Cunvertisce"
 msgid "Convert"
 msgstr "Cunvertisce"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Cupià"
@@ -3304,7 +3333,7 @@ msgstr "&Cupià"
 msgid "Copy"
 msgstr "Cupià"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Taglià"
@@ -3313,13 +3342,13 @@ msgstr "&Taglià"
 msgid "Cut"
 msgstr "Taglià"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Squassà"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Squassà"
@@ -3406,7 +3435,7 @@ msgstr "Discu duru"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Aiutu"
 
@@ -3426,7 +3455,7 @@ msgstr "Indentazione"
 msgid "&Index"
 msgstr "&Indice"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indice"
 
@@ -3495,7 +3524,7 @@ msgstr "&Novu"
 msgid "New"
 msgstr "Novu"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nò"
 
@@ -3512,12 +3541,12 @@ msgstr "&Apre..."
 msgid "Open..."
 msgstr "Apre..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Incullà"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Incullà"
@@ -3547,7 +3576,7 @@ msgid "Print..."
 msgstr "Stampà..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Pruprietà"
 
@@ -3579,10 +3608,6 @@ msgstr "Rimpiazzà…"
 msgid "Revert to Saved"
 msgstr "Rivene à a versione arregistrata"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Arregistrà"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Arregistrà &cù u nome..."
@@ -3591,7 +3616,7 @@ msgstr "Arregistrà &cù u nome..."
 msgid "Save As..."
 msgstr "Arregistrà cù u nome…"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Tuttu selezziunà"
@@ -3698,7 +3723,7 @@ msgstr "In&sù"
 msgid "Up"
 msgstr "Sù"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Sì"
 
@@ -3786,46 +3811,46 @@ msgstr "Arregistrà u ducumentu attuale"
 msgid "Save current document with a different filename"
 msgstr "Arregistrà u ducumentu attuale cù un nome di schedariu sfarente"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 "A cunversione versu u gruppu di caratteri « %s » ùn funziuneghja micca."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "scunnisciutu"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "u bloccu d’intestatura hè incumpletu in tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 "sbagliu di a somma di cuntrollu durante a lettura di u bloccu d’intestatura "
 "di tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "dati inaccettevule in l’intestatura estesa di tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "l’elementu tar ùn hè micca apertu"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fine di schedariu imprevista"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ùn currisponde micca à l’intestatura tar per l’elementu « %s »"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "a dimensione pruvista per l’elementu tar hè incurretta"
 
@@ -3834,7 +3859,7 @@ msgstr "a dimensione pruvista per l’elementu tar hè incurretta"
 msgid "'%s' is probably a binary buffer."
 msgstr "« %s » hè forse un stampone binariu."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Ùn si pò micca caricà u schedariu."
 
@@ -3848,47 +3873,47 @@ msgstr "Fiascu per leghje u schedariu di testu « %s »."
 msgid "can't write buffer '%s' to disk."
 msgstr "impussibule di scrive u stampone « %s » nant’à u discu."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Fiascu per ottene l’ora lucale di u sistema"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "Fiascu di « wxGetTimeOfDay »."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "« %s » ùn hè micca un catalogu accettevule di messaghji."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catalogu inaccettevule di messaghji."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Fiascu di l’analisa di e forme plurale : « %s »"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "impiegu di u catalogu « %s » da « %s »."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "A risorsa « %s » ùn hè micca un catalogu accettevule di messaghji."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Ùn si pò micca enumerà e traduzzioni"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Nisuna appiecazione predefinita hè cunfigurata per i schedarii HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Fiascu per apre l’indirizzu web « %s » in u navigatore predefinitu."
@@ -3921,7 +3946,7 @@ msgstr "« %s » cuntene caratteru(i) inaccettevule"
 msgid "Error: %s (%d)"
 msgstr "Sbagliu : %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Ùn basta u spaziu discu liberu per u scaricamentu."
 
@@ -3929,20 +3954,20 @@ msgstr "Ùn basta u spaziu discu liberu per u scaricamentu."
 msgid "libcurl could not be initialized"
 msgstr "Ùn si pò micca inizià « libcurl »"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync ùn hè micca accettatu"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Sbagliu à l'esecuzione di JavaScript : %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Sta piattaforma ùn accetta micca a trasparenza di sfondulu."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Ùn si pò micca trasferisce i dati à a finestra"
 
@@ -3995,8 +4020,8 @@ msgstr "Parametru di creazione %s intruvevule in i parametri RTTI dichjarati"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Classa d’oggettu illegale (Non-wxEvtHandler) cum’è fonte d’evenimentu"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "U tipu deve avè una cunversione longa d’enumerazione"
 
@@ -4050,84 +4075,84 @@ msgstr "L’oggetti devenu avè un attributu d’identificazione"
 msgid "Doubly used id : %d"
 msgstr "Identificazione impiegata in doppiu : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Pruprietà scunnisciuta %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una cullezzione micca viota deve cuntene nodi « elementi »"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "catena di ghjestione d’evenimentu incurretta, puntu assente"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "ùn si pò micca inizià torna u flussu di scumpressione zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "ùn si pò micca inizià torna u flussu di cumpressione zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Un arregistramentu addiziunale di dati malcunciliu hè statu ignuratu, forse "
 "u schedariu zip hè deteriuratu"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "si suppone chì ghjè un cuncatinamentu zip à parechje parti"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "schedariu zip inaccettevule"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "ùn si pò micca truvà u cartulare principale in u zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "sbagliu à a lettura di u cartulare principale di u zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "sbagliu à a lettura di l’intestatura lucale di u zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "spustamentu incurrettu di l’elementu in u schedariu zip"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr ""
 "a longhezza di u schedariu arregistrata ùn hè micca in l’intestatura di u zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "a metoda di cumpressione zip ùn hè micca accettata"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lettura di u flussu zip (elementu %s) : longhezza incurretta"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lettura di u flussu zip (elementu %s) : CRC incurrettu"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "sbagliu à a scrittura di l’elementu zip « %s » : schedariu troppu maiò senza "
 "ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4214,32 +4239,32 @@ msgstr "Grafismi da "
 msgid "Translations by "
 msgstr "Traduzzioni da "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versione "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Apprupositu di %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licenza"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Sviluppatori"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autori di a documentazione"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artisti"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Traduttori"
 
@@ -4290,43 +4315,42 @@ msgid "Password:"
 msgstr "Parolla d’intesa :"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "veru"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "falsu"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Linea %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Riduce"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Allargà"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elementi)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Culonna %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4337,8 +4361,7 @@ msgid "Left"
 msgstr "Manca"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4434,7 +4457,7 @@ msgid "Home directory"
 msgstr "Cartulare d’accolta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Scagnu"
 
@@ -4447,8 +4470,7 @@ msgstr "Nome di cartulare inaccettevule."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Sbagliu"
 
@@ -4632,16 +4654,16 @@ msgstr "Vede i schedarii in una lista detagliata"
 msgid "Go to parent directory"
 msgstr "Andà à u cartulare superiore"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "U schedariu « %s » esiste dighjà, vulete rimpiazzallu ?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Cunfirmà"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Sciglite un schedariu esistente."
 
@@ -4735,7 +4757,7 @@ msgstr "A dimensione di puntu di a grafia."
 msgid "Whether the font is underlined."
 msgstr "S’è a grafia hè sottulineata."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Fighjulata :"
@@ -4753,52 +4775,51 @@ msgstr "Cliccu per abbandunà a selezzione di a grafia."
 msgid "Click to confirm the font selection."
 msgstr "Cliccu per cunfirmà a selezzione di a grafia."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Sceglie a grafia"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "A copia di più d’un bloccu selezziunatu versu u preme’papei ùn hè micca "
 "accettata."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Ùn si pò truvà u cartulare d’aiutu « %s »."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Ùn si pò truvà u schedariu d’aiutu « %s »."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "A linea %lu di u schedariu di cartugrafia « %s » hà una sintassa incurretta "
 "è hè stata ignurata."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Nisuna cartugrafia accettevule si trova in u schedariu « %s »."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Nisunu elementu trovu."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indice d’aiutu"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Elementi pertinente :"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Elementi trovi"
 
@@ -4904,59 +4925,59 @@ msgstr "Ùn si pò micca principià a stampa."
 msgid "Printing page %d..."
 msgstr "Stampa di a pagina %d…"
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Ozzioni di a stampetta"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Stampà in un schedariu"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Cunfigurà…"
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Stampetta :"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Statu :"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tuttu"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Pagine"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Stesa di stampa"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Da :"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "À :"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Copie :"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Schedariu PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Cunfigurazione di a stampa"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Stampetta"
 
@@ -4964,25 +4985,25 @@ msgstr "Stampetta"
 msgid "Default printer"
 msgstr "Stampetta predefinita"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Dimensione di a carta"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Verticale"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Orizuntale"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientazione"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Ozzioni"
 
@@ -4994,52 +5015,52 @@ msgstr "Stampà in culore"
 msgid "Print spooling"
 msgstr "File d’attesa di stampa"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Cumanda per a stampetta :"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Ozzioni di a stampetta :"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Margine à manca (mm) :"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Margine superiore (mm) :"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Margine à diritta (mm) :"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Margine inferiore (mm) :"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Stampetta…"
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Tralascià"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Scunnisciutu"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Compiu."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Ricercà"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Ùn si pò micca truvà l’unghjetta per l’identificazione"
 
@@ -5075,11 +5096,11 @@ msgstr "&Piantà"
 msgid "< &Back"
 msgstr "< &Precedente"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Ringraziamenti à i traduttori"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5089,11 +5110,11 @@ msgstr ""
 "cagiunà prublemi cù a ghjestione di l’interfaccia grafica è scintillime. "
 "Pensate à disattivà GTK_IM_MODULE o definisce à « ibus »."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Impussibule d’inizià GTK+ ; DISPLAY seria definitu currettamente ?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Fiascu di cambiamentu di u cartulare attuale versu « %s »"
@@ -5122,11 +5143,11 @@ msgstr ""
 "Ùn si pò micca arregistrà a cunfigurazione di grafia impieghendu fonte "
 "private."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Sbagliu impurtantissimu"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5139,7 +5160,7 @@ msgstr ""
 "definiscendu a variabile d’ambiente GDK_BACKEND=x11 nanzu di lancià u vostru "
 "prugramma."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5150,7 +5171,7 @@ msgstr ""
 "Si pò circurtà què definiscendu a variabile d’ambiente\n"
 "GDK_BACKEND=x11 nanzu di lancià u vostru prugramma."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Zitellu MDI"
 
@@ -5166,17 +5187,13 @@ msgstr "Sbagliu durante a stampa : "
 msgid "Page Setup"
 msgstr "Parametri di a pagina"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Fiascu per framette u testu in u cuntrollu."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 "Riacquistà l’esciuta di u scenariu JavaScript ùn hè micca accettatu cù "
 "WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5185,7 +5202,7 @@ msgstr ""
 "permette a cumpusizione di screnu ; ci vole à installà GTK+ 2.12 o più "
 "recente."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5193,17 +5210,13 @@ msgstr ""
 "A cumpusizione di screnu ùn hè micca accettata da stu sistema ; ci vole à "
 "attivalla in u vostru Ghjestiunariu Windows."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Stu prugramma hè statu cumpilatu cù una versione troppu anziana di GTK+ ; ci "
 "vole à custruiscelu torna cù GTK+ 2.12 o più recente."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Sciglite una grafia accettevule."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5302,45 +5315,45 @@ msgstr "Ùn si pò micca apre u schedariu di tavula di cuntenutu : %s"
 msgid "Cannot open index file: %s"
 msgstr "Ùn si pò micca apre u schedariu d’indice : %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "senzanome"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Ùn si pò micca apre u manuale d’aiutu HTML : %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Affissera di l’aiutu quandu si naviga nant’à i manuali à manu manca."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(indette)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Aghjunghje a pagina currente à l’indette"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Caccià a pagina currente da l’indette"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Tavula di cuntenutu"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Truvà"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Tuttu affissà"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5348,19 +5361,19 @@ msgstr ""
 "Affissà tutti l’elementi di l’indice chì cuntenenu una sottucatena "
 "particulare. A ricerca ùn sfarenzieghja micca maiuscule è minuscule."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Affissà tutti l’elementi di l’indice"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Sfarenzià maiuscule è minuscule"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Solu e parolle sane"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5368,147 +5381,147 @@ msgstr ""
 "Ricercà in a tavula di cuntenutu di i manuali d’aiutu tutte l’occurrenze di "
 "u testu stampittatu quì sopra"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Affissà o piattà u pannellu di navigazione"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Ritornu"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Cuntinuà"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Andà à u livellu superiore in a ierarchia di u ducumentu"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Apre u ducumentu HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Stampà sta pagina"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Affissà a finestra di l’ozzioni"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Sciglite a pagina à affissà :"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Rubriche d’aiutu"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Ricerca…"
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Nisuna pagina currispundente ùn hè stata ancu trova"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i currispundenze sò state trove"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Aiutu)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d nant’à %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu nant’à %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Circà in tutti i manuali"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Ozzioni di u navigatore di l’aiutu"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Grafia nurmale :"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Dimensione fissa di a grafia :"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Dimensione di a grafia :"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "dimensione di a grafia"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Nurmale<br>è <u>sottulineata</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Grassa.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Grassa cursiva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Grafia di dimensione fissa.<br> <b>grassa</b> <i>cursiva</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>grassa cursiva <u>sottulineata</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Aiutu per stampà"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Ùn si pò micca stampà una pagina viota."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Schedarii HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Manuali d’aiutu (*.htb)|*.htb|Manuali d’aiutu (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Prughjettu d’aiutu HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Schedariu d’aiutu HTML cumpressu (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i nant’à %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u nant’à %u"
@@ -5589,32 +5602,6 @@ msgstr ""
 "Un prublema hè accadutu durante a messa in pagina : forse hè bisognu di "
 "cunfigurà una stampetta predefinita."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Fiascu di l’affissera di u ducumentu HTML cù a cudificazione %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets ùn pò micca apre un affissera per « %s » : abbandonu."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtru"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Cartulari"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Schedarii"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selezzione"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Fiascu à l’apertura di u preme’papei."
@@ -5656,63 +5643,63 @@ msgstr "Fiascu di u dialogu di selezzione di culore cù u sbagliu %0lx."
 msgid "Failed to create cursor."
 msgstr "Fiascu à a creazione di u cursore."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Fiascu à l’arregistramentu di u servitore DDE « %s »"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Fiascu à u disarregistramentu di u servitore DDE « %s »"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "Fiascu à a creazione di a cunnessione à u servitore « %s » nant’à u "
 "sughjettu « %s »"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Fiascu di a richiesta DDE « poke »"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Fiascu per stabilisce un « advise loop » cù u servitore DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Fiascu per compie un « advise loop » cù u servitore DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Fiascu à l’inviu d’una nutificazione d’« advise » DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Fiascu à a creazione di a catena DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "nisunu sbagliu DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "una dumanda di transazzione sincrona « advise » hà ecciditu u tempu massimu."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "a risposta à a transazzione hà cagiunatu a definizione di u bit DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "una dumanda di transazzione sincrona di dati hà ecciditu u tempu massimu."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5724,7 +5711,7 @@ msgstr ""
 "o un identificazione d’istanza inaccettevule\n"
 "hè stata passata à una funzione DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5736,47 +5723,47 @@ msgstr ""
 "o un’appiecazione iniziata cum’è APPCMD_CLIENTONLY hà\n"
 "pruvatu d’effettuà transazzioni servitore."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "una dumanda di transazzione sincrona d’esecuzione hà ecciditu u tempu "
 "massimu."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "fiascu di a cunvalidazione d’un parametru da a DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 "un’appiecazione DDEML hà creatu una situazione di cuncurrenza allungata."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "fiascu d’un’attribuzione di memoria."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "fiascu d’un tentativu d’un cliente per stabilisce una discursata."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "fiascu d’una transazzione."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "una dumanda di transazzione sincrona « poke » hà ecciditu u tempu massimu."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "fiascu d’una chjama interna à a funzione PostMessage. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "prublema di rientrenza."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5786,17 +5773,17 @@ msgstr ""
 "una discursata chì hè stata compia da u cliente, osinnò u\n"
 "servitore hè statu piantatu nanzu di compie a transazzione."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "un sbagliu internu hè accadutu in a DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "una dumanda per compie una transazzione « advise » hà ecciditu u tempu "
 "massimu."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5807,12 +5794,12 @@ msgstr ""
 "Quandu l’appiecazione hè rivenuta d’una richjama XTYP_XACT_COMPLETE,\n"
 "l’identificazione di transazzione per sta richjama ùn hè più accettevule."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Sbagliu DDE scunnisciutu %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5821,7 +5808,7 @@ msgstr ""
 "d’accessu alluntanatu (RAS) ùn hè micca installatu nant’à sta mascina. "
 "Installatela."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5831,67 +5818,67 @@ msgstr ""
 "mascina hè troppu vechju, mudernizatelu (quella funzione richiesta hè "
 "assente : %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Fiascu per ritruvà u testu di u messaghju di sbagliu RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "sbagliu scunnisciutu (codice di sbagliu %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Ùn si pò micca truvà di cunnessione tefonica attiva : %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Parechje cunnessioni tefoniche attive esistenu, una hè stata scelta à "
 "l’azardu."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Ùn si pò micca stabilisce a cunnessione tefonica : %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Ùn si pò micca ottene i nomi di i FAI : %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Fiascu di a cunnessione : nisunu numeru di FAI à chjamà."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Sceglie u FAI à chjamà"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Sciglite à chì FAI vulete cunnettevi"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr ""
 "Fiascu di a cunnessione : nome d’utilizatore è/o parolla d’intesa assente."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Ùn si pò micca truvà a lucalizazione di u schedariu di l’indirizzi"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Ùn si pò micca inizià a cunnessione tefonica : %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Ùn si pò micca riappiccà, nisuna cunnessione tefonica attiva."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Ùn si pò micca piantà a cunnessione tefonica : %s"
@@ -5912,18 +5899,17 @@ msgstr ""
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Ùn si pò micca enumerà i schedarii in u cartulare « %s »"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Ùn si pò micca ottene u nome di u cartulare"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(sbagliu %d : %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Ùn si pò micca aghjunghje una fiura à a lista di e fiure."
 
@@ -5939,7 +5925,7 @@ msgstr ""
 "Fiascu à a creazione di u dialogu classicu circà/rimpiazzà (codice di "
 "sbagliu %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Fiascu di u dialogu di schedariu cù u codice di sbagliu %0lx."
@@ -5983,16 +5969,16 @@ msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 "Ùn si pò micca surveglià i cambiamenti di u cartulare non esistente « %s »."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "U pilotu OpenGL ùn accetta micca a versione OpenGL 3.0 o più recente."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Ùn si pò micca creà u cuntestu OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Fiascu à l'iniziu d’OpenGL"
 
@@ -6001,7 +5987,7 @@ msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 "Ùn si pò micca arregistrà u caricadore persunalizatu di grafia DirectWrite."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6009,7 +5995,7 @@ msgstr ""
 "E funzioni d’aiutu MS HTML sò indispunibule perchè a biblioteca d’aiutu MS "
 "HTML ùn hè micca installata nant’à sta mascina. Installatela."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Fiascu à l'iniziu di l’aiutu MS HTML."
 
@@ -6018,7 +6004,7 @@ msgstr "Fiascu à l'iniziu di l’aiutu MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "Ùn si pò micca squassà u schedariu INI « %s »"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6140,7 +6126,7 @@ msgstr "Ùn si pò micca arregistrà u furmatu « %s » di preme’papei."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "U furmatu « %d » di preme’papei ùn esiste micca."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Tralascià"
 
@@ -6229,59 +6215,59 @@ msgstr ""
 "a so squassatura lasceria u vostru sistema in un statu inutilizevule :\n"
 "l’operazione hè abbandunata."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Ùn si pò micca squassà a chjave « %s »"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Ùn si pò micca squassà u valore « %s » da a chjave « %s »"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Ùn si pò micca leghje u valore di a chjave « %s »"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Ùn si pò micca definisce u valore di « %s »"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "U valore di registru « %s » ùn hè micca numericu (ma di tipu %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "U valore di registru « %s » ùn hè micca binariu (ma di tipu %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "U valore di registru « %s » ùn hè micca testu (ma di tipu %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Ùn si pò micca leghje u valore di « %s »"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Ùn si pò micca enumerà i valori di a chjave « %s »"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Ùn si pò micca enumerà e sottuchjavi di a chjave « %s »"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6289,17 +6275,17 @@ msgstr ""
 "Espurtazione di a chjave di registru : u schedariu « %s » esiste dighjà è ùn "
 "serà micca rimpiazzatu."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Ùn si pò micca espurtà u valoru di u tipu %d non ricunnisciutu."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "U valore « %s » di a chjave « %s » hè ignuratu."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6307,42 +6293,42 @@ msgstr ""
 "Impussibule di creà un cuntrollu « rich edit  », adopru piuttostu d’un "
 "cuntrollu di testu simplice. Ci vole à installà riched32.dll torna"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 "Ùn si pò micca avvià u filu d’esecuzione : sbagliu à a scrittura di TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Ùn si pò micca definisce a priurità di u filu d’esecuzione"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Ùn si pò micca creà u filu d’esecuzione"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Ùn si pò micca piantà u filu d’esecuzione"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Ùn si pò micca aspettà a fine di u filu d’esecuzione"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Ùn si pò micca interrompe u filu d’esecuzione %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Ùn si pò micca ripiglià u filu d’esecuzione %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Ùn si pò micca ottene u puntatore di u filu d’esecuzione currente"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6350,7 +6336,7 @@ msgstr ""
 "Fiascu à l’iniziu di u modulu di u filu d’esecuzione : impussibule "
 "d’attribuisce l’indice in l’allucamentu lucale di fili d’esecuzione"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6383,12 +6369,12 @@ msgstr "Fiascu per caricà a risorsa « %s »."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Fiascu per ammarchjunà a risorsa « %s »."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "custruzzione %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", edizione 64-bit"
 
@@ -6401,51 +6387,51 @@ msgid "Failed to redirect the child process IO"
 msgstr ""
 "Fiascu di a ridirezzione di l’entrate è di l’esciute di u trattamentu zitellu"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Fiascu di l’esecuzione di a cumanda « %s »"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Fiascu di u caricamentu di mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Ùn si pò micca leghje u nome di u tipu da « %s » !"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Ùn si pò micca caricà l’icona da « %s »."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 "Fiascu per truvà un livellu di simulazione di vista di u web in u registru"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 "Fiascu per definisce a vista di u web à u livellu di simulazione mudernu"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 "Fiascu per reinizià a vista di u web à u livellu di simulazione classicu"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 "Ùn si pò micca lancià u scenariu JavaScript senza un ducumentu HTML "
 "accettevule"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Ùn si pò micca ottene l’oggettu JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "fiascu di a valutazione"
 
@@ -6478,7 +6464,7 @@ msgid "Check to make the font italic."
 msgstr "Selezziunà per rende cursiva a grafia."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Sottulineata"
@@ -6545,15 +6531,33 @@ msgstr "<Qualunque teletipu>"
 msgid "File type:"
 msgstr "Tipu di schedariu :"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Finestra"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Aiutu"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimizà"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Ingrandamentu"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Tuttu mette di fronte"
 
@@ -6570,465 +6574,465 @@ msgstr "U schedariu di grafia « %s » ùn esiste micca."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "U schedariu di grafia « %s » ùn pò micca esse impiegatu perchè ùn si trova "
 "micca in u cartulare di e grafie « %s »."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Apprupositu di %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Apprupositu…"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferenze..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Servizii"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Piattà %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Appiecazione"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Piattà l'altre"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Tuttu affissà"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Esce di %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Appiecazione"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "A stampa ùn hè micca accettata da u cuntrollu web di u sistema"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "L’operazione di stampa ùn pò micca esse iniziata"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Dimensione di puntu"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nome di a grafia"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stilu"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Spessore"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Famiglia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "SpaziuTravagliuAppiecazione"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "BorduAttivu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "SottutituluAttivu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "FacciaButtone"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "SopralineàButtone"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "UmbriaButtone"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "TestuButtone"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "TestuSottutitulu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "CuntrolluScuru"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "CuntrolluChjaru"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "TestuGrisgiu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Sopralineà"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "TestuSopralineà"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "BorduInattivu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "SottutituluInattivu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "TestuSottutituluInattivu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Interfaccia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "BarraSfilarata"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "BollaInfurmazione"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "TestuBollaInfurmazione"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "QuadruFinestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "TestuFinestra"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Persunalizatu"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Neru"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Cerriu"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Marina"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Purpura"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Smeraldu"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Grisgiu"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Aliva"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Castagnu"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Turchinu"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Rusulatu"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Rossu"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Aranciu"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Argentu"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Limone verde"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Acqua"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Ghjallu"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Biancu"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Predefinitu"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Fleccia"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Fleccia diritta"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Biancu"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Sibula"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Caratteru"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Croce"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Manu"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "Puntatore in I"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Buttone mancu"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Luppa"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Buttone centrale"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Sensu interdettu"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Pinnellu à tinta"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Mina"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Puntu à mancu"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Puntu à dirittu"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Fleccia di dumanda"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Buttone dirittu"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Pusizione NE-SO"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Pusizione N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Pusizione NO-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Pusizione O-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Pusizione"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Vapurizadore"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Attesa"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Surveglianza"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Fleccia d’attesa"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Effettuà una selezzione :"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Pruprietà"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valore"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Modu categuriale"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Modu alfabeticu"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falsu"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Veru"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Non specificatu"
 
@@ -7043,12 +7047,12 @@ msgstr ""
 "Un valore inaccettevule hè statu stampittatu. Appughjate nant’à SCAP per "
 "abbandunà a mudificazione."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Sbagliu in a risorsa : %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7057,36 +7061,36 @@ msgstr ""
 "Fiascu di u tipu d’operazione « %s » : A pruprietà cù l’etichetta « %s » hè "
 "di tipu « %s », è MICCA « %s »."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Basa %d scunnisciuta. A basa 10 serà impiegata."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "U valore deve esse %s o superiore."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "U valore deve esse trà %s è %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "U valore deve esse %s o inferiore."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Micca %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Sceglie un cartulare :"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Sceglie un schedariu"
 
@@ -7553,117 +7557,117 @@ msgstr "Internu"
 msgid "Outset"
 msgstr "Esternu"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Cambià u stilu"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Cambià u stilu di l’oggettu"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Cambià e pruprietà"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Cambià u stilu di a lista"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Rinumerà a lista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Framette un testu"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Framette una fiura"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Framette un oggettu"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Framette un campu"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Troppu chjamate à EndStyle !"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "schedarii"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "classicu/circulare"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "classicu/cuntornu circulare"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "classicu/quadratu"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "classicu/lusanga"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "classicu/triangulu"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Pruprietà di a scatula"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Pruprietà di cellule multiple"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Pruprietà di cellula"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Definisce u stilu di cellula"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Squassà una linea"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Squassà una culonna"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Aghjunghje una linea"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Aghjunghje una culonna"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Pruprietà di u tavulone"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Pruprietà di a fiura"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "fiura"
 
@@ -7871,24 +7875,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Trascinà"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Squassà u testu"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Caccià a puce"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "U testu ùn pò micca esse arregistratu."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Rimpiazzà"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Grafia :"
 
@@ -8857,53 +8861,53 @@ msgstr "Stili di lista"
 msgid "Box styles"
 msgstr "Stili di scatula"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "A grafia da quella piglià u simbulu."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Sottuinseme :"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Affisseghja un sottuinseme Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Codice di caratteru :"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "U codice di caratteru."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Da :"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "L’intervallu à affissà."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Framette"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Testu nurmale)"
 
@@ -9098,7 +9102,7 @@ msgstr "Impussibule d’ottene l’evenimenti da « kqueue »"
 msgid "Media playback error: %s"
 msgstr "Sbagliu di ripruduzzione medià : %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Fiascu durante l’approntu di a ripruduzzione di « %s »."
@@ -9203,23 +9207,23 @@ msgstr "U furmatu di i dati sonori ùn hè micca accettatu."
 msgid "Couldn't open audio: %s"
 msgstr "Impussibule d’apre u schedariu audio : %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 "Ùn si pò micca ricuperà a strategia di pianificazione di i fili d’esecuzione."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Ùn si pò micca ottene una gamma di priurità per a strategia di "
 "pianificazione %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "A definizione di a priurità di u filu d’esecuzione hè ignurata."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9227,64 +9231,64 @@ msgstr ""
 "Fiascu per ghjunghje un filu d’esecuzione, avventata d’una sfughjime di "
 "memoria pussibule ; ci vole à rilancià u prugramma"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 "Fiascu per definisce u livellu di cuncumitanza di u filu d’esecuzione à %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Fiascu per definisce a priurità %d di u filu d’esecuzione."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Fiascu di a piantata di u u filu d’esecuzione."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Fiascu à l’iniziu di u modulu di u filu d’esecuzione : fiascu à a creazione "
 "di a chjave di u filu d’esecuzione"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Impussibule d’ottene l’entrata di u trattamentu zitellu"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Ùn si pò micca scrive in u « stdin » di u trattamentu zitellu"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Fiascu di l’esecuzione di « %s »\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Fiascu di u « fork »"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Fiascu per definisce a priurità di u trattamentu"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr ""
 "Fiascu di a ridirezzione di l’entrate è di l’esciute di u trattamentu zitellu"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Impussibule di cunfigurà un cundottu senza blucchime, u prugramma puderia "
 "piantassi."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Ùn si pò micca ottene u nome d’ospite"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Ùn si pò micca ottene u nome d’ospite ufficiale"
 
@@ -9302,12 +9306,12 @@ msgstr "Fiascu per passà u cundottu di svegliata à u modu senza blucchime"
 msgid "Failed to read from wake-up pipe"
 msgstr "Fiascu per leghje in u cundottu di svegliata"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Specificazione geometrica « %s » inaccettevule"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets ùn pò micca apre un affissera. Abbandonu."
 
@@ -9321,30 +9325,59 @@ msgstr "Fiascu durante a chjusura di l’affissera « %s »."
 msgid "Failed to open display \"%s\"."
 msgstr "Fiascu durante l’apertura di l’affissera « %s »."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Sbagliu d’analisa XML : « %s » à a linea %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Ùn si pò micca caricà e risorse da « %s »."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Ùn si pò micca apre u schedariu di risorse « %s »."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Ùn si pò micca caricà e risorse da u schedariu « %s »."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Fiascu durante a creazione di %s « %s »."
+
+#~ msgid "Printing "
+#~ msgstr "Stampa "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Fiascu per framette u testu in u cuntrollu."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Sciglite una grafia accettevule."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Fiascu di l’affissera di u ducumentu HTML cù a cudificazione %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets ùn pò micca apre un affissera per « %s » : abbandonu."
+
+#~ msgid "Filter"
+#~ msgstr "Filtru"
+
+#~ msgid "Directories"
+#~ msgstr "Cartulari"
+
+#~ msgid "Files"
+#~ msgstr "Schedarii"
+
+#~ msgid "Selection"
+#~ msgstr "Selezzione"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "fiascu di a cunversione in cudificazione 8-bit"

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2021-06-28 19:01+0200\n"
 "Last-Translator: PB <pbfordev@gmail.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -15,11 +15,11 @@ msgstr ""
 "X-Poedit-Bookmarks: 1524,-1,-1,-1,-1,-1,-1,-1,-1,-1\n"
 "X-Generator: Poedit 2.4.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Všechny soubory (*.*)|*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Všechny soubory (*)|*"
 
@@ -36,24 +36,21 @@ msgid "Remaining time:"
 msgstr "Zbývající čas:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ano"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Storno"
@@ -103,7 +100,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Nelze vytvořit I/O port dokončení."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Výtisk"
 
@@ -140,7 +137,7 @@ msgstr "Vlastnosti objektu"
 msgid "Printing"
 msgstr "Tisk"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symboly"
 
@@ -209,7 +206,7 @@ msgstr "&Předchozí"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Okno"
 
@@ -738,11 +735,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "zobrazí tuto nápovědu"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "v logu vypisovat podrobné zprávy"
 
@@ -764,84 +761,84 @@ msgstr "Nepodporované téma '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Špatné určení grafického režimu '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Možnost '%s' nemůže být znegována"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Neznámá dlouhá volba '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Neznámá volba '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Volbu '%s' následovaly neočekávané znaky."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Volba '%s' vyžaduje hodnotu."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Za volbou '%s' se očekává oddělovač."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' není správnou číselnou hodnotou pro volbu '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Volba '%s': '%s' nemůže být převedena na datum."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Neočekávaný parametr '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (nebo %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Musíte zadat hodnotu volby '%s'."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Požadovaný parametr '%s' nebyl zadán."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Použití: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "řetězec"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "číslo"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "číslo s plovoucí čárkou"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "datum"
 
@@ -859,7 +856,7 @@ msgid "Can't &Undo "
 msgstr "&Nelze vzít zpět "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Zpět"
@@ -869,7 +866,7 @@ msgid "&Redo "
 msgstr "P&rovést znovu "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "P&rovést znovu"
@@ -897,12 +894,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' obsahuje přebytečné '..', ignorováno."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "zaškrtnuto"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "zaškrtnuto"
 
@@ -911,103 +908,103 @@ msgstr "zaškrtnuto"
 msgid "undetermined"
 msgstr "neurčité"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "dnes"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "včera"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "zítra"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "prvního"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "druhého"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "třetího"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "čtvrtého"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "pátého"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "šestého"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sedmého"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "osmého"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "devátého"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "desátého"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "jedenáctého"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dvanáctého"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "třináctého"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "čtrnáctého"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "patnáctého"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "šestnáctého"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "sedmnáctého"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "osmnáctého"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "devatenáctého"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "dvacátého"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "poledne"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "půlnoc"
 
@@ -1074,44 +1071,81 @@ msgstr "Nelze spustit curl, instalujte ho, prosím, do PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Nelze nahrát protokol ladění (kód chyby %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Uložit jako"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Zahodit změny a znovu nahrát poslední uloženou verzi?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "nepojmenovaný"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Chcete uložit změny v %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Uložit"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Neukládat"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Chcete uložit změny v %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Text nelze uložit."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Soubor \"%s\" nelze otevřít pro zápis."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Nelze uložit dokument do souboru \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Soubor \"%s\" nelze otevřít pro čtení."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Nelze načíst dokument ze souboru \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1120,57 +1154,57 @@ msgstr ""
 "Soubor '%s' neexistuje a nemohl být otevřen.\n"
 "Byl odstraněn ze seznamu naposledy použitých souborů."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Nelze vytvořit náhled tisku."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Náhled tisku"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formát souboru '%s' nelze určit."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "nepojmenovaný%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Otevřít soubor"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Chyba souboru"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Je nám líto, tento soubor nelze otevřít."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Je nám líto, tento formát souboru je neznámý."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Vyberte šablonu dokumentu"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Šablony"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Vyberte zobrazení dokumentu"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Pohledy"
 
@@ -1204,41 +1238,41 @@ msgstr "Chyba při čtení ze souboru '%s'"
 msgid "Write error on file '%s'"
 msgstr "Chyba při zápisu do souboru '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "nelze vyprázdnit buffer souboru '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Chyba hledání v souboru '%s' (stdio nepodporuje velké soubory)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Chyba při nastavování pozice v souboru '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nelze zjistit současnou pozici v souboru '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Nelze nastavit přístupová práva k dočasnému souboru"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nelze odstranit soubor '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nelze uložit změny v souboru '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nelze odstranit dočasný soubor '%s'"
@@ -1263,27 +1297,27 @@ msgstr "nelze číst z popisovače souboru %d"
 msgid "can't write to file descriptor %d"
 msgstr "nelze zapisovat do popisovače souboru %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nelze vyprázdnit popisovač souboru %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nelze změnit pozici pro popisovač souboru %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nelze zjistit pozici pro popisovač souboru %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "nelze zjistit délku souboru pro popisovač souboru %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "nelze zjistit, jestli byl dosažen konec souboru pro popisovač %d"
@@ -1307,107 +1341,107 @@ msgstr "Změny nebudou uloženy, aby se zabránilo přepsání souboru \"%s\""
 msgid "Error reading config options."
 msgstr "Chyba při čtení voleb nastavení."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Nelze načíst volby nastavení."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "soubor '%s': neočekávaný znak %c na řádku %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "soubor '%s', řádka %zu: '%s' po hlavičce skupiny ignorováno."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "soubor '%s', řádka %zu: očekáváno '='."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "soubor '%s', řádka %zu: hodnota pro neměnný klíč '%s' ignorována."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "soubor '%s', řádka %zu: klíč '%s' byl poprvé nalezen na řádce %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Položka konfigurace nesmí začínat na '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "nelze otevřít uživatelský konfigurační soubor."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "nelze zapisovat do uživatelského konfigurační souboru."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Nelze aktualizovat soubor uživatelského nastavení."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Chyba při ukládání dat uživatelského nastavení."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "nelze smazat uživatelský konfigurační soubor '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "položka '%s' se ve skupině '%s' vyskytuje víc než jednou"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "pokus o změnu neměnného klíče '%s' ignorován."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "zpětné lomítko na konci ignorováno v '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "neočekávané \" na pozici %d v '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Selhalo kopírování souboru '%s' do '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nelze zjistit přístupová práva souboru '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nelze přepsat soubor '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Selhalo kopírování souboru '%s' do '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nelze nastavit přístupová práva souboru '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1415,40 +1449,40 @@ msgid ""
 msgstr ""
 "Nelze přejmenovat soubor '%s' na '%s' protože cílový soubor již existuje."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Soubor '%s' nelze přejmenovat na '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Soubor '%s' nelze odstranit"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nelze vytvořit adresář '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nelze smazat adresář '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nelze vyjmenovat soubory odpovídající masce '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Nelze zjistit aktuální pracovní adresář"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Nelze nastavit současný pracovní adresář"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Soubory (%s)"
@@ -1475,17 +1509,17 @@ msgstr "Nelze vytvořit jméno dočasného souboru"
 msgid "Failed to open temporary file."
 msgstr "Nelze otevřít dočasný soubor."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Nelze změnit hodnoty časů souboru '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Nelze nastavit čas na aktuální pro soubor '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Nelze zjistit hodnoty časů souboru '%s'"
@@ -1494,22 +1528,22 @@ msgstr "Nelze zjistit hodnoty časů souboru '%s'"
 msgid "Browse"
 msgstr "Procházet"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Všechny soubory (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "Soubory %s (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Otevřít soubor %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Uložit soubor %s"
@@ -1872,99 +1906,99 @@ msgstr "výchozí"
 msgid "unknown-%d"
 msgstr "neznámé-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "podtržené"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " přeškrtnuté"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " tenké"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " velmi tenké"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " tenké"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " polotučné"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " tříčtvrtečně tučné"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " tučné"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " velmi tučné"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " tučné"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " velmi tučné"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kurzíva"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "přeškrtnuté"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "tenké"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "velmi tenké"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "tenké"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normální"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "středně tučné"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "tříčvrtečně tučné"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "tučné"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "velmi tučné"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "tučné"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "velmi tučné"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kurzíva"
 
@@ -2043,7 +2077,7 @@ msgstr "Při čekání na spojení s FTP serverem vypršel čas, zkuste pasivní
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Nelze nastavit přenosový mód FTP na %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2064,7 +2098,7 @@ msgstr "FTP server nepodporuje pasivní mód."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nesprávné rozměry snímku GIF (%u, %d) pro snímek č. %u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Nelze přidělit barvu pro OpenGL"
 
@@ -2080,7 +2114,7 @@ msgstr "Přizpůsobit sloupce"
 msgid "&Customize..."
 msgstr "&Upravit..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Nelze otevřít URL \"%s\"' ve výchozím prohlížeči."
@@ -2100,155 +2134,154 @@ msgstr "Nelze načíst obrázek %d z proudu."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Nelze načíst ikonu ze zdroje '%s' ."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nelze uložit poškozený obrázek."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nemá vlastní wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nelze zapsat hlavičku souboru (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nelze zapsat hlavičku souboru (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nelze zapsat RGB paletu."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nelze zapsat data."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nelze přidělit paměť."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB hlavička: Obrázek má šířku větší než 32767 pixelů."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB hlavička: Obrázek má výšku větší než 32767 pixelů."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB hlavička: Neznámá bitová hloubka."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB hlavička: Neznámé kódování."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB hlavička: Kódování neodpovídá bitové hloubce."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Nelze přidělit paměť."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB hlavička: Obrázek má šířku větší než 32767 pixelů."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB hlavička: Obrázek má výšku větší než 32767 pixelů."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB hlavička: Neznámá bitová hloubka."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB hlavička: Neznámé kódování."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB hlavička: Kódování neodpovídá bitové hloubce."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Chyba při čtení obrázku DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Chyba při načítání DIB masky."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Obrázek je na ikonu příliš vysoký."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Obrázek je na ikonu příliš široký."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Chyba při zapisování obrázku!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Neplatný index ikony."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Obrázek a maska mají různé rozměry."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "V obrázku není maskována žádná nepoužitá barva."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nelze načíst bitmapu \"%s\" ze zdrojů."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nelze načíst ikonu \"%s\" ze zdrojů."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Nelze načíst obrázek ze souboru \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Obrázek nelze uložit do souboru '%s': neznámá přípona."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Nenalezen žádný ovladač pro tento typ obrázků."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nebyla stanovena žádná obslužná rutina obrázku pro typ %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Soubor s obrázkem není typu %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Nelze automaticky zjistit formát obrázku pro nepřevíjitelný vstup."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Neznámy formát dat obrázku."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Toto není %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nebyla stanovena žádná obslužná rutina obrázku pro typ %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Obrázek není typu %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Nelze zkontrolovat formát souboru s obrázkem \"%s\"."
@@ -2350,52 +2383,52 @@ msgstr "PNM: Soubor je nejspíš uříznutý před koncem."
 msgid " (in module \"%s\")"
 msgstr " (v modulu \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Chyba při načítání obrázku."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Poškozený index v TIFF obrázku."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Rozměr obrázku je abnormálně velký."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nelze přidělit paměť."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Chyba při čtení obrázku."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ignorována neznámá jednotka rozlišení TIFF %d"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Chyba při ukládání obrázku."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Chyba při zapisování obrázku."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "Argument příkazové řádky %d nelze převést na Unicode a bude ignorován."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Zavedení selhala v post init, ukončuji."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nepodařilo se nastavit místní a jazykové nastavení na \"%s\"."
@@ -2491,7 +2524,7 @@ msgstr "chyba komprese LZMA: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Chyba komprese LZMA při vyprazdňování výstupních dat: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Přebytečná '{' v záznamu mime typu %s."
@@ -2511,7 +2544,7 @@ msgstr "Závislost \"%s\" modulu \"%s\" neexistuje."
 msgid "Module \"%s\" initialization failed"
 msgstr "Zavédení modulu \"%s\" selhalo"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Zpráva"
 
@@ -3013,7 +3046,7 @@ msgstr "Chyba tisku"
 msgid "Print"
 msgstr "Tisk"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Nastavení stránky"
 
@@ -3048,19 +3081,15 @@ msgstr "Tisk strany %d z %d"
 msgid " (copy %d of %d)"
 msgstr " (kopie %d z %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Tisk "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "První  stránka"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Předchozí stránka"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Následující stránka"
 
@@ -3104,16 +3133,16 @@ msgstr "Strana %d z %d"
 msgid "Page %d"
 msgstr "Strana %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "neznámá chyba"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Špatný regulární výraz '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Nelze nalézt shodu pro regulární výraz: %s"
@@ -3123,21 +3152,21 @@ msgstr "Nelze nalézt shodu pro regulární výraz: %s"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Vykreslovač \"%s\" má nekompatibilní verzi %d.%d a nemohl být načten."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Není dostupné pro tuto platformu"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Nelze uložit heslo pro \"%s\": %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Nelze načíst heslo pro \"%s\": %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Nelze smazat heslo pro \"%s\": %s."
@@ -3146,11 +3175,11 @@ msgstr "Nelze smazat heslo pro \"%s\": %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Nelze monitorovat I/O kanály"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Uložit"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Neukládat"
 
@@ -3231,10 +3260,10 @@ msgid "Clear"
 msgstr "Vymazat"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Zavřít"
 
@@ -3246,7 +3275,7 @@ msgstr "&Převést"
 msgid "Convert"
 msgstr "Převést"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopírovat"
@@ -3255,7 +3284,7 @@ msgstr "&Kopírovat"
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Vyjmout"
@@ -3264,13 +3293,13 @@ msgstr "&Vyjmout"
 msgid "Cut"
 msgstr "Vyjmout"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Odstranit"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Delete"
@@ -3357,7 +3386,7 @@ msgstr "Pevný disk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Nápověda"
 
@@ -3377,7 +3406,7 @@ msgstr "Odsazení"
 msgid "&Index"
 msgstr "&Rejstřík"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Rejstřík"
 
@@ -3446,7 +3475,7 @@ msgstr "&Nový"
 msgid "New"
 msgstr "Nový"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Ne"
 
@@ -3463,12 +3492,12 @@ msgstr "&Otevřít..."
 msgid "Open..."
 msgstr "Otevřít..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Vložit"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Vložit"
@@ -3498,7 +3527,7 @@ msgid "Print..."
 msgstr "Tisk..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Vlastnosti"
 
@@ -3530,10 +3559,6 @@ msgstr "Nahradit..."
 msgid "Revert to Saved"
 msgstr "Vrátit k uloženému"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Uložit"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Uložit &jako..."
@@ -3542,7 +3567,7 @@ msgstr "Uložit &jako..."
 msgid "Save As..."
 msgstr "Uložit &jako..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Vybrat &vše"
@@ -3649,7 +3674,7 @@ msgstr "Nahor&u"
 msgid "Up"
 msgstr "Nahoru"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ano"
 
@@ -3737,43 +3762,43 @@ msgstr "Uložit aktuální dokument"
 msgid "Save current document with a different filename"
 msgstr "Uložit aktuální dokument s jiným jménem"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Převod do znakové sady '%s' nefunguje."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "neznámý"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "neúplný blok hlavičky v tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "selhání kontrolního součtu při čtení bloku tar hlavičky"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "neplatná data v rozšířené tar hlavičce"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "záznam tar není otevřen"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "neočekávaný konec souboru"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s se nevešlo do tar hlavičky záznamu '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "předána neplatná velikost pro tar záznam"
 
@@ -3782,7 +3807,7 @@ msgstr "předána neplatná velikost pro tar záznam"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' je zřejmě binární buffer."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Soubor nelze načíst."
 
@@ -3796,47 +3821,47 @@ msgstr "Nelze načíst textový soubor \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "nelze zapsat vyrovnávací paměť '%s' na disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Nelze zjistit místní systémový čas"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay selhalo."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' není katalogem zpráv."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Neplatný katalog zpráv."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Nelze analyzovat formy množného čísla: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "používám katalog '%s' z '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Zdroj '%s' není platný katalog zpráv."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Nelze vyjmenovat překlady"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Není nastavena žádná výchozí aplikace pro HTML soubory."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Nelze otevřít URL \"%s\"' ve výchozím prohlížeči."
@@ -3869,7 +3894,7 @@ msgstr "'%s' obsahuje neplatné znaky"
 msgid "Error: %s (%d)"
 msgstr "Chyba: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Na disku není dostatek volného místa pro dokončení stahování."
 
@@ -3877,20 +3902,20 @@ msgstr "Na disku není dostatek volného místa pro dokončení stahování."
 msgid "libcurl could not be initialized"
 msgstr "nelze zavést knihovnu libcurl"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Chyba při spuštění JavaScriptu: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Tato platforma nepodporuje průhlednost pozadí."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Nelze přenést data do okna"
 
@@ -3942,8 +3967,8 @@ msgstr "Create Parameter %s nebyl nalezen v deklarovaných parametrech RTTI"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Neplatná třída objektu (Není wxEvtHandler) jako zdroj události"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Typ musí podporovat převod typu enum na long"
 
@@ -3993,80 +4018,80 @@ msgstr "Objekt musí mít atribut id"
 msgid "Doubly used id : %d"
 msgstr "Dvojitě použité id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Neznámá vlastnost %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Sbírka, která není prázdná, musí obsahovat uzly 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "nesprávný řetězec obslužné rutiny události, chybí tečka"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nelze znovu zavést proud zlib deflate"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nelze znovu zavést proud zlib inflate"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr "Ignorován chybný extra datový záznam, soubor ZIP může být poškozen"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "předpokládám, že toto je vícenásobný zřetězený zip"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "neplatný zip soubor"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "v zipu nelze najít centrální adresář"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "chyba při čtení centrálního adresáře zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "chyba při čtení místní zip hlavičky"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "špatná adresa záznamu v souboru zip"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "v hlavičce zip není uložená délka souboru"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "nepodporovaná metoda komprese zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "čtení proudu zip (záznam %s): špatná délka"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "čtení proudu zip (záznam %s): špatná CRC"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "chyba při zápisu záznamu zip '%s': soubor je bez použití ZIP64 příliš velký"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "chyba při zápisu záznamu zip '%s': špatná CRC nebo délka"
@@ -4151,32 +4176,32 @@ msgstr "Grafika "
 msgid "Translations by "
 msgstr "Překlad "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Verze "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "O aplikaci %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licence"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Vývojáři"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autoři dokumentace"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Umělci"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Překladatelé"
 
@@ -4227,43 +4252,42 @@ msgid "Password:"
 msgstr "Heslo:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "pravda"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "nepravda"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Řádka %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Sbalit"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Rozbalit"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d pložek)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Sloupec %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4274,8 +4298,7 @@ msgid "Left"
 msgstr "Doleva"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4371,7 +4394,7 @@ msgid "Home directory"
 msgstr "Domovský adresář"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Plocha"
 
@@ -4384,8 +4407,7 @@ msgstr "Neplatné jméno adresáře."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Chyba"
 
@@ -4570,16 +4592,16 @@ msgstr "Zobrazit soubory v detailním pohledu"
 msgid "Go to parent directory"
 msgstr "Jít do nadřazeného adresáře"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Soubor '%s' existuje, opravdu ho chcete přepsat?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Potvrdit"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Prosím vyberte existující soubor."
 
@@ -4673,7 +4695,7 @@ msgstr "Velikost písma v bodech."
 msgid "Whether the font is underlined."
 msgstr "Zdali má být písmo podtržené."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Náhled:"
@@ -4691,48 +4713,47 @@ msgstr "Klikněte pro zrušení výběru písma."
 msgid "Click to confirm the font selection."
 msgstr "Klikněte pro potvrzení výběru písma."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Vyberte písmo"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "Kopírování více bloků najednou do Schránky není podporováno."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Adresář Nápovědy \"%s\" nenalezen."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Soubor s nápovědou \"%s\" nebyl nalezen."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Řádek %luz mapovacího souboru \"%s\" nemá platný formát, přeskočen."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Nenalezeno žádné platné mapování v souboru \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Nenalezeny žádné položky."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Index nápovědy"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Související položky:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Nalezené položky"
 
@@ -4836,59 +4857,59 @@ msgstr "Nelze zahájit tisk."
 msgid "Printing page %d..."
 msgstr "Tisk strany %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Nastavení tiskárny"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Tisk do souboru"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Nastavení..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Tiskárna:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Stav:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Vše"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Strany"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Rozsah tisku"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopie:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "soubor PostScriptu"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Nastavení tisku"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Tiskárna"
 
@@ -4896,25 +4917,25 @@ msgstr "Tiskárna"
 msgid "Default printer"
 msgstr "Výchozí tiskárna"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Velikost papíru"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Na výšku"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Na šířku"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientace"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Nastavení"
 
@@ -4926,52 +4947,52 @@ msgstr "Tisknout barevně"
 msgid "Print spooling"
 msgstr "Tisková fronta"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Příkaz tisku:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Nastavení tiskárny:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Levý okraj (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Horní okraj (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Pravý okraj (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Dolní okraj (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Tiskárna..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Pře&skočit"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Neznámo"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Hotovo."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Hledat"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Nelze najít záložku pro id"
 
@@ -5007,11 +5028,11 @@ msgstr "&Dokončit"
 msgid "< &Back"
 msgstr "< &Zpět"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "překladatel-poděkování"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5021,11 +5042,11 @@ msgstr ""
 "problémy se zadáváním znaků a blikáním obrazovky. Zvažte odstranění proměnné "
 "GTK_IM_MODULE nebo její nastavení na \"ibus\"."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nelze spustit GTK+, je ZOBRAZENÍ nastaveno správně?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Změna současného adresáře na \"%s\" selhala"
@@ -5051,11 +5072,11 @@ msgstr "Nelze přidat vlastní font \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Nelze zaregistrovat nastavení fontu pro soukromé fonty."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Kritická chyba"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5067,7 +5088,7 @@ msgstr ""
 "backendem pomocí\n"
 "nastavení proměnné prostředí GDK_BACKEND=x11 před spuštěním tohoto programu."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5080,7 +5101,7 @@ msgstr ""
 "spuštěním\n"
 "tohoto programu."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI syn"
 
@@ -5096,15 +5117,11 @@ msgstr "Chyba při tisku: "
 msgid "Page Setup"
 msgstr "Nastavení stránky"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Do textového pole nelze vložit text."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "WebKit v1 neumožňuje získání výsledku spuštění skriptu JavaScript"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5112,24 +5129,20 @@ msgstr ""
 "GTK+ instalovaný na tomto stroji je příliš starý pro podporu skládání "
 "obrazovky, nainstalujte prosím GTK+ 2.12 nebo novější."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "Skládání není podporováno v tomto systému, povolte ho prosím ve správci oken."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Tento program byl sestaven s příliš starou verzí GTK+, znovu ho, prosím, "
 "sestavte s GTK+ 2.12 nebo novější."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Prosím vyberte platný font."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5228,45 +5241,45 @@ msgstr "Nelze otevřít soubor s obsahem: %s"
 msgid "Cannot open index file: %s"
 msgstr "Nelze otevřít soubor s rejstříkem: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "bezejmenná"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nelze otevřít knihu HTML nápovědy: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Při procházení knih zobrazí vlevo nápovědu."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(záložky)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Přidá tuto stránku do záložek"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Odstraní tuto stránku ze záložek"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Obsah"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Najít"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Zobraz vše"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5274,19 +5287,19 @@ msgstr ""
 "Zobrazí všechny položky rejstříku, které obsahují daný podřetězec. "
 "Nerozlišuje velká a malá písmena."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Zobrazí všechny položky v rejstříku"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Rozlišovat velká/malá"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Pouze celá slova"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5294,147 +5307,147 @@ msgstr ""
 "Prohledá obsah knih(y) s nápovědou a vypíše všechny výskyty textu, který "
 "jste zadali"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Zobraz/skryj navigační panel"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Jdi zpět"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Jdi dopředu"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Jdi o úroveň výš"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Otevřít dokument HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Vytiskne tuto stránku"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Zobrazí dialogové okno s nastaveními"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Prosím vyberte stránku k zobrazení:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Témata nápovědy"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Hledám..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Ještě nebylo nic nalezeno"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Nalezeno výskytů: %i"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Nápověda)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d z %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu z %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Hledej ve všech knihách"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Nastavení prohlížeče nápovědy"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normální písmo:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Neproporcionální písmo:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Velikost písma:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "velikost písma"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normální písmo<br>a <u>podtržené</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kurzíva.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Tučně.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Tučná kurzíva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Písmo s pevnou velikostí.<br> <b>tučné</b> <i>kurzíva</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>tučná kurzíva <u>podtržené</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Tisk nápovědy"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Nelze tisknout prázdnou stránku."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Soubory HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Knihy s nápovědou (*.htb)|*.htb|Knihy s nápovědou (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projekt Nápovědy HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimovaný soubor Nápovědy HTML (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i z %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u z %u"
@@ -5511,32 +5524,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "Při nastavování stránky nastala chyba: nastavte výchozí tiskárnu."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Nelze zobrazit HTML dokument v kódování %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets nemůže otevřít zobrazení pro '%s': ukončeno."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtr"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Adresáře"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Soubory"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Výběr"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Nelze otevřít schránku."
@@ -5578,58 +5565,58 @@ msgstr "Dialogové okno výběru barvy selhalo s chybou %0lx."
 msgid "Failed to create cursor."
 msgstr "Nelze vytvořit kurzor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Nelze zaregistrovat DDE server '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Nelze odregistrovat DDE server '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Nelze navázat spojení se serverem '%s' na téma '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Požadavek na šťouchnutí DDE selhal"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Nelze navázat 'advise loop' s DDE serverem"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Nelze ukončit 'advise loop' s DDE serverem"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Nepodařilo se poslat DDE advise notifikaci"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Nelze vytvořit DDE řetězec"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "žádná chyba DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "požadavek na synchronní advise transakci vypršel."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odpověď na transakci způsobila nastavení bitu DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "požadavek na synchronní datovou transakci vypršel."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5640,7 +5627,7 @@ msgstr ""
 "nebo dostala neplatný identifikátor\n"
 "instance."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5652,43 +5639,43 @@ msgstr ""
 "nebo se aplikace zavedená jako APPCMD_CLIENTONLY pokusila\n"
 "o přenos přes server."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "požadavek na synchronní execute transakci vypršel."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "nepodařilo se ověřit parametr pomocí DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML aplikace způsobila prodloužený souběh."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "selhalo přidělení paměti."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "klientův pokus navázat konverzaci selhal."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "transakce se nepodařila."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "požadavek na synchronní poke transakci vypršel."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "interní volání PostMessage selhalo. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problém reentrance."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5698,15 +5685,15 @@ msgstr ""
 "transakci, nebo se server před\n"
 "dokončením transakce ukončil ."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "nastala interní chyba v DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "požadavek na ukončení advise transakce vypršel."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5716,12 +5703,12 @@ msgstr ""
 "Jakmile se aplikace vrátí z XTYP_XACT_COMPLETE callbacku, \n"
 "identifikátor transakce se stává neplatným."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Neznámá chyba DDE: %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5729,7 +5716,7 @@ msgstr ""
 "Funkce vytáčeného připojení nejsou dostupné, protože Služba vzdáleného "
 "přístupu (RAS) není nainstalována. Prosím, nainstalujte ji."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5738,65 +5725,65 @@ msgstr ""
 "Verze Služby vzdáleného přístupu (RAS) instalované na tomto počítači je "
 "příliš stará, prosím aktualizujte (následující požadovaná funkce chybí: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Nepodařilo se získat text chybového hlášení RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "neznámá chyba (kód %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nelze nalézt aktivní vytáčené připojení: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Nalezeno několik aktivních vytáčených připojení, vybírám jedno náhodně."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Nelze navázat vytáčené spojení: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Nepodařilo se získat jména ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Nelze se připojit: žádný ISP."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Vyberte ISP, ke kterému se má připojit"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Prosím vyberte si poskytovatele (ISP), ke kterému se chcete připojit"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Nepodařilo se připojit: chybí uživatelské jméno nebo heslo."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Nelze nalézt umístění souboru s adresářem"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Nelze zahájit vytáčené spojení: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nelze zavěsit - žádná aktivní vytáčená připojení."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Nelze ukončit vytáčené spojení: %s"
@@ -5816,18 +5803,17 @@ msgstr "Nelze přidělit %luKb paměti pro bitmapová data."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nelze vyjmenovat soubory v adresáři '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Nelze získat název složky"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(chyba %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Nelze přidat obrázek do seznamu obrázků."
 
@@ -5841,7 +5827,7 @@ msgstr "Nelze načíst metasoubor ze souboru \"%s\"."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Nelze vytvořit standardní dialogové okno najít/nahradit (kód chyby %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialogové okno souboru selhalo s kódem chyby %0lx."
@@ -5882,16 +5868,16 @@ msgstr "Nelze nastavit sledování pro '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nelze sledovat změny neexistujícího adresáře \"%s\"."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 nebo novější není podporován ovladačem."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Nelze vytvořit OpenGL kontext"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Nelze zavést OpenGL"
 
@@ -5899,7 +5885,7 @@ msgstr "Nelze zavést OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "Nelze zaregistrovat vlastní zavaděč fontů DirectWrite."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5907,7 +5893,7 @@ msgstr ""
 "Funkce MS HTML nápovědy nejsou dostupné, protože chybí příslušná komponenta. "
 "Prosím nainstalujte ji."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Nelze zavést MS HTML Help ."
 
@@ -5916,7 +5902,7 @@ msgstr "Nelze zavést MS HTML Help ."
 msgid "Can't delete the INI file '%s'"
 msgstr "Nelze smazat INI soubor '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nelze získat informace o položce seznamu %d."
@@ -6036,7 +6022,7 @@ msgstr "Nelze zaregistrovat formát schránky '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Formát schránky '%d' neexistuje."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Přeskočit"
 
@@ -6121,75 +6107,75 @@ msgstr ""
 "pokud ho smažete, systém bude nestabilní:\n"
 "operace přerušena."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nelze smazat klíč '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nelze smazat hodnotu '%s' z klíče '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nelze načíst hodnotu klíče '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nelze nastavit hodnotu '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Hodnota registru \"%s\" není číselná (má typ %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Hodnota registru \"%s\" není binární (má typ %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Hodnota registru \"%s\" není textová (má typ %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nelze přečíst hodnotu '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nelze vyjmenovat hodnoty klíče '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nelze vyjmenovat podklíče klíče '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "Exportuji klíč registru: soubor \"%s\" již existuje a nebude přepsán."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nelze exportovat hodnotu nepodporovaného typu %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignoruji hodnotu \"%s\" klíče \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6197,41 +6183,41 @@ msgstr ""
 "Není možné vytvořit prvek rich edit, místo něj použit obyčejný. "
 "Přeinstalujte prosím riched32.dll."
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nelze spustit vlákno: chyba při zápisu do TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Nelze nastavit prioritu vlákna"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Nelze vytvořit vlákno"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Nelze ukončit vlákno"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Nelze počkat na ukončení vlákna"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nelze pozastavit vlákno %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nelze obnovit vlákno %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Nelze získat ukazatel na aktuální vlákno"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6239,7 +6225,7 @@ msgstr ""
 "Vlákno pro modul se nepodařilo zavést: Nelze přidělit index do místního "
 "úložiště vláken"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6270,12 +6256,12 @@ msgstr "Nelze načíst zdroj \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Nelze uzamknout zdroj \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "sestavení %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64bitová edice"
 
@@ -6287,46 +6273,46 @@ msgstr "Nelze vytvořit anonymní rouru"
 msgid "Failed to redirect the child process IO"
 msgstr "Chyba při přesměrovávání vstupu a výstupu synovského procesu"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Chyba při volání příkazu '%s'"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Nelze načíst knihovnu mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nelze přečíst typ z '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nelze načíst ikonu z '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "Nelze nalézt úroveň emulace pro web view v registru"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Nelze nastavit komponentu web view na moderní úroveň emulace"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "Nelze vyresetovat komponentu web view na výchozí úroveň emulace"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Skript v JavaScriptu nelze spustit bez platného dokumentu HTML"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Nelze získat objekt JavaScriptu"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "nelze vyhodnotit"
 
@@ -6359,7 +6345,7 @@ msgid "Check to make the font italic."
 msgstr "Zaškrtněte pro kurzívu."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podtržené"
@@ -6426,15 +6412,33 @@ msgstr "<Libovolné neproporcionální>"
 msgid "File type:"
 msgstr "Typ souboru:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Okno"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Nápověda"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimalizovat"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Přiblížit"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Všechna do popředí"
 
@@ -6451,492 +6455,492 @@ msgstr "Soubor s fontem \"%s\" neexistuje."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Soubor s fontem \"%s\" nelze použít protože není ve složce s fonty \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "O aplikaci %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "O aplikaci..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Předvolby..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Služby"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Skrýt %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Aplikace"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Skrýt ostatní"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Zobrazit vše"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Ukončit %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Aplikace"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Systémová komponenta web control nepodporuje tisk"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Nelze zavést tiskovou operaci."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Velikost bodu"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Jméno písma"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Styl"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Tučnost"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Písmo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "Prostor aplikace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "Aktivní okraj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "Aktivní nadpis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "Plocha tlačítka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "Zvýraznění tlačítka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "Stín tlačítka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "Text tlačítka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "Text nadpisu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "Barva stínu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "Barva světla"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "Neaktivní text"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Zvýraznění"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Zvýraznění textu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "Neaktivní okraj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "Neaktivní nadpis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "Text neaktivního nadpisu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Posuvník"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Popisek"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "Text popisku"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Okno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "Rám okna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "Text okna"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Vlastní"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Černá"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Kaštanová"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Tmavě modrá"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Nachová"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Modrozelená"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Šedá"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Zelená"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Olivová"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Hnědá"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Modrá"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuchsiová"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Červená"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Oranžová"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Stříbrná"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Limetková"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Akvamarinová"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Žlutá"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Bílá"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Výchozí"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Šipka"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Šipka doprava"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Prázdné"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Střed terče"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Karet"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Křížek"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Ruka"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "Výběr textu"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Levé tlačítko"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Prostřední tlačítko"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Není k dispozici"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Štětec"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Tužka"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Ukazatel doleva"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Ukazatel doprava"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Výběr nápovědy"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Pravé tlačítko"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Diagonální změna velikosti 2"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Změna výšky"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Diagonální změna velikosti 1"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Změna šířky"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Změna velikosti"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Sprej"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Zaneprázdněn"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Hodinky"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Práce na pozadí"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Provést výběr:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Vlastnost"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Hodnota"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Podle kategorií"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Podle abecedy"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Nepravda"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Pravda"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Neurčeno"
 
@@ -6949,12 +6953,12 @@ msgstr "Chyba vlastnosti"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Zadali jste nesprávnou hodnotu. Stiskněte ESC pro zrušení úprav."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Chyba ve zdroji: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6963,36 +6967,36 @@ msgstr ""
 "Operace typu \"%s\" selhala: Vlastnost označená \"%s\" je typu \"%s\", NE "
 "\"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Neznámý základ %d. Bude použitá desítková soustava."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Hodnota musí být %s nebo větší."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Hodnota musí být mezi %s a %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Hodnota musí být %s nebo menší."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Není %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Zvolte adresář:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Zvolte soubor"
 
@@ -7459,117 +7463,117 @@ msgstr "Ďolík"
 msgid "Outset"
 msgstr "Návrší"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Změnit styl"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Změnit styl objektu"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Změnit vlastnosti"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Změnit styl seznamu"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Znovu očíslovat seznam"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Vložit text"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Vložit obrázek"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Vložit objekt"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Vložit pole"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Příliš mnoho volání EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "soubory"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standardní/kruh"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standardní/obrys kruhu"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standardní/čtverec"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standardní/kosočtverec"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standardní/trojúhelník"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Vlastnosti rámečku"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Vlastnosti více buněk"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "&Vlastnosti buňky"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Nastavit styl buňky"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Smazat řádek"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Smazat sloupec"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Přidat řádek"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Přidat sloupec"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Vlastnosti tabulky"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Vlastnosti obrázku"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "obrázek"
 
@@ -7777,24 +7781,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Táhnout"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Smazat text"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Odstranit odrážku"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Text nelze uložit."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Nahradit"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Písmo:"
 
@@ -8763,53 +8767,53 @@ msgstr "Styly seznamů"
 msgid "Box styles"
 msgstr "Styly rámečku"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Písmo, z kterého použít symbol."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "Pod&skupina:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Zobrazí podskupinu Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "Kód &znaku:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Kód znaku."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Rozsah k zobrazení."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normální text)"
 
@@ -8994,7 +8998,7 @@ msgstr "Nelze získat události z kqueue"
 msgid "Media playback error: %s"
 msgstr "Chyba při přehrávání: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "\"%s\" nelze připravit k přehrávání."
@@ -9094,20 +9098,20 @@ msgstr "Zvuková data jsou v nepodporovaném formátu."
 msgid "Couldn't open audio: %s"
 msgstr "Nelze otevřít zvuk: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nelze získat plánovací politiku vlákna."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nelze zjistit rozsah priorit pro plánovací politiku %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Nastavení priority vlákna je ignorováno."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9115,58 +9119,58 @@ msgstr ""
 "Nelze připojit vlákno, zjištěna možná chybná alokace paměti - restartujte "
 "prosím program"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Nelze nastavit úroveň souběžnosti vlákna na %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Nelze nastavit prioritu vlákna %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Nelze ukončit vlákno."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Selhalo zavedení modulu s vlákny: nelze vytvořit klíč vlákna"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Není možné získat vstup synovského procesu"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Nelze zapisovat na std. výstup podřazeného procesu"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Nelze spustit '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Selhalo forkování"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Nelze nastavit prioritu procesu"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Nepodařilo se přesměrovat vstup/výstup synovského procesu"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Nelze nastavit neblokující rouru, program se může zaseknout."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Nelze zjistit jméno počítače"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Nelze zjistit oficiální jméno počítače"
 
@@ -9182,12 +9186,12 @@ msgstr "Nelze přepnout rouru buzení do neblokovacího režimu"
 msgid "Failed to read from wake-up pipe"
 msgstr "Nelze číst z probouzecí roury"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Špatné určení geometrie '%s'."
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nemůže otevřít zobrazení. Ukončeno."
 
@@ -9201,30 +9205,59 @@ msgstr "Nelze uzavřít zobrazení \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Nelze otevřít zobrazení \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Chyba při načítání XML: '%s' na řádce %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nelze načíst zdroje z '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nelze otevřít soubor zdrojů '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nelze načíst zdroje ze souboru '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Vytvoření %s \"%s\" selhalo."
+
+#~ msgid "Printing "
+#~ msgstr "Tisk "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Do textového pole nelze vložit text."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Prosím vyberte platný font."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Nelze zobrazit HTML dokument v kódování %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nemůže otevřít zobrazení pro '%s': ukončeno."
+
+#~ msgid "Filter"
+#~ msgstr "Filtr"
+
+#~ msgid "Directories"
+#~ msgstr "Adresáře"
+
+#~ msgid "Files"
+#~ msgstr "Soubory"
+
+#~ msgid "Selection"
+#~ msgstr "Výběr"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "převod do 8bitového kódování selhal"
@@ -9389,8 +9422,8 @@ msgstr "Vytvoření %s \"%s\" selhalo."
 #~ msgstr "Vykreslovač data nemůže vykreslit hodnotu; typ hodnoty: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/da.po
+++ b/locale/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2017-07-26 00:00+0000\n"
 "Last-Translator: scootergrisen\n"
 "Language-Team: Danish\n"
@@ -19,11 +19,11 @@ msgstr ""
 "X-Language: da_DK\n"
 "X-Source-Language: C\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Alle filer (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Alle filer (*)|*"
 
@@ -40,24 +40,21 @@ msgid "Remaining time:"
 msgstr "Resterende tid:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nej"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Annuller"
@@ -107,7 +104,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Kunne ikke oprette I/O completion port"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Udskrift"
 
@@ -144,7 +141,7 @@ msgstr "Objektegenskaber"
 msgid "Printing"
 msgstr "Udskriver"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symboler"
 
@@ -213,7 +210,7 @@ msgstr "&Tilbage"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Vindue"
 
@@ -743,11 +740,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "vis denne hjælp-meddelelse"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "generer udførlige logmeddelelser"
 
@@ -769,84 +766,84 @@ msgstr "Ikke-understøttet tema \"%s\"."
 msgid "Invalid display mode specification '%s'."
 msgstr "Ugyldig skærmtilstandsspecifikation \"%s\"."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Tilvalget \"%s\" kan ikke annulleres"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Ukendt langt tilvalg \"%s\""
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Ukendt tilvalg \"%s\""
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Uventede tegn efter tilvalget \"%s\"."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Tilvalget \"%s\" kræver en værdi."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Separator forventet efter tilvalget \"%s\"."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "\"%s\" er ikke en korrekt numerisk værdi til tilvalget \"%s\"."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Tilvalget \"%s\": \"%s\" kan ikke konverteres til en dato."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Uventet parameter \"%s\""
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (eller %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Værdien til tilvalget \"%s\" skal angives."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Den nødvendige parameter \"%s\" blev ikke angivet."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Brug: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "nummer"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "double"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "dato"
 
@@ -864,7 +861,7 @@ msgid "Can't &Undo "
 msgstr "Kan ikke &fortryde "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Fortryd"
@@ -874,7 +871,7 @@ msgid "&Redo "
 msgstr "&Omgør "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Omgør"
@@ -902,12 +899,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "\"%s\" har ekstra \"..\", ignoreret."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "tilvalgt"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "fravalgt"
 
@@ -916,103 +913,103 @@ msgstr "fravalgt"
 msgid "undetermined"
 msgstr "ubestemt"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "i dag"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "i går"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "i morgen"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "første"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "anden"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tredje"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "fjerde"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "femte"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sjette"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "syvende"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "ottende"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "niende"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "tiende"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "elvte"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "tolvte"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "trettende"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "fjortende"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "femtende"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "sekstende"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "syttende"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "attende"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "nittende"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "tyvende"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "middag"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "midnat"
 
@@ -1052,8 +1049,8 @@ msgstr "Generering af fejlfindingsrapport fejlede."
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
-"Behandling af fejlfindingsrapport fejlede. Efterlader filerne i mappen \"%s"
-"\"."
+"Behandling af fejlfindingsrapport fejlede. Efterlader filerne i mappen "
+"\"%s\"."
 
 #: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
@@ -1081,44 +1078,81 @@ msgstr "Kunne ikke eksekvere curl. Installer den venligst i PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Kunne ikke uploade fejlfindingsrapport (fejlkode %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Gem som"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Forkast ændringer og genindlæs den sidst gemte version?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "unavngivet"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Ønsker du at gemme ændringer til %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Gem"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Gem ikke"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Ønsker du at gemme ændringer til %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Teksten kunne ikke gemmes."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Filen \"%s\" kunne ikke åbnes for skrivning."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Kunne ikke gemme dokumentet i filen \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Filen \"%s\" kunne ikke åbnes for læsning."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Kunne ikke læse dokument fra filen \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1127,57 +1161,57 @@ msgstr ""
 "Filen \"%s\" findes ikke og kunne ikke åbnes.\n"
 "Den er fjernet fra listen over senest brugte filer."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Oprettelse af udskriftsvisning fejlede."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Udskriftsvisning"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formatet på filen \"%s\" kunne ikke bestemmes."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "unavngivet%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Åbn fil"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Filfejl"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Beklager, kunne ikke åbne denne fil."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Beklager, formatet for denne fil er ukendt."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Vælg en dokumentskabelon"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Skabeloner"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Vælg en dokumentvisning"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Visninger"
 
@@ -1211,41 +1245,41 @@ msgstr "Læsefejl på filen \"%s\""
 msgid "Write error on file '%s'"
 msgstr "Skrivefejl på filen \"%s\""
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "kunne ikke flushe filen \"%s\""
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Søgefejl på filen \"%s\" (store filer understøttes ikke af stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Søgefejl på filen \"%s\""
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kan ikke finde aktuel position i filen \"%s\""
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Kunne ikke sætte midlertidige filrettigheder"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "kan ikke fjerne filen \"%s\""
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "kan ikke udføre ændringer på filen \"%s\""
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "kan ikke fjerne midlertidig fil \"%s\""
@@ -1270,27 +1304,27 @@ msgstr "kan ikke læse fra fildeskriptoren %d"
 msgid "can't write to file descriptor %d"
 msgstr "kan ikke skrive til fildeskriptoren %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "kan ikke flushe fildeskriptoren %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "kan ikke søge på fildeskriptoren %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "kan ikke få søgeposition på fildeskriptoren %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "kan ikke finde længden af filen på fildeskriptor %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "kan ikke afgøre om slutningen på filen er nået på deskriptoren %d"
@@ -1316,108 +1350,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Fejl ved læsning af konfigurationsvalg."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Kunne ikke læse konfigurationsvalg."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fil \"%s\": uventet tegn %c på linje %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "fil \"%s\", linje %zu: \"%s\" ignoreret efter gruppe-header."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fil \"%s\", linje %zu: forventede \"=\"."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "fil \"%s\", linje %zu: værdi af uforanderlig nøgle \"%s\" blev ignoreret."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "fil \"%s\", linje %zu: nøgle \"%s\" blev først fundet på linje %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurationspunkt må ikke begynde med \"%c\"."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "kan ikke åbne brugerkonfigurationsfilen."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "kan ikke skrive brugerkonfigurationsfilen."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Fejl under gem bruger konfiguration data."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "kan ikke slette brugerkonfigurationsfilen \"%s\""
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "indgang \"%s\" optræder mere end en gang i gruppe \"%s\""
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "forsøg på at ændre uforanderlig nøgle \"%s\" ignoreret."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "efterstillet omvendt skråstreg ignoreret i \"%s\""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "uventet \" på position %d i \"%s\"."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kunne ikke kopiere filen \"%s\" til \"%s\""
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Kunne ikke få rettigheder til filen \"%s\""
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Kunne ikke overskrive filen \"%s\""
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Kunne ikke kopiere filen \"%s\" til \"%s\"."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Kunne ikke sætte rettigheder for filen \"%s\""
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1425,40 +1459,40 @@ msgid ""
 msgstr ""
 "Kunne ikke omdøbe filen \"%s\" til \"%s\". Destinationsfilen findes allerede."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Filen \"%s\" kunne ikke omdøbes til \"%s\""
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Filen \"%s\" kunne ikke fjernes"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Mappen \"%s\" kunne ikke oprettes"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Mappen \"%s\" kunne ikke slettes"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kan ikke læse fillisten i mappen \"%s\""
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Kunne ikke få den aktuelle arbejdsmappe"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Kunne ikke sætte den aktuelle arbejdsmappe"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Filer (%s)"
@@ -1485,17 +1519,17 @@ msgstr "Kunne ikke oprette et midlertidigt filnavn"
 msgid "Failed to open temporary file."
 msgstr "Kunne ikke åbne midlertidig fil."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Kunne ikke ændre filtid for \"%s\""
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Kunne ikke røre (touch) filen \"%s\""
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Kunne ikke hente filtider for \"%s\""
@@ -1504,22 +1538,22 @@ msgstr "Kunne ikke hente filtider for \"%s\""
 msgid "Browse"
 msgstr "Gennemse"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle filer (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s filer (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Læs %s fil"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Gem %s fil"
@@ -1882,105 +1916,105 @@ msgstr "standard"
 msgid "unknown-%d"
 msgstr "ukendt-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "understreget"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " gennemstreget"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " let"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " let"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " fed"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " fed"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " fed"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kursiv"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "gennemstreget"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "let"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "let"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "fed"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "fed"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "fed"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kursiv"
 
@@ -2062,7 +2096,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Kunne ikke sætte FTP transfer mode til %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2083,7 +2117,7 @@ msgstr "FTP-serveren understøtter ikke passiv-tilstand."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Forkert GIF billedstørrelse (%u, %d) for ramme #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Kunne ikke tildele farve til OpenGL"
 
@@ -2099,7 +2133,7 @@ msgstr "Tilpas kolonner"
 msgid "&Customize..."
 msgstr "&Tilpas..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Kunne ikke åbne URL \"%s\" standard-browseren."
@@ -2119,155 +2153,154 @@ msgstr "Kunne ikke læse billede %d fra strøm."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Kunne ikke indlæse ikoner fra ressource \"%s\"."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: kunne ikke gemme ugyldigt billede."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage har ikke sin egen wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: kunne ikke skrive filheaderen (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: kunne ikke skrive filheaderen (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: kunne ikke skrive RGB-farvekort."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: kunne ikke skrive data."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: kunne ikke tildele hukommelse."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB-header: billedbredde > 32767 pixels for filen."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB-header: billedhøjde > 32767 pixels i filen."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB-header: ukendt bitdybde i filen."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB-header: ukendt kodning i filen."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB-header: kodning svarer ikke til bitdybden."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: kunne ikke tildele hukommelse."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB-header: billedbredde > 32767 pixels for filen."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB-header: billedhøjde > 32767 pixels i filen."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB-header: ukendt bitdybde i filen."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB-header: ukendt kodning i filen."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB-header: kodning svarer ikke til bitdybden."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Fejl ved læsning af billede DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: fejl ved læsning af maske DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: billede for højt til ikon."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: billede for bredt til ikon."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: fejl ved skrivning af billedfilen!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ugyldigt ikonindeks."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Billede og maske har forskellige størrelser."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Ingen ubrugte farver i det billede, der skal maskes."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Kunne ikke indlæse bitmap \"%s\" fra ressourcer."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Kunne ikke indlæse ikon \"%s\" fra ressourcer."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Kunne ikke indlæse billede fra file \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kan ikke gemme til filen \"%s\": ukendt filtype."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Ingen rutine fundet til denne billedtype."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Ingen billedrutine defineret for type %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Billedfilen er ikke af type %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Kan ikke automatisk bestemme billedformat for ikke-søgbart input."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Ukendt billeddataformat."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Dette er ikke nogen %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Ingen billedrutine defineret for type %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Billedet er ikke af typen %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Kunne ikke tjekke format af billedfilen \"%s\"."
@@ -2370,41 +2403,41 @@ msgstr "PNM: filen synes at være afskåret."
 msgid " (in module \"%s\")"
 msgstr " (i modul \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: fejl ved læsning af billede."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Ugyldigt TIFF billedindeks."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: billedstørrelse er unormalt stor."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: kunne ikke få hukommelse."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: fejl ved læsning af billede."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ukendt TIFF opløsningsenhed %d ignoreret"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: fejl ved gemning af billede."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: fejl ved skrivning af billede."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2412,11 +2445,11 @@ msgid ""
 msgstr ""
 "Kommandolinjeparameter %d kunne ikke konverteres til Unicode og ignoreres."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Initialisering fejlede i efterinitialisering, afbryder."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan ikke sætte lokale til sproget \"%s\"."
@@ -2514,7 +2547,7 @@ msgstr "fejl ved komprimering"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Uparret \"{\" i en indgang for mime type %s."
@@ -2534,7 +2567,7 @@ msgstr "Afhængighed \"%s\" af modulet \"%s\" findes ikke."
 msgid "Module \"%s\" initialization failed"
 msgstr "Modul \"%s\" initialisering fejlede"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Meddelelse"
 
@@ -3036,7 +3069,7 @@ msgstr "Udskriftsfejl"
 msgid "Print"
 msgstr "Udskriv"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Sideopsætning"
 
@@ -3071,19 +3104,15 @@ msgstr "Udskriver side %d af %d"
 msgid " (copy %d of %d)"
 msgstr " (kopi %d af %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Udskriver "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Første side"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Foregående side"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Næste side"
 
@@ -3127,16 +3156,16 @@ msgstr "Side %d af %d"
 msgid "Page %d"
 msgstr "Side %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "ukendt fejl"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ugyldigt regulært udtryk: \"%s\": %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Kunne ikke finde match for det regulære udtryk: %s"
@@ -3147,21 +3176,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Gengiver \"%s\" er en inkompatibel version %d.%d og kunne ikke indlæses."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Kunne ikke gemme adganskode for \"%s/%s\": %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Kunne ikke læse adganskode for \"%s/%s\": %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Kunne ikke slette adganskode for \"%s/%s\": %s."
@@ -3170,11 +3199,11 @@ msgstr "Kunne ikke slette adganskode for \"%s/%s\": %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Kunne ikke overvåge I/O-kanaler"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Gem"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Gem ikke"
 
@@ -3258,10 +3287,10 @@ msgid "Clear"
 msgstr "Rens"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Luk"
 
@@ -3273,7 +3302,7 @@ msgstr "&Konverter"
 msgid "Convert"
 msgstr "Konverter"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiér"
@@ -3282,7 +3311,7 @@ msgstr "&Kopiér"
 msgid "Copy"
 msgstr "Kopiér"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Klip"
@@ -3291,13 +3320,13 @@ msgstr "&Klip"
 msgid "Cut"
 msgstr "Klip"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Slet"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Slet"
@@ -3386,7 +3415,7 @@ msgstr "Harddisk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Hjælp"
 
@@ -3406,7 +3435,7 @@ msgstr "Indryk"
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3475,7 +3504,7 @@ msgstr "&Ny"
 msgid "New"
 msgstr "Ny"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nej"
 
@@ -3492,12 +3521,12 @@ msgstr "&Åben..."
 msgid "Open..."
 msgstr "Åbn..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Sæt ind"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Sæt ind"
@@ -3527,7 +3556,7 @@ msgid "Print..."
 msgstr "Udskriv..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Egenskaber"
 
@@ -3561,10 +3590,6 @@ msgstr "Erstat"
 msgid "Revert to Saved"
 msgstr "Tilbagefør til gemt"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Gem"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Gem &som..."
@@ -3574,7 +3599,7 @@ msgstr "Gem &som..."
 msgid "Save As..."
 msgstr "Gem &som..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Vælg &alt"
@@ -3681,7 +3706,7 @@ msgstr "&Op"
 msgid "Up"
 msgstr "Op"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ja"
 
@@ -3772,43 +3797,43 @@ msgstr "Gem aktuelle dokument"
 msgid "Save current document with a different filename"
 msgstr "Gem det aktuelle dokument under et andet filnavn"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konvertering til tegnsæt \"%s\" virker ikke."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "ukendt"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "ukomplet header-blok i tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "checksum fejlede ved læsning af tar-header-blok"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "ugyldige data i udvidet tar-header"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar-entry ikke åben"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "uventet afslutning på fil"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s passede ikke til tar-headeren for \"%s\""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "forkert størrelse givet for tar-entry"
 
@@ -3817,7 +3842,7 @@ msgstr "forkert størrelse givet for tar-entry"
 msgid "'%s' is probably a binary buffer."
 msgstr "\"%s\" er sandsynligvis en binær buffer."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Fil kunne ikke indlæses."
 
@@ -3831,47 +3856,47 @@ msgstr "Kunne ikke læse dokument fra filen \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "kan ikke skrive buffer \"%s\" til disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Kunne ikke få lokal systemtid"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay fejlede."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "\"%s\" er ikke et gyldigt meddelelseskatalog."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Ugyldigt meddelelseskatalog."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Kunne ikke fortolke flertalsformer: \"%s\""
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "bruger katalog \"%s\" fra \"%s\"."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Ressource \"%s\" er ikke et gyldigt meddelelseskatalog."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Kunne ikke optælle oversættelser"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Intet standardprogram konfigureret for HTML-filer."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Kunne ikke åbne URL \"%s\" standard-browseren."
@@ -3904,7 +3929,7 @@ msgstr "\"%s\" indeholder ulovlige tegn"
 msgid "Error: %s (%d)"
 msgstr "Fejl: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3913,20 +3938,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Fil kunne ikke indlæses."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Denne platform understøtter ikke gennemsigtig baggrund."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Kunne ikke overføre data til vindue"
 
@@ -3978,8 +4003,8 @@ msgstr "Create-parameter %s ikke fundet i deklarerede RTTI-parametre"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Ulovlig Objektklasse (ikke-wxEvtHandler) som Event Source"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Type skal have enum - long-konvertering"
 
@@ -4029,79 +4054,79 @@ msgstr "Objekter skal have en id-attribut"
 msgid "Doubly used id : %d"
 msgstr "Id brugt to gange : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Ukendt egenskab %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "En samling som ikke er tom skal bestå af \"element\"-knuder"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "forkert event-handler-streng. Mangler punktum"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "kan ikke re-initialisere zlib deflate strøm"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "kan ikke re-initialisere zlib inflate strøm"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "antager at dette er en sammensat multi-part zip"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "ugyldig zip-fil"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "kan ikke finde den centrale mappe i zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "fejl ved læsning af centrale zip-mappe"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "fejl ved læsning af zip local header"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "forkert zip-fil offset til entry"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "gemt fillængde ikke i Zip-header"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "ikke-understøttet zip-komprimeringsmetode"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "læser zip-strøm (entry %s): forkert længde"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "læser zip-strøm (entry %s): forkert crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "fejl ved skrivning af zip-entry \"%s\": forkert crc eller længde"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "fejl ved skrivning af zip-entry \"%s\": forkert crc eller længde"
@@ -4185,32 +4210,32 @@ msgstr "Illustrationer af "
 msgid "Translations by "
 msgstr "Oversat af "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Om %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licens"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Udviklere"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Dokumentforfattere"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Kunstnere"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Oversættere"
 
@@ -4261,43 +4286,42 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "sand"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "falsk"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Række %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Fold sammen"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Fold ud"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d punkter)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Kolonne %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4308,8 +4332,7 @@ msgid "Left"
 msgstr "Venstre"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4405,7 +4428,7 @@ msgid "Home directory"
 msgstr "Hjemmemappe"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Skrivebord"
 
@@ -4418,8 +4441,7 @@ msgstr "Ulovligt mappenavn."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Fejl"
 
@@ -4603,16 +4625,16 @@ msgstr "Vis filer med detaljeretvisning"
 msgid "Go to parent directory"
 msgstr "Gå til overordnet mappe"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Filen \"%s\" findes allerede, vil du virkelig overskrive den?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Bekræft"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Vælg venligst en eksisterende fil."
 
@@ -4706,7 +4728,7 @@ msgstr "Skriftens punktstørrelse."
 msgid "Whether the font is underlined."
 msgstr "Om skriften er understreget."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Udskriftsvisning:"
@@ -4724,48 +4746,47 @@ msgstr "Klik for at annullere valg af skrifttype."
 msgid "Click to confirm the font selection."
 msgstr "Klik for at bekræfte valg af skrifttype."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Vælg skrifttype"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Hjælp-mappen \"%s\" ikke fundet."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Hjælp-filen \"%s\" ikke fundet."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Linje %lu i map-filen \"%s\" har ugyldig syntaks, sprunget over."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ingen gyldige kortlægninger fundet i filen \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Ingen indgange fundet."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Hjælp-indeks"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevante indgange:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Indgange fundet"
 
@@ -4869,59 +4890,59 @@ msgstr "Kunne ikke starte udskrivning."
 msgid "Printing page %d..."
 msgstr "Udskriver side %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Printervalg"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Udskriv til fil"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Opsætning..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Printer:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Alle"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Sider"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Udskriv sider"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Fra:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Til:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopier:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript-fil"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Udskriftsopsætning"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Printer"
 
@@ -4929,25 +4950,25 @@ msgstr "Printer"
 msgid "Default printer"
 msgstr "Standardprinter"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Papirstørrelse"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Opretstående"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Liggende"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientering"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Indstillinger"
 
@@ -4959,52 +4980,52 @@ msgstr "Udskriv i farver"
 msgid "Print spooling"
 msgstr "Udskriftsspooling"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Printerkommando:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Printervalg:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Venstre margen (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Topmargen (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Højre margen (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Bundmargen (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Printer..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Spring over"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Ukendt"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Færdig."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Søg"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Kunne ikke finde tab til id"
 
@@ -5040,22 +5061,22 @@ msgstr "&Slut"
 msgid "< &Back"
 msgstr "< &Tilbage"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "scootergrisen"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Kunne ikke initialisere GTK+. Er DISPLAY sat korrekt?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Kunne ikke ændre den aktuelle mappe til \"%s\""
@@ -5081,12 +5102,12 @@ msgstr "Kunne ikke læse dokument fra filen \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Kunne ikke opdatere brugerkonfigurationsfil."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Filfejl"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5094,7 +5115,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5102,7 +5123,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI-barn"
 
@@ -5118,15 +5139,11 @@ msgstr "Fejl under udskrift: "
 msgid "Page Setup"
 msgstr "Sideopsætning"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Kunne ikke indsætte tekst i kontrollen."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5134,7 +5151,7 @@ msgstr ""
 "Den GTK+, som er installeret maskine, er for gammel til at understøtte "
 "skærmkomposition. Installer venligst GTK+ 2.12 eller senere."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5142,17 +5159,13 @@ msgstr ""
 "Komposition understøttes ikke af dette system. Slå det venligst til i din "
 "vindueshåndtering."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Dette program blev kompileret med en for gammel version af GTK+. Genbyg "
 "venligst med GTK+ 2.12 eller nyere."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Vælg venligst en gyldig skrifttype."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5251,45 +5264,45 @@ msgstr "Kan ikke åbne indholdsfilen: %s"
 msgid "Cannot open index file: %s"
 msgstr "Kan ikke åbne indeksfilen %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "unavngivet"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Kan ikke åbne HTML Hjælp-bog: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Viser hjælp mens du gennemser bøgerne til venstre."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(bogmærker)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Tilføj denne side til bogmærker"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Fjern den aktuelle side fra bogmærkerne"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Indhold"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Find"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Vis alle"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5297,165 +5310,165 @@ msgstr ""
 "Vis alle indeksemner, der indeholder understrengen. Ingen forskel på store "
 "og små bogstaver."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Vis alle punkter i indeks"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Forskel på store og små bogstaver"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Kun hele ord"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Søg i hjælp-bøger efter alle forekomster af den indtastede tekst"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Vis/skjul navigationspanel"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Tilbage"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Frem"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Et niveau op i dokument hierarkiet"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Åbn HTML-dokument"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Udskriv denne side"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Vis dialogen Indstillinger"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Vælg siden der skal vises:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Hjælp-emner"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Søger..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Fandt ingen passende side endnu"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Fandt %i matchende"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(hjælp)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d af %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu af %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Søg i alle bøger"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Hjælp til browserindstillinger"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normal skrift:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fast type:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Skriftstørrelse:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "skriftstørrelse"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal skrift<br>og <u>understreget</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursiv skrift.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Fed skrift.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Fed kursiv skrift.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Fast skriftstørrelse.<br> <b>fed</b> <i>kursiv</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>fed kursiv <u>understreget</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Hjælp til udskrift"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Kan ikke udskrive tom side."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-filer (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hjælp-bøger (*.htb)|*.htb|Hjælp-bøger (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Hjælp-projekt (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimeret HTML Hjælp-fil (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i af %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u af %u"
@@ -5534,32 +5547,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "Problem ved sideopsætning: du skal muligvis vælge en standardprinter."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Kunne ikke vise HTML-dokument i %s-kodning"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets kunne ikke åbne skærmen for \"%s\": afslutter."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filter"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Mapper"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Filer"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Markering"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Kunne ikke åbne udklipsholder."
@@ -5601,58 +5588,58 @@ msgstr "Dialogen Valg af farver fejlede med fejlkode %0lx."
 msgid "Failed to create cursor."
 msgstr "Kunne ikke oprette markør."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Kunne ikke registrere DDE-serveren \"%s\""
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Kunne ikke afregistrere DDE-serveren \"%s\""
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Kunne ikke oprette forbindelse til serveren \"%s\" ang. emne \"%s\""
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE-poke anmodning fejlede"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Kunne ikke oprette advice loop med DDE-server"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Kunne ikke afslutte advice loop med DDE-server"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Kunne ikke sende DDE-advice påmindelse"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Kunne ikke oprette DDE-streng"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "ingen DDE-fejl."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "en anmodning om synkron advise-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "svaret på transaktionen bevirkede, at bitten DDE_FBUSY blev sat."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "en anmodning om en synkron data-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5663,7 +5650,7 @@ msgstr ""
 "eller der er sendt en ugyldig instans\n"
 "indentifikator til en DDEML-funktion."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5675,43 +5662,43 @@ msgstr ""
 "eller et program initialiseret som APPCMD_CLIENTONLY\n"
 "har forsøgt at udføre server-transaktioner."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "en anmodning om en synkron execute-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "en parameter kunne ikke valideres af DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "en DDEML-applikation har lavet en forlænget race condition."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "en hukommelsestildeling fejlede."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "en klients forsøg på at starte en samtale slog fejl."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "en transaktion fejlede."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "en anmodning om en synkron poke-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "et internt kald til PostMessage-funktionen fejlede. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "reentrancy problem."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5721,15 +5708,15 @@ msgstr ""
 "der blev afsluttet af klienten, eller serveren afsluttede\n"
 "inden fuldførslen af en transaktion."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "intern fejl opstået i DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "en anmodning om at afslutte en advise-transaktion fik timeout."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5739,12 +5726,12 @@ msgstr ""
 "Når programmet er returneret fra et XTYP_XACT_COMPLETE-tilbagekald,\n"
 "er transaktion identifikationen for dette tilbagekald ikke længere gyldig."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Ukendt DDE-fejl %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5752,7 +5739,7 @@ msgstr ""
 "Opkaldsfunktion er ikke tilgængelig, fordi Remote Access Service (RAS) ikke "
 "er installeret på computeren. Installer det venligst."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5762,64 +5749,64 @@ msgstr ""
 "computer, er for gammel, opgradering anbefales. (følgende nødvendige "
 "funktion mangler: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Kunne ikke hente tekst fra RAS fejlmeddelelse"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "ukendt fejl (fejlkode %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kan ikke finde aktiv netværk via modem forbindelse: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Har fundet flere netværk via modem forbindelser, vælger en tilfældig."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Kunne ikke etablere netværk via modem forbindelse: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Kunne ikke få ISP-navne: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Kunne ikke oprette forbindelse: ingen ISP at foretage opkald til."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Vælg ISP til opkald"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Vælg venligst den ISP, du vil oprette forbindelse til"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Kunne ikke oprette forbindelse: mangler brugernavn/adgangskode."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Kan ikke finde placering af adressebog filen"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Kunne ikke initialisere netværk via modem forbindelse: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kan ikke afbryde - ingen aktiv netværk via modem forbindelse."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Kunne ikke afslutte netværk via modem forbindelse: %s"
@@ -5839,18 +5826,17 @@ msgstr "Kunne ikke allokere %luKb hukommelse til bitmap data."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kan ikke få liste af filer i mappen \"%s\""
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Kunne ikke få fat i mappenavn"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (fejl %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Kunne ikke tilføje et billede til billedlisten."
 
@@ -5864,7 +5850,7 @@ msgstr "Kunne ikke indlæse metafil fra filen \"%s\"."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Kunne ikke oprette den almindelige søg/erstat dialog (fejlkode %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Fildialog fejlede med fejlkode %0lx."
@@ -5906,16 +5892,16 @@ msgstr "Kunne ikke opsætte overvågning af \"%s\""
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan ikke overvåge den ikke-eksisterende mappe \"%s\" for ændringer."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 eller senere understøttes ikke af OpenGL-driveren."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Kunne ikke oprette OpenGL-kontekst"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Kunne ikke initialisere OpenGL"
 
@@ -5923,7 +5909,7 @@ msgstr "Kunne ikke initialisere OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5931,7 +5917,7 @@ msgstr ""
 "MS HTML Hjælp-funktioner er ikke tilgængelig fordi MS HTML Hjælp-biblioteket "
 "ikke er installeret på denne computer. Vi foreslår at installere det."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Kunne ikke initialisere MS HTML Hjælp."
 
@@ -5940,7 +5926,7 @@ msgstr "Kunne ikke initialisere MS HTML Hjælp."
 msgid "Can't delete the INI file '%s'"
 msgstr "Kan ikke slette INI-filen \"%s\""
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kunne ikke hente information om listekontrolemne %d."
@@ -6060,7 +6046,7 @@ msgstr "Kunne ikke registrere udklipsholderformatet \"%s\"."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Udklipsholderformat \"%d\" findes ikke."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Spring over"
 
@@ -6145,59 +6131,59 @@ msgstr ""
 "hvis du sletter den vil efterlade dit system i ubrugelig tilstand:\n"
 "operationen blev afbrudt."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kan ikke slette nøglen \"%s\""
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kan ikke slette værdi \"%s\" fra nøglen \"%s\""
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kan ikke læse værdien af nøglen \"%s\""
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kan ikke sætte værdien af \"%s\""
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Registreringsværdien \"%s\" er ikke numerisk (men af typen %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Registreringsværdien \"%s\" er ikke binær (men af typen %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Registreringsværdien \"%s\" er ikke tekst (men af typen %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kan ikke læse værdien af \"%s\""
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kan ikke få en liste af værdierne fra nøglen \"%s\""
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kan ikke få liste af undernøgler til nøglen \"%s\""
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6205,17 +6191,17 @@ msgstr ""
 "Eksporterer registernøgle: filen \"%s\" findes allerede og vil ikke blive "
 "overskrevet."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kan ikke eksportere værdi af ikke-understøttet type %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorerer værdien \"%s\" i nøglen \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6223,41 +6209,41 @@ msgstr ""
 "Kunne ikke oprette rich edit-kontrol, bruger i stedet en simpel "
 "tekstkontrol. Geninstallér venligst riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kan ikke starte tråd: fejl ved skrivning af TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Kan ikke sætte trådprioritet"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Kan ikke oprette tråd"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Kunne ikke afslutte tråd"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Kan ikke vente på afslutning af tråd"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kan ikke suspendere tråd %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kan ikke genoptage tråd %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Kunne ikke få aktuelle trådpointer"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6265,7 +6251,7 @@ msgstr ""
 "Trådmodul initialisering fejlede: umuligt at allokere indeks i trådens "
 "private lager"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6296,12 +6282,12 @@ msgstr "Kunne ikke indlæse ressource \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Kunne ikke låse ressource \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "byg %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bit-udgave"
 
@@ -6313,47 +6299,47 @@ msgstr "Kunne ikke oprette anonym pipe"
 msgid "Failed to redirect the child process IO"
 msgstr "Kunne ikke omdirigere input/output fra underproces"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Afvikling af kommandoen \"%s\" fejlede"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Kunne ikke åbne mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kan ikke læse typenavn fra \"%s\"!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kan ikke hente ikon fra \"%s\"."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Kan ikke sætte trådprioritet"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Kunne ikke eksekvere \"%s\"\n"
@@ -6387,7 +6373,7 @@ msgid "Check to make the font italic."
 msgstr "Slå til for at gøre teksten kursiv."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Understreget"
@@ -6455,17 +6441,32 @@ msgstr "<Teletype>"
 msgid "File type:"
 msgstr "Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Vindue"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hjælp"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimér"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zoom ind"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6482,492 +6483,492 @@ msgstr ": filen findes ikke!"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Om %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Om..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Indstillinger..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Tjenester"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Skjul %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Program"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Skjul andre"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Vis alle"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Afslut %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Program"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip understøttes ikke af denne version af zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Punktstørrelse"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Skriftnavn"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Typografi"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Vægt"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "Program arbejdsområde"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "Aktiv kant"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "Aktiv overskrift"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "Knap ansigt"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "Knap fremhævning"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "Knap skygge"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "Knap tekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "Overskrifttekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "Kontrol mørk"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "Kontrol lys"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "Grå tekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Fremhæv"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Fremhævet tekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "Inaktiv kant"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "Inaktiv overskrift"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "Inaktiv overskrifttekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Rullebjælke"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Værktøjstip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "Tekst til værktøjstip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Vindue"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "Vinduesramme"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "Vinduestekst"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Speciel"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Sort"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Rødbrun"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Marineblå"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Lilla"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Grønblå"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Grå"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Grøn"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Oliven"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Brun"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Blå"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuchsiafarvet"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Rød"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Orange"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Sølv"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Limegrøn"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Akvamarin"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Gul"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Hvid"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Standard"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Pil"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Højre-pil"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Tom"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Bullseye"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Tegn"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Kryds"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Hånd"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "Lodret streg"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Venstre knap"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Forstørrelsesglas"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Midterknap"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Ingen adgang"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Malerpensel"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Pen"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Peg-venstre"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Peg-højre"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Spørgsmålspil"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Højre knap"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Størrelse NØ-SV"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Størrelse N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Størrelse NV-SØ"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Størrelse V-Ø"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Størrelse"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Spraydåse"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Vent"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Overvåg"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Ventepil"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Foretag et valg:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Egenskab"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Værdi"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategoritilstand"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alfabetisk mode"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falsk"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Sand"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Uspecificeret"
 
@@ -6981,50 +6982,50 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Du har indtastet en ugyldig værdi. Tryk på ESC for at annullere redigeringen."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Fejl i ressource: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
-"Type-operation \"%s\" fejlede: egenskab med navnet \"%s\" er af typen \"%s"
-"\", ikke \"%s\"."
+"Type-operation \"%s\" fejlede: egenskab med navnet \"%s\" er af typen "
+"\"%s\", ikke \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Værdien skal være %s eller højere."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Værdien skal være mellem %s og %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Værdien skal være %s eller lavere."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Ikke %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Vælg mappe:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Vælg en fil"
 
@@ -7491,117 +7492,117 @@ msgstr "Sænket"
 msgid "Outset"
 msgstr "Start"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Skift typografi"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Skift objekttypografi"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Rediger egenskaber"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Skift listetypografi"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renummerer liste"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Indsæt tekst"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Indsæt billede"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Indsæt objekt"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Indsæt felt"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "For mange EndStyle-kald!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "filer"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standard/cirkel"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standard/cirkel-omrids"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standard/firkant"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standard/trekant"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Boks-egenskaber"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Egenskaber for flere celler"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Celleegenskaber"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Indstil celletypografi"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Slet række"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Slet kolonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Tilføj række"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Tilføj kolonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Tabel-egenskaber"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Billedegenskaber"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "billede"
 
@@ -7809,24 +7810,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Træk"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Slet tekst"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Fjern punkttegn"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Teksten kunne ikke gemmes."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Erstat"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Skrift:"
 
@@ -8795,53 +8796,53 @@ msgstr "Listetypografier"
 msgid "Box styles"
 msgstr "Bokstypografier"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Skrifttypen hvorfra symbolet skal tages."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Del af tegnsæt:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Viser en del af Unicode-tegnsættet."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Tegnkode:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Tegnkode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Fra:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Område, der skal vises."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Indsæt"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(normal tekst)"
 
@@ -9027,7 +9028,7 @@ msgstr "Kunne ikke hente events fra kø"
 msgid "Media playback error: %s"
 msgstr "Medieafspilningsfejl: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Kunne ikke forberede afspilning af \"%s\"."
@@ -9127,20 +9128,20 @@ msgstr "Lyddata er i et ikke understøttet format."
 msgid "Couldn't open audio: %s"
 msgstr "Kunne ikke åbne lyd: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kan ikke hente trådafviklingsalgoritme."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Kan ikke få prioritetsområde for afviklingsalgoritme %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Prioritetsindstilling for tråd ignoreret."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9148,58 +9149,58 @@ msgstr ""
 "Kunne ikke slutte til en tråd, muligt hukommelsestab registreret - genstart "
 "venligst programmet"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Kunne ikke sætte tråd-samtidighed-niveau til %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Kunne ikke sætte trådprioritet %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Kunne ikke afslutte en tråd."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Trådmodul initialisering fejlede: kunne ikke oprette trådnøgle"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Kunne ikke få input til underproces"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Kan ikke skrive til barneprocesens stdin"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Kunne ikke eksekvere \"%s\"\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Fork fejlede"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Kunne ikke sætte procesprioritet"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Kunne ikke omdirigere input/output fra underproces"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Kunne ikke opsætte ikke-blokerende pipe. Programmet hænger muligvis."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Kan ikke finde værtsnavn"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Kan ikke finde det officielle værtsnavn"
 
@@ -9215,12 +9216,12 @@ msgstr "Kunne ikke skifte wake up pipe til ikke-blokerende-tilstand"
 msgid "Failed to read from wake-up pipe"
 msgstr "Kunne ikke læse fra wake-up pipe"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Ugyldig geometrispecifikation \"%s\""
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets kunne ikke åbne skærmen. Afslutter."
 
@@ -9234,30 +9235,59 @@ msgstr "Kunne ikke lukke skærmen \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Kunne ikke åbne skærmen \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML tolkningsfejl: \"%s\" på linje %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kan ikke indlæse ressourcer fra \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kan ikke åbne ressourcefilen \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kan ikke indlæse ressourcer fra filen \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Oprettelse af %s \"%s\" fejlede."
+
+#~ msgid "Printing "
+#~ msgstr "Udskriver "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Kunne ikke indsætte tekst i kontrollen."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Vælg venligst en gyldig skrifttype."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Kunne ikke vise HTML-dokument i %s-kodning"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets kunne ikke åbne skærmen for \"%s\": afslutter."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Mapper"
+
+#~ msgid "Files"
+#~ msgstr "Filer"
+
+#~ msgid "Selection"
+#~ msgstr "Markering"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "konvertering til 8-bit kodning fejlede"

--- a/locale/de.po
+++ b/locale/de.po
@@ -8,18 +8,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: wxWidgets 3.1.6\n"
+"Project-Id-Version: wxWidgets 3.3.x\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-02-06 16:05+0100\n"
-"PO-Revision-Date: 2022-04-09 12:47+0200\n"
-"Last-Translator: Milo Ivir <mail@milotype.de>\n"
+"PO-Revision-Date: 2023-02-06 17:46+0100\n"
+"Last-Translator: Ulrich Telle <ulrich@telle-online.eu>\n"
 "Language-Team: wxWidgets Team <wx-dev@wxwidgets.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
-"X-Generator: Poedit 2.4.3\n"
+"X-Generator: Poedit 3.2.2\n"
 
 #: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
@@ -1108,35 +1108,33 @@ msgstr "&Speichern"
 
 #: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
 msgid "&Discard changes"
-msgstr ""
+msgstr "Änderungen &Verwerfen"
 
 #: ../src/common/docview.cpp:524
-#, fuzzy
 msgid "Do&n't close"
-msgstr "Nicht speichern"
+msgstr "Nicht schließen"
 
 #: ../src/common/docview.cpp:554
-#, fuzzy, c-format
+#, c-format
 msgid "Do you want to save changes to %s before closing it?"
-msgstr "Möchten Sie die Änderungen nach %s speichern?"
+msgstr "Möchten Sie die Änderungen vor dem Schließen nach %s speichern?"
 
 #: ../src/common/docview.cpp:560
-#, fuzzy
 msgid "The document must be closed."
-msgstr "Der Text konnte nicht gespeichert werden."
+msgstr "Das Dokument muss geschlossen werden."
 
 #: ../src/common/docview.cpp:572
 #, c-format
 msgid "Saving %s failed, would you like to retry?"
-msgstr ""
+msgstr "Speichern %s fehlgeschlagen, wollen Sie es erneut versuchen?"
 
 #: ../src/common/docview.cpp:578
 msgid "Retry"
-msgstr ""
+msgstr "Erneut versuchen"
 
 #: ../src/common/docview.cpp:578
 msgid "Discard changes"
-msgstr ""
+msgstr "Änderungen verwerfen"
 
 #: ../src/common/docview.cpp:680
 #, c-format
@@ -2217,6 +2215,8 @@ msgstr "DIB-Header: Kodierung entspricht nicht der Bittiefe."
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
+"BMP: Kopfeintrag hat das Attribut biClrUsed=%d wobei Attribut biBitCount=%d "
+"ist."
 
 #: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
@@ -3946,9 +3946,8 @@ msgid "libcurl could not be initialized"
 msgstr "libcurl konnte nicht initialisiert werden"
 
 #: ../src/common/webview.cpp:334
-#, fuzzy
 msgid "RunScriptAsync not supported"
-msgstr "Umwandlung in Zeichenkette wird nicht unterstützt"
+msgstr "RunScriptAsync wird nicht unterstützt"
 
 #: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
@@ -6516,34 +6515,29 @@ msgid "File type:"
 msgstr "Dateityp:"
 
 #: ../src/osx/cocoa/menu.mm:243
-#, fuzzy
 msgctxt "macOS menu name"
 msgid "Window"
 msgstr "Fenster"
 
 #: ../src/osx/cocoa/menu.mm:260
-#, fuzzy
 msgctxt "macOS menu name"
 msgid "Help"
 msgstr "Hilfe"
 
 #: ../src/osx/cocoa/menu.mm:299
-#, fuzzy
 msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimieren"
 
 #: ../src/osx/cocoa/menu.mm:304
-#, fuzzy
 msgctxt "macOS menu item"
 msgid "Zoom"
-msgstr "Vergrößern"
+msgstr "Zoomen"
 
 #: ../src/osx/cocoa/menu.mm:310
-#, fuzzy
 msgctxt "macOS menu item"
 msgid "Bring All to Front"
-msgstr "Alles nach vorne bringen"
+msgstr "Alle nach vorne bringen"
 
 #: ../src/osx/core/sound.cpp:143
 #, c-format
@@ -6592,10 +6586,9 @@ msgid "Hide %s"
 msgstr "%s ausblenden"
 
 #: ../src/osx/menu_osx.cpp:522
-#, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
-msgstr "Anwendung"
+msgstr "Anwendung ausblenden"
 
 #: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
@@ -6614,10 +6607,9 @@ msgid "Quit %s"
 msgstr "%s beenden"
 
 #: ../src/osx/menu_osx.cpp:536
-#, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
-msgstr "Anwendung"
+msgstr "Anwendung beenden"
 
 #: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
@@ -6865,174 +6857,146 @@ msgid "White"
 msgstr "Weiß"
 
 #: ../src/propgrid/advprops.cpp:1642
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Standard"
 
 #: ../src/propgrid/advprops.cpp:1643
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Pfeil"
 
 #: ../src/propgrid/advprops.cpp:1644
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Rechts-Pfeil"
 
 #: ../src/propgrid/advprops.cpp:1645
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Leer"
 
 # Sieht aus wie das innere Feld bei Darts
 #: ../src/propgrid/advprops.cpp:1646
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
-msgstr "Bullseye"
+msgstr "Zielscheibe"
 
 #: ../src/propgrid/advprops.cpp:1647
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Zeichen"
 
 #: ../src/propgrid/advprops.cpp:1648
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Kreuz"
 
 #: ../src/propgrid/advprops.cpp:1649
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Hand"
 
 #: ../src/propgrid/advprops.cpp:1650
-#, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "Profilstahl"
 
 #: ../src/propgrid/advprops.cpp:1651
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Links-Taste"
 
 #: ../src/propgrid/advprops.cpp:1652
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Lupe"
 
 #: ../src/propgrid/advprops.cpp:1653
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Mittlere Taste"
 
 #: ../src/propgrid/advprops.cpp:1654
-#, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Kein Eintrag"
 
 #: ../src/propgrid/advprops.cpp:1655
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Pinsel"
 
 #: ../src/propgrid/advprops.cpp:1656
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Stift"
 
 #: ../src/propgrid/advprops.cpp:1657
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Punkt links"
 
 #: ../src/propgrid/advprops.cpp:1658
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Punkt rechts"
 
 #: ../src/propgrid/advprops.cpp:1659
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Fragepfeil"
 
 #: ../src/propgrid/advprops.cpp:1660
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Rechts-Taste"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von NO nach SW zeigen
 #: ../src/propgrid/advprops.cpp:1661
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Größenänderung NO-SW"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von Norden nach Süden zeigen
 #: ../src/propgrid/advprops.cpp:1662
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Größenänderung N-S"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von NW nach SO zeigen
 #: ../src/propgrid/advprops.cpp:1663
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Größenänderung NW-SO"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von W nach O zeigen
 #: ../src/propgrid/advprops.cpp:1664
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Größenänderung W-O"
 
 #: ../src/propgrid/advprops.cpp:1665
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Größenänderung"
 
 #: ../src/propgrid/advprops.cpp:1666
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Sprühdose"
 
 #: ../src/propgrid/advprops.cpp:1667
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "﻿Warten"
 
 #: ../src/propgrid/advprops.cpp:1668
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Uhr"
 
 #: ../src/propgrid/advprops.cpp:1669
-#, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Wartepfeil"

--- a/locale/de.po
+++ b/locale/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1.6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-04-09 12:47+0200\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: wxWidgets Team <wx-dev@wxwidgets.org>\n"
@@ -21,11 +21,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Generator: Poedit 2.4.3\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Alle Dateien (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Alle Dateien (*)|*"
 
@@ -42,24 +42,21 @@ msgid "Remaining time:"
 msgstr "Verbleibende Zeit:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nein"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -109,7 +106,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Der I/O-Completion-Port konnte nicht erstellt werden"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Ausdruck"
 
@@ -146,7 +143,7 @@ msgstr "Objekteigenschaften"
 msgid "Printing"
 msgstr "Drucken"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symbole"
 
@@ -215,7 +212,7 @@ msgstr "&Zurück"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Fenster"
 
@@ -746,11 +743,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "Zeige diesen Hilfstext"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "ausführliche Log-Nachrichten erstellen"
 
@@ -773,84 +770,84 @@ msgstr "Unbekanntes Thema „%s“."
 msgid "Invalid display mode specification '%s'."
 msgstr "Ungültige Angabe „%s“ des Displays."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Option „%s“ konnte nicht negiert werden"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Unbekannte „long“-Option „%s“"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Unbekannte Option „%s“"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Unerwartete Zeichen folgen der Option „%s“."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Option „%s“ erwartet einen Wert."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Trennungszeichen nach der Option „%s“ erwartet."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "„%s“ ist kein gültiger numerischer Wert für Option „%s“."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Option „%s“: „%s“ kann nicht in ein Datum umgewandelt werden."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Unerwarteter Parameter „%s“"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (oder %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Der Wert für die Option „%s“ muss angegeben werden."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Der benötigte Parameter „%s“ wurde nicht angegeben."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Verwendung: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "Doppelte Genauigkeit"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "Datum"
 
@@ -868,7 +865,7 @@ msgid "Can't &Undo "
 msgstr "K&ann nicht rückgängig machen "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Rückgängig"
@@ -878,7 +875,7 @@ msgid "&Redo "
 msgstr "&Wiederholen "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Wiederholen"
@@ -909,12 +906,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "„%s“ hat extra „..“, ignoriert."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "ausgewählt"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "nicht ausgewählt"
 
@@ -923,103 +920,103 @@ msgstr "nicht ausgewählt"
 msgid "undetermined"
 msgstr "untentschieden"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "heute"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "Gestern"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "morgen"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "erste"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "zweite"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "dritte"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "vierte"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "fünfte"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sechste"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "siebte"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "achte"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "neunte"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "zehnte"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "elfte"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "zwölfte"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "dreizehnte"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "vierzehnte"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "fünfzehnte"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "sechzehnte"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "siebzehnte"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "achtzehnte"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "neunzehnte"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "zwanzigste"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "mittags"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "Mitternacht"
 
@@ -1087,44 +1084,81 @@ msgstr "Konnte curl nicht starten, bitte im PATH installieren."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Konnte den Fehlerbericht nicht hochladen (Fehlercode %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Speichern unter"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Änderungen verwerfen und letzte gesicherte Version laden?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "Unbenannt"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Möchten Sie die Änderungen nach %s speichern?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Speichern"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nicht speichern"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Möchten Sie die Änderungen nach %s speichern?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Der Text konnte nicht gespeichert werden."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Die Datei „%s“ konnte nicht zum Schreiben geöffnet werden."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Das Dokument konnte nicht in die Datei „%s“ gesichert werden."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Die Datei „%s“ konnte nicht zum Lesen geöffnet werden."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Konnte Dokument aus der Datei „%s“ nicht lesen."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1133,57 +1167,57 @@ msgstr ""
 "Die Datei „%s“ existiert nicht und konnte nicht geöffnet werden.\n"
 "Sie wurde aus der Liste kürzlich verwendeter Dateien entfernt."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Erzeugung der Druckvorschau fehlgeschlagen."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Druckvorschau"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Das Format der Datei „%s“ konnte nicht bestimmt werden."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "Unbenannt%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Datei öffnen"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Dateifehler"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Datei konnte nicht geöffnet werden."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Unbekanntes Dateiformat."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Dokument-Vorlage wählen"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Vorlagen"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Dokument-Anzeige („View“) wählen"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Darstellung"
 
@@ -1217,43 +1251,43 @@ msgstr "Lesefehler in Datei „%s“"
 msgid "Write error on file '%s'"
 msgstr "Schreibfehler bei Datei „%s“"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "Versuch, die Datei „%s“ zu entladen, fehlgeschlagen"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Positionierungsfehler bei Datei „%s“ (große Dateien werden nicht von stdio "
 "unterstützt)."
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Suchfehler in Datei „%s“"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kann aktuelle Position in Datei „%s“ nicht finden."
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Konnte die Zugriffsrechte der temporären Datei nicht setzen"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "Kann Datei „%s“ nicht löschen"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "Kann Änderungen in Datei „%s“ nicht sichern"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "Kann temporäre Datei „%s“ nicht löschen"
@@ -1278,27 +1312,27 @@ msgstr "Kann Dateibeschreibung „%d“ nicht lesen"
 msgid "can't write to file descriptor %d"
 msgstr "Kann auf Dateibeschreibung „%d“ nicht schreiben"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "Kann auf die Dateibeschreibung „%d“ nicht entladen"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "Kann auf der Dateibeschreibung „%d“ nicht suchen"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "Kann auf die Dateibeschreibung %d nicht positionieren"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "Kann auf Dateibeschreibung „%d“ die Dateilänge nicht finden"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1326,110 +1360,110 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Fehler beim Parsen der Optionen."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Lesen der Konfigurationsoptionen fehlgeschlagen."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "Datei „%s“: unerwartetes Zeichen %c in Zeile %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "Datei „%s“, Zeile %zu: „%s“ hinter Gruppenkopf ignoriert."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "Datei „%s“, Zeile %zu: „=“ erwartet."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "Datei „%s“, Zeile %zu: Wert für nicht-änderbaren Eintrag „%s“ ignoriert."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "Datei „%s“, Zeile %zu: Eintrag „%s“ taucht erstmals in Zeile %d auf."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 "Die Bezeichnung des Konfigurations-Eintrags kann nicht mit „%c“ beginnen."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "Kann Benutzer-Konfigurationsdatei nicht öffnen."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "Kann Benutzer-Konfigurationsdatei nicht schreiben."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Kann Benutzer-Konfigurationsdatei nicht aktualisieren."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Fehler beim Speichern der Benutzer-Optionen."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "Kann Konfigurationsdatei „%s“ nicht löschen"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "Eintrag „%s“ erscheint in Gruppe „%s“ mehrfach"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 "Versuch den unveränderlichen Schlüssel „%s“ anzupassen wurde ignoriert."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "Abschließenden Gegenschrägstrich in „%s“ ignoriert"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "unerwartetes \" an Position %d in „%s“."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Konnte die Datei „%s“ nicht nach „%s“ kopieren"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Konnte die Zugriffsrechte der Datei „%s“ nicht ermitteln"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Versuch die Datei „%s“ zu überschreiben, fehlgeschlagen"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Fehler beim Speichern der Datei „%s“ nach „%s“."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Konnte die Zugriffsrechte für Datei „%s“ nicht setzen"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1438,40 +1472,40 @@ msgstr ""
 "Umbenennen der Datei „%s“ nach „%s“ fehlgeschlagen, da die Zieldatei bereits "
 "existiert."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Die Datei „%s“ konnte nicht nach „%s“ umbenannt werden."
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Die Datei „%s“ konnte nicht gelöscht werden"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Verzeichnis „%s“ konnte nicht angelegt werden"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Verzeichnis „%s“ konnte nicht gelöscht werden"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kann Dateien „%s“ nicht auflisten"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Konnte Arbeitsverzeichnis nicht ermitteln"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Konnte das Arbeitsverzeichnis nicht setzen"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Dateien (%s)"
@@ -1498,17 +1532,17 @@ msgstr "Konnte keinen temporären Dateinamen erstellen"
 msgid "Failed to open temporary file."
 msgstr "Konnte temporäre Datei nicht öffnen."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Konnte Zugriffszeit von Datei „%s“ nicht ändern"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Konnte die Datei „%s“ nicht „berühren“"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Konnte Zugriffszeit von Datei „%s“ nicht ermitteln"
@@ -1517,22 +1551,22 @@ msgstr "Konnte Zugriffszeit von Datei „%s“ nicht ermitteln"
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle Dateien (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s-Dateien (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "%s-Datei laden"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Datei %s speichern"
@@ -1895,99 +1929,99 @@ msgstr "Standard"
 msgid "unknown-%d"
 msgstr "unbekannt-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "unterstrichen"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " durchgestrichen"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " dünn"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " sehr dünn"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " dünn"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " mittel"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " halbfett"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " fett"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " sehr fett"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " heavy"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " sehr schwer"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kursiv"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "Durchstreichen"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "dünn"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "extra dünn"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "dünn"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "mittel"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "halbfett"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "fett"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "sehr fett"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "schwer"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "sehr schwer"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kursiv"
 
@@ -2073,7 +2107,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Konnte den FTP-Transfermodus nicht auf „%s“ setzen."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2094,7 +2128,7 @@ msgstr "Der FTP-Server unterstützt keinen passiven Transfermodus."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Ungültige GIF Bildgröße (%u, %d) für das Bild #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Anforderung von Farbe für OpenGL fehlgeschlagen"
 
@@ -2111,7 +2145,7 @@ msgstr "Spalten anpassen"
 msgid "&Customize..."
 msgstr "&Anpassen …"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Konnte die URL „%s“ nicht im voreingestellten Browser öffnen"
@@ -2131,157 +2165,156 @@ msgstr "Konnte das Bild %d aus dem Strom nicht laden."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Konnte die Symbole aus der Ressource „%s“ nicht laden."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Konnte ungültiges Bild nicht speichern."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage hat keine eigene wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Dateikopf (Bitmap) konnte nicht geschrieben werden."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Dateikopf (BitmapInfo) konnte nicht geschrieben werden."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Konnte RGB Farbtabelle nicht speichern."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Konnte Daten nicht speichern."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Speicheranforderung fehlgeschlagen."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB-Header: Bildbreite > 32767 Pixel."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB-Header: Bildhöhe > 32767 Pixel."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB-Header: Unbekannte Bittiefe."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB-Header: Unbekannte Kodierung."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB-Header: Kodierung entspricht nicht der Bittiefe."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Speicheranforderung fehlgeschlagen."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB-Header: Bildbreite > 32767 Pixel."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB-Header: Bildhöhe > 32767 Pixel."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB-Header: Unbekannte Bittiefe."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB-Header: Unbekannte Kodierung."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB-Header: Kodierung entspricht nicht der Bittiefe."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Fehler beim Lesen des DIB-Bildes."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Fehler beim Lesen der DIB-Maske."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Bild zu groß für ein Icon."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Bild zu breit für ein Icon."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Schreibfehler beim Speichern!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ungültiger Icon-Index."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Bild und Bildmaske haben verschiedene Größen."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Keine unbenutzte Farbe wurde im Bild unterdrückt."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Konnte das Bitmap „%s“ aus der Ressource nicht laden."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Konnte das Symbol „%s“ aus der Ressource nicht laden."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Konnte das Bild aus der Datei „%s“ nicht laden."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kann Bild nicht aus Datei „%s“ laden: Unbekannte Dateiendung."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Dieses Bildformat wird nicht unterstützt."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Bildformat %d wurde nicht definiert."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Bilddatei hat nicht den Typ %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Das Bildformat für nicht durchsuchbare Eingabe kann nicht automatisch "
 "bestimmt werden."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Unbekanntes Bilddateiformat."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Dies ist kein %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Bildformat %s wurde nicht definiert."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Bilddatei hat nicht den Typ %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Überprüfung des Formats der Bilddatei „%s“ fehlgeschlagen."
@@ -2384,41 +2417,41 @@ msgstr "PNM: Datei wurde abgeschnitten."
 msgid " (in module \"%s\")"
 msgstr " (im Modul „%s“)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Fehler beim Laden des Bildes."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Ungültiger Index des TIFF-Bilds."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Bildgröße ist außergewöhnlich groß."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Speicheranforderung fehlgeschlagen."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Fehler beim Lesen des Bildes."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unbekannte TIFF-Auflösungseinheit %d ignoriert"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Schreibfehler beim Speichern."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Schreibfehler beim Speichern."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2427,11 +2460,11 @@ msgstr ""
 "Kommandozeilenargument %d konnte nicht nach Unicode konvertiert werden und "
 "wird ignoriert."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Initialisierung in „post init“ fehlgeschlagen, breche ab."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Lokalisierung kann nicht auf die Sprache „%s“ gesetzt werden."
@@ -2532,7 +2565,7 @@ msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 "EIn LZMA-Komprimierungsfehler ist aufgetreten beim Leeren der Ausgabe: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Unzutreffendes „{“-Zeichen in einem Eintrag des MIME-Typs %s."
@@ -2552,7 +2585,7 @@ msgstr "Abhängigkeit „%s“ des Moduls „%s“ existiert nicht."
 msgid "Module \"%s\" initialization failed"
 msgstr "Initialisierung von Modul „%s“ fehlgeschlagen"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Nachricht"
 
@@ -3054,7 +3087,7 @@ msgstr "Fehler beim Drucken"
 msgid "Print"
 msgstr "Drucken"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Seiten-Einstellungen"
 
@@ -3089,19 +3122,15 @@ msgstr "Drucke Seite %d von %d"
 msgid " (copy %d of %d)"
 msgstr " (Kopie %d von %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Drucken von "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Erste Seite"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Vorherige Seite"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Nächste Seite"
 
@@ -3145,16 +3174,16 @@ msgstr "Seite %d von %d"
 msgid "Page %d"
 msgstr "Seite %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "unbekannter Fehler"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ungültiger regulärer Ausdruck „%s“: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Konnte keine Übereinstimmung mit regulärem Ausdruck %s finden"
@@ -3165,21 +3194,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer „%s“ hat eine ungültige Version %d.%d und kann nicht geladen werden."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Nicht verfügbar für diese Platform"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Speichern des Passwortes für „%s“ fehlgeschlagen: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Lesen des Passwortes für „%s“ fehlgeschlagen: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Löschen des Passwortes für „%s“ fehlgeschlagen: %s."
@@ -3188,11 +3217,11 @@ msgstr "Löschen des Passwortes für „%s“ fehlgeschlagen: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Die Überwachung der I/O Kanäle ist fehlgeschlagen"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Speichern"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Nicht speichern"
 
@@ -3273,10 +3302,10 @@ msgid "Clear"
 msgstr "Löschen"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Schließen"
 
@@ -3288,7 +3317,7 @@ msgstr "&Konvertieren"
 msgid "Convert"
 msgstr "Konvertieren"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopieren"
@@ -3297,7 +3326,7 @@ msgstr "&Kopieren"
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Ausschneiden"
@@ -3306,13 +3335,13 @@ msgstr "&Ausschneiden"
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Löschen"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Löschen"
@@ -3399,7 +3428,7 @@ msgstr "Festplatte"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Hilfe"
 
@@ -3419,7 +3448,7 @@ msgstr "Einrücken"
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Index"
 
@@ -3488,7 +3517,7 @@ msgstr "&Neu"
 msgid "New"
 msgstr "Neu"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nein"
 
@@ -3505,12 +3534,12 @@ msgstr "Ö&ffnen …"
 msgid "Open..."
 msgstr "Öffnen …"
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Ein&fügen"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Einfügen"
@@ -3540,7 +3569,7 @@ msgid "Print..."
 msgstr "Drucken …"
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Eigenschaften"
 
@@ -3572,10 +3601,6 @@ msgstr "Ersetzen..."
 msgid "Revert to Saved"
 msgstr "Gespeicherte Version wiederherstellen"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Speichern"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Speichern &unter …"
@@ -3584,7 +3609,7 @@ msgstr "Speichern &unter …"
 msgid "Save As..."
 msgstr "Speichern unter…"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Alles auswählen"
@@ -3691,7 +3716,7 @@ msgstr "&Hoch"
 msgid "Up"
 msgstr "Hoch"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ja"
 
@@ -3779,43 +3804,43 @@ msgstr "Aktuelles Dokument speichern"
 msgid "Save current document with a different filename"
 msgstr "Aktuelles Dokument mit einen anderen Dateinamen speichern"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konvertierung zum Zeichensatz „%s“ funktioniert nicht."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "unbekannt"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "unvollständiger Kopfeintrag in tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "Prüfsummenfehler beim Lesen der tar-Kopfeintrages"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "ungültige Daten in erweitertem tar-Kopfeintrag"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar-Eintrag nicht geöffnet"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "Unerwartetes Ende der Datei"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s passte nicht zum tar Kopfeintrag für den Eintrag „%s“"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "Falsche Größe für tar-Eintrag"
 
@@ -3824,7 +3849,7 @@ msgstr "Falsche Größe für tar-Eintrag"
 msgid "'%s' is probably a binary buffer."
 msgstr "„%s“ ist vermutlich ein Binärpuffer."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Datei konnte nicht geladen werden."
 
@@ -3838,47 +3863,47 @@ msgstr "Konnte Textdatei „%s“ nicht lesen."
 msgid "can't write buffer '%s' to disk."
 msgstr "Kann den Puffer „%s“ nicht schreiben."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Versuch örtliche Systemzeit zu bekommen, fehlgeschlagen"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay fehlgeschlagen."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "„%s“ ist kein gültiger Nachrichtenkatalog."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Ungültiger Nachrichtenkatalog."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Analyse der Pluralformen fehlgeschlagen: „%s“"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "Verwende Nachrichtenkatalog „%s“ von „%s“."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Ressource „%s“ ist kein gültiger Nachrichtenkatalog."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Konnte Übersetzungen nicht aufzählen"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Keine voreingestellte Anwendung für HTML-Dateien."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Konnte die URL „%s“ nicht im voreingestellten Browser öffnen."
@@ -3911,7 +3936,7 @@ msgstr "„%s“ enthält ungültige(s) Zeichen"
 msgid "Error: %s (%d)"
 msgstr "Fehler: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 "Nicht genügend freier Festplattenplatz für das Herunterladen vorhanden."
@@ -3920,21 +3945,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "libcurl konnte nicht initialisiert werden"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Umwandlung in Zeichenkette wird nicht unterstützt"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Fehler beim Ausführen von JavaScript: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Diese Plattform unterstützt keine Hintergrundtransparenz."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Kann Daten nicht ins Fenster übertragen"
 
@@ -3987,8 +4012,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Ungültige Objektklasse (nicht wxEvtHandler) als Ereignisquelle"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Typ muss eine enum-long-Umwandlung haben"
 
@@ -4038,81 +4063,81 @@ msgstr "Objekte müssen ein ID-Attribut besitzen"
 msgid "Doubly used id : %d"
 msgstr "ID doppelt verwendet: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Unbekannte Eigenschaft %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Eine nicht leere Sammlung muss aus „element“-Knoten bestehen"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "Event-Handler-Zeichenkette falsch, Punkt fehlt"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Kann den zlib deflate-stream nicht reinitialisieren"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Kann den zlib inflate-stream nicht reinitialisieren"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Fehlformatierte Zusatzinformation wird ignoriert, ZIP-Datei ist "
 "möglicherweise beschädigt"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "Nehme an, dies ist ein mehrteiliges, zusammenhängendes Zip-Archiv"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "Ungültige Zip-Datei"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "kann Zentralverzeichnis im Zip nicht finden"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "Fehler beim Lesen des Zentralverzeichnisses im Zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "Fehler beim Lesen des lokalen Headers in Zipdatei"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "ungültiges Offset zum Einsprung in der Zipdatei"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "Gespeicherte Dateilänge nicht in Zip-Header"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "nicht unterstütztes Zip-Kompressionsformat"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "Beim Lesen von Zipstream (Eintrag %s): Falsche Länge"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "Beim Lesen von Zipstream (Eintrag %s): Falsche Prüfsumme"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "Fehler beim Schreiben des Zip-Eintrages „%s“: Datei zu groß ohne ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4200,32 +4225,32 @@ msgstr "Grafikgestaltung von "
 msgid "Translations by "
 msgstr "Übersetzungen von "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Über %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Lizenz"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Entwickler"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autoren der Dokumentation"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Künstler"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Übersetzer"
 
@@ -4276,43 +4301,42 @@ msgid "Password:"
 msgstr "Kennwort:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "wahr"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "falsch"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Zeile %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Zusammenklappen"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Aufklappen"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d Elemente)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Spalte %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4323,8 +4347,7 @@ msgid "Left"
 msgstr "Links"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4424,7 +4447,7 @@ msgid "Home directory"
 msgstr "Benutzerverzeichnis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Arbeitsoberfläche"
 
@@ -4437,8 +4460,7 @@ msgstr "Ungültiger Verzeichnisname."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Fehler"
 
@@ -4622,17 +4644,17 @@ msgstr "Dateien mit Details anzeigen"
 msgid "Go to parent directory"
 msgstr "Gehe zum „Parent“-Verzeichnis"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 "Datei „%s“ existiert bereits, möchten Sie diese wirklich überschreiben?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Bitte wählen Sie eine bestehende Datei."
 
@@ -4726,7 +4748,7 @@ msgstr "Die Schriftgröße in Punkt."
 msgid "Whether the font is underlined."
 msgstr "Ob der Schrifttyp unterstrichen ist."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Vorschau:"
@@ -4744,50 +4766,49 @@ msgstr "Klicken um Wahl der Schriftart abzubrechen."
 msgid "Click to confirm the font selection."
 msgstr "Klicken um Wahl der Schriftart zu bestätigen."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Schriftart wählen"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "Das Kopieren von mehr als einem ausgewählten Block in die Zwischenablage "
 "wird nicht unterstützt."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Hilfeverzeichnis „%s“ nicht gefunden."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Hilfedatei „%s“ nicht gefunden."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Zeile %lu der Abbildungsdatei „%s“ hat ungültige Syntax, übersprungen."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Keine gültige Abbildung in der Datei „%s“ gefunden."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Keine Einträge gefunden."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Hilfeindex"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevante Einträge:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Einträge gefunden"
 
@@ -4891,59 +4912,59 @@ msgstr "Kann Ausdruck nicht beginnen."
 msgid "Printing page %d..."
 msgstr "Drucke Seite %d …"
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Drucker-Einstellungen"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "In Datei drucken"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Einstellungen …"
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Drucker:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Alle"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Seiten"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Seitenbereich"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Von:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Bis:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopien:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript-Datei"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Druckereinstellungen"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Drucker"
 
@@ -4951,25 +4972,25 @@ msgstr "Drucker"
 msgid "Default printer"
 msgstr "Standarddrucker"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Papierformat"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Hochformat"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Querformat"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Ausrichtung"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Einstellungen"
 
@@ -4981,52 +5002,52 @@ msgstr "Farbig drucken"
 msgid "Print spooling"
 msgstr "Druckersteuerung"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Druckbefehl:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Drucker-Einstellungen:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Linker Rand (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Oberer Rand (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Rechter Rand (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Unterer Rand (mm)"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Drucker …"
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Ü&berspringen"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Fertig."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Suchen"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Konnte Seite für ID nicht finden"
 
@@ -5062,11 +5083,11 @@ msgstr "&Fertigstellen"
 msgid "< &Back"
 msgstr "< &Zurück"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Übersetzer"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5076,11 +5097,11 @@ msgstr ""
 "zu Problemen mit der Eingabebehandlung und zum Flackern führen. Erwägen Sie "
 "das Zurücksetzen von GTK_IM_MODULE oder das Setzen auf \"ibus\"."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nicht möglich GTK+ zu initialisieren, ist DISPLAY korrekt gesetzt?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Wechseln des aktuellen Ordners auf „%s“ fehlgeschlagen"
@@ -5109,11 +5130,11 @@ msgstr ""
 "Registrierung der Schriftart-Konfiguration mit privaten Schriftarten "
 "fehlgeschlagen."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Nicht behebbarer Fehler"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5127,7 +5148,7 @@ msgstr ""
 "indem Sie die Umgebungsvariable GDK_BACKEND=x11 setzen, bevor Sie ihr "
 "Programm starten."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5139,7 +5160,7 @@ msgstr ""
 "umgehen, indem Sie die Umgebungsvariable GDK_BACKEND=x11 setzen, bevor\n"
 "Sie ihr Programm starten."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
@@ -5155,17 +5176,13 @@ msgstr "Fehler während des Druckens: "
 msgid "Page Setup"
 msgstr "Seiten-Einstellungen"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Einfügen von Text in das Steuerelement fehlgeschlagen."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 "Das Erhalten einer Ausgabe einer JavaScript Meldung wird mit WebKit v1 nicht "
 "unterstützt"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5173,7 +5190,7 @@ msgstr ""
 "Das GTK+, das auf dieser Maschine installiert ist, ist zu alt um "
 "Bildschirmanordnung zu unterstützen, bitte GTK+ 2.12 oder neuer installieren."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5181,17 +5198,13 @@ msgstr ""
 "Zusammenfügen wird nicht durch dieses System unterstützt, bitte über den "
 "Fenster Manager einstellen."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Dieses Programm wurde mit einer zu alten Version von GTK+ übersetzt, bitte "
 "mit GTK+2.12 oder neuer erstellen."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Bitte wählen Sie eine gültige Schriftart."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5290,47 +5303,47 @@ msgstr "Kann den Inhalt der Datei %s nicht öffnen"
 msgid "Cannot open index file: %s"
 msgstr "Kann Indexdatei %s nicht öffnen"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "namenlos"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML-Hilfebuch %s kann nicht geöffnet werden"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 "Anzeigen bieten Unterstützung beim Navigieren der Bücher auf der linken "
 "Seite."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(Lesezeichen)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Aktuelle Seite zu Lesezeichen hinzufügen"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Aktuelle Seite aus Lesezeichen entfernen"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Inhalte"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Suchen"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Alles zeigen"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5338,19 +5351,19 @@ msgstr ""
 "Alle Indexelemente anzeigen, die den gegebenen Suchbegriff enthalten. Groß-/"
 "Kleinschreibung wird nicht beachtet."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Alle Themen im Index anzeigen"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Groß-/Kleinschreibung"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Nur ganze Worte"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5358,147 +5371,147 @@ msgstr ""
 "Den Inhalt der Hilfebücher nach allen Vorkommen des oben eingegebenen "
 "Begriffs durchsuchen"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Suchbaum ein-/ausblenden"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Zurück"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Vorwärts"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "In die nächste Dokumentebene gehen"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Öffne HTML-Dokument"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Diese Seite drucken"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Einstellungen-Dialog anzeigen"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Bitte wählen Sie die darzustellende Seite:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Hilfethemen"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Suchen …"
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Passende Seite noch nicht gefunden"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Suchbegriff %i mal gefunden"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Hilfe)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d von %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu von %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Alle Bücher durchsuchen"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Hilfe zu den Browser-Einstellungen"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normal Font:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Schrift fester Breite:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Schriftgröße:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "Schriftgröße"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normale Schrift<br>und <u>unterstrichen</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursive Schrift.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Fette Schrift.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Fette kursive Schrift</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Schrift fester Breite.<br> <b>fett</b> <i>kursiv</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>fett kursiv <u>unterstrichen</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Hilfe drucken"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Leere Seite kann nicht gedruckt werden."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-Dateien (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hilfe-Bücher (*.htb)|*.htb|Hilfe-Bücher (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML-Hilfe-Projekt (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimierte HTML-Hilfedatei (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i von %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u von %u"
@@ -5578,32 +5591,6 @@ msgstr ""
 "Es gab ein Problem bei der Seiteneinrichtung: eventuell müssen Sie einen\n"
 "Standarddrucker einrichten."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Konnte HTML-Dokument nicht in der Kodierung %s anzeigen"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets konnte „open display“ nicht ausführen für „%s“: Abbruch."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filter"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Verzeichnisse"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Dateien"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Auswahl"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Konnte Zwischenablage nicht öffnen."
@@ -5646,63 +5633,63 @@ msgstr "Farbauswahldialog schlug mit Fehler %0lx fehl."
 msgid "Failed to create cursor."
 msgstr "Cursor konnte nicht erzeugt werden."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Versuch DDE-Server „%s“ zu registrieren, fehlgeschlagen"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Die Registrierung des DDE-Servers „%s“ konnte nicht aufgehoben werden"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Aufbau der Verbindung zum Server „%s“ „on topic“ „%s“ fehlgeschlagen"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE „poke“ Anfrage fehlgeschlagen"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Aufbau einer „advise Schleife“ mit dem DDE-Server fehlgeschlagen"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 "Versuch fehlgeschlagen, die „advise Schleife“ mit DDE-Server zu beenden"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Versuch fehlgeschlagen, eine DDE-Benachrichtigung zu schicken"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Erstellung der DDE-Zeichenkette fehlgeschlagen"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "kein DDE-Fehler."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "Eine Anfrage für eine „synchronous advise transaction“ ist fehlgeschlagen "
 "(time-out)"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "das Ergebnis zur Transaktion hat das „DDE_FBUSY“-Bit gesetzt."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "Eine Anfrage für eine „synchronous data transaction“ ist fehlgeschlagen "
 "(time-out)"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5714,7 +5701,7 @@ msgstr ""
 "oder ein ungültiger „instance identifier“\n"
 "wurde an eine DDEML-Funktion übergeben."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5726,48 +5713,48 @@ msgstr ""
 "oder eine Anwendung, die als ein „APPCMD_CLIENTONLY“ gestartet wurde, \n"
 "versuchte eine Server-Transaktion auszuführen."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "Eine Anfrage für eine „synchronous execute transaction“ ist fehlgeschlagen "
 "(time-out)"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "Ein Parameter wurde von DDEML nicht verifiziert."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "Eine DDEML-Anwendung hat eine „prolonged race condition“ ausgelöst."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "Eine Speicheranforderung ist fehlgeschlagen."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 "Der Versuch eines Clients, eine Verbindung herzustellen, ist fehlgeschlagen."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "Eine Transaktion ist fehlgeschlagen."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "Eine Anfrage für eine „synchronous poke transaction“ ist fehlgeschlagen "
 "(time-out)"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "Ein interner Aufruf zur „PostMessage“-Funktion ist fehlgeschlagen. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "Probleme beim Wiedereintreten."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5777,17 +5764,17 @@ msgstr ""
 "wurde vom Client unterbrochen, oder der Server\n"
 "beendete bevor die Transaktion vollständig beendet wurde."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "Ein interner Fehler ist im DDEML aufgetreten."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "Eine Anfrage, eine „advise transaction“ zu beenden ist, fehlgeschlagen (time-"
 "out)"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5798,12 +5785,12 @@ msgstr ""
 "Sobald die Anwendung aus einem „XTYP_XACT_COMPLETE“-Callback zurückkehrt,\n"
 "ist die Transaktions-Identifizierung für diesen Callback nicht mehr gültig."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Unbekannter DDE-Fehler %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5812,7 +5799,7 @@ msgstr ""
 "(Remote Access Service) auf dieser Maschine nicht installiert ist. Bitte "
 "installieren."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5822,67 +5809,67 @@ msgstr ""
 "Bitte auf den neusten Stand bringen (die folgende benötigte Funktion fehlt: "
 "%s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Versuch den Inhalt der RAS-Fehlernachricht zu holen, fehlgeschlagen"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "unbekannter Fehler (Fehlercode %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kann keine aktive DFÜ-Verbindung finden: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Mehrere aktive DFÜ-Verbindungen gefunden, eine davon wird zufällig "
 "ausgewählt."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Aufbau der DFÜ-Verbindung fehlgeschlagen: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Konnte ISP-Namen „%s“ nicht ermitteln"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Verbindungsversuch fehlgeschlagen: kein anwählbares ISP."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Anzuwählenden ISP auswählen"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Bitte gewünschte ISP-Verbindung auswählen"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr ""
 "Verbindung fehlgeschlagen: Es fehlt der Benutzername bzw. das Passwort."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Kann Adressbuchdatei nicht finden"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Versuch fehlgeschlagen, die Einwählverbindung einzuleiten: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kann nicht auflegen - keine aktive DFÜ-Verbindung vorhanden."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Versuch fehlgeschlagen, die DFÜ-Verbindung zu beenden: %s"
@@ -5902,18 +5889,17 @@ msgstr "Anforderung von %lu Kb Speicher für Bitmap fehlgeschlagen."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kann Dateien in Verzeichnis „%s“ nicht auflisten"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Verzeichnisname konnte nicht ermittelt werden"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(Fehler %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Kann Bild nicht zur Liste hinzufügen."
 
@@ -5927,7 +5913,7 @@ msgstr "Konnte Metadatei aus Datei „%s“ nicht laden."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Konnte keinen Standard-Finden/Ersetzen-Dialog erstellen (Fehler %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Datei Dialog schlug fehl mit dem Fehlercode %0lx."
@@ -5971,16 +5957,16 @@ msgstr ""
 "Das nicht vorhandene Verzeichnis „%s“ kann nicht auf Änderungen überwacht "
 "werden."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 und neuer, wird vom OpenGL-Treiber nicht unterstützt."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Kann keinen OpenGL Inhalt erzeugen"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Konnte OpenGL nicht initialisieren"
 
@@ -5990,7 +5976,7 @@ msgstr ""
 "Der benutzerspezifische DirectWrite Schriftartlader konnte nicht registriert "
 "werden."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5998,7 +5984,7 @@ msgstr ""
 "Die MS-HTML-Hilfe funktioniert nicht, da die MS-HTML-Hilfe-Bibliothek nicht "
 "installiert ist. Bitte installieren Sie diese."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Konnte MS-HTML-Hilfe nicht initialisieren."
 
@@ -6007,7 +5993,7 @@ msgstr "Konnte MS-HTML-Hilfe nicht initialisieren."
 msgid "Can't delete the INI file '%s'"
 msgstr "Kann INI-Datei „%s“ nicht löschen"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kann keine Informationen über das Listenelement %d bekommen."
@@ -6127,7 +6113,7 @@ msgstr "Konnte Zwischenablage-Format „%s“ nicht registrieren."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Das Format „%d“ für die Zwischenablage existiert nicht."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Überspringen"
 
@@ -6217,59 +6203,59 @@ msgstr ""
 "durch seine Entfernung wird das System unbrauchbar:\n"
 "Abbruch."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kann Schlüssel „%s“ nicht löschen"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kann Wert „%s“ von Schlüssel „%s“ nicht löschen."
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kann Wert von Eintrag „%s“ nicht lesen"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kann Wert von „%s“ nicht setzen"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Registrierungswert „%s“ ist nicht numerisch (ist aber von der Art %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Registrierungswert „%s“ ist nicht binär (ist aber von der Art %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Registrierungswert „%s“ ist kein Text (ist aber von der Art %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kann Wert von „%s“ nicht lesen"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kann Werte von Schlüssel „%s“ nicht auflisten"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kann Unterschlüssel von „%s“ nicht auflisten"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6277,17 +6263,17 @@ msgstr ""
 "Exportiere Registrierungsschlüssel: Datei „%s“ besteht bereits und wird "
 "nicht überschrieben."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kann Wert des nicht unterstützten Typs %d nicht kopieren."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignoriere Wert „%s“ des Schlüssels „%s“."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6295,41 +6281,41 @@ msgstr ""
 "Versuch eine „rich edit control“ zu erstellen fehlgeschlagen, verwende "
 "stattdessen ein einfaches Text-Control. Bitte „riched32.dll“ neu installieren"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kann Thread nicht starten: Fehler beim Beschreiben des TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Kann Thread-Priorität nicht setzen"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Kann Thread nicht erzeugen"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Kann Thread nicht beenden"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Kann nicht auf Threadende warten"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kann Thread %lx nicht anhalten"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kann Thread %lx nicht fortsetzen"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Kann den aktuellen Threadzeiger nicht bekommen"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6337,7 +6323,7 @@ msgstr ""
 "Thread-Modul-Initialisierung fehlgeschlagen: Index konnte nicht im lokalen "
 "Speicherbereich des Thread allokiert werden"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6368,12 +6354,12 @@ msgstr "Konnte die Ressource „%s“ nicht laden."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Konnte die Ressource „%s“ nicht sperren."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "Erzeugungsversion %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bit Edition"
 
@@ -6385,51 +6371,51 @@ msgstr "Konnte keine anonyme Unix-Pipe erstellen"
 msgid "Failed to redirect the child process IO"
 msgstr "Umleitung der Ein-/Ausgabe des Unterprozesses fehlgeschlagen"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Befehlsausführung „%s“ schlug fehl"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Konnte mpr.dll nicht laden."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kann die Typnamen nicht aus „%s“ lesen!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kann das Icon nicht von „%s“ laden."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 "Der Grad der Web Ansichtnachbildung konnte in der Registratur nicht gefunden "
 "werden"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Das Setzen der Web Ansicht auf moderne Nachbildung ist fehlgeschlagen"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 "Das Setzen der Web Ansicht auf den Grad der Standard-Nachbildung ist "
 "fehlgeschlagen"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 "JavaScript kann nicht ohne ein gültiges HTML-Dokument ausgeführt werden"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Kann das JavaScript-Objekt nicht erhalten"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "Auswertung fehlgeschlagen"
 
@@ -6462,7 +6448,7 @@ msgid "Check to make the font italic."
 msgstr "Klicken um die Schriftart auf kursiv zu stellen."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Unterstrichen"
@@ -6529,15 +6515,33 @@ msgstr "<Beliebige Schreibmaschinen-Schrift>"
 msgid "File type:"
 msgstr "Dateityp:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Fenster"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hilfe"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimieren"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Vergrößern"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Alles nach vorne bringen"
 
@@ -6554,517 +6558,517 @@ msgstr "Schriftartdatei \"%s\" existiert nicht."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Die Schriftartdatei \"%s\" kann nicht verwendet werden, da sie sich nicht im "
 "Schriftartenverzeichnis \"%s\" befindet."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Über %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Über …"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Einstellungen …"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Dienste"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "%s ausblenden"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Anwendung"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Andere ausblenden"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Alles zeigen"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "%s beenden"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Anwendung"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Drucken wird vom Web-Kontrollelement des Systems nicht unterstützt"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Druckoperation konnte nicht initialisiert werden"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Größe in Punkt"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Schriftname"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Dicke"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familie"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ButtonText"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "GrayText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Hervorheben"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "HighlightText"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menü"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Bildlaufleiste"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Minihilfe"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "Minihilfe-Text"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Fenster"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 # Original wird verwendet
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Schwarz"
 
 # http://bfw.ac.at/020/farbtabelle.html
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Kastanienbraun"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Marineblau"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Violett"
 
 # http://bfw.ac.at/020/farbtabelle.html
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Entenbraun"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Grau"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Grün"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Olivgrün"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Braun"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Blau"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Magenta"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Rot"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Orange"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Silber"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Zitronengrün"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Cyan"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Gelb"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Weiß"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Standard"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Pfeil"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Rechts-Pfeil"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Leer"
 
 # Sieht aus wie das innere Feld bei Darts
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Bullseye"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Zeichen"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Kreuz"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Hand"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "Profilstahl"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Links-Taste"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Lupe"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Mittlere Taste"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Kein Eintrag"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Pinsel"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Stift"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Punkt links"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Punkt rechts"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Fragepfeil"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Rechts-Taste"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von NO nach SW zeigen
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Größenänderung NO-SW"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von Norden nach Süden zeigen
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Größenänderung N-S"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von NW nach SO zeigen
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Größenänderung NW-SO"
 
 # Ein Cursor für die Größenänderung, dessen Pfeile von W nach O zeigen
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Größenänderung W-O"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Größenänderung"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Sprühdose"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "﻿Warten"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Uhr"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Wartepfeil"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Bitte auswählen:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Eigenschaft"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Wert"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategorie-Modus"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alphabetischer Modus"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falsch"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Wahr"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Nicht angegeben"
 
@@ -7079,12 +7083,12 @@ msgstr ""
 "Sie haben einen ungültigen Wert eingegeben. Drücken Sie ESC um die "
 "Bearbeitung zu beenden."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Fehler in der Ressource: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7093,36 +7097,36 @@ msgstr ""
 "Die Typoperation „%s“ ist fehlgeschlagen: Die Eigenschaft bezeichnet mit "
 "„%s“ ist vom Typ „%s“, NICHT „%s“."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Unbekannte Basis %d. Basis 10 wird verwendet."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Wert muss %s oder höher sein."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Wert muss zwischen %s und %s liegen."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Wert muss %s oder kleiner sein."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Nicht %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Verzeichnis wählen:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Datei wählen"
 
@@ -7589,117 +7593,117 @@ msgstr "Einfügen"
 msgid "Outset"
 msgstr "Beginn"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Stil ändern"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Stil des Objektes ändern"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Eigenschaften ändern"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Stil der Liste ändern"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Liste neu nummerieren"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Text einfügen"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Bild einfügen"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Objekt einfügen"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Feld einfügen"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Zu viele EndStyle-Aufrufe!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "Dateien"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "Standard/Kreis"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "Standard/Kreisumriss"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "Standard/Quadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "Standard/Raute"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "Standard/Dreieck"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Rahmen-Eigenschaften"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Mehrfache Zelleneigenschaften"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Zelleneigenschaften"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Stil der Zelle einstellen"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Zeile löschen"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Spalte löschen"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Zeile hinzufügen"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Spalte hinzufügen"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Tabelleneigenschaften"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Bildeigenschaften"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "Bild"
 
@@ -7907,24 +7911,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Freigeben"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Text löschen"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Gliederungspunkt entfernen"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Der Text konnte nicht gespeichert werden."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Ersetzen"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Schriftart:"
 
@@ -8893,53 +8897,53 @@ msgstr "Listenstile"
 msgid "Box styles"
 msgstr "Rahmen-Stile"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Die Schriftart aus der das Symbol entnommen wurde."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Teilsatz:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Zeigt einen Unicode-Teilzeichensatz."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Zeichencode:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Der Zeichencode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Von:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Der anzuzeigende Bereich."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Einfügen"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normaler Text)"
 
@@ -9125,7 +9129,7 @@ msgstr "Ereignisse von Kqueue zu erhalten fehlgeschlagen"
 msgid "Media playback error: %s"
 msgstr "Medienwiedergabe-Fehler: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Fehler bei der Vorbereitung zum Abspielen von „%s“."
@@ -9225,20 +9229,20 @@ msgstr "Klangdaten haben ein nicht unterstütztes Format."
 msgid "Couldn't open audio: %s"
 msgstr "Fehler beim Öffnen der Audiodatei: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kann Scheduling-Verfahren der Threads nicht ermitteln."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Kein Prioritätsbereich für Scheduling-Verfahren %d ermittelbar."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Thread-Prioritätseinstellung wird ignoriert."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9246,63 +9250,63 @@ msgstr ""
 "Thread-Verbindung fehlgeschlagen. Dies ist ein mögliches Speicherleck - "
 "Bitte Programm neu starten"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 "Versuch fehlgeschlagen, die Thread-Nebenläufigkeit auf Stufe %lu zu setzen"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Versuch fehlgeschlagen, die Thread-Priorität %d zu setzen."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Versuch den Thread zu beenden, fehlgeschlagen."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Thread-Modul-Initialisierung fehlgeschlagen: Thread-Schlüssel konnte nicht "
 "erstellt werden"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Es war nicht möglich, die Eingabe des Unterprozesses zu verarbeiten"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Kann nicht in den Standard-Eingabekanal des Kindprozesses schreiben"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Kann „%s“ nicht ausführen\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "„Fork“ fehlgeschlagen"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Versuch fehlgeschlagen, die Prozess-Priorität zu setzen"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Umleitung der Ein-/Ausgabe des Unterprozesses fehlgeschlagen"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Das Erzeugen einer nicht blockierenden Pipe ist fehlgeschlagen, das Programm "
 "könnte stehen bleiben."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Hostnamen nicht ermittelbar"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Offizieller Hostname nicht ermittelbar"
 
@@ -9319,12 +9323,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "Konnte nicht aus dem Weckkanal lesen"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Ungültige Angabe „%s“ der Fenstergröße"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets konnte Display nicht öffnen. Abbruch."
 
@@ -9338,30 +9342,59 @@ msgstr "Konnte das Display „%s“ nicht schließen"
 msgid "Failed to open display \"%s\"."
 msgstr "Öffnen des Displays „%s“ fehlgeschlagen."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Fehler beim Lesen des XML: „%s“ in Zeile %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kann die Ressourcen nicht aus „%s“ laden."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kann die Ressourcendatei „%s“ nicht öffnen."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kann die Ressourcen nicht aus der Datei „%s“ laden."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Erstellung von %s „%s“ fehlgeschlagen."
+
+#~ msgid "Printing "
+#~ msgstr "Drucken von "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Einfügen von Text in das Steuerelement fehlgeschlagen."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Bitte wählen Sie eine gültige Schriftart."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Konnte HTML-Dokument nicht in der Kodierung %s anzeigen"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets konnte „open display“ nicht ausführen für „%s“: Abbruch."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Verzeichnisse"
+
+#~ msgid "Files"
+#~ msgstr "Dateien"
+
+#~ msgid "Selection"
+#~ msgstr "Auswahl"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "Umwandlung in 8-Bit-Kodierung fehlgeschlagen"
@@ -9529,8 +9562,8 @@ msgstr "Erstellung von %s „%s“ fehlgeschlagen."
 #~ msgstr "Datums-Renderer kann den Wert nicht darstellen; Werttyp: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/el.po
+++ b/locale/el.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2005-02-16 09:03+0200\n"
 "Last-Translator: InterZone <info@interzone.gr>\n"
 "Language-Team: Tsolakos Stavros <tsolako1@otenet.gr>, Nassos Yiannopoulos "
@@ -12,11 +12,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Όλα τα αρχεία (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Όλα τα αρχεία (*)|*"
 
@@ -36,24 +36,21 @@ msgid "Remaining time:"
 msgstr "Xρόνος που απομένει : "
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ναι"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Όχι"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Ακυρο"
@@ -105,7 +102,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Αποτυχία δημιουργίας δείκτη."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "Εκτύπωση"
@@ -149,7 +146,7 @@ msgstr "&Ιδιότητες"
 msgid "Printing"
 msgstr "Γίνεται εκτύπωση του "
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 #, fuzzy
 msgid "Symbols"
 msgstr "&Στυλ:"
@@ -219,7 +216,7 @@ msgstr "&Προηγούμενο"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Παράθυρο"
 
@@ -784,11 +781,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "ctrl"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "εμφάνιση αυτού του μηνύματος βοηθείας"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "δημιουργία αναλυτικών (verbose) μηνυμάτων καταγραφής (log)"
 
@@ -813,84 +810,84 @@ msgstr ""
 "Λανθασμένος καθορισμός(specification) κατάστασης λειτουργίας(mode) "
 "οθόνης(display) '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "’γνωστη επιλογή long '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "’γνωστη επιλογή '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Απροσδόκητη παράμετρος '%s'"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Η επιλογή '%s' απαιτεί μια τιμή."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Αναμενόταν διαχωριστικό μετά την επιλογή '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' δεν είναι μία σωστή αριθμητική τιμή για την επιλογή '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Επιλογή '%s': το '%s' δεν μπροει να μετατραπει σε ημερομηνία."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Απροσδόκητη παράμετρος '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ή %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Η τιμή για την επιλογή '%s' πρέπει να προσδιοριστεί,"
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Η απαραίτητη παράμετρος '%s' δεν προσδιορίστηκε."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Χρήση: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "ημερομηνία"
 
@@ -908,7 +905,7 @@ msgid "Can't &Undo "
 msgstr "Δεν είναι δυνατή η αναίρεση"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Αναίρεση"
@@ -918,7 +915,7 @@ msgid "&Redo "
 msgstr "&Επανάληψη "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Επανάληψη"
@@ -947,12 +944,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' περιέχει επιπλέον '..', αγνοήθηκαν."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -962,103 +959,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "υπογεγραμμένο"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "σήμερα"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "χθες"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "αύριο"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "πρώτο"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "δεύτερο"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "τρίτο"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "τέταρτο"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "πέμπτο"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "έκτο"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "έβδομο"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "όγδοο"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "ένατο"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "δέκατο"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "έβδομο"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "δωδέκατο"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "δέκατο τρίτο"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "δέκατο τέταρτο"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "δέκατο-πέμπτο"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "δέκατο έκτο"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "δέκατο-έβδομο"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "δέκατο όγδοο"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "δέκατο ένατο"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "εικοστό"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "μεσημέρι"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "μεσάνυκτα"
 
@@ -1125,44 +1122,80 @@ msgstr ""
 "Απέτυχε η δημιουργία καθιερωμένου παράθυρου διαλόγου εύρεσης/αντικατάστασης "
 "(κωδικός σφάλματος %d)"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Αποθήκευση ως"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "απροσδιόριστο"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Θέλετε να αποθηκεύσετε τις αλλαγές στο έγγραφο %s ;"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Αποθήκευση"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+msgid "Do&n't close"
+msgstr ""
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Θέλετε να αποθηκεύσετε τις αλλαγές στο έγγραφο %s ;"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Το κείμενο δεν μπόρεσε να αποθυκευτεί."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Αποτυχία αποθήκευσης της εικόνας στο αρχείο \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από το αρχείο '%s'."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1171,58 +1204,58 @@ msgstr ""
 "Το αρχείο '%s' δεν υπάρχει και δεν μπόρεσε να ανοιχτεί.\n"
 "Αφαιρέθηκε από την λίστα με τα πρόσφατα χρησιμοποιημένα αρχεία."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Δημιουργία pipe απέτυχε"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Προεπισκόπηση Εκτύπωσης"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "απροσδιόριστο%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Ανοιγμα Αρχείου"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Σφάλμα αρχείου"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Συγγνώμη, δεν μπόρεσε να ανοιχθεί αυτό το αρχείο."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Συγγνώμη, η μορφή αυτού του αρχείου είναι άγνωστη."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Επιλέξτε ένα πρότυπα εγγράφου"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Πρότυπα"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Επιλέξτε μια προβολή εγγράφων"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Προβολές"
 
@@ -1257,41 +1290,41 @@ msgstr "Λάθος ανάγνωσης στο αρχείο '%s'"
 msgid "Write error on file '%s'"
 msgstr "Σφάλμα εγγραφής (write error) στο αρχείο '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "Αποτυχία αδειάσματος buffer (flush) του αρχείου '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Λάθος ανίχνευσης (seek error) στο αρχείο '%s'."
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Δεν είναι δυνατή η εύρεση της τρέχουσας θέσης στο αρχείου '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Αποτυχία θέσπισης δικαιωμάτων προσωρινού αρχείου"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "δεν είναι δυνατό το σβήσιμο του αρχείου '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "αδύνατη η δέσμευση των αλλαγών στο αρχείο '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "δεν είναι δυνατό το σβήσιμο του προσωρινού αρχείου '%s'"
@@ -1316,32 +1349,32 @@ msgstr "αδύνατη η ανάγνωση από περiγραφέα (descripto
 msgid "can't write to file descriptor %d"
 msgstr "δεν είναι δυνατή η εγγραφή του περιγραφέα αρχείου(file descriptor) %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 "δεν μπορεί να πραγματοποιηθεί το άδειασμα (flush) του περιγραφέα αρχείου %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "αδύνατη η αναζήτηση(seek) στον περγραφέα(descriptor) αρχείου %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "αδύνατη η λήψη θέσης αναζήτησης (seek position) στον περιγραφέα(descriptor) "
 "αρχείου %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "αδύνατη η εύρεση του μεγέθους αρχείου στον περιγραφέα αρχείου (file "
 "desciptor) %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1367,153 +1400,153 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Σφάλμα κατά την ανάγνωση των ρυθμίσεων."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Σφάλμα κατά την ανάγνωση των ρυθμίσεων."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "αρχείο '%s': απροσδόκητος χαρακτήρας %c στη γραμμή %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr ""
 "αρχείο '%s', γραμμή %d: το '%s' αγνοήθηκε μετά την επικεφαλίδα του γκρούπ."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "αρχείο '%s', γραμμή %d: αναμενόταν '=' ."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "αρχείο '%s', γραμμή %d: τιμή για αμετάβλητο κλειδί '%s' αγνοήθηκε."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "αρχείο '%s', γραμμή %d: το κλειδί '%s' βρέθηκε για πρώτη φορά στη γραμμή %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 "Το όνομα εισόδου διαμόρφωσης (Config entry name) δεν μπορεί να αρχίζει με "
 "'%c'"
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "αδύνατο το άνοιγμα αρχείου ρυθμίσεων του χρήστη."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "Αδύνατη η εγγραφή αρχείου ρυθμίσεων χρήστη."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Σφάλμα κατά την εγγραφή των ρυθμίσεων χρήστη."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "Δεν είναι δυνατή η διαγραφή του αρχείου ρυθμίσεων '%s' του χρήστη"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "η εισαγωγή(entry) '%s' εμφανίζεται πάνω από μία φορά στο γκρούπ '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "η προσπάθεια αλλαγής αμετάβλητου κλειδιού '%s' αγνοήθηκε."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "απροσδόκητο \" στη θέση %d στο '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Αποτυχία αντιγραφής του αρχείου '%s' στο '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Αδύνατη η λήψη των δικαιωμάτων για το αρχείο '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Αδύνατη η επικάλυψη του αρχείου '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Αποτυχία αντιγραφής του αρχείου '%s' στο '%s'"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Αδύνατος ο ορισμός των δικαιωμάτων για το αρχείο '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Δεν ήταν δυνατή η δημιουργία του καταλόγου '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Δεν είναι δυνατή η απαρίθμηση των αρχείων '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Αρχεία (%s)"
@@ -1540,17 +1573,17 @@ msgstr "Αποτυχία δημιουργίας ονόματος προσωρι�
 msgid "Failed to open temporary file."
 msgstr "Αποτυχία ανοίγματος προσωρινού αρχείου"
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Αποτυχία τροποποίησης ώρας του αρχείου '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Αποτυχία αγγίγματος (touch) του αρχείου '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Αποτυχία λήψης της ώρας του αρχείου '%s'"
@@ -1559,22 +1592,22 @@ msgstr "Αποτυχία λήψης της ώρας του αρχείου '%s'"
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Όλα τα αρχεία (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s αρχεία (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Φόρτωση %s αρχείου"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Αποθήκευση %s αρχείου"
@@ -1949,109 +1982,109 @@ msgstr "προκαθορισμένο"
 msgid "unknown-%d"
 msgstr "άγνωστο-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "υπογεγραμμένο"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "απαλό(light)"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 #, fuzzy
 msgid " light"
 msgstr "απαλό(light)"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "έντονο"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 #, fuzzy
 msgid " bold"
 msgstr "έντονο"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "έντονο"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 #, fuzzy
 msgid " italic"
 msgstr "πλάγιο"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "απαλό(light)"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "απαλό(light)"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Κανονικό"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "έντονο"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "έντονο"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "έντονο"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "πλάγιο"
 
@@ -2139,7 +2172,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Αποτυχία θέσης FTP transfer mode σε '%s'"
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2161,7 +2194,7 @@ msgstr ""
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Αποτυχία δημιουργίας δείκτη."
@@ -2180,7 +2213,7 @@ msgstr "μέγεθος γραμματοσειράς"
 msgid "&Customize..."
 msgstr "μέγεθος γραμματοσειράς"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
@@ -2200,161 +2233,160 @@ msgstr "Αποτυχία φόρτωσης της εικόνας %d από το �
 msgid "Failed to load icons from resource '%s'."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Δεν είναι δυνατή η αποθήκευση μη έγκυρης εικόνας."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: Το wxImage δεν κατέχει κάποιο wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Δεν ήταν δυνατή η εγγραφή της κεφαλής του αρχείου Bitmap."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Δεν ήταν δυνατή η εγγραφή της κεφαλής του αρχείου BitmapInfo."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Δεν ήταν δυνατή η εγγραφή του χάρτη RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Δεν ήταν δυνατή η εγγραφή δεδομένων."
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Δεν ήταν δυνατή η δέσμευση(allocation) μνήμης."
 
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr ""
 "DIB Header: Το πλάτος της εικόνας είναι > 32767 εικονοστοιχεία για το αρχείο."
 
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr ""
 "DIB Header: Το ύψος της εικόνας είναι > 32767 εικονοστοιχεία για το αρχείο."
 
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "DIB Header: Αγνωστο βάθος bit στο αρχείο."
 
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "DIB Header: Αγνωστη κωδικοποίηση στο αρχείο."
 
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "DIB Header: Η κωδικοποίηση δεν ταιρίζει με το βάθος bit."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1279
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Σφάλμα κατά την ανάγνωση εικόνας DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Σφάλμα στην ανάγνωση μάσκας DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Εικόνα πολύ ψηλή για εικονίδιο(icon)."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Εικόνα πολύ πλατιά για εικονίδιο(icon)."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Σφάλμα κατά την εγγραφή του αρχείου εικόνας!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Λανθασμένος δείκτης(index) εικονιδίου(icon)."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Εικόνα και μάσκα έχουν διαφορετικά μεγέθη."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr ""
 "Δεν υπάρχει μη χρησιμοποιούμενο χρώμα στην εικόνα που εφααρμόζεται η μάσκα"
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Αποτυχία φόρτωσης της εικόνας %d από το αρχείο '%s'."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Δεν είναι δυνατή η αποθήκευση της εικόνας στο αρχείο '%s': άγνωστη επέκταση"
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Δεν βρέθηκε χειριστής για τύπο εικόνας."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Αρχείο εικόνας δεν είναι τύπυ %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "σφάλμα στη μορφή των δεδομένων"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: αυτό δεν είναι αρχείο PCX."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Δεν έχει οριστεί χειριστής εικόνας για τον τύπο %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Αρχείο εικόνας δεν είναι τύπυ %d."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Αποτυχία αποθήκευσης της εικόνας στο αρχείο \"%s\"."
@@ -2458,52 +2490,52 @@ msgstr "PNM: Το αρχείο μοιάζει να είναι αποκομμέν
 msgid " (in module \"%s\")"
 msgstr "tiff module: %s"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Λάθος κατά την φόρτωση εικόνας."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Λανθασμένος δείκτης εικόνας TIFF."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Αδύνατη η δέσμευση μνήμης."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Λάθος κατά την ανάγνωση εικόνας."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Λάθος κατά την αποθήκευση εικόνας."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Λάθος κατα την εγγραφή εικόνας."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2601,7 +2633,7 @@ msgstr "σφάλμα συμπίεσης"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Αταίριαστο '{' σε μία είσοδο (entry) για τον τύπο mime %s."
@@ -2621,7 +2653,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "%s μήνυμα"
@@ -3170,7 +3202,7 @@ msgstr "Σφάλμα Εκτύπωσης"
 msgid "Print"
 msgstr "Εκτύπωση"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Ρύθμιση(setup) Σελίδας"
 
@@ -3206,20 +3238,16 @@ msgstr "Γίνεται εκτύπωση σελίδας %d..."
 msgid " (copy %d of %d)"
 msgstr "Σελίδα %d από %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Γίνεται εκτύπωση του "
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "Επόμενη σελίδα"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Προηγούμενη σελίδα"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Επόμενη σελίδα"
 
@@ -3266,16 +3294,16 @@ msgstr "Σελίδα %d από %d"
 msgid "Page %d"
 msgstr "Σελίδα %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "άνωστο λάθος"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Λανθασμένη κανονική έκφραση (regular expression) '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
@@ -3288,21 +3316,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Ο Renderer \"%s\" είναι σε ασύμβατη έκδοση %d.%d και δεν μπορεί να φορτωθεί."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
@@ -3311,11 +3339,11 @@ msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr ""
 
@@ -3402,10 +3430,10 @@ msgid "Clear"
 msgstr "&Καθαρισμός"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -3419,7 +3447,7 @@ msgstr "Περιεχόμενα"
 msgid "Convert"
 msgstr "Περιεχόμενα"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Αντιγραφή"
@@ -3429,7 +3457,7 @@ msgstr "&Αντιγραφή"
 msgid "Copy"
 msgstr "&Αντιγραφή"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Απο&κοπή"
@@ -3439,13 +3467,13 @@ msgstr "Απο&κοπή"
 msgid "Cut"
 msgstr "Απο&κοπή"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Διαγραφή"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 #, fuzzy
 msgid "Delete"
@@ -3542,7 +3570,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Βοήθεια"
 
@@ -3562,7 +3590,7 @@ msgstr "Στοίχιση"
 msgid "&Index"
 msgstr "&Ευρετήριο"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Ευρετήριο"
 
@@ -3636,7 +3664,7 @@ msgstr "&Νέο"
 msgid "New"
 msgstr "&Νέο"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Όχι"
 
@@ -3654,12 +3682,12 @@ msgstr "&Ανοιγμα..."
 msgid "Open..."
 msgstr "&Ανοιγμα..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Επικόληση"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 #, fuzzy
 msgid "Paste"
@@ -3694,7 +3722,7 @@ msgid "Print..."
 msgstr "&Εκτύπωση..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Ιδιότητες"
 
@@ -3730,10 +3758,6 @@ msgstr "&Αντικατάσταση"
 msgid "Revert to Saved"
 msgstr "Επαναφορά από το αποθηκευμένο"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Αποθήκευση"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Αποθήκευση &ως..."
@@ -3743,7 +3767,7 @@ msgstr "Αποθήκευση &ως..."
 msgid "Save As..."
 msgstr "Αποθήκευση &ως..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Επιλογή &Ολων"
@@ -3862,7 +3886,7 @@ msgstr "&Επάνω"
 msgid "Up"
 msgstr "Επάνω"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ναι"
 
@@ -3961,44 +3985,44 @@ msgstr "Επιλέξτε μια προβολή εγγράφων"
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Η μετατροπή στο σετ χαρακτήρων '%s' δεν λειτουργεί"
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "άγνωστο"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 #, fuzzy
 msgid "unexpected end of file"
 msgstr "Απροσδόκητο τέλος αρχείου κατά την ανάγνωση πόρου."
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -4007,7 +4031,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' είναι πιθανόν ένας δυαδικός ( binary ) buffer"
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
 
@@ -4021,49 +4045,49 @@ msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από 
 msgid "can't write buffer '%s' to disk."
 msgstr "αδύνατη η εγγραφή της προσωρινής μνήμης (buffer) '%s' στο δίσκο."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Αποτυχία καθορισμού της ώρας του τοπικού συστήματος"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "το wxGetTimeOfDay απέτυχε."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Δεν είναι δυνατή η ανάγνωση Plural-Forms:'%s'."
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "χρήση καταλόγου '%s' από '%s'"
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' δεν είναι ένας σωστός κατάλογος μηνυμάτων."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Δεν ήταν δυνατός ο τερματισμός του thread"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
@@ -4096,7 +4120,7 @@ msgstr "'%s' πρέπει να περιέχει μόνο αλφαβητικού�
 msgid "Error: %s (%d)"
 msgstr "Σφάλμα: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4105,21 +4129,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Το αρχείο δεν μπόρεσε να φορτωθεί."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Οι μετατροπές strings δεν υποστηρίζονται"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Δεν ήταν δυνατή η μεταφορά δεδομένων στο παράθυρο."
 
@@ -4171,8 +4195,8 @@ msgstr "Η παράμετρος Create δεν βρέθηκε στις δηλωμ
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Εσφαλμένη κλάση αντικειμένου (μη-wxEvtHandler) σαν πηγή Events"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Ο τύπος πρέπει να έχει μετατροπή enum - long"
 
@@ -4223,80 +4247,80 @@ msgstr "Τα αντικείμενα πρέπει να έχουν ένα χαρα
 msgid "Doubly used id : %d"
 msgstr "Id χρησιμοποιούμενο δύο φορές : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "’γνωστη Ιδιότητα %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Μία μη άδεια συλλογή πρέπει να αποτελείται από κόμβους 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "εσφαλμένο string χειριστή event, λείπει τελεία"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib deflate."
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Δεν είναι δυνατή η αρχικοποίηση της ροής zlib inflate."
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "μη έγκυρο συμπιεσμένο αρχείο"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr ""
 "Δεν είναι δυνατή η εύρεση του κεντρικού καταλόγου στο συμπιεσμένο αρχείο"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "σφάλμα κατα την ανάγνωση κεντρικού καταλόγου στο συμπιεσμένο αρχείο"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "σφάλμα κατά την ανάγνωση τοπικής κεφαλίδας του συμπιεσμένου αρχείου"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "το μήκος του αποθκευμένου αρχείου δεν υπάρχει στην κεφαλίδα Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "μη υποστηριζόμενη μέθοδος συμπίεσης Zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "ανάγνωση ροής zip (εγγραφή %s): λανθασμένο μήκος"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "ανάγνωση ροής zip (εγγραφή %s): εσφαλμένο crc "
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "σφάλμα κατά την εγγραφή αρχείου zip '%s': εσφαλμένο crc ή μήκος"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "σφάλμα κατά την εγγραφή αρχείου zip '%s': εσφαλμένο crc ή μήκος"
@@ -4383,33 +4407,33 @@ msgstr ""
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Δικαιώματα"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "&Περί..."
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr ""
 
@@ -4461,44 +4485,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Αρχείο"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (ή %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4509,8 +4532,7 @@ msgid "Left"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 #, fuzzy
@@ -4601,7 +4623,7 @@ msgid "Home directory"
 msgstr "Αρχικός κατάλογος"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr ""
 
@@ -4614,8 +4636,7 @@ msgstr "Μη έγκυρο όνομα καταλόγου."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Σφάλμα"
 
@@ -4801,16 +4822,16 @@ msgstr "Εμφάνιση αρχείων σε προβολή με λεπτομέ�
 msgid "Go to parent directory"
 msgstr "Προς πατρικό κατάλογο"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Το αρχείο '%s' υπάρχει ήδη, πραγματικά θέλετε να επικαλυφτεί;"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Επιβεβαίωση"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Παρακλώ επιλέξτε ένα υπάρχον αρχείο."
 
@@ -4905,7 +4926,7 @@ msgstr "Το μέγεθος κουκίδας γραμματοσειράς"
 msgid "Whether the font is underlined."
 msgstr "Επιλογή εαν η γραμματοσειρά είναι υπογραμμισμένη ή όχι."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Προεπισκόπηση:"
@@ -4923,48 +4944,47 @@ msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογ
 msgid "Click to confirm the font selection."
 msgstr "Κάνετε κλικ για να επιβεβαιώσετε την επιλογή γραμματοσειράς."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Επιλέξτε γραμματοσειρά"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "αρχείο καταλόγου για την περιοχή (domain) '%s' δεν βρέθηκε."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Δεν βρέθηκαν εισαγωγές(entries)."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Ευρετήριο Βοηθείας"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Σχετικές εγγραφές:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Εισαγωγές(entries) βρέθηκαν"
 
@@ -5076,59 +5096,59 @@ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωση
 msgid "Printing page %d..."
 msgstr "Γίνεται εκτύπωση σελίδας %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Επιλογές εκτυπωτή"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Εκτύπωση σε Αρχείο"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Ρυθμίσεις..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Εκτυπωτής:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Κατάσταση: "
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Όλα"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Σελίδες"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Εύρος εκτύπωσης"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Από:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Πρός:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Αντίγραφα:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Αρχείο PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Οργάνωση(setup) Εκτύπωσης"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Εκτυπωτής"
 
@@ -5136,25 +5156,25 @@ msgstr "Εκτυπωτής"
 msgid "Default printer"
 msgstr "Προκαθορισμένος εκτυπωτής"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Μέγεθος χαρτιού"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Πορτραίτο"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Τοπίο"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Προσανατολισμός"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Επιλογές"
 
@@ -5166,54 +5186,54 @@ msgstr "Εγχρωμη εκτύπωση"
 msgid "Print spooling"
 msgstr "Spooling εκτύπωσης"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Εντολή εκτυπωτή:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Επιλογές εκτυπωτή:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Αριστερό περιθώριο (mm)"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Πάνω περιθώριο (mm)"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Δεξί περιθώριο (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Κάτω περιθώριο (mm)"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Εκτυπωτής..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 #, fuzzy
 msgid "&Skip"
 msgstr "Παράλειψη"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 #, fuzzy
 msgid "Unknown"
 msgstr "άγνωστο"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Έτοιμο."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Αναζήτηση"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Δεν ήταν δυνατή η εύρεση tab για το id"
 
@@ -5249,22 +5269,22 @@ msgstr "&Τέλος"
 msgid "< &Back"
 msgstr "< &Πίσω"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Απέτυχε η δημιουργία καταλόγου '%s'/.gnome."
@@ -5290,12 +5310,12 @@ msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από 
 msgid "Failed to register font configuration using private fonts."
 msgstr "Αποτυχία ανανέωσης του αρχείου ρυθμίσεων του χρήστη."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Μοιραίο σφάλμα"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5303,7 +5323,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5311,7 +5331,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI παιδί"
 
@@ -5329,36 +5349,27 @@ msgstr "Σφάλμα κατά την αναμονή στη σημαφόρο"
 msgid "Page Setup"
 msgstr "Οργάνωση(setup) Σελίδας"
 
-#: ../src/gtk/textctrl.cpp:1273
-#, fuzzy
-msgid "Failed to insert text in the control."
-msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Παρακαλώ επιλέξτε μία αποδεκτή γραμματοσειρά."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5457,45 +5468,45 @@ msgstr "Δεν είναι δυνατό το άνοιγμα των περιεχο
 msgid "Cannot open index file: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα του αρχείου ευρετηρίου(index): %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "ανώνυμο"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα βιβλίου βοήθειας HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(σελιδοδείκτες)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Προσθήκη της τρέχουσας σελίδας στους σελιδοδείκτες"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Αφαίρεση τρέχουσας σελίδας από τους σελιδοδείκτες"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Περιεχόμενα"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Εύρεση"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Εμφάνιση όλων"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5503,19 +5514,19 @@ msgstr ""
 "Εμφάνιση όλων των στοιχείων του ευρετηρίου δεδομένου substring. Η αναζήτηση "
 "διακρίνει μεταξύ κεφαλαίων/πεζών."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Εμφάνιση όλων των στοιχείων στο ευρετήριο"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Διάκριση κεφαλαίων-πεζών"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Ολόκληρες λέξεις μόνο"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -5524,147 +5535,147 @@ msgstr ""
 "Αναζήτηση στα περιεχόμενα του/των βιβλίου/βιβλίων βοηθείας για όλες τις "
 "εμφανίσεις του κειμένου που γράψατε επάνω"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Εμφλανιση/Κρύψιμο πλαίσιο πλοήγησης (navigation panel)"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Πήγαινε πίσω"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Πήγαινε εμπρός"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Πήγαινε ένα επίπεδο πάνω στην ιεραρχεία του εγγράφου"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "’νοιγμα εγγράφου HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Εκτύπωση αυτής της σελίδας"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Εμφάνιση του διαλόγου επιλογών"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Παρακλώ επιλέξτε την σελίδα για απεικόνιση:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Θέματα Βοήθειας"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Γίνεται αναζήτηση..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Δεν βρέθηκε ακόμα σελίδα που να ταιράζει"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Βρέθηκαν %i αντιστοιχίες"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Βοήθεια)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i από %i"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i από %i"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Εύρεση σε όλα τα βιβλία"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Επιλογές Περιηγητή Βοηθείας"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Κανονική γραμματοσειρά:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Γραμματοσειρά σταθερού μεγέθους:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Μέγεθος γραμματοσειράς:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "μέγεθος γραμματοσειράς"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Κανονική όψη<br>και <u>υπογραμμισμένη</u>."
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Πλάγια όψη."
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Έντονη όψη</b>"
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Εντονη πλάγια όψη.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Όψη σταθερού μεγέθους.<br> <b>έντονη</b> <i>πλάγια</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>έντονα πλάγια <u>υπογραμμισμένα</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Βοήθεια Εκτύπωσης"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Δεν είναι δυνατή η εκτύπωση άδειας σελίδας."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Αρχεία HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Βιβλία βοήθειας (*.htb)|*.htb|Αρχεία βοήθειας (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Εργασία HTML βοήθειας (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Αρχείο βοήθειας συμπιεσμένης HTML (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i από %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i από %i"
@@ -5737,38 +5748,6 @@ msgstr ""
 "Υπήρξε πρόβλημα κατά την διάρκεια οργάνωσης δελίδας (page setup): ίσως να "
 "χρειαστεί να θέσετε έναν προεπιλεγμένο (default) εκτυπωτή."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Απέτυχε η προβολή του εγγράφου HTML στην κωδικοποίηση %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr ""
-"Η βιλιοθήκη wxWidgets δεν μπορεί να ανοίξει την απεικόνιση για το '%s': "
-"έξοδος..."
-
-#: ../src/motif/filedlg.cpp:218
-#, fuzzy
-msgid "Filter"
-msgstr "Αρχείο"
-
-#: ../src/motif/filedlg.cpp:219
-#, fuzzy
-msgid "Directories"
-msgstr "Διακοσμητικός"
-
-#: ../src/motif/filedlg.cpp:220
-#, fuzzy
-msgid "Files"
-msgstr "Αρχείο"
-
-#: ../src/motif/filedlg.cpp:220
-#, fuzzy
-msgid "Selection"
-msgstr "Τμήματα"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Αποτυχία ανοίγματος του προχείρου (clipboard)."
@@ -5812,65 +5791,65 @@ msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφ�
 msgid "Failed to create cursor."
 msgstr "Αποτυχία δημιουργίας δείκτη."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Απέτυχε η καταχώρηση του DDE εξυπηρετητή (server) '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
 "Αποτυχία απο-καταχώρησης (unregister) του DDE εξυπηρετητή (server) '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "Αποτυχία κατά την δημιουργία σύνδεσης με τον εξυπηρετητή (server) '%s' στο "
 "θέμα '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Η DDE poke αίτηση απέτυχε"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Αποτυχία επίτευξης βρόχου advise με τον διακομιστή DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Αποτυχία τερματισμού του advise loop με τον DDE εξυπηρετητή (server)"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Αποτυχία κατά την αποστολή DDE advise επισήμανσης"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Απέτυχε η δημιουργεία ενός DDE αλφαρηθμιτικού (string)"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "κανένα λάθος DDE"
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "μία αίτηση για σύγχρονη(synchronous) ενημερωτική(advise) "
 "συναλλαγή(transaction) ξεπέρασε το χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "η απάντηση στη συναλλαγή ανάγκασε το DDE_FBUSY bit να τεθεί."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "μία αίτηση για σύγχρονη(synchronous) συναλλαγή(transaction) δεδομένων(data) "
 "ξεπέρασε το χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5882,7 +5861,7 @@ msgstr ""
 "ή ένα λανθασμένο αναγνωριστικό(identifier) instance\n"
 "δόθηκε σε μια DDEML συνάρτηση(function)."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5894,49 +5873,49 @@ msgstr ""
 "ή μία εφαρμογή που αρχικοποιήθηκε ως APPCMD_CLIENTONLY\n"
 "προσπάθησε να κάνει συναλλαγές εξυπηρετητή (server transactions)."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "μία αίτηση για σύγχρονη(synchronous) συναλλαγή(transaction) "
 "εκτέλεσης(execute) ξεπέρασε το χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "απέτυχε η επικύρωση μιας παραμέτρου από το DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "μια DDEML εφαρμογή έχει δημιουργήσει έναν παρατεταμένο race condition."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "μία προσπάθεια δέσμευσης (allocation) μνήμης απέτυχε."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 "η προσπάθεια ενός πελάτη(client) να εδραιώσει(establish) μία "
 "συνδιάλεξη(conversation) απέτυχε."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "μία συναλλαγή (transaction) απέτυχε."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "μία αίτηση για σύγχρονη(synchronous) poke συναλλαγή(transaction) ξεπέρασε το "
 "χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "μία εσωτερική κλήση στην συνάρτηση (function) PostMessage απέτυχε."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "πρόβλημα επανεισαγωγής (reentrancy problem)."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5947,17 +5926,17 @@ msgstr ""
 "που είχε τερματιστεί από τον πελάτη(client), ή ο εξυπηρετητής (server)\n"
 "τερμάτισε πριν ολοκληρωθεί μια συναλλαγή( transaction)."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "ένα εσωτερικό λάθος συνέβη στο DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "μία αίτηση για τερματισμό μιας ενημερωτικής(advise) συναλλαγής(transaction) "
 "ξεπέρασε το χρονικό περιθώριο (timed out)"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5968,12 +5947,12 @@ msgstr ""
 "Όταν η εφαρμογή επιστρέψει από ένα XTYP_XACT_COMPLETE callback,\n"
 "το αναγνωριστικό συναλλαγής για εκείνο το callback δεν θα είναι πλέον έγκυρο."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "’γνωστο σφάλμα DDE %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5982,7 +5961,7 @@ msgstr ""
 "γιατί η υπηρεσία απομακρυσμένης πρόσβασης (remote access service, RAS) δεν "
 "είναι εκατεστημένη σε αυτό το μηχάνημα. Παρακαλώ εγκαταστήστε τη."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5992,71 +5971,71 @@ msgstr ""
 "(remote access service, RAS) είναι πολύ παλία, παρακαλώ αναβαθμίστε (η "
 "ακόλουθη απαραίτητη συνάρτηση λείπει: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Αποτυχία στη λήψη κειμένου από το μήνυμα σφάλματος RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "άνωστο λάθος (κωδικός λάθους %08x)"
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Δεν είναι δυνατή η εύρεση της ενεργού τηλεφωνικής συνδέσεως: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Βρέθηκαν πολλαπλές ενεργές τηλεφωνικές συνδέσεις, γίνεται τυχαία επιλογή "
 "μίας."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, fuzzy, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Αποτυχία %s της σύνδεσης μέσω τηλεφώνου : %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Αποτυχία κατά την λήψη των ονομάτων των ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 "Αποτυχία συνδεσης: κανένας παροχέας υπηρεσιών Internet (ISP) για να καλέσω."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Επιλέξτε παροχέα Internet για κλήση"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 "Παρακαλώ επιλέξτε τον παροχέα υπηρεσιών Internet (ISP) με τον οποίο θέλετε "
 "να συνδεθείτε"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Αποτυχία συνδεσης: λείπει το όνομα χρήστη/συνθηματικό"
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Δεν είναι δυνατή η εύρεση της θέσης του αρχείου βιβλίου διευθύνσεων"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Αποτυχία τερματισμού της σύνδεσης μέσω τηλεφώνου : %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr ""
 "Δεν είναι δυνατό το κλείσιμο της γραμμής - δεν υπάρχει ενεργός τηλεφωνική "
 "σύνδεση."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Αποτυχία τερματισμού της σύνδεσης μέσω τηλεφώνου : %s"
@@ -6076,19 +6055,18 @@ msgstr "Αποτυχία δέσμευσης %luKb μνήμης για δεδομ
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Δεν είναι δυνατή η απαρίθμηση των αρχείων στον κατάλογο '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (σφάλμα %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Δεν ήταν δυνατή η προσθήκη μιας εικόνας στην λίστα εικόνων."
 
@@ -6104,7 +6082,7 @@ msgstr ""
 "Απέτυχε η δημιουργία καθιερωμένου παράθυρου διαλόγου εύρεσης/αντικατάστασης "
 "(κωδικός σφάλματος %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Η εκτέλεση της εντολής '%s' απέτυχε με σφάλμα: %ul"
@@ -6149,17 +6127,17 @@ msgstr "Αποτυχία αγγίγματος (touch) του αρχείου '%s'
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Δεν ήταν δυνατή η δημιουργία χρονοδιακόπτη (timer)"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Απέτυχε η αρχικοποίηση του OpenGL"
 
@@ -6167,7 +6145,7 @@ msgstr "Απέτυχε η αρχικοποίηση του OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6175,7 +6153,7 @@ msgstr ""
 "Οι συναρτήσεις (functions) της MS HTML Help δεν είναι διαθέσιμες γιατί η "
 "βιβλιοθήκη MS HTML Help δεν είναι εγκατεστημένη. Παρακαλώ εγκαταστήστε την."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Αποτυχία στην αρχικοποίηση του MS HTML Help."
 
@@ -6184,7 +6162,7 @@ msgstr "Αποτυχία στην αρχικοποίηση του MS HTML Help."
 msgid "Can't delete the INI file '%s'"
 msgstr "Δεν είναι δυνατή η διαγραφή του αρχείου INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6309,7 +6287,7 @@ msgstr ""
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O τύπος προχείρου(clipboard format) '%d' δεν υπάρχει."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Παράλειψη"
 
@@ -6397,75 +6375,75 @@ msgstr ""
 "διαγράφοντάς το θα αφήσει το σύστημά σας σε κατάσταση αχρηστίας:\n"
 "η λειτουργία ματαιώθηκε."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Δεν είναι δυνατή η διαγραφή του κλειδιού '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Δεν είναι δυνατή η διαγραφή της τιμής '%s' από το κλειδί '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Δεν είναι δυνατή η ανάγνωση της τιμής του κλειδιού '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Δεν είναι δυνατή η ανάθεση τιμής του '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Δεν είναι δυνατή η ανάγνωση της τιμής του '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Δεν είναι δυνατή η απαρίθμηση των τιμών του κλειδιού '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Δεν είναι δυνατή η απαρίθμηση των υποκλειδιών του '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Δεν είναι δυνατή η εξαγωγή τιμών μη υποστηριζομένου τύπου %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6474,46 +6452,46 @@ msgstr ""
 "γίνεται χρήση του simpe text στοιχείου ελέγχου. Παρακαλώ επανεγκαταστήστε το "
 "riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 "Δεν είναι δυνατή η εκκίνηση του νήματος(thread): Σφάλμα κατά την εγγραφή του "
 "TLS"
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του νήματος εκτέλεσης (thread)"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Δεν είναι δυνατή η δημιουργία του νήματος εκτέλεσης (thread)"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Δεν ήταν δυνατός ο τερματισμός του thread"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr ""
 "Δεν είναι δυνατή η αναμονή(wait) για τον τερματισμό του νήματος "
 "εκτέλεσης(thread)"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Δεν είναι δυνατή η αναστολή εκτέλεσης(suspend) του νήματος(thread) %x"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Δεν είναι δυνατή η συνέχιση(resume) του νήματος(thread) %x"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 "Δεν ήταν δυνατή η ανάκτηση toy τρέχοντος δείκτη νήματος εκτέλεσης(thread)"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6522,7 +6500,7 @@ msgstr ""
 "δεσμευτεί (allocate) δείκτης (index) στην στην τοπική αποθήκευση νήματος "
 "(thread local storage)"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6554,12 +6532,12 @@ msgstr "Αποτυχία φόρτωσης της μετα-εικόνας από 
 msgid "Failed to lock resource \"%s\"."
 msgstr "Αποτυχία κλειδώματος του αρχείου 'κλειδωνιά'(lock file) '%s'"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6572,47 +6550,47 @@ msgid "Failed to redirect the child process IO"
 msgstr ""
 "Αποτυχία στην ανακατεύθυνση του IO διεργασίας απογόνου (child process IO)"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Η εκτέλεση της εντολής '%s' απέτυχε"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Αποτυχία φόρτωσης του mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Δεν είναι δυνατή η ανάγνωση ονομάτων τύπων(typenames) από το '%s'"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Δεν είναι δυνατή η φόρτωση εικονιδίου από το '%s'"
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του νήματος εκτέλεσης (thread)"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Αποτυχία εκτέλεσης του '%s'\n"
@@ -6652,7 +6630,7 @@ msgid "Check to make the font italic."
 msgstr "Κάνετε κλικ για να ακυρώσετε την επιλογή γραμματοσειράς."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 #, fuzzy
 msgid "Underlined"
@@ -6732,17 +6710,32 @@ msgstr "Τηλέτυπο"
 msgid "File type:"
 msgstr "Τηλέτυπο"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Παράθυρο"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Βοήθεια"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Ελα&χιστοποίηση"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "&Αύξηση ζουμ"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6759,492 +6752,492 @@ msgstr "Το αρχείο %s δεν υπάρχει."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "&Περί..."
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "&Περί"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "&Προτιμήσεις"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Βοήθεια: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Τμήματα"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Εμφάνιση όλων"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Έ&ξοδος"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Τμήματα"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Το Gzip δεν υποστηρίζεται από αυτήν την έκδοση της zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Δεν είναι δυνατή η αρχικοποίηση απεικόνησης."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "Μέγεθος κουκίδας:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "ΝέοΌνομα"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 #, fuzzy
 msgid "Style"
 msgstr "&Στυλ:"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "&Βάρος:"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "Οικογένεια γραμματοσειράς:"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Μοντέρνο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "απαλό(light)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Μοντέρνο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Μενού"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Παράθυρο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Παράθυρο"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Παράθυρο"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "μέγεθος γραμματοσειράς"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "&Επανάληψη"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "προκαθορισμένο"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "αύριο"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Απαλό(light)"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Μέγεθος κουκίδας:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Στοίχιση Δεξιά"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Ερώτημα"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Απαλό(light)"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Απαλό(light)"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Τμήματα"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "&Ιδιότητες"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 #, fuzzy
 msgid "False"
 msgstr "Αρχείο"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 #, fuzzy
 msgid "Unspecified"
 msgstr "Ευθυγραμμισμένα"
@@ -7259,49 +7252,49 @@ msgstr "Σφάλμα Εκτύπωσης"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Δώστε έναν αριθμό σελίδας μεταξύ %d και %d:"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "&Περί..."
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Δημιουργία καταλόγου"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "Επιλέξτε γραμματοσειρά"
@@ -7795,128 +7788,128 @@ msgstr "Στοίχιση"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "Στοίχιση"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "Στοίχιση"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 #, fuzzy
 msgid "files"
 msgstr "Αρχείο"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Διαγραφή στοιχείου"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "&Διαγραφή"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "Τμήματα"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Ιδιότητες"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 #, fuzzy
 msgid "image"
 msgstr "Ώρα"
@@ -8130,27 +8123,27 @@ msgstr ""
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 #, fuzzy
 msgid "Delete Text"
 msgstr "Διαγραφή στοιχείου"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Απομάκρυνση"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Το κείμενο δεν μπόρεσε να αποθυκευτεί."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 #, fuzzy
 msgid "Replace"
 msgstr "&Αντικατάσταση"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 #, fuzzy
 msgid "&Font:"
 msgstr "Οικογένεια γραμματοσειράς:"
@@ -9231,56 +9224,56 @@ msgstr ""
 msgid "Box styles"
 msgstr "&Επόμενο >"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 #, fuzzy
 msgid "&From:"
 msgstr "Από:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 #, fuzzy
 msgid "Unicode"
 msgstr "Α&ποστοίχιση"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 #, fuzzy
 msgid "Insert"
 msgstr "Στοίχιση"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 #, fuzzy
 msgid "(Normal text)"
 msgstr "Κανονική γραμματοσειρά:"
@@ -9481,7 +9474,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
@@ -9583,20 +9576,20 @@ msgstr "Τα δεδομένα ήχου είναι σε μη υποστηριζό
 msgid "Couldn't open audio: %s"
 msgstr "Δεν είναι δυνατό το άνοιγμα του ήχου: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Δεν είναι δυνατή η ανάκτηση της thread scheduling policy."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, fuzzy, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Δεν είναι δυνατή η ανάγνωση του εύρους προτεραιοτήτων"
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Η ρύθμιση προτεραιότητας του νήματος εκτέλεσης (thread) αγνοήθηκε. "
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9604,64 +9597,64 @@ msgstr ""
 "Απέτυχε η συνένωση(join) ενός νήματος εκτέλεσης (thread), πιθανή διαρροή "
 "μνήμης εντοπίστηκε - παρακαλώ επανεκκινήστε το πρόγραμμα"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, fuzzy, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Αποτυχία τερματισμού του thread"
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Η αρχικοποίηση μονάδας νήματος εκτέλεσης (thread module) απέτυχε: αποτυχία "
 "δημιουργίας κλειδιού νήματος (thread key)"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Αδύνατη η λήψη της εισόδου της διεργασίας (process) απογόνου(child)"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Αποτυχία θανάτωσης της διαδικασίας(process) %d"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Αποτυχία εκτέλεσης του '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Fork απέτυχε"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Δεν είναι δυνατή η θέση προτεραιότητας του thread"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr ""
 "Αποτυχία στην ανακατεύθυνση της εισόδου/εξόδου διεργασίας απογόνου (child "
 "process input/output)"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Δεν είναι δυνατή η ανάγνωση του ονόματος διακομιστή(hostname)"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr ""
 "Δεν είναι δυνατή η ανάγνωση του επισήμου ονόματος διακομιστή(official "
@@ -9681,12 +9674,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "Απέτυχε η ανάγνωση PID από αρχείο κλειδωνιά(lock file)."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Λανθασμένος γεωμετρικός καθορισμός(specification) '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "Η βιλιοθήκη wxWidgets δεν μπορεί να ανοίξει την απεικόνιση. 'Εξοδος..."
 
@@ -9700,30 +9693,66 @@ msgstr "Αποτυχία κλεισίματος του προχείρου(clipbo
 msgid "Failed to open display \"%s\"."
 msgstr "Αποτυχία ανοίγματος του '%s' για το '%s'"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML σφάλμα ανάγνωσης (parsing error): '%s' στη γραμμή %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Δεν είναι δυνατή η φόρτωση πόρων(resources) από το αρχείο '%s'"
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
+
+#~ msgid "Printing "
+#~ msgstr "Γίνεται εκτύπωση του "
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Αποτυχία λήψης καταλόγου εργασίας (working directory)"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Παρακαλώ επιλέξτε μία αποδεκτή γραμματοσειρά."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Απέτυχε η προβολή του εγγράφου HTML στην κωδικοποίηση %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr ""
+#~ "Η βιλιοθήκη wxWidgets δεν μπορεί να ανοίξει την απεικόνιση για το '%s': "
+#~ "έξοδος..."
+
+#, fuzzy
+#~ msgid "Filter"
+#~ msgstr "Αρχείο"
+
+#, fuzzy
+#~ msgid "Directories"
+#~ msgstr "Διακοσμητικός"
+
+#, fuzzy
+#~ msgid "Files"
+#~ msgstr "Αρχείο"
+
+#, fuzzy
+#~ msgid "Selection"
+#~ msgstr "Τμήματα"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "η μετατροπή σε 8-bit κωδικοποίηση απέτυχε"
@@ -9871,8 +9900,8 @@ msgstr "Η εξαγωγή του '%s' στο '%s' απέτυχε"
 #~ msgstr "Δεν ήταν δυνατή η εκκίνηση της εκτύπωσης."
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/es.po
+++ b/locale/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-06-29 09:27+0200\n"
 "Last-Translator: Miguel Giménez <tecnico@solener.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Todos los archivos (*.*)|*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Todos los archivos (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "Tiempo restante:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sí"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Aceptar"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
@@ -102,7 +99,7 @@ msgid "Unable to create I/O completion port"
 msgstr "No se pudo crear el puerto de finalización de E/S"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Impresión"
 
@@ -139,7 +136,7 @@ msgstr "Propiedades del objeto"
 msgid "Printing"
 msgstr "Imprimiendo"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Símbolos"
 
@@ -208,7 +205,7 @@ msgstr "&Anterior"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Ventana"
 
@@ -737,11 +734,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "mostrar este mensaje de ayuda"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "generar mensajes de log explicativos"
 
@@ -763,84 +760,84 @@ msgstr "No se admite el tema '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificación de modo de pantalla no válida: '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "La opción «%s» no puede negarse"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "El parámetro '%s' de entero largo es desconocido"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "La opción «%s» es desconocida"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracteres inesperados tras la opción '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "La opción «%s» exige un valor."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Se esperaba un separador después de la opción «%s»."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' no es un valor numérico correcto para el parámetro '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Parámetro «%s»: «%s» no puede convertirse en fecha."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parámetro «%s» inesperado"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "El valor para la opción '%s' debe especificarse."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "El parámetro requerido '%s' no fue especificado."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Uso: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "cad"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "núm"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "doble"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "fecha"
 
@@ -858,7 +855,7 @@ msgid "Can't &Undo "
 msgstr "No se puede &deshacer "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Deshacer"
@@ -868,7 +865,7 @@ msgid "&Redo "
 msgstr "&Rehacer "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Rehacer"
@@ -899,12 +896,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' tiene '..' adicional, se ignora."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "activada"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "desactivada"
 
@@ -913,103 +910,103 @@ msgstr "desactivada"
 msgid "undetermined"
 msgstr "sin determinar"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "hoy"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "ayer"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "mañana"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primero"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "segundo"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tercero"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "cuarto"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "quinto"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sexto"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "séptimo"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "octavo"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "noveno"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "décimo"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "undécimo"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "duodécimo"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "decimotercero"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "decimocuarto"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "decimoquinto"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "decimosexto"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "decimoséptimo"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "decimoctavo"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "decimonoveno"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vigésimo"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "mediodía"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "medianoche"
 
@@ -1077,44 +1074,81 @@ msgstr "Fallo al ejecutar curl, por favor instálelo en el PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Fallo al enviar el informe de depuración (código error %d)"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Guardar como"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "¿Descartar los cambios y recargar la última versión guardada?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "anónimo"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "¿Desea guardar los cambios hechos a %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Guardar"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "No guardar"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "¿Desea guardar los cambios hechos a %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "El texto no pudo guardarse."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "No se pudo abrir el archivo «%s» para su escritura."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Falló el guardado del documento en el archivo «%s»."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "No se pudo abrir el archivo «%s» para su lectura."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Falló la lectura del documento a partir del archivo «%s»."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1123,57 +1157,57 @@ msgstr ""
 "El archivo '%s' no existe y no puede abrirse.\n"
 "También ha sido eliminado de la lista de archivos recientes."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Error al crear la previsualización de impresión."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Previsualización de la impresión"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "No se pudo determinar el formato del archivo «%s»."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "anónimo%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Abrir archivo"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Error de archivo"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "No pudo abrirse este archivo."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Se desconoce el formato de este archivo."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Seleccionar una plantilla de documento"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Plantillas"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Seleccionar una vista de documento"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Vistas"
 
@@ -1207,42 +1241,42 @@ msgstr "Error de lectura en el archivo '%s'"
 msgid "Write error on file '%s'"
 msgstr "Error de escritura en el archivo '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "no se pudo limpiar el archivo '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Error de búsqueda en el archivo «%s» (stdio no admite los archivos grandes)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Error de búsqueda en el archivo «%s»"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "No se puede encontrar la posición actual en el archivo «%s»"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "No se pudieron cambiar permisos del archivo temporal"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "no se puede eliminar el archivo '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "no se pueden hacer efectivos los cambios en archivo '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "no se puede eliminar el archivo temporal '%s'"
@@ -1267,28 +1301,28 @@ msgstr "no se puede leer desde el descriptor de archivo %d"
 msgid "can't write to file descriptor %d"
 msgstr "no se puede escribir el descriptor de archivo %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "no se puede vaciar el descriptor de archivo %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "no se puede buscar en el descriptor de archivo %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "no se puede alcanzar posición de búsqueda en el descriptor de archivo %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "no se puede obtener el tamaño del archivo con descriptor %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1316,110 +1350,110 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Error al leer las opciones de configuración."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Falló la lectura de las opciones de configuración."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "archivo «%s»: carácter %c inesperado en el renglón %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "archivo «%s», renglón %zu: «%s» ignorado después de cabecera de grupo."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "archivo «%s», renglón %zu: se esperaba «=»."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "archivo «%s», renglón %zu: se ignoró el valor para la clave inmutable «%s»."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "archivo «%s», renglón %zu: se encontró la clave «%s» por primera vez en el "
 "renglón %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Un nombre de entrada de configuración no puede empezar por «%c»."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "no puede abrirse el archivo de configuración de usuario."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "no puede escribirse el archivo de configuración de usuario."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "No se pudo actualizar el archivo de configuración de usuario."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Error al guardar los datos de configuración del usuario."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "no se puede eliminar el archivo de configuración de usuario '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "la entrada '%s' aparece más de una vez en el grupo '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "intento de cambiar clave inmutable '%s', ignorado."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "ignorada la barra inversa al final de '%s'."
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inesperada en la posición %d en '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "No se pudo copiar el archivo '%s' a '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Imposible obtener permisos para el archivo '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Imposible sobrescribir el archivo «%s»"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Falló la copia del archivo «%s» en «%s»."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Imposible establecer los permisos del archivo «%s»"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1428,40 +1462,40 @@ msgstr ""
 "No se pudo renombrar el archivo '%s' a '%s' porque el archivo de destino ya "
 "existe."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "No se pudo cambiar el nombre del archivo «%s» como «%s»"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "No se pudo quitar el archivo «%s»"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "No se pudo crear el directorio «%s»"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "No se pudo eliminar el directorio «%s»"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "No se pueden enumerar los archivos «%s»"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Error al obtener el directorio de trabajo"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "No se pudo establecer la carpeta de trabajo actual"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Archivos (%s)"
@@ -1488,17 +1522,17 @@ msgstr "No se pudo crear un nombre temporal de archivo"
 msgid "Failed to open temporary file."
 msgstr "Falló la apertura del archivo temporal."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "No se pudo modificar la hora del archivo para '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "No se pudo  retocar' el archivo '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "No se pudo obtener horas del archivo para '%s'"
@@ -1507,22 +1541,22 @@ msgstr "No se pudo obtener horas del archivo para '%s'"
 msgid "Browse"
 msgstr "Navegar"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Todos los archivos (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "archivos %s (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Cargar el archivo %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Guardar el archivo %s"
@@ -1885,99 +1919,99 @@ msgstr "predeterminado"
 msgid "unknown-%d"
 msgstr "desconocido-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "subrayado"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " tachado"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " fina"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " extraligera"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " ligera"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " media"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " negrita media"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " negrita"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " negrita extra"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " pesada"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " extrapesada"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "tachado"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "fina"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "extraligera"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "ligera"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "media"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "negrita media"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "negrita"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "negrita extra"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "pesada"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "extrapesada"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "cursiva"
 
@@ -2059,7 +2093,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Falló la definición del modo de transferencia FTP a %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2081,7 +2115,7 @@ msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 "Tamaño de fotograma incorrecto en el GIF (%u, %d) para el fotograma #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Fallo al reservar un color para OpenGL"
 
@@ -2097,7 +2131,7 @@ msgstr "Personalizar columnas"
 msgid "&Customize..."
 msgstr "&Personalizar…"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Falló la apertura de la URL '%s' en el navegador predeterminado"
@@ -2117,159 +2151,158 @@ msgstr "No se pudo abrir la imagen %d desde el flujo."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Falló la carga de los iconos a partir del recurso «%s»."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: no se pudo guardar una imagen no válida."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage no tiene su propia wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: no se pudo escribir la cabecera (Bitmap) del archivo."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: no se pudo escribir la cabecera (BitmapInfo) del archivo."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: no se pudo escribir el mapa de color RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: no se pudieron escribir los datos."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: no se pudo reservar memoria."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Cabecera DIB: Anchura de imagen > 32767 pixels por archivo."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Cabecera DIB: Altura de la imagen > 32767 pixels por archivo."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Cabecera DIB: Profundidad de color desconocida en archivo."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Cabecera DIB: Codificación desconocida en archivo."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Cabecera DIB: La codificación no coincide con la profundidad de bits."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: la cabecera tiene biClrUsed=%d pero biBitCount=%d."
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: no se pudo reservar memoria."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Cabecera DIB: Anchura de imagen > 32767 pixels por archivo."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Cabecera DIB: Altura de la imagen > 32767 pixels por archivo."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Cabecera DIB: Profundidad de color desconocida en archivo."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Cabecera DIB: Codificación desconocida en archivo."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Cabecera DIB: La codificación no coincide con la profundidad de bits."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Error al leer la imagen DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Error al leer máscara DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imagen demasiado alta para un icono."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imagen demasiado ancha para un icono."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: ¡Error al escribir el archivo de imagen!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Indice de icono no válido."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "La imagen y la máscara son de tamaños distintos."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr ""
 "No hay ningún color sin utilizar en la imagen que se está enmascarando."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "No se pudo cargar la imagen \"%s\" desde los recursos."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "No se pudo cargar el icono \"%s\"  desde los recursos."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "No se pudo abrir la imagen desde el archivo \"'%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "No se puede guardar la imagen en el archivo «%s»: extensión desconocida."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "No se ha encontrado ningún manipulador para el tipo de imagen."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "No hay definido ningún manipulador de imagen para tipo %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "El archivo de imagen no es del tipo %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "No se puede determinar automáticamente el formato de imagen en entradas "
 "secuenciales."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Formato de imagen desconocido."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Esto no es un %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "No hay definido ningún manipulador de imagen para tipo %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "La imagen no es del tipo %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Fallo comprobando el formato del archivo de imagen \"%s\"."
@@ -2372,41 +2405,41 @@ msgstr "PNM: el archivo parece estar truncado."
 msgid " (in module \"%s\")"
 msgstr " (en el módulo «%s»)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: error al cargar la imagen."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Índice de imagen TIFF no válido."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: el tamaño de la imagen es anormalmente grande."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: no se pudo reservar memoria."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: error al leer la imagen."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ignorada la unidad desconocida de resolución TIFF %d"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: error al guardar la imagen."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: error al escribir la imagen."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2414,11 +2447,11 @@ msgid ""
 msgstr ""
 "No se pudo convertir el argumento de consola %d en Unicode y se ignorará."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Falló la inicialización en la fase «post init»; se ha interrumpido."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "No se puede cambiar la configuración regional al idioma «%s»."
@@ -2512,7 +2545,7 @@ msgstr "Error de compresión LZMA %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Error de compresión LZMA al vaciar la salida: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Llave abierta no emparejada en una entrada para tipo mime %s."
@@ -2532,7 +2565,7 @@ msgstr "No existe la dependencia \"%s\" del módulo \"%s\"."
 msgid "Module \"%s\" initialization failed"
 msgstr "Falló la inicialización del módulo «%s»"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Mensaje"
 
@@ -3034,7 +3067,7 @@ msgstr "Error de impresión"
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Configurar página"
 
@@ -3069,19 +3102,15 @@ msgstr "Imprimiendo página %d de %d"
 msgid " (copy %d of %d)"
 msgstr " (copia %d de %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Imprimiendo "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Primera página"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Página anterior"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Página siguiente"
 
@@ -3125,16 +3154,16 @@ msgstr "Página %d de %d"
 msgid "Page %d"
 msgstr "Página %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "error desconocido"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expresión regular no válida «%s»: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Failed to find match for regular expression: %s"
@@ -3146,21 +3175,21 @@ msgstr ""
 "El renderizador \"%s\" tiene una versión %d.%d incompatible y no se ha "
 "podido abrir."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "No disponible para esta plataforma"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Fallo al guardar la contaseña para \"%s\": %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Fallo al leer la contraseña para \"%s\": %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Fallo al borrar la contraseña para \"%s\": %s."
@@ -3169,11 +3198,11 @@ msgstr "Fallo al borrar la contraseña para \"%s\": %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Fallo al monitorizar los canales de E/S"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Guardar"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "No guardar"
 
@@ -3254,10 +3283,10 @@ msgid "Clear"
 msgstr "Limpiar"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Cerrar"
 
@@ -3269,7 +3298,7 @@ msgstr "&Convertir"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
@@ -3278,7 +3307,7 @@ msgstr "&Copiar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cor&tar"
@@ -3287,13 +3316,13 @@ msgstr "Cor&tar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Eliminar"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Eliminar"
@@ -3380,7 +3409,7 @@ msgstr "Disco duro"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "Ay&uda"
 
@@ -3400,7 +3429,7 @@ msgstr "Sangría"
 msgid "&Index"
 msgstr "Índ&ice"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Índice"
 
@@ -3469,7 +3498,7 @@ msgstr "&Nuevo"
 msgid "New"
 msgstr "Nuevo"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&No"
 
@@ -3486,12 +3515,12 @@ msgstr "A&brir…"
 msgid "Open..."
 msgstr "Abrir…"
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Pegar"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Pegar"
@@ -3521,7 +3550,7 @@ msgid "Print..."
 msgstr "Imprimir..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Propiedades"
 
@@ -3553,10 +3582,6 @@ msgstr "Sustituir..."
 msgid "Revert to Saved"
 msgstr "Recuperar versión guardada"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Guardar"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "G&uardar como…"
@@ -3565,7 +3590,7 @@ msgstr "G&uardar como…"
 msgid "Save As..."
 msgstr "Guardar como…"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Seleccionar &todo"
@@ -3672,7 +3697,7 @@ msgstr "&Arriba"
 msgid "Up"
 msgstr "Arriba"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Sí"
 
@@ -3760,43 +3785,43 @@ msgstr "Guardar documento actual"
 msgid "Save current document with a different filename"
 msgstr "Guardar el documento actual con otro nombre"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Conversión a juego de caracteres '%s' no funciona."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "desconocido"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "bloque de cabecera incompleto en tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "fallo de suma de comprobación leyendo bloque de cabecera de tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "datos no válidos en la cabecera de TAR extendida"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "elemento tar no abierto"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fin de archivo inesperado"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s no se ajustó a la cabecera tar para la entrada '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tamaño incorrecto para elemento de TAR"
 
@@ -3805,7 +3830,7 @@ msgstr "tamaño incorrecto para elemento de TAR"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' es probablemente un buffer binario."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "No se pudo abrir el archivo."
 
@@ -3819,47 +3844,47 @@ msgstr "Falló la lectura del archivo de texto  '%s'."
 msgid "can't write buffer '%s' to disk."
 msgstr "no se puede guardar el buffer '%s' al disco."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Error al obtener el sistema horario local"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay falló."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' no es un catálogo de mensajes válido."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catálogo de mensajes no válido."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "No se pudieron analizar las formas plurales: «%s»"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "se usa el catálogo «%s» de «%s»."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "El recurso '%s' no es un catálogo de mensajes válido."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "No se pudieron enumerar las traducciones"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "No se ha configurado la aplicación predeterminada para archivos HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Falló la apertura del URL «%s» en el navegador predeterminado."
@@ -3892,7 +3917,7 @@ msgstr "'%s' contiene caracteres no permitidos"
 msgid "Error: %s (%d)"
 msgstr "Error: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "No hay espacio suficiente en el disco para la descarga."
 
@@ -3900,20 +3925,20 @@ msgstr "No hay espacio suficiente en el disco para la descarga."
 msgid "libcurl could not be initialized"
 msgstr "no se pudo inicializar libcurl"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync no soportado"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Error ejecutando JavaScript: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Esta plataforma no admite transparencias de fondo."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "No se pudieron transferir datos a la ventana"
 
@@ -3966,8 +3991,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Clase de objeto no permitida (Non-wxEvtHandler) como origen de sucesos"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "El tipo debe tener conversión de enum a long"
 
@@ -4017,83 +4042,83 @@ msgstr "Los objetos deben tener un atributo de identificación"
 msgid "Doubly used id : %d"
 msgstr "Identificador usado dos veces: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propiedad %s desconocida"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una colección no vacía debe consistir en nodos del tipo «element»"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "cadena de identificador de suceso incorrecta; falta el punto"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "no se puede reinicializar el flujo de compresión de zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "no se puede reinicializar el flujo de descompresión de zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Ignorando regiatro de datgos extra mal formado, el archivo ZIP puede estar "
 "corrompido"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "suponemos que es un archivo zip multiparte concatenado"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "archivo ZIP no válido"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "no se puede encontrar el directorio central del ZIP"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "error al leer el directorio central del ZIP"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "error al leer la cabecera local del archivo zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "desplazamiento erróneo al elemento del archivo zip"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "longitud del archivo almacenada no está en la cabecera del Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "no se admite el método de compresión ZIP"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "al leer flujo de zip (elemento %s): longitud errónea"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "al leer flujo de zip (elemento %s): crc erróneo"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "error escribiendo la entrada zip '%s': el archivo es demasiado grande, "
 "necesita ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "error al escribir el elemento de zip '%s': crc o longitud erróneos"
@@ -4181,32 +4206,32 @@ msgstr "Arte gráfico por "
 msgid "Translations by "
 msgstr "Traducciones por "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versión "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Acerca de %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licencia"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Desarrolladores"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Redactores de documentación"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Traductores"
 
@@ -4257,42 +4282,42 @@ msgid "Password:"
 msgstr "Contraseña:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "verdadero"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "falso"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Fila %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Contraer"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Expandir"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elementos)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Columna %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4303,7 +4328,7 @@ msgid "Left"
 msgstr "Izquierda"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4399,7 +4424,7 @@ msgid "Home directory"
 msgstr "Directorio de usuario"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Escritorio"
 
@@ -4412,8 +4437,7 @@ msgstr "El nombre del directorio no está permitido."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Error"
 
@@ -4597,16 +4621,16 @@ msgstr "Ver archivos como vista detallada"
 msgid "Go to parent directory"
 msgstr "Ir al directorio contenedor"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "El archivo «%s» ya existe; ¿realmente quiere sobrescribirlo?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Elija un archivo existente."
 
@@ -4700,7 +4724,7 @@ msgstr "El tamaño en puntos del tipo de letra."
 msgid "Whether the font is underlined."
 msgstr "Si la fuente está subrayada."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Previsualización:"
@@ -4718,49 +4742,48 @@ msgstr "Pulse para cancelar la selección del tipo de letra."
 msgid "Click to confirm the font selection."
 msgstr "Pulse para confirmar la selección del tipo de letra."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Elija un tipo de letra"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "No se puede copiar más de un bloque seleccionado al portapapeles."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "No se encontró el directorio de ayuda «%s»."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "No se encontró el archivo de ayuda «%s»."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "El renglón %lu del archivo de mapa «%s» tiene sintaxis no válida; se omite."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "No se han encontrado asignaciones válidas en el archivo «%s»."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "No se han encontrado documentos."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Contenido de la ayuda"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Entradas relevantes:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Entradas encontradas"
 
@@ -4865,59 +4888,59 @@ msgstr "No se pudo iniciar la impresión."
 msgid "Printing page %d..."
 msgstr "Imprimiendo página %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opciones de impresión"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Imprimir a archivo"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configuración…"
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Impresora:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Estado:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Todo"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Páginas"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Intervalo de impresión"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "De:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Hasta:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Copias:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Archivo PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Configuración de impresión"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Impresora"
 
@@ -4925,25 +4948,25 @@ msgstr "Impresora"
 msgid "Default printer"
 msgstr "Impresora predeterminada"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Tamaño del papel"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Vertical"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Horizontal"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientación"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opciones"
 
@@ -4955,52 +4978,52 @@ msgstr "Impresión en color"
 msgid "Print spooling"
 msgstr "Cola de impresión"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Orden de la impresora:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opciones de impresión:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Margen izquierdo (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Margen superior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Margen derecho (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Margen inferior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Impresora..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Saltar"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Hecho."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Buscar"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "No se pudo encontrar pestaña para id"
 
@@ -5036,11 +5059,11 @@ msgstr "&Finalizar"
 msgid "< &Back"
 msgstr "< &Atrás"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Andriy Byelikov https://github.com/andriybyelikov"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5050,11 +5073,11 @@ msgstr ""
 "problemas con la gestión de la entrada y parpadeos. Le recomendamos borrar "
 "el contenido de GTK_IM_MODULE o configurarlo como \"ibus\"."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "No se pudo inicializar GTK+, ¿está DISPLAY configurada correctamente?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Falló el cambio del directorio actual a «%s»"
@@ -5081,11 +5104,11 @@ msgid "Failed to register font configuration using private fonts."
 msgstr ""
 "No se pudo registrar la configuración de la fuente usando fuentes privadas."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Error fatal"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5097,7 +5120,7 @@ msgstr ""
 "modificando la\n"
 "variable de entorno GDK_BACKEND=x11 antes de arrancar su programa."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5108,7 +5131,7 @@ msgstr ""
 "solucionarlo modificando la variable de entorno GDK_BACKEND=x11 antes\n"
 "de iniciar su programa."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Ventana hija MDI"
 
@@ -5124,15 +5147,11 @@ msgstr "Error al imprimir: "
 msgid "Page Setup"
 msgstr "Configurar página"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "No se pudo insertar texto en el control."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "No se puede obtener la salida de un guión JavaScript usando WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5140,24 +5159,20 @@ msgstr ""
 "El GTK+ instalado en esta máquina es demasiado antiguo para admitir la "
 "composición de pantallas; instale GTK+ 2.12 o posterior."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "El sistema no admite la composición. Actívela en su gestor de ventanas."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Este programa se compiló con una versión muy antigua de GTK+. Recompílelo "
 "con GTK+ 2.12 o posterior."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Elija un tipo de letra válido."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5256,45 +5271,45 @@ msgstr "No se puede abrir el archivo de contenidos: %s"
 msgid "Cannot open index file: %s"
 msgstr "No se puede abrir el archivo de índice: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "anónimo"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "No se puede abrir el libro de ayuda HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Muestra la ayuda mientras revisa los libros a la izquierda."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(favoritos)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Añadir página actual a Marcadores"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Eliminar la página actual de favoritos"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Contenidos"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Buscar"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Mostrar todo"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5302,166 +5317,166 @@ msgstr ""
 "Mostrar todos los elementos del índice que contengan la subcadena dada. La "
 "búsqueda es Insensitiva."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Mostrar todos los datos en el índice"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Distingue mayúsculas y minúsculas"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Sólo palabras completas"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 "Buscar en los libros de ayuda todas las apariciones del texto que ha escrito"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Mostrar/ocultar panel de navegación"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Retroceder"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Avanzar"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Subir un nivel en la jerarquía del documento"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Abrir documento HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Imprimir esta página"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Mostrar el diálogo de opciones"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Elija la página que quiera mostrar:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Temas de ayuda"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Buscando…"
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Todavía no se ha encontrado una página con coincidencias"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Se encontraron %i coincidencias"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Ayuda)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Buscar en todos los libros"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opciones del Navegador de ayuda"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Tipo de letra normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Tipo monoespaciado:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Tamaño de letra:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "tamaño de fuente"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Tipo de letra normal<br>y <u>subrayado</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Negrita.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Negrita cursiva.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Tipo de letra de tamaño fijo.<br> <b>negrita</b> <i>cursiva</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negrita cursiva <u>subrayada</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Ayuda de impresión"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "No se puede imprimir una página vacía."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Archivos HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libros de ayuda (*.htb)|*.htb|Libros de ayuda (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Proyecto de ayuda HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Archivo de ayuda HTML comprimido (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i de %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u de %u"
@@ -5542,32 +5557,6 @@ msgstr ""
 "Hubo un problema al configurar la página: se necesita una impresora "
 "predeterminada."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Error al mostrar el documento HTML con codificación %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets no pudo abrir el 'display' para '%s': saliendo."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtro"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Directorios"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Archivos"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selección"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Falló la apertura del portapapeles."
@@ -5609,58 +5598,58 @@ msgstr "El diálogo de selección de color falló con error %0lx."
 msgid "Failed to create cursor."
 msgstr "Falló la creación del cursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Error al registrar el servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Error al desregistrar el servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Falló la creación de la conexión con el servidor «%s» en «%s»"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Falló la petición de rastreo DDE"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Fallo al establecer un lazo de aviso con el servidor DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Error al terminar el bucle de aviso con el servidor DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Fallo al enviar notificación de aviso DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Fallo al crear cadena DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "no hay error DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "una petición para una transación síncrona ha finalizado."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "la respuesta a la transacción causó que se activase el bit DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "una petición para una transacción de datos síncrona ha finalizado."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5672,7 +5661,7 @@ msgstr ""
 "o se pasó un identificador de instancia no válido\n"
 "a una función DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5684,43 +5673,43 @@ msgstr ""
 "o una aplicación inicializada como APPCMD_CLIENTONLY ha\n"
 "intentado realizar transacciones de servidor."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "una petición para una transación de ejecución síncrona ha finalizado."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "fallo al validar un parémetro por DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "una aplicación DDEML ha creado una condición acelerada prolongada."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "fallo al reservar memoria."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "el intento de un cliente de establece conversación falló."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "fallo en la transacción."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "una petición para una transacción síncrona de revisión ha finalizado."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ha fallado una llamada interna a la función PostMessage. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5730,15 +5719,15 @@ msgstr ""
 "que fue finalizada por el cliente, o el servidor\n"
 "terminó antes de completar una transacción."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "ha ocurrido un error interno en DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "una petición para una transacción síncrona de auditoría ha finalizado."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5749,12 +5738,12 @@ msgstr ""
 "XTYP_XACT_COMPLETE,\n"
 "el identificador de la transacción para esa llamada deja de ser válido."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Error DDE desconocido %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5762,7 +5751,7 @@ msgstr ""
 "Las funciones de marcado no están disponibles porque los servicios de acceso "
 "remoto (RAS) no están instalados. Por favor instálelos."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5772,65 +5761,65 @@ msgstr ""
 "demasiado vieja, por favor actualícela (la función requerida no está "
 "disponible: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Fallo al recuperar el mensaje de error de RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "error desconocido (código %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "No se puede encontrar ninguna conexión telefónica activa: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Se han encontrado varias conexiones activas, eligiendo una aleatoriamente."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Fallo al establecer la conexión: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Error al obtener nombres de ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Fallo al conectar: no hay ISP al que llamar."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Elija un ISP al que conectar"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Elija el ISP con el que se quiera conectar"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Fallo al conectar: faltan usuario/contraseña."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "No se puede encontrar el archivo de libreta de direcciones"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Error al iniciar la conexión de marcado: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "No se puede colgar: no hay ninguna conexión telefónica activa."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Error al terminar la conexión: %s"
@@ -5851,18 +5840,17 @@ msgstr ""
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "No se pueden enumerar los archivos en el directorio «%s»"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "No se pudo obtener el nombre la carpeta"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(error %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "No se pudo añadir una imagen a la lista de imágenes."
 
@@ -5877,7 +5865,7 @@ msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Fallo al crear el diálogo estándar de buscar/reemplazar (código de error %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "El diálogo de archivo falló con código de error %0lx."
@@ -5920,16 +5908,16 @@ msgstr "No se pudo activar la vista para '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "No se pueden monitorizar los cambios del directorio inexistente «%s»."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "El controlador de OpenGL no admite OpenGL 3.0 o más reciente."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "No se pudo crear el contexto OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Falló la inicialización de OpenGL"
 
@@ -5937,7 +5925,7 @@ msgstr "Falló la inicialización de OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "No se pudo registrar el cargador modificado de fuentes DirectWrite."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5945,7 +5933,7 @@ msgstr ""
 "La funciones de Ayuda MS HTML no están disponibles porque la biblioteca de "
 "Ayuda MS HTML no está instalada. Instálela."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Fallo al inicializar la ayuda MS HTML."
 
@@ -5954,7 +5942,7 @@ msgstr "Fallo al inicializar la ayuda MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "No se puede elimininar el archivo INI «%s»"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6075,7 +6063,7 @@ msgstr "No se pudo registrar el formato del portapapeles «%s»."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "El formato %d del portapapeles no existe."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Saltar"
 
@@ -6161,59 +6149,59 @@ msgstr ""
 "si se elimina puede dejar el sistema en un estado inestable:\n"
 "operación abortada."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "No se puede eliminar la clave «%s»"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "No se puede eliminar el valor «%s» de la clave «%s»"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "No se puede leer el valor de la clave «%s»"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "No se puede establecer el valor de «%s»"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "El valor del Registro «%s» no es numérico (sino del tipo %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "El valor del Registro «%s» no es binario (sino del tipo %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "El valor del Registro «%s» no es de texto (sino del tipo %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "No se puede leer el valor de «%s»"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "No se pueden enumerar los valores de la clave «%s»"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "No se pueden enumerar las subclaves de la clave «%s»"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6221,17 +6209,17 @@ msgstr ""
 "Exportando clave de Registro: el archivo «%s» ya existe y no se "
 "sobrescribirá."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "No se puede exportar el valor del tipo no admitido %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Se ignora el valor «%s» de la clave «%s»."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6239,41 +6227,41 @@ msgstr ""
 "Imposible crear control 'rich edit', se usará el control de texto simple. "
 "Por favor instale riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "No se puede iniciar el hilo de ejecución: error al escribir TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "No se puede establecer la prioridad del hilo de ejecución"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "No se puede crear el hilo de ejecución"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "No se pudo finalizar el hilo de ejecución"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "No se puede esperar a la finalización del hilo de ejecución"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "No se puede suspender el hilo de ejecución %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "No se puede reanudar el hilo de ejecución %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "No se pudo obtener el puntero al hilo de ejecución actual"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6281,7 +6269,7 @@ msgstr ""
 "Error en la inicialización del módulo de hilos de ejecución: imposible "
 "reservar índice en el almacen local de hilos"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6313,12 +6301,12 @@ msgstr "Falló la carga del recurso «%s»."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Falló el bloqueo del recurso «%s»."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "compilación %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", edición de 64 bits"
 
@@ -6330,47 +6318,47 @@ msgstr "Fallo al crear tubería anónima"
 msgid "Failed to redirect the child process IO"
 msgstr "Error en la redirección de la entrada/salida del proceso hijo"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Falló la ejecución de la orden «%s»"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "No se pudo cargar mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "¡No se puede leer el nombre del tipo desde '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "No se puede cargar el icono desde «%s»."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 "No se pudo encontrar el nivel de emulación de la vista web en el registro"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "No se pudo cambiar el nivel moderno de emuilación web"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "No se pudo restaurar el nivel estándar de emulación web"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "No se puede ejecutar un guión JavaScript sin un documento HTML válido"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "No se puede obtener el objeto JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "fallo al evaluar"
 
@@ -6403,7 +6391,7 @@ msgid "Check to make the font italic."
 msgstr "Active para definir en cursiva el tipo de letra."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subrayado"
@@ -6470,15 +6458,33 @@ msgstr "<Cualquiera Teletipo>"
 msgid "File type:"
 msgstr "Tipo de archivo:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Ventana"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ayuda"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Acercar"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Traer todo al primer plano"
 
@@ -6501,457 +6507,457 @@ msgstr ""
 "No se puede usar el archivo de fuente \"%s\" porque no está en la carpeta de "
 "fuentes \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Acerca de %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Acerca de…"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferencias..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Servicios"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Ocultar %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Ocultar aplicación"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Ocultar otros"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Mostrar todo"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Salir de %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Salir de la aplicación"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "El control web no soporta la impresión"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "No se pudo inicializar la operación de impresión"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Tamaño de punto"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nombre del tipo de letra"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Peso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ButtonText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "GrayText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Highlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menú"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Barra de desplazamiento"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Pista"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "TooltipText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Ventana"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Negro"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Marrón"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Azul marino"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Morado"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Turquesa"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Gris"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Aceituna"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Marrón"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Azul"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fucsia"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Rojo"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Naranja"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Plata"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Lima"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Aguamarina"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Amarillo"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Blanco"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Predeterminado"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Flecha"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Flecha derecha"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Vacío"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Diana"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Carácter"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Cruz"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Mano"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Botón izquierdo"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Botón central"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "No hay entrada"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Brocha"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Lápiz"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Apuntar a la izquierda"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Apuntar a la derecha"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Pregunta Flecha"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Botón derecho"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Dimensionado NE-SO"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Dimensionado N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Dimensionado NO-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Dimensionado O-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Dimensionado"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Aerosol"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Espere"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Mirar"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Espera Flecha"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Hacer una selección:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Propiedad"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Modo categorizado"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Modo alfabético"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Verdadero"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "No especificado"
 
@@ -6965,12 +6971,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Ha introducido un valor incorrecto. Pulse ESC para cancelar la edición."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Error en recurso: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6979,36 +6985,36 @@ msgstr ""
 "La operación de tipos \"%s\" falló: la propiedad etiquetada \"%s\" es del "
 "tipo \"%s\", NO \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Base %d desconocida, se usará base 10."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "El valor debe ser %s o mayor."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "El valor debe estar entre %s y %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "El valor debe ser %s o inferior."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "No %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Elija un directorio:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Elija un archivo"
 
@@ -7475,117 +7481,117 @@ msgstr "Recuadro"
 msgid "Outset"
 msgstr "Comienzo"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Cambiar estilo"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Cambiar estilo de objeto"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Cambiar propiedades"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Cambiar estilo de lista"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renumerar Lista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Insertar texto"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Insertar imagen"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Insertar objeto"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Insertar campo"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "¡Demasiadas llamadas a EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "archivos"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "estándar/círculo"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "estándar/circunferencia"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "estándar/cuadrado"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "estándar/diamante"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "estándar/triángulo"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Propiedades de caja"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Múltiples propiedades de celda"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Propiedades de celda"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Cambiar estilo de celda"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Eliminar fila"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Eliminar columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Añadir fila"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Añadir columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Propiedades de tabla"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Propiedades de la imagen"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "imagen"
 
@@ -7793,24 +7799,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Arrastrar"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Eliminar texto"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Eliminar marca"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "El texto no pudo guardarse."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Sustituir"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Tipo de letra:"
 
@@ -8779,53 +8785,53 @@ msgstr "Estilos de lista"
 msgid "Box styles"
 msgstr "Estilos de caja"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "El tipo de letra del que tomar el símbolo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subconjunto:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Muestra un subconjunto Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Código de carácter:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "El código de carácter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Desde:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "El intervalo que mostrar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insertar"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
@@ -9011,7 +9017,7 @@ msgstr "No se pudieron obtener sucesos de kqueue"
 msgid "Media playback error: %s"
 msgstr "Error de reproducción del medio: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Falló la preparación de la reproducción de «%s»."
@@ -9111,23 +9117,23 @@ msgstr "Los datos de sonido están en un formato no admitido."
 msgid "Couldn't open audio: %s"
 msgstr "No se pudo abrir el audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 "No se puede recuperar la normativa de planificación de hilos de ejecución."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "No se puede obtener un intervalo de prioridades para la normativa de "
 "planificación %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "La configuración de la prioridad del hilo de ejecución es ignorada."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9135,62 +9141,62 @@ msgstr ""
 "Error al sincronizar con un hilo de ejecución, pérdida potencial de memoría "
 "detectada - por favor reinicie el programa"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 "Error al establecer el nivel de concurrencia del hilo de ejecución a %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Error al establecer la prioridad del hilo de ejecución %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Error al terminar un hilo de ejecución."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Error en la inicialización del módulo de hilos de ejecución: error al crear "
 "clave de hilo"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Imposible obtener la entrada del proceso hijo"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "No se puede escribir en stdin del proceso hijo"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Error al ejecutar '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Error en bifurcación de proceso (fork)"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Error al establecer la prioridad del proceso"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Error en la redirección de la entrada/salida del proceso hijo"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Fallo al establecer una tubería no bloqueante, el progrma puede colgarse."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "No se puede obtener el nombre de la máquina"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "No se puede obtener el nombre oficial de la máquina"
 
@@ -9207,12 +9213,12 @@ msgstr "Fallo al cambiar la tubería de aviso a modo no bloqueante"
 msgid "Failed to read from wake-up pipe"
 msgstr "Fallo leyendo de la tubería de aviso"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificación de geometría no válida: '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets no pudo abrir el display. Saliendo."
 
@@ -9226,30 +9232,59 @@ msgstr "No se pudo cerrar el display \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Falló la apertura de la pantalla «%s»."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Error de parseo de XML: '%s' en la línea %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "No se pueden cargar recursos desde «%s»."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "No se puede cargar el archivo de recursos «%s»."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "No se pueden cargar los recursos a partir del archivo «%s»."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Falló la creación de %s «%s»."
+
+#~ msgid "Printing "
+#~ msgstr "Imprimiendo "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "No se pudo insertar texto en el control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Elija un tipo de letra válido."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Error al mostrar el documento HTML con codificación %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets no pudo abrir el 'display' para '%s': saliendo."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Directorios"
+
+#~ msgid "Files"
+#~ msgstr "Archivos"
+
+#~ msgid "Selection"
+#~ msgstr "Selección"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "falló la conversión a codificación de 8 bits"

--- a/locale/eu.po
+++ b/locale/eu.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2015-07-18 21:39+0200\n"
 "Last-Translator: Xabier Aramendi <azpidatziak@gmail.com>\n"
 "Language-Team: (EUS_Xabier Aramendi) <azpidatziak@gmail.com>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.2\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Agiri denak (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Agiri denak (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "Gelditzen den denbora:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Bai"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "EZ"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "&Ongi"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "E&zeztatu"
@@ -102,7 +99,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Ezinezkoa Sar/Irt osaketa ataka sortzea"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Irarketa"
 
@@ -139,7 +136,7 @@ msgstr "Objetu Ezaugarriak"
 msgid "Printing"
 msgstr "Irarkitzen"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Sinboloak"
 
@@ -208,7 +205,7 @@ msgstr "&Aurrekoa"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Leihoa"
 
@@ -738,11 +735,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawKtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "erakutsi laguntza mezu hau"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "sortu ohar mezu berritsuak"
 
@@ -764,84 +761,84 @@ msgstr "Azalgai sostengatu gabea'%s'"
 msgid "Invalid display mode specification '%s'."
 msgstr "Erakus modu zehaztapen baliogabea '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' aukera ezin da ukatua izan"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Aukera luze ezezaguna '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Aukera ezezaguana '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Ustekabeko hizkiak '%s' aukeraren ondoren."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "'%s' aukerak balio bat behar du."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Banantzailea '%s' aukeraren ondoren itxaroten da."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' ez da zenbaki balio zuzena '%s' aukerarako."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "'%s' aukera: '%s' ezin du bihurtu data batera."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Ustekabeko parametroa '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (edo %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' aukerarentzako balioa adierazi behar da."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "'%s' beharrezko parametroa ez da adierazi."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Erabilia: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "zenb"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "bikoitza"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "eguna"
 
@@ -859,7 +856,7 @@ msgid "Can't &Undo "
 msgstr "Ezin da De&segin"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desegin"
@@ -869,7 +866,7 @@ msgid "&Redo "
 msgstr "&Berregin"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Berregin"
@@ -898,12 +895,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' estra '..', ezikusita."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -913,103 +910,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "azpimarratua"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "gaur"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "atzo"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "atzo"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "lehen"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "bigarren"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "hirugarren"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "laugarren"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "bostgarren"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "seigarren"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "zazpigarren"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "zortzigarren"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "bederatzigarren"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "hamargarren"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "hamaikagarren"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "hamabigarren"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "hamahirugarren"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "hamalaugarren"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "hamabostgarren"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "hamaseigarren"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "hemezazpigarren"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "hemezortzigarren"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "hemeretzigarren"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "hogeigarren"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "eguerdia"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "gauerdia"
 
@@ -1077,44 +1074,81 @@ msgstr "Hutsegitea curl exekutatzerakoan, mesedez ezarri HELBURUAN."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Hutsegitea garbiketa jakinarazpena igotzerakoan (akats kodea %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Gorde Honela"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Baztertu aldaketak eta gertatu gordetako azken bertsioa?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "izengabea"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Nahi duzu %s-ri aldaketak gordetzea?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Gorde"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ez Gorde"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Nahi duzu %s-ri aldaketak gordetzea?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Idazkia ezin da gorde."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "\"%s\" agiria ezin da idazteko ireki."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Hutsegitea agiria \"%s\" agirian gordetzerakoan."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "\"%s\" agiria ezin da irakurtzeko ireki."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1123,57 +1157,57 @@ msgstr ""
 "'%s' agiria ez dago edo ezin da ireki.\n"
 "Kendua izanda berrikien erabilitako agiri zerrendatik."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Irarketa aurreikuspena sortzeak huts egin du."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Irarketa Aurreikuspena"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "'%s' agiriaren heuskarria ezin da zehaztu."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "izengabea%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " -"
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Ireki Agiria"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Agiri akatsa"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Barkatu, ezin da agiria hau ireki."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Barkatu, agiri honentzako heuskarria ezezaguna da."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Hautatu agiri eredu bat"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Ereduak"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Hautatu agiri ikuspena"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Ikus"
 
@@ -1207,42 +1241,42 @@ msgstr "Irakurri akatsa '%s' agirian"
 msgid "Write error on file '%s'"
 msgstr "Idaz akatsa '%s' agirian"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "hutsegitea '%s' agiria jalgitzean "
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Bilatu akatsak '%s' agirian (stdiok ez du agiri handiagorik sostengatzen)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Bilatu akatsak '%s' agirian"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Ezin da aurkitu oraingo kokapena '%s' agirian"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Hutsegitea aldibaterako agiri baimenak ezartzerakoan"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ezin da kendu '%s' agiria"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "ezin da aldaketarik egin '%s' agirian"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "ezin da kendu '%s' aldibaterako agiria"
@@ -1267,27 +1301,27 @@ msgstr "ezin da irakurri %d agiri azaltzailetik"
 msgid "can't write to file descriptor %d"
 msgstr "ezin da idatzi %d agiri azaltzailera"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "ezin da jaso %d agiri azaltzailea"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "ezin da bilatu %d agiri azaltzailean"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "ezin da bilaketa kokapenik bilatu %d agiri azaltzailean"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "ezin da aurkitu agiri luzera %d agiri azaltzailean"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "ezin da zehaztu agiriaren amaiera lortu den %d azaltzailean"
@@ -1312,107 +1346,107 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Akatsa itxurap aukerak irakurtzean."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Hutsegitea itxurap aukerak irakurtzerakoan."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "'%s' agira: ustekabeko %c hizkia %d lerroan."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "'%s' agiria, %d lerroa: '%s' baztertua idazburu taldearen ondoren."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "'%s' agiria,%d lerroa: '=' ustekoa."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "'%s' agiria, %d lerroa: '%s' tekla aldaezinarentzako balioa baztertua."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "'%s' agiria, %d lerroa: '%s' tekla  lehenik aurkitu da %d lerroan."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Itxurap sarrera izean ezin da '%c'-rekin hasi."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "ezin da ireki erabiltzailearen itxurapen agiria."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "ezin da idatzi erabiltzailearen itxurapen agiria."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Akatsa erabiltzaile itxurapen datuak gordetzean."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "ezin da ezabatu '%s' erabiltzailearen itxurapen agiria"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "'%s' sarrera behin baino gehiagotan agertzen da '%s' taldean"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "'%s' tekla aldaezina aldatzeko saiakera baztertuta."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "amaierako ezkerbarra '%s'-n baztertuta"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "ustekabeko \" kokapena %d '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Hutsegitea '%s' agiria '%s'-ra kopiatzerakoan"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Ezinezkoa '%s' agiriarentzat baimenak lortzea"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Ezinezkoa '%s' agiria gainidaztea"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Hutsegitea '%s' agiria '%s'-ra kopiatzerakoan"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Ezinezkoa '%s' agiriarentzako baimenak ezartzea"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1421,40 +1455,40 @@ msgstr ""
 "Hutsegitea '%s' agiria '%s'-ra birrizendatzean zerezn helmuga agiria jadanik "
 "badago."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' agiria ezin da berrizendatu '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' agiria ezin da kendu"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' zuzenbidea ezin da sortu"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "%s' zuzenbidea ezin da ezabatu"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Ezin dira '%s' agiriak zenbakitu"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Hutsegitea lan zuzenbidea lortzerakoan"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Ezinezkoa oraingo lan zuzenbidea ezartzea"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Agiriak (%s)"
@@ -1481,17 +1515,17 @@ msgstr "Hutsegitea aldibaterako agiri izena sortzerakoan"
 msgid "Failed to open temporary file."
 msgstr "Hutsegitea aldibaterako agiria irekitzerakoan."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Hutsegitea '%s'-rako agiri denborak aldatzerakoan"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Hutsegitea '%s' agiria ikutzerakoan"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Hutsegitea '%s'-rako agiri denborak berreskuratzerakoan"
@@ -1500,22 +1534,22 @@ msgstr "Hutsegitea '%s'-rako agiri denborak berreskuratzerakoan"
 msgid "Browse"
 msgstr "Bilatu"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Agiri denak (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s agiri (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Gertatu %s agiria"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Gorde %s agiria"
@@ -1878,105 +1912,105 @@ msgstr "berezkoa"
 msgid "unknown-%d"
 msgstr "ezezaguna-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "azpimarratua"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr "Marratuta"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " arina"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " arina"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " lodia"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " lodia"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " lodia"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " etzana"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "Marratuta"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "arina"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "arina"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "arrunta"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "lodia"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "lodia"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "lodia"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "etzana"
 
@@ -2057,7 +2091,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Hutsegitea FTP eskualdaketa modua %s-ra ezartzerakoan."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2078,7 +2112,7 @@ msgstr "FTP zerbitzariak ez du modu pasiboa sostengatzen."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF frame neurri okerra (%u, %d) #%u framean"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Hutsegitea OpenGL-rako margoa esleitzerakoan"
 
@@ -2094,7 +2128,7 @@ msgstr "Norbereraratu Zutabeak"
 msgid "&Customize..."
 msgstr "&Norbereratu..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Hutsegitea \"%s\" URL-a berezko bilatzailean irekitzerakoan."
@@ -2114,157 +2148,156 @@ msgstr "Hutsegitea %d irudia jariotik gertatzerakoan."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Hutsegitea \"%s\" ikurra baliabideetatik gertatzerakoan."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Ezinezkoa baliogabeko irudia gordetzea."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImagek ez du ber wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Ezinezkoa agiri idazburua (Bitmapa) idaztea."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Ezinezkoa agiri idazburua (BitmapaArgib.) idaztea."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Ezinezkoa RGB margo mapa idaztea."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Ezinezkoa datuak idaztea."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Ezinezkoa oroimena esleitzea."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Idazburua: Irudi zabalera > 32767 pixel agiriko."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Idazburua: Irudi garaiera > 32767 pixel agiriko."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Idazburua: Bit-sakonera ezezaguna agirian."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Idazburua: Kodeaketa ezezaguna agirian."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Idazburua: Kodeaketak ez du bitsakonera."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Ezinezkoa oroimena esleitzea."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB Idazburua: Irudi zabalera > 32767 pixel agiriko."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB Idazburua: Irudi garaiera > 32767 pixel agiriko."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB Idazburua: Bit-sakonera ezezaguna agirian."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB Idazburua: Kodeaketa ezezaguna agirian."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB Idazburua: Kodeaketak ez du bitsakonera."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Akatsa DIB irudia irakurtzean."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Akatsa DIB mozorroa irakurtzerakoan."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Irudi garaiegia ikur batentzat."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Irudi zabalegia ikur batentzat."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Akatsa irudi agiria idazterakoan!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ikur aurkibide baliogabea."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Irudia eta mozorroak neurri ezberdinak dituzte."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Ez dago erabiligabeko margorik mozorrotzen den irudian."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Hutsegitea \"%s\" bitmapa baliabideetatik gertatzerakoan."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Hutsegitea \"%s\" ikurra baliabideetatik gertatzerakoan."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Hutsegita irudia \"%s\" agiritik gertatzerakoan."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Ezin da irudia '%s' agirian gorde: luzepen ezezaguna."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Ez da kudeatzailerik aurkitu irudi motarentzat."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Ez da irudi kudeatzailerik adierazi %d motarako."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Irudi agiria ez da %d motakoa."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Ezin da berezgaitasunez zehaztu irudi heuskarria sarrera ez-"
 "bilagarriarentzat."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Irudi datu heuskarri ezezaguna"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Hau ez da %s bat."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Ez da irudi kudeatzailerik adierazi %s motarako."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Irudia ez da %s motakoa."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Hutsegitea \"%s\" irudi agiriaren heuskarria egiaztatzerakoan"
@@ -2367,41 +2400,41 @@ msgstr "PNM: Agiriak trunkatua dirudi."
 msgid " (in module \"%s\")"
 msgstr " (\"%s\" moduloan)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Akatsa irudia gertatzen."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "TIFF irudi aurkibide baliogabea."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Irudi neurria handiegia da."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Ezinezkoa oroimena esleitzea."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Akats irudia irakurtzen."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "TIFF bereizmen unitate ezezaguna %d baztertuta"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Akatsa irudia gordetzen."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Akatsa irudia idazterakoan."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2409,11 +2442,11 @@ msgid ""
 msgstr ""
 "%d agindu lerro argumentua ezin da Unicodera bihurtu eta ezikusi egingo da."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Abiatzeak huts egin du abiostean, uzten."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Ezin da ezarri tokikoa \"%s\" hizkuntzari."
@@ -2511,7 +2544,7 @@ msgstr "konpresio akatsa"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Alderaezina  '{' mime motako %s sarrera batean."
@@ -2531,7 +2564,7 @@ msgstr "Elkargunea \"%s\" Moduloa \"%s\" ez dago."
 msgid "Module \"%s\" initialization failed"
 msgstr "\"%s\" moduloa abiatzeak huts egin du"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Mezua"
 
@@ -3033,7 +3066,7 @@ msgstr "Irarketa Akatsa"
 msgid "Print"
 msgstr "Irarkitu"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Orrialde ezarpena"
 
@@ -3068,19 +3101,15 @@ msgstr "%d orrialdea irarkitzen %d-tik..."
 msgid " (copy %d of %d)"
 msgstr " (kopiatu %d --> %d-tik"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Irarkitzen"
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Lehen orrialdea"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Aurreko orrialdea"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Hurrengo orrialdea"
 
@@ -3124,16 +3153,16 @@ msgstr "%d orrialde %d-tik"
 msgid "Page %d"
 msgstr "%d orrialde"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "akats ezezaguna"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Adierazpen arrunt baliogabea '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
@@ -3145,21 +3174,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "\"%s\" aurkezlea bateraezina da %d bertsioarekin.%d ezinezkoa gertatzea."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Hutsegitea %s \"%s\" sortzerakoan."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Hutsegitea %s \"%s\" sortzerakoan."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Hutsegitea %s \"%s\" sortzerakoan."
@@ -3168,11 +3197,11 @@ msgstr "Hutsegitea %s \"%s\" sortzerakoan."
 msgid "Failed to monitor I/O channels"
 msgstr "Hutsegitea Sar/Irt bideak monitorizatzerakoan"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Gorde"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Ez Gorde"
 
@@ -3256,10 +3285,10 @@ msgid "Clear"
 msgstr "Garbitu"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "It&xi"
 
@@ -3271,7 +3300,7 @@ msgstr "&Bihurtu"
 msgid "Convert"
 msgstr "Bihurtu"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiatu"
@@ -3280,7 +3309,7 @@ msgstr "&Kopiatu"
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Eba&ki"
@@ -3289,13 +3318,13 @@ msgstr "Eba&ki"
 msgid "Cut"
 msgstr "Ebaki"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "Ezabatu"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Ezabatu"
@@ -3384,7 +3413,7 @@ msgstr "Diska-gogorra"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Laguntza"
 
@@ -3404,7 +3433,7 @@ msgstr "Elkarmarratxoa"
 msgid "&Index"
 msgstr "&Aurkibidea"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Aurkibidea"
 
@@ -3473,7 +3502,7 @@ msgstr "Berria"
 msgid "New"
 msgstr "Berria"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Ez"
 
@@ -3490,12 +3519,12 @@ msgstr "&Ireki..."
 msgid "Open..."
 msgstr "Ireki..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Itsatsi"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Itsatsi"
@@ -3525,7 +3554,7 @@ msgid "Print..."
 msgstr "Irarkitu..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Ezaugarriak"
 
@@ -3559,10 +3588,6 @@ msgstr "Ordeztu"
 msgid "Revert to Saved"
 msgstr "Itzuli Gordetakora"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Gorde"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Gorde &Honela..."
@@ -3572,7 +3597,7 @@ msgstr "Gorde &Honela..."
 msgid "Save As..."
 msgstr "Gorde &Honela..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Hautatu &Denak"
@@ -3679,7 +3704,7 @@ msgstr "&Igo"
 msgid "Up"
 msgstr "Gora"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Bai"
 
@@ -3770,43 +3795,43 @@ msgstr "Gorde oraingo agiria"
 msgid "Save current document with a different filename"
 msgstr "Gorde oraingo agiria agirizen ezberdinarekin"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "'%s' hizki-kodera bihurtzeak ez du lanik egiten. "
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "ezezaguna"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "idazburu bloke osatugabea tar-en"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "Egiaztapen hutsegitea tar idazburu blokea irakurtzean"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "datu baliogabea tar hedatu idazburuan"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar sarrera ez dago irekita"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "ustekabekoa agiri amaiera"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s-k ez du finkatzen tar idazburua '%s' sarrerarentzat"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tar sarrereak neurri okerra eman du"
 
@@ -3815,7 +3840,7 @@ msgstr "tar sarrereak neurri okerra eman du"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' zihurrenik buffer binario bat da."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Agiria ezin da gertatu."
 
@@ -3829,47 +3854,47 @@ msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
 msgid "can't write buffer '%s' to disk."
 msgstr "ezin da idatzi '%s' bufferra diskara"
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Hutsegitea tokiko sistema ordua lortzerakoan"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay hutsegitea."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ez da mezu katalogo baliozkoa."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Mezu katalogo baliogabea."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Hutsegitea Anitz-Erak aztertzerakoan: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' katalogoa '%s' hemendik erabiltzen."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' baliabidea ez da baliozko mezu katalogoa."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Ezinezkoa itzulpenak zenbatzea"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Ez dago berezko aplikaziorik itxuratuta HTML agirientzat."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Hutsegitea \"%s\" URL-a berezko bilatzailean irekitzerakoan."
@@ -3902,7 +3927,7 @@ msgstr "'%s' legezkanpoko hizkiak ditu"
 msgid "Error: %s (%d)"
 msgstr "Akatsa:"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3911,20 +3936,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Zutabe azalpena ezin da abiarazi."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Plataforma honek ez dut barren gardentasuna sostengatzen."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Ezinezkoa datuak leihora eskualdatzea"
 
@@ -3976,8 +4001,8 @@ msgstr "%s Sortu Paremetroa ez da aurkitu aitorturiko RTTI Parametroetan"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Legezkanpoko Objetu Klasea (Ez-wxEvtHandler) Gertaera Iturubur bezala"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Motak enum- long bihurketa izan behar du"
 
@@ -4027,79 +4052,79 @@ msgstr "Objetuek id ezaugarria izan behar dute"
 msgid "Doubly used id : %d"
 msgstr "id bikoiztua : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Ezaugarri %s ezezaguna"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Bilduma ez hutsa 'elementu' elkarguneak izan behar da"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "gertaera kudeatzaile kate okerra, puntu gabe"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "ezin da birrabiarazi zlib deflate jarioa"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "ezin da birrabiarazi zlib inflate jarioa "
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "onartzen zip zati-anitz kateatutakoa dela "
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "zip agiri baliogabea"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "ezin da aurkitu zuzenbide nagusia zip-ean"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "akatsa ziparen zuzenbide nagusia irakurtzean"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "akatsa ziparen tokiko idazburua irakurtzen"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "zipagiri okerra orekatuta sarrerarako"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "bildutako agiri zabalera ez dago Zip idazburuan"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "Zip konpresio metodo sostengatu gabea"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zip jario irakurtzen (sarrera %s): luzera okerra"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zip jario irakurtzen (sarrera %s): crc okerra"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "akatsa '%s' zip sarrera irakurtzean: crc okerra edo luzeegia"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "akatsa '%s' zip sarrera irakurtzean: crc okerra edo luzeegia"
@@ -4183,32 +4208,32 @@ msgstr "Grafiko egilea"
 msgid "Translations by "
 msgstr "Itzultzailea"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Bertsioa"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "%s-ri buruz"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Baimena"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Garatzaileak"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Agiri idazleak"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistak"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Itzultzaileak"
 
@@ -4262,44 +4287,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Faltsua"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (edo %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Gehitu Zutabea"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4310,8 +4334,7 @@ msgid "Left"
 msgstr "Ezker"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4407,7 +4430,7 @@ msgid "Home directory"
 msgstr "Hasierako zuzenbidea"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Mahigaina"
 
@@ -4420,8 +4443,7 @@ msgstr "Legezkanpoko zuzenbide izena."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Akatsa"
 
@@ -4605,16 +4627,16 @@ msgstr "Ikusi agiriak xehetasunekin"
 msgid "Go to parent directory"
 msgstr "Joan gaineko zuzenbidera"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' agiria jadanik badago, egitan nahi duzu gainidaztea?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Baieztatu"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Mesedez hautatu dagoen agiri bat."
 
@@ -4708,7 +4730,7 @@ msgstr "Hizkiaren puntu neurria."
 msgid "Whether the font is underlined."
 msgstr "Hizkia azpimarratuta badago."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Aurreikuspena:"
@@ -4726,48 +4748,47 @@ msgstr "Klikatu hizki hautapena ezeztatzeko."
 msgid "Click to confirm the font selection."
 msgstr "Klikatu hizki hautapena baieztatzeko."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Hautatu hizkia"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "\"%s\" laguntza zuzenbidea ez da aurkitu."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "\"%s\" laguntza agiri ez da aurkitu."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "%lu lerroa \"%s\" mapa agirian joskera baliogabea du, ahaztuta."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ez da baliozko mapaketarik aurkitu \"%s\" agirian."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Ez da sarrerarik aurkitu."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Laguntza Aurkibidea"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Sarrera nabarmenak:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Aurkitutako sarrerak"
 
@@ -4871,59 +4892,59 @@ msgstr "Ezin da irarketa hasi"
 msgid "Printing page %d..."
 msgstr "%d orrialdea irarkitzen..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Irarkailu aukerak"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Irarkitu Agirira"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Ezarpena..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Irarkailua:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Egoera:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Denak"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Orrialdeak"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Irarketa Maila"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Hemendik:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Hona:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopiak:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript agiria"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Irarketa Ezarpena"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Irarkailua"
 
@@ -4931,25 +4952,25 @@ msgstr "Irarkailua"
 msgid "Default printer"
 msgstr "Berezko irarkailua"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Paper neurria"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Argazkia"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Etzana"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Norantza"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Aukerak"
 
@@ -4961,52 +4982,52 @@ msgstr "Irarkitu margoekin"
 msgid "Print spooling"
 msgstr "Irarketa lerrokapena"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Irarkailu komandoa:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Irarkailu aukerak:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Ezker bazterra (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Goiko bazterra (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Eskuin bazterra (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Beheko bazterra (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Irarkailua..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Ahaztu"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Ezezaguna"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Eginda."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Bilatu"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Ezin da id-arentzako tab aurkitu"
 
@@ -5042,22 +5063,22 @@ msgstr "&Amaitu"
 msgid "< &Back"
 msgstr "< &Atzera"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "itzultzaileak"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Ezinezkoa GTK+ hastea, ERAKUTSI ongi ezarrita dago?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Hutsegita oraingo zuzenbidea \"%s\"-ra aldatzerakoan"
@@ -5083,12 +5104,12 @@ msgstr "Hutsegitea \"%s\" agiritik agiria irakurtzerakoan."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Hutsegitea erabiltzaile itxurapen agiria eguneratzerakoan."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Agiri akatsa"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5096,7 +5117,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5104,7 +5125,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
@@ -5120,15 +5141,11 @@ msgstr "Akatsa irarkitzerakoan:"
 msgid "Page Setup"
 msgstr "Orrialde Ezarpena"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Hutsegitea agintean idazkia sartzerakoan."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5136,7 +5153,7 @@ msgstr ""
 "Gailu honetan ezarritako GTK+ zaharregia da ikusleiho osaketa sostengatzeko, "
 "mesedez ezarri GTK+2.12 edo berriagoa."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5144,17 +5161,13 @@ msgstr ""
 "Osaketa ez dago sostengaturik sistema honetan, mesedez gaitu ezazu zure "
 "Leiho Kudeatzailean."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Plataforma hau GTK+ bertsio zahar batekin bildua da, mesedez berreraiki GTK+ "
 "2.12 edo berriago batekin."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Mesedez hautatu baliozko hizki bat."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5253,45 +5266,45 @@ msgstr "Ezin da ireki eduki agiria: %s"
 msgid "Cannot open index file: %s"
 msgstr "Ezin da ireki aurkibide agiria: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "izengabe"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Ezin da ireki HTML laguntza libuura: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Laguntza erakusten du ezkerreko liburuetan nabigatzean."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(lastermarkak)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Gehitu oraingo orrialdea lastermarketara"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Kendu oraingo orrialdea lastermarketatik"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Edukiak"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Bilatu"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Erakutsi denak"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5299,19 +5312,19 @@ msgstr ""
 "Erakutsi emandako azpikatea duten aurkibideko gai guztiak. Bilaketak hizki "
 "xehe-larriak bereizten ditu."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Erakutsi gai guzitak aurkibidean"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Hizki larri-xeheak"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Hitz osoak bakarrik"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5319,147 +5332,147 @@ msgstr ""
 "Bilatu edukiak laguntza liburuan gainean idatzi duzun idazkiaren gertaera "
 "guztientzat"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Erakusi/ezkutatu nabigazio panela"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Joan atzera"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Joan aurrera"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Joan maila bat gora agiri hierarkian"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Ireki HTML agiria"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Irarkitu orrialde hau"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Erakutsi aukeren elkarrizketa"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Mesedez hautatu erakusteko orrialdea:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Laguntza Gaiak"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Bilatzen...."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Ez da bat datorren orrialderik aurkitu oraindik"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Aurkituta %i bat egite"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Laguntza)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d %lu-tik"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu -> %lu-tik"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Bilatu liburu guztietan"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Laguntza Bilatzaile Aukerak"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Hizki arrunta:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Zuzendutako hizkia:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Hizki neurria:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "hizki neurria"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Alde arrunta<br>eta <u>azpimarratua</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Alde etzana.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Alde lodia..</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Alde etzan lodia.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Zuzendutako neurri aldea.<br> <b>lodia</b> <i>etzana</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>lodi etzana <u>azpimarratuta</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Laguntza Irarketa"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Ezin da irarkitu orrialde hutsa."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML agiriak (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Laguntza liburuak (*.htb)|*.htb|Laguntza liburuak (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Laguntza Egitasmoa (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Konprimitutako HTML Laguntza agiria (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i -> %u-tik"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u -> %u-tik"
@@ -5540,32 +5553,6 @@ msgstr ""
 "Arazo bat egon da orrialde ezarpenean: badaiteke berezko irarkailu bat "
 "ezarri behar izatea. "
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Hutsegitea HTML agiria %s kodeaketan erakusterakoan"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidget-ek ezin du '%s' erakuspena ireki: irtetzen."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Iragazkia"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Zuzenbideak"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Agiriak"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Hautapena"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Hutsegitea gakoa irekitzeakoan."
@@ -5607,58 +5594,58 @@ msgstr "Margo hautapen elkarrizketa hutsegitea %0lx akatsarekin."
 msgid "Failed to create cursor."
 msgstr "Hutsegitea kurtsorea sortzerakoan."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Hutsegitea '%s' DDE zerbitzaria erregistratzerakoan"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Hutsegitea '%s' DDE zerbitzaria erregistratu gabetzerakoan"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Hutsegitea '%s' zerbitzariarekin '%s' gaian elkarketa sortzerakoan"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE eskabideak huts egin du"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Hutsegitea DDE zerbitzariarekin ohar bigizta ezartzerakoan"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Hutsegitea DDE zerbitzariarekin ohar bigizta amaitzerakoan"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Hutsegitea DDE ohar jakinarazpena bildaltzerakoan"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Hutsegitea DDE katea sortzerakoan"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "no DDE akatsa."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "ohar eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "eragiketaren erantzunak DDE_FBUSY bit zehaztea eragindu."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "datu eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5669,7 +5656,7 @@ msgstr ""
 "edo ekinbide ezagutarazle baliogabe bat\n"
 "pasatu da DDEML eginkizun batera."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5681,43 +5668,43 @@ msgstr ""
 "edo APPCMD_CLIENTONLY bezala abiatutako aplikazio bat \n"
 "zerbitzari transakzioak egiten saiatu da."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "exekuzio eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "paremetro batek huts egin du DDEML-ak balidatzerakoan."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML aplikazio batek lasterketa baldintza luzatu bat sortu du."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "oroimen esleipen hutsegitea."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "hutsegitea bezero baten elkarrizketa baten ezartze saiakeran"
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "eskualdaketa hutsegitea."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "sarrera eskualdaketa sinkrono baterako eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage eginkizunerako barne deiak huts egin du."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "birsarrera arazoa."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5727,15 +5714,15 @@ msgstr ""
 "bezeroak amaitu duena, edo zerbitzariak\n"
 "amaitu du eskualdaketa bat osatu aurretik."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "barne akats bat gertatu da DDEML-an."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "ohar eskualdaketa amaiera eskabidea denboraz-kanpo."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5745,12 +5732,12 @@ msgstr ""
 "Behin aplikazioak XTYP_XACT_COMPLETE irizkizunetik erantzundakoan,\n"
 "irizkizun horretarako ezgutarazlea ez da baliogarria gehiago."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "DDE akats %08x ezezaguna"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5758,7 +5745,7 @@ msgstr ""
 "Dei eginkizunak ez daude eskuragarri hurreneko sarbide zerbitzua (RAS) ez "
 "dagoelako ezarrita makina honetan. Mesedez ezarri ezazu."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5767,64 +5754,64 @@ msgstr ""
 "Gailu honetan ezarrita dagoen hurruneko sarbide zerbitzuaren (RAS) bertsioa "
 "oso zaharra da, mesedez eguneratu (ez dagoen beharrezkoa den eginkizuna: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Hutsegitea RAS akats mezutik idazkia berreskuratzerakoan"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "akats ezezaguana (kode akatsa %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Ezin da aurkitu urrutizkin elkarketa eragindua: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Dei elkarketa ugari aurkitu dira lanean, zorizko bat hautatzen."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Hutsegitea urrutizkin elkarketa ezartzerakoan: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Hutsegitea ISP izenak lortzerakoan: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Hutsegitea elkarketatzerakoan:: ez dago ISP deitzeko."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Hautatu dialerako ISP-a"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Mesedez zein IZH-ra nahi duzun elkarketatzea"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Hutsegitea elkarketatzerakoan: ez dago erabiltzaile-izen/sar-hitzik."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Ezin da aurkitu helbide liburu agiriaren kokalekua"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Hutsegitea urrutizkin elkarketa hasterakoan: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Ezinezkoa eskegitzea - ez dago dei elkarketarik lanean."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Hutsegitea urrutizkin elkarketa amaitzerakoan: %s"
@@ -5844,18 +5831,17 @@ msgstr "Hutsegitea bitmaparako oroimenaren %luKb-a esleitzerakoan."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Ezin dira '%s' zuzenbidean agirak zenbakitu"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Ezinezkoa agiritegi izena lortzea"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (%ld akatsa: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Ezinezkoa irudia gehitzea irudi zerrendara."
 
@@ -5871,7 +5857,7 @@ msgstr ""
 "Hutsegitea bilaketa estandarra/ordeztu elkarrizketa sortzerakoan (akats "
 "kodea %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Agiri elkarrizketa hutsegitea %0lx akats kodearekin."
@@ -5912,18 +5898,18 @@ msgstr "Ezinezkoa Unable to set up watch for '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Ezin da monitorizatu ez-dagoen \"%s\" zuzenbidea aldaketetarako."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 #, fuzzy
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "Core OpenGL profila ez dago sostengatuta OpenGL gidatzailean."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Ezinezkoa denboragailu bat sortzea"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Hutsegitea OpenGL abiatzerakoan"
 
@@ -5931,7 +5917,7 @@ msgstr "Hutsegitea OpenGL abiatzerakoan"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5939,7 +5925,7 @@ msgstr ""
 "MS HTML Laguntza eginkizunak ez daude eskuragarri MS HTML Laguntza "
 "liburutegia ez delako ezarri gailu honetan. Mesedez ezarri ezazu."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Hutsegitea MS HTML Laguntza abiatzerakoan."
 
@@ -5948,7 +5934,7 @@ msgstr "Hutsegitea MS HTML Laguntza abiatzerakoan."
 msgid "Can't delete the INI file '%s'"
 msgstr "Ezin da '%s' INI agiria ezabatu"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Ezinezkoa %d zerrenda aginte gaiari buruzko argibideak berreskuratzea."
@@ -6068,7 +6054,7 @@ msgstr "Ezinezkoa '%s' gako heuskarrri erregistratzea."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "'%d' gako heuskarria ez dago."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Jauzi"
 
@@ -6153,59 +6139,59 @@ msgstr ""
 "ezabatzen bada zure sistema erabiltezin geldituko da:\n"
 "eragiketa utzita."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Ezin da '%s' giltza ezabatu"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Ezin da '%s' balioa '%s' giltzatik ezabatu"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Ezin da '%s' giltzaren balioa irakurri"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Ezin da '%s'-ren balioa ezarri"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Ezin da '%s'-ren balioa irakurri"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Ezin dira '%s' giltzaren balioak zenbakitu"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Ezin '%s' gitzaren azpigiltzak zenbakitu"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6213,17 +6199,17 @@ msgstr ""
 "Esportatzen erregistro giltza: \"%s\" agiria jadanik badago eta ezin da "
 "gainidatzi."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Ezin da %d hizkimota sostengugabetik balioa esportatu."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "\"%s\" giltzaren \"%s\" balioa ezikusten."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6231,41 +6217,41 @@ msgstr ""
 "Ezinezkoa aberastu edizio aginte bat sortzea, idazki arrunt agintea "
 "erabiltzen ordez. Mesedez berrezarri riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Ezin da haria hasi: akatsa TLS idazterakoan."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Ezin da hari lehentasuna ezarri"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Ezin da haria sortu"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Ezinezkoa haria amaitzea"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Ezin da hari amaiera itxaron"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Ezin da %lx haria utzi"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Ezin da %lx haria kendu"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Ezinezkoa oraingo hari puntua lortzea"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6273,7 +6259,7 @@ msgstr ""
 "Hari modulo abiarazpen hutsegitea: ezinezkoa aurkibidea esleitzea hariaren "
 "tokiko biltegian"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6305,12 +6291,12 @@ msgstr "Hutsegitea \"%s\" baliabidea gertatzerakoan."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Hutsegitea \"%s\" baliabidea blokeatzerakoan."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "%lu eraiketa"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bit edizioa"
 
@@ -6322,47 +6308,47 @@ msgstr "Hutsegitea izengabeko hodia sortzerakoan"
 msgid "Failed to redirect the child process IO"
 msgstr "Hutsegitea child garapen SI berbideratzerakoan"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Hutsegitea '%s' komandoa exekutatzerakoan"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Hutsegitea mpr.dll gertatzerakoan."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Ezinezkoa mota-izena '%s'-tik irakurtzea"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Ezin da gertatu ikurra '%s'-tik."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Ezin da hari lehentasuna ezarri"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Hutsegitea '%s' exekutatzerakoan\n"
@@ -6396,7 +6382,7 @@ msgid "Check to make the font italic."
 msgstr "Hautatu hizkia etzana egiteko."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Azpimarratuta"
@@ -6464,17 +6450,32 @@ msgstr "<Teletiporen bat>"
 msgid "File type:"
 msgstr "Teletipoa"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Leihoa"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Laguntza"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "I&kurtu"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zooma Handitu"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6491,493 +6492,493 @@ msgstr "%s agiria ez dago."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "%s-ri buruz"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Honi buruz..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Hobespenak..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Zerbitzuak"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Ezkutatu %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Aplikazioa"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Ezkutatu Besteak"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Erakutsi Denak"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Utzi %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Aplikazioa"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip ez dago sostengaturik zlib bertsio honetarako"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Zutabe azalpena ezin da abiarazi."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Puntu Neurria"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Aurpegi Izena"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estiloa"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Pisua"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Sendia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "Aplik-Laningurua"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "Hertza-Gaituta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "Harpena-Gaituta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "Botoi-Aldea"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "Botoi-Nabarmentzea"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "Botoi-Itzala"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "Botoi-Idazkia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "Idazki Larria"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "Aginte-Iluna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "Aginte-Argia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "Urdainabar-Idazkia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Nabarmendu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Nabarmendu-Idazkia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "Hertza-Ezgaituta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "Harpena-Ezgaituta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "Harpen-Idazkia-Ezgaituta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menua"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Irristabarra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Tresnaburu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "Tresnaburu Idazkia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Leihoa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "Leiho-Uztaia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "Leiho-Idazkia"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Norberea"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Beltza"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Gorriluna"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Itsas-urdina"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Purpura"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Zertzeta"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Urdinabarra"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Orlegia"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Oliba"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Marroia"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Urdina"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuksia"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Gorria"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Laranja"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Zilarra"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Lima"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Ura"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Oria"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Zuria"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Berezkoa"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Gezia"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Eskuin Gezia"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Hutsik"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Idibegia"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Hizkia"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Zeharka"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Eskua"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Ezker Botoia"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Handitzailea"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Erdiko Botoia"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Sarrerarik Ez"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Margoketa Brotxa"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Bolaluma"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Ezker Puntua"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Eskuin Puntua"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Galdera Gezia"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Eskuin Botoia"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Neurritzen IE-HM"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Neurritzen I-H"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Neurritzen IM-HE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Neurritzen M-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Neurritzen"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Spraycan"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Itxaron"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Behatu"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Itxaron Gezia"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Egin hautapen bat:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Ezaugarria"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Balioa"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategoriatutako Modua"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alfabeto Moduan"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Faltsua"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Egia"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Zehaztugabea"
 
@@ -6990,12 +6991,12 @@ msgstr "Ezaugarri Akatsa"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Balio okerra sartu duzu. Sakatu IRTEN edizioa ezeztatzeko."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Akatsa baliabidean: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7004,36 +7005,36 @@ msgstr ""
 " \"%s\" eragiketa hutsegitea:  \"%s\" ezaugarri etiketatua \"%s\" motakoa "
 "da, EZ \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Baliloa izan behar da %s edo handiagoa."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Balioa izan behar da %s eta %s artekoa."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Balioa izan behar da %s edo txikiagoa."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Ez %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Hautatu zuzenbide bat:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Hautatu agiri bat"
 
@@ -7500,117 +7501,117 @@ msgstr "Sartu"
 msgid "Outset"
 msgstr "Hasiera"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Aldatu Estiloa"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Aldatu Objetu Estiloa"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Aldatu Ezaugarriak"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Aldatu Zerrenda Estiloa"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Birzenbakitu Zerrenda"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Sartu Idazkia"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Sartu Irudia"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Sartu Objetua"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Txertatu Eremua"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "EndStyle dei gehiegi!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "agiriak"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "estandarra/borobila"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "estandarra/borobil-ingurua"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "estandarra/laukia"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "estandarra/diamantea"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "estandarra/hirukia"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Kutxaren Ezaugarriak"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Gelaxka Anitz Ezaugarriak"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Gelaxka Ezaugarriak"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Ezarri Gelaxka estiloa"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Ezabatu Lerroa"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Ezabatu Zutabea"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Gehitu Lerroa"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Gehitu Zutabea"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Taula Ezaugarriak"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Irudiaren Ezaugarriak"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "irudia"
 
@@ -7818,24 +7819,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Harrastatu"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Ezabatu Idazkia"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Kendu Buleta"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Idazkia ezin da gorde."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Ordeztu"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Hizkia:"
 
@@ -8804,53 +8805,53 @@ msgstr "Zerrenda estiloak"
 msgid "Box styles"
 msgstr "Kutxaren estiloak"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Sinboloa hartzeko hizki mota."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Azpiezarpena:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Unicode azpiezarpena erakusten du."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Hizki kodea:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Hizki kodea."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Hemendik:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Erakusteko maila."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Sartu"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Idazki arrunta)"
 
@@ -9036,7 +9037,7 @@ msgstr "Ezinezkoa kqueue-tik gertaera lortzea"
 msgid "Media playback error: %s"
 msgstr "Multimedia irakurketa akatsa: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Hutsegitea \"%s\" irakurketa gertatzerakoan."
@@ -9136,20 +9137,20 @@ msgstr "Soinu datua heuskarri sostengatu gabean dago."
 msgid "Couldn't open audio: %s"
 msgstr "Ezinezkoa audioa irekitzea: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Ezinezkoa hari egitaraupen araudia berreskuratzea."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Ezin da lortu lehentasun maila %d egitarautzaile itunerako."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Hari lehentasun ezarpena ezikusia da."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9157,59 +9158,59 @@ msgstr ""
 "Hutsegitea harira batzerakoan, oroimen galera potentziala atzeman da - "
 "mesedez berrabiarazi programa"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Hutsegitea hari lehentasuna %lu ezartzerakoan."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Hutsegitea %d hari lehentasuna ezartzerakoan."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Hutsegitea hari bat amaitzerakoan."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Hari modulo abiarazpen hutsegitea: hutsegitea hari giltza sortzerakoan"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Ezinezkoa child garapen sarrera lortu"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Ezin da child prozesuaren stdin idatzi"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Hutsegitea '%s' exekutatzerakoan\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Adar hutsegitea"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Hutsegitea prozesu lehentasuna ezartzerakoan"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Hutsegitea child garapen sarrera/irteera berbideratzerakoan"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Hutsegitea ez-blokeo hodia ezartzerakoan, programa blokeatu egin daiteke."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Ezin da lortu hostalari-izena"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Ezin da lortu hostalari-izen ofiziala"
 
@@ -9226,12 +9227,12 @@ msgstr "Hutsegitea iratzar hodia ez-blokeatzen modura aldatzerakoan"
 msgid "Failed to read from wake-up pipe"
 msgstr "Hutsegitea iratzar hoditik irakurtzerakoan"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Geometria zehaztapen baliogabea '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidget-ek ezin du erakuspena ireki. Irtetzen."
 
@@ -9245,30 +9246,59 @@ msgstr "Hutsegitea \"%s\" erakuspena isterakoan"
 msgid "Failed to open display \"%s\"."
 msgstr "Hutsegitea \"%s\" erakustea irekitzerakoan."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML azterketa akatsa : '%s' %d lerroan"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Ezin dira gertatu baliabideak '%s'-tik."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Ezinezkoa '%s' baliabide agiria irekitzea."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Ezin dira gertatu baliabideak '%s' agiritik."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Hutsegitea %s \"%s\" sortzerakoan."
+
+#~ msgid "Printing "
+#~ msgstr "Irarkitzen"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Hutsegitea agintean idazkia sartzerakoan."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Mesedez hautatu baliozko hizki bat."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Hutsegitea HTML agiria %s kodeaketan erakusterakoan"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidget-ek ezin du '%s' erakuspena ireki: irtetzen."
+
+#~ msgid "Filter"
+#~ msgstr "Iragazkia"
+
+#~ msgid "Directories"
+#~ msgstr "Zuzenbideak"
+
+#~ msgid "Files"
+#~ msgstr "Agiriak"
+
+#~ msgid "Selection"
+#~ msgstr "Hautapena"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "hutsegitea 8-bitera bihurtzerakoan"
@@ -9431,8 +9461,8 @@ msgstr "Hutsegitea %s \"%s\" sortzerakoan."
 #~ msgstr "Datu aurkezleak ezin du balioa aurkeztu; balio mota:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/fa_IR.po
+++ b/locale/fa_IR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2020-07-17 12:42+0430\n"
 "Last-Translator: \n"
 "Language-Team: Ali Asadi <ali.asadi@wxwidgets.ir>\n"
@@ -15,11 +15,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n==0 || n==1);\n"
 "X-Generator: Poedit 2.2\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr ""
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr ""
 
@@ -36,24 +36,21 @@ msgid "Remaining time:"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr ""
@@ -103,7 +100,7 @@ msgid "Unable to create I/O completion port"
 msgstr ""
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr ""
 
@@ -140,7 +137,7 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr ""
 
@@ -209,7 +206,7 @@ msgstr ""
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr ""
 
@@ -738,11 +735,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr ""
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr ""
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr ""
 
@@ -764,84 +761,84 @@ msgstr ""
 msgid "Invalid display mode specification '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (or %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "رشته"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr ""
 
@@ -859,7 +856,7 @@ msgid "Can't &Undo "
 msgstr ""
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr ""
@@ -869,7 +866,7 @@ msgid "&Redo "
 msgstr ""
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr ""
@@ -896,12 +893,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -910,103 +907,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "نامشخص"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "امروز"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "دیروز"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "فردا"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "سومین"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "دهم"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "دوازدهم"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "سیزدهم"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "بیستم"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr ""
 
@@ -1072,101 +1069,136 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr ""
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "بی نام"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr ""
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr ""
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+msgid "Do&n't close"
+msgstr ""
+
+#: ../src/common/docview.cpp:554
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr ""
+
+#: ../src/common/docview.cpp:560
+msgid "The document must be closed."
+msgstr ""
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr ""
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr ""
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr ""
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr ""
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr ""
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr ""
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr ""
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr ""
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr ""
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr ""
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr ""
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr ""
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr ""
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr ""
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr ""
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr ""
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr ""
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr ""
 
@@ -1200,41 +1232,41 @@ msgstr ""
 msgid "Write error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr ""
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr ""
@@ -1259,27 +1291,27 @@ msgstr ""
 msgid "can't write to file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1303,147 +1335,147 @@ msgstr ""
 msgid "Error reading config options."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr ""
@@ -1470,17 +1502,17 @@ msgstr ""
 msgid "Failed to open temporary file."
 msgstr ""
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr ""
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr ""
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr ""
@@ -1489,22 +1521,22 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s files (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr ""
@@ -1867,104 +1899,104 @@ msgstr ""
 msgid "unknown-%d"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "زیر خط دار"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " سبک"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " سبک"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " پررنگ"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " پررنگ"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " پررنگ"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " مایل"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "متن برجسته"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr " سبک"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr " پررنگ"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr ""
 
@@ -2034,7 +2066,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr ""
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr ""
 
@@ -2055,7 +2087,7 @@ msgstr ""
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr ""
 
@@ -2071,7 +2103,7 @@ msgstr ""
 msgid "&Customize..."
 msgstr ""
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr ""
@@ -2091,155 +2123,154 @@ msgstr ""
 msgid "Failed to load icons from resource '%s'."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr ""
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr ""
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr ""
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr ""
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr ""
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr ""
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr ""
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
@@ -2340,52 +2371,52 @@ msgstr ""
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr ""
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2481,7 +2512,7 @@ msgstr ""
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr ""
@@ -2501,7 +2532,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr ""
 
@@ -3003,7 +3034,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr ""
 
@@ -3038,19 +3069,15 @@ msgstr ""
 msgid " (copy %d of %d)"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr ""
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr ""
 
@@ -3094,16 +3121,16 @@ msgstr ""
 msgid "Page %d"
 msgstr ""
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "خطای ناشناخته"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr ""
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
@@ -3113,21 +3140,21 @@ msgstr ""
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr ""
@@ -3136,11 +3163,11 @@ msgstr ""
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr ""
 
@@ -3222,10 +3249,10 @@ msgid "Clear"
 msgstr ""
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr ""
 
@@ -3237,7 +3264,7 @@ msgstr ""
 msgid "Convert"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr ""
@@ -3246,7 +3273,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr ""
@@ -3255,13 +3282,13 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr ""
@@ -3348,7 +3375,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr ""
 
@@ -3368,7 +3395,7 @@ msgstr ""
 msgid "&Index"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr ""
 
@@ -3437,7 +3464,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr ""
 
@@ -3454,12 +3481,12 @@ msgstr ""
 msgid "Open..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr ""
@@ -3489,7 +3516,7 @@ msgid "Print..."
 msgstr ""
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr ""
 
@@ -3521,10 +3548,6 @@ msgstr ""
 msgid "Revert to Saved"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr ""
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr ""
@@ -3533,7 +3556,7 @@ msgstr ""
 msgid "Save As..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr ""
@@ -3640,7 +3663,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr ""
 
@@ -3728,43 +3751,43 @@ msgstr ""
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "ناشناخته"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "ورودی تار باز نیست"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "پایان غیر منتظره فایل"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s did not fit the tar header for entry '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3773,7 +3796,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr ""
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr ""
 
@@ -3787,47 +3810,47 @@ msgstr ""
 msgid "can't write buffer '%s' to disk."
 msgstr ""
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr ""
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay انجام نشد."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr ""
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr ""
@@ -3860,7 +3883,7 @@ msgstr ""
 msgid "Error: %s (%d)"
 msgstr ""
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3868,20 +3891,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr ""
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr ""
 
@@ -3933,8 +3956,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr ""
 
@@ -3984,79 +4007,79 @@ msgstr ""
 msgid "Doubly used id : %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "طول پرونده ذخیره شده در سربرگ Zip نیست"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "روش فشرده سازی فایل های فشرده پشتیبانی نمی شود"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4140,32 +4163,32 @@ msgstr ""
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr ""
 
@@ -4216,43 +4239,42 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "درست"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d items)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4263,8 +4285,7 @@ msgid "Left"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4351,7 +4372,7 @@ msgid "Home directory"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr ""
 
@@ -4364,8 +4385,7 @@ msgstr ""
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr ""
 
@@ -4545,16 +4565,16 @@ msgstr ""
 msgid "Go to parent directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr ""
 
@@ -4648,7 +4668,7 @@ msgstr ""
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr ""
@@ -4666,48 +4686,47 @@ msgstr ""
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr ""
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr ""
 
@@ -4811,59 +4830,59 @@ msgstr ""
 msgid "Printing page %d..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr ""
 
@@ -4871,25 +4890,25 @@ msgstr ""
 msgid "Default printer"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr ""
 
@@ -4901,52 +4920,52 @@ msgstr ""
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr ""
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr ""
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr ""
 
@@ -4982,22 +5001,22 @@ msgstr ""
 msgid "< &Back"
 msgstr "< &Back"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "مترجم-اعتبارات"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr ""
@@ -5021,12 +5040,12 @@ msgstr ""
 msgid "Failed to register font configuration using private fonts."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "%s Error"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5034,7 +5053,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5042,7 +5061,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
@@ -5058,34 +5077,26 @@ msgstr ""
 msgid "Page Setup"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr ""
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
-msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
 msgstr ""
 
 #: ../src/html/chm.cpp:138
@@ -5185,209 +5196,209 @@ msgstr ""
 msgid "Cannot open index file: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(نشانک)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(راهنما)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d of %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu of %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Italic face.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Bold face.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Bold italic face.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>bold italic <u>underlined</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i of %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u of %u"
@@ -5458,32 +5469,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr ""
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr ""
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr ""
@@ -5525,58 +5510,58 @@ msgstr ""
 msgid "Failed to create cursor."
 msgstr ""
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "پاسخ به ترکنش باعث شد بیت DDE_FBUSY تنظیم شود."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5584,7 +5569,7 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5592,140 +5577,140 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
 "old, please upgrade (the following required function is missing: %s)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr ""
@@ -5745,18 +5730,17 @@ msgstr ""
 msgid "Cannot enumerate files in directory '%s'"
 msgstr ""
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr ""
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr ""
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr ""
 
@@ -5770,7 +5754,7 @@ msgstr ""
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
@@ -5811,16 +5795,16 @@ msgstr ""
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr ""
 
@@ -5828,13 +5812,13 @@ msgstr ""
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr ""
 
@@ -5843,7 +5827,7 @@ msgstr ""
 msgid "Can't delete the INI file '%s'"
 msgstr ""
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -5963,7 +5947,7 @@ msgstr ""
 msgid "The clipboard format '%d' doesn't exist."
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr ""
 
@@ -6045,121 +6029,121 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr ""
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr ""
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr ""
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr ""
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6188,12 +6172,12 @@ msgstr ""
 msgid "Failed to lock resource \"%s\"."
 msgstr ""
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6205,46 +6189,46 @@ msgstr ""
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr ""
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr ""
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr ""
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr ""
 
@@ -6277,7 +6261,7 @@ msgid "Check to make the font italic."
 msgstr ""
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr ""
@@ -6344,15 +6328,29 @@ msgstr "<هرگونه Teletype>"
 msgid "File type:"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "(راهنما)"
+
+#: ../src/osx/cocoa/menu.mm:299
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6369,462 +6367,462 @@ msgstr ": فایل موجود نیست!"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr ""
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr ""
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr ""
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "فردا"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr ""
 
@@ -6837,48 +6835,48 @@ msgstr ""
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr ""
 
@@ -7345,117 +7343,117 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "استاندارد / دایره"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "طرح کلی / دایره"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "استاندارد / مربع"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "استاندارد / الماس"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "استاندارد / مثلث"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr ""
 
@@ -7663,24 +7661,24 @@ msgstr ""
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr ""
 
@@ -8649,53 +8647,53 @@ msgstr ""
 msgid "Box styles"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(متن عادی)"
 
@@ -8879,7 +8877,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr ""
@@ -8979,77 +8977,77 @@ msgstr ""
 msgid "Couldn't open audio: %s"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr ""
 
@@ -9065,12 +9063,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr ""
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets نمی تواند نمایش را باز کند. خارج شدن."
 
@@ -9084,27 +9082,27 @@ msgstr ""
 msgid "Failed to open display \"%s\"."
 msgstr ""
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr ""

--- a/locale/fi.po
+++ b/locale/fi.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2023-02-02 22:04+0200\n"
 "Last-Translator: Lauri Nurmi <lanurmi@iki.fi>\n"
 "Language-Team: \n"
@@ -22,11 +22,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Kaikki tiedostot (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Kaikki tiedostot (*)|*"
 
@@ -43,24 +43,21 @@ msgid "Remaining time:"
 msgstr "Jäljellä oleva aika:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Kyllä"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ei"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Peruuta"
@@ -112,7 +109,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Osoittimen luonti epäonnistui."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "Tulosta"
@@ -153,7 +150,7 @@ msgstr "&Ominaisuudet"
 msgid "Printing"
 msgstr "Tulostetaan "
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symbolit"
 
@@ -223,7 +220,7 @@ msgstr "&Edellinen"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Ikkuna"
 
@@ -790,11 +787,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "näytä tämä ohjeviesti"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "luo yksityiskohtaiset lokiviestit"
 
@@ -816,84 +813,84 @@ msgstr "Teemaa ”%s” ei tueta."
 msgid "Invalid display mode specification '%s'."
 msgstr "Virheellinen näyttötilamääritelmä ”%s”."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Tuntematon pitkä valitsin ”%s”"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Tuntematon valitsin ”%s”"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Odottamaton parametri ”%s”"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Valinta ”%s” vaatii arvon."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Erotinmerkki tarvitaan option ”%s” jälkeen."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "”%s” ei ole oikea numeerinen arvo valitsimelle ”%s”."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Valinta ”%s”: ”%s” ei voida muuntua päiväykseksi."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Odottamaton parametri ”%s”"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (tai %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Valinnan ”%s” arvo täyty olla määritelty."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Tarvittavaa parametria ”%s” ei ole määritelty."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Käyttö: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "merkkijono"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num."
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "päiväys"
 
@@ -911,7 +908,7 @@ msgid "Can't &Undo "
 msgstr "Ei voi &Kumota "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Kumoa"
@@ -921,7 +918,7 @@ msgid "&Redo "
 msgstr "&Tee uudelleen "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Toista"
@@ -950,12 +947,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "”%s” sisältää ylimääräisen ”..”, ohitettu."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -965,103 +962,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "alleviivattu"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "tänään"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "eilen"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "huomenna"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "ensimmäinen"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "toinen"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "kolmas"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "neljäs"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "viides"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "kuudes"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "seitsemäs"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "kahdeksas"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "yhdeksäs"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "kymmenes"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "yhdestoista"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "kahdestoista"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "kolmastoista"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "neljästoista"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "viidestoista"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "kuudestoista"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "seitsemästoista"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "kahdeksastoista"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "yhdeksästoista"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "kahdeskymmenes"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "keskipäivä"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "keskiyö"
 
@@ -1131,45 +1128,82 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Ohjelmavirheilmoitusta ei voitu lähettää (virhekoodi %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Tallenna nimellä"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Hylätäänkö muutokset ja ladataanko uudelleen viimeisin tallennettu versio?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "nimetön"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Haluatko tallentaa muutokset asiakirjaan %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Tallenna"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "älä tallenna"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Haluatko tallentaa muutokset asiakirjaan %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Tekstiä ei voitu tallentaa."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Kohteen ”%s” avaaminen kirjoittamista varten epäonnistui"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Touch epäonnistui tiedostolle ”%s”"
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Kohteen ”%s” avaaminen lukemista varten epäonnistui"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1178,58 +1212,58 @@ msgstr ""
 "Tiedosto ”%s” ei ole olemassa ja eikä sitä voi avata.\n"
 "Se on myös poistettu MRU-tiedostojen luettelosta"
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Putken luonti epäonnistui"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Tulostuksen esikatselu"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Sarakkeen leveyttä ei voitu määritellä"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "nimetön%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Valitse Tiedosto"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Tiedostovirhe"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Tätä tiedostoa ei voi avata."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Tämän tiedoston muoto on tuntematon."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Valitse asiakirjamalli"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Asiakirjamallit"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Valitse asiakirjanäkymä"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Näkymät"
 
@@ -1263,41 +1297,41 @@ msgstr "Lukuvirhe tiedostossa ”%s”"
 msgid "Write error on file '%s'"
 msgstr "Tiedostoon ”%s” ei voi kirjoittaa"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "tiedostoa ”%s” ei voitu kirjoittaa"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Hakuvirhe tiedostossa ”%s” (stdio ei tue suuria tiedostoja)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Hakuvirhe tiedostossa ”%s”"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Tiedoston ”%s” nykyistä kohtaa ei löydy"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Tilapäistiedoston oikeuksia ei voitu asettaa."
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "tiedostoa ”%s” ei voi poistaa"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "ei voi toimittaa muutoksia tiedostoon ”%s”"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "väliaikaistiedostoa ”%s” ei voi poistaa"
@@ -1322,27 +1356,27 @@ msgstr "tiedoston kuvauksen %d luku epäonnistui"
 msgid "can't write to file descriptor %d"
 msgstr "kirjoittaminen epäonnistui tiedoston kuvaukseen %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "tiedoston kuvausta %d ei voida tyhjentää"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "paikanmääritys tiedoston kuvauksessa %d ei onnistu"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "tiedoston koko ei löydy tiedoston kuvauksesta %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "ei voida päätellä tuliko kuvaajan %d loppu vastaan"
@@ -1368,107 +1402,107 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Virhe asetusten lukemisessa."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Asetuksia ei voitu lukea."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "tiedosto ”%s”: odottamaton merkki %c rivillä %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "tiedosto ”%s”, rivi %d: ”%s” ohitettu ryhmäotsikon jälkeen."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "tiedosto ”%s”, rivi %d: ”=” odotettu."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "tiedosto ”%s”, rivi %d: muuttamattoman avaimen ”%s” arvo ohitettu."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "tiedosto ”%s”, rivi %d: avain ”%s” löytyi ensiksi riviltä %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Asetuskohdan nimi ei voi alkaa merkillä ”%c”."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "käyttäjän asetustiedoston avaus ei onnistu."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "käyttäjän asetustiedoston kirjoitus epäonnistui."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Virhe käyttäjän asetusten tallentamisessa."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "käyttäjän asetustiedostoa ”%s” ei voi poistaa"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "kohta ”%s” ilmenee useammin kuin kerran ryhmässä ”%s”"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "muuttumattoman avaimen ”%s” muutosyritys ohitettu."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "Odottamaton \"-merkki kohdassa %d tiedostossa '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Tiedoston ”%s” kopiointi kohteeseen ”%s” epäonnistui."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Tiedoston ”%s” oikeuksien saanti on mahdotonta"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Tiedostoa ”%s” ei voida korvata"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Tiedoston ”%s” kopiointi kohteeseen ”%s” epäonnistui."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Lupien asetus tiedostolle ”%s” on mahdotonta"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1477,41 +1511,41 @@ msgstr ""
 "Tiedoston '%s' uudelleennimeäminen tiedostoksi '%s' epäonnistui, koska "
 "kohdetiedosto on jo olemassa."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Hakemistoa ”%s” ei voitu luoda"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Tiedostojen ”%s” luettelointi epäonnistui"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Työhakemistoa ei saatu"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Työhakemistoa ei saatu"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Tiedostot (%s)"
@@ -1538,17 +1572,17 @@ msgstr "Tilapäistiedoston nimen luonti epäonnistui."
 msgid "Failed to open temporary file."
 msgstr "Tilapäistiedoston avaus epäonnistui."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, fuzzy, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Tiedoston ”%s” aikoja ei voitu muuttaa"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Touch epäonnistui tiedostolle ”%s”"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, fuzzy, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Tiedoston ”%s” aikoja ei voida hakea"
@@ -1557,22 +1591,22 @@ msgstr "Tiedoston ”%s” aikoja ei voida hakea"
 msgid "Browse"
 msgstr "Selaa"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Kaikki tiedostot (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s-tiedostot (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Lataa %s tiedosto"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Tallenna %s tiedosto"
@@ -1945,106 +1979,106 @@ msgstr "oletus"
 msgid "unknown-%d"
 msgstr "tuntematon-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "alleviivattu"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " yliviivaus"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " heikko"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " heikko"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " lihavoitu"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " lihavoitu"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " lihavoitu"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kursivoitu"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 #, fuzzy
 msgid "strikethrough"
 msgstr "Yliviivaus"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "heikko"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "heikko"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "tavallinen"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "lihavoitu"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "lihavoitu"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "lihavoitu"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kursivoitu"
 
@@ -2126,7 +2160,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP:n siirtotilan %s asetus epäonnistui."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2147,7 +2181,7 @@ msgstr "FTP-palvelin ei tue passiivista tilaa."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Virheellinen GIF-kehyksen koko (%u, %d) kehykselle #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Osoittimen luonti epäonnistui."
@@ -2165,7 +2199,7 @@ msgstr "Valinnainen koko"
 msgid "&Customize..."
 msgstr "&Mukauta..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "URL-osoitetta ”%s” ei voitu avata oletusselaimessa."
@@ -2185,158 +2219,157 @@ msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Virheellistä kuvaa ei voitu tallentaa."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage:lla ei ole omaa wxPalette:a."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Tiedoston otsaketta (Bitmap) ei voitu kirjoittaa."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: En voinut kirjoittaa tiedoston (BitmapInfo) otsaketta."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB-värikarttaa ei voitu kirjoittaa."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Dataa ei voitu kirjoittaa."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Muistin varaaminen epäonnistui."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Otsake: Kuvan leveys > 32767 pikseliä."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Otsake: Kuvan korkeus > 32767 pikseliä."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Otsake: tuntematon bittisyvyys."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Otsake: Tiedostolla tuntematon koodaus."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Otsake: Koodaus ei vastaa bittisyvyyttä."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Muistin varaaminen epäonnistui."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB Otsake: Kuvan leveys > 32767 pikseliä."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB Otsake: Kuvan korkeus > 32767 pikseliä."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB Otsake: tuntematon bittisyvyys."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB Otsake: Tiedostolla tuntematon koodaus."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB Otsake: Koodaus ei vastaa bittisyvyyttä."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "DIB: virhe kuvan lukemisessa ."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Virhe DIB peitteen lukemisessa."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Kuva liian suuri kuvakkeeksi."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Kuva liian leveä kuvakkeeksi."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Virhe kuvatiedoston kirjoittamisessa."
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Väärä kuvake-indeksi."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Kuvan ja peitteen koot ovat erisuuruiset."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Tiedostoon ”%s” ei voi tallentaa kuvaa: tuntematon tiedostopääte."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Kuvatyypin käsittelijää ei löytynyt."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, fuzzy, c-format
 msgid "No image handler for type %d defined."
 msgstr "Kuvatyypin %d käsittelijää ei määritelty."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Kuvatiedoston tyyppi ei ole %ld."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Kuvamuotoa ei voi määrittää automaattisesti syötteelle, joka ei ole "
 "haettavissa."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "virhe dataformaatissa"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: tämä ei ole PCX tiedosto."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, fuzzy, c-format
 msgid "No image handler for type %s defined."
 msgstr "Kuvatyypin %s käsittelyohjelmaa ei määritelty."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Kuvatiedoston tyyppi ei ole %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
@@ -2440,41 +2473,41 @@ msgstr "PNM: Tiedosto on ehkä typistetty."
 msgid " (in module \"%s\")"
 msgstr "tiff-moduuli: %s"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Virhe kuvan latauksessa."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Virheellinen TIFF-kuvaindeksi."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Muistinvaraus epäonnistui."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Virhe kuvan lukemisessa ."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Virhe kuvan tallennuksesa."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Virhe kuvan kirjoituksessa."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2483,11 +2516,11 @@ msgstr ""
 "Komentoriviparametria %d ei voitu muuntaa Unicode-merkistöön, joten se "
 "ohitetaan ."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Alustus epäonnistui jälkialustuksessa, keskeytetään."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, fuzzy, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kieliasetusta ei voida asettaa kieleen ”%s”"
@@ -2585,7 +2618,7 @@ msgstr "pakkausvirhe"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Pariton ”{” mime-tyyppi-merkinnässä %s."
@@ -2605,7 +2638,7 @@ msgstr "Riippuvuutta ”%s” moduulille ”%s” ei ole."
 msgid "Module \"%s\" initialization failed"
 msgstr "Moduulin ”%s” alustus epäonnistui"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "%s-viesti"
@@ -3128,7 +3161,7 @@ msgstr "Tulostusvirhe"
 msgid "Print"
 msgstr "Tulosta"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Sivun asetukset"
 
@@ -3165,20 +3198,16 @@ msgstr "Tulostetaan sivua %d..."
 msgid " (copy %d of %d)"
 msgstr "Sivu %d / %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Tulostetaan "
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "Seuraava sivu"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Edellinen sivu"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Seuraava sivu"
 
@@ -3225,16 +3254,16 @@ msgstr "Sivu %d / %d"
 msgid "Page %d"
 msgstr "Sivu %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "tuntematon virhe"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Virheellinen säännösetellinen lauseke ”%s”: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Ei voitu löytää osumia säännölliselle lausekkeelle: %s"
@@ -3244,21 +3273,21 @@ msgstr "Ei voitu löytää osumia säännölliselle lausekkeelle: %s"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
@@ -3267,11 +3296,11 @@ msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 msgid "Failed to monitor I/O channels"
 msgstr "I/O-kanavien seuraaminen epäonnistui"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Tallenna"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "älä tallenna"
 
@@ -3357,10 +3386,10 @@ msgid "Clear"
 msgstr "&Tyhjennä"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Sulje"
 
@@ -3373,7 +3402,7 @@ msgstr "&Muunna"
 msgid "Convert"
 msgstr "Sisältä"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "K&opioi"
@@ -3382,7 +3411,7 @@ msgstr "K&opioi"
 msgid "Copy"
 msgstr "Kopioi"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Leikkaa"
@@ -3391,13 +3420,13 @@ msgstr "&Leikkaa"
 msgid "Cut"
 msgstr "Leikkaa"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Poista"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Poista"
@@ -3491,7 +3520,7 @@ msgstr "Kiintolevy"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Ohje"
 
@@ -3511,7 +3540,7 @@ msgstr "Sisennys"
 msgid "&Index"
 msgstr "&Indeksi"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Sisältä"
 
@@ -3582,7 +3611,7 @@ msgstr "&Uusi"
 msgid "New"
 msgstr "&Uusi"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Ei"
 
@@ -3600,12 +3629,12 @@ msgstr "&Avaa..."
 msgid "Open..."
 msgstr "&Avaa..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "L&iitä"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Liitä"
@@ -3639,7 +3668,7 @@ msgid "Print..."
 msgstr "&Tulosta..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Ominaisuudet"
 
@@ -3674,10 +3703,6 @@ msgstr "Korvaa"
 msgid "Revert to Saved"
 msgstr "Palauta tallennettuun"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Tallenna"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Tallenna &nimellä..."
@@ -3687,7 +3712,7 @@ msgstr "Tallenna &nimellä..."
 msgid "Save As..."
 msgstr "Tallenna &nimellä..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Valitse k&aikki"
@@ -3800,7 +3825,7 @@ msgstr "&Ylös"
 msgid "Up"
 msgstr "Ylös"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Kyllä"
 
@@ -3892,43 +3917,43 @@ msgstr "Tallenna nykyinen asiakirja"
 msgid "Save current document with a different filename"
 msgstr "Tallenna nykyinen asiakirja eri nimellä"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Muunnos merkistöön ”%s” ei toimi."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "tuntematon"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "odottamaton tiedoston loppu"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ei mahtunut kohteen '%s' tar-otsakkeeseen"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3937,7 +3962,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr "”%s” on todennäköisesti binääripuskuri."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Tiedostoa ei voitu ladata."
 
@@ -3951,49 +3976,49 @@ msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 msgid "can't write buffer '%s' to disk."
 msgstr "puskuria ”%s” ei voida kirjoittaa levylle."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Paikallista systeemiaikaa ei saatu"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay epäonnistui."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "”%s” ei ole kelvollinen viestiluettelo."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "”%s” ei ole kelvollinen viestiluettelo."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Monikkomuotoja ”%s” ei voida käsitellä"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "käytössä luettelo ”%s” ”%s”sta."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "”%s” ei ole kelvollinen viestiluettelo."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Säiettä ei voi päättää"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Oletusohjelmaa HTML-tiedostojen hallintaan ei ole asetettu."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "URL-osoitetta ”%s” ei voitu avata oletusselaimessa."
@@ -4026,7 +4051,7 @@ msgstr "”%s” saa sisältää vain kirjaimia."
 msgid "Error: %s (%d)"
 msgstr "Virhe: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4035,20 +4060,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Sarakkeen kuvausta ei voitu alustaa."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Tiedonsiirto ikkunaan ei onnistu"
 
@@ -4100,8 +4125,8 @@ msgstr "Parametrin %s luontia ei löydy ilmoitetuista RTTI-parametreista"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr ""
 
@@ -4153,79 +4178,79 @@ msgstr "Objekteilla täytyy olla id-määre"
 msgid "Doubly used id : %d"
 msgstr "Kahteen kertaan käytetty id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Tuntematon ominaisuus %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Muun kuin tyhjän kokoelman tulee muodostua 'element'-solmuista"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "virheellinen zip-tiedosto"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "ei-tuettu Zip-pakkaustyyppi"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "luetaan zip-virtaa (kohta %s): virheellinen pituus"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "luetaan zip-virtaa (kohta %s): virheellinen crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4310,33 +4335,33 @@ msgstr "Graafisen taiteen tekijä:"
 msgid "Translations by "
 msgstr "Suomentajat:"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Versio %s"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Tietoja ohjelmasta %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Lisenssi"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Kehittäjät"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Dokumentaation kirjoittajat"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistit"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Suomentajat"
 
@@ -4389,44 +4414,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Tiedosto"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (tai %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4437,8 +4461,7 @@ msgid "Left"
 msgstr "Vasen"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4526,7 +4549,7 @@ msgid "Home directory"
 msgstr "Kotihakemisto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Työpöytä"
 
@@ -4539,8 +4562,7 @@ msgstr "Virheellinen hakemiston nimi."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Virhe"
 
@@ -4725,16 +4747,16 @@ msgstr "Näytä tiedostot lisätiedoilla"
 msgid "Go to parent directory"
 msgstr "Mene ylähakemistoon"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Tiedosto ”%s” on jo olemassa, korvataanko se varmasti?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Varmista"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Valitse olemassa oleva tiedosto."
 
@@ -4828,7 +4850,7 @@ msgstr "Kirjasinkoko."
 msgid "Whether the font is underlined."
 msgstr "Onko kirjasin alleviivattu."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Esikatselu:"
@@ -4846,49 +4868,48 @@ msgstr "Napsauta peruuttaaksesi kirjasimen valinnan."
 msgid "Click to confirm the font selection."
 msgstr "Napsauta varmistaaksesi fontin valinnan."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Valitse kirjasinlaji"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, fuzzy, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Ohjehakemistoa ”%s” ei löytynyt."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Ohjetiedostoa ”%s” ei löytynyt."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "Rivillä %lu karttatiedostossa \"%s\" on virheellinen syntaksi, ohitettu."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Kohtia ei löytynyt."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Ohjeen sisältä"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Tähdelliset kohdat:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Löydetyt kohdat"
 
@@ -4994,59 +5015,59 @@ msgstr "Tulostus epäonnistui."
 msgid "Printing page %d..."
 msgstr "Tulostetaan sivua %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Tulostimen valinnat"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Tulosta tiedostoon"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Asetukset..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Tulostin:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Tila:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Kaikki"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Sivut"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Tulostusalue"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Lähettäjä:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Vastaanottaja:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopiot:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript-tiedosto"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Tulostusasetukset"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Tulostin"
 
@@ -5054,25 +5075,25 @@ msgstr "Tulostin"
 msgid "Default printer"
 msgstr "Oletustulostin"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Paperin koko"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Pystysuunta"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Vaakasuunta"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Suunta"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Valinnat"
 
@@ -5085,52 +5106,52 @@ msgstr "Väritulostus"
 msgid "Print spooling"
 msgstr "Tulostuksen sivuajo"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Tulostinkomento:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Tulostimen valinnat:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Vasen marginaali (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Ylämarginaali (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Oikea marginaali (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Alamarginaali (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Tulostin..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Ohita"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Valmis."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Etsi"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Ei löydetty sisennystä tunnukselle"
 
@@ -5166,25 +5187,25 @@ msgstr "&Lopeta"
 msgid "< &Back"
 msgstr "< &Takaisin"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 "Elias Julkunen <elias.julkunen@gmail.com>, 2008.Jaakko Salli "
 "<jmsalli79@hotmail.com>, 2005.Lauri Nurmi <lanurmi@iki.fi>, 2004.Kaj G "
 "Backas <kgb@compart.fi>, 2000."
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Hakemiston ”%s” luonti epäonnistui."
@@ -5210,12 +5231,12 @@ msgstr "Kuvaa %d ei voi ladata tiedostosta ”%s”."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Käyttäjän asetustiedoston päivitys ei onnistu."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Tuhoisa virhe"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5223,7 +5244,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5231,7 +5252,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI lapsi"
 
@@ -5247,36 +5268,27 @@ msgstr "Virhe tulostettaessa: "
 msgid "Page Setup"
 msgstr "Sivun asetukset"
 
-#: ../src/gtk/textctrl.cpp:1273
-#, fuzzy
-msgid "Failed to insert text in the control."
-msgstr "Työhakemistoa ei saatu"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Valitse kelvollinen fontti."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5375,45 +5387,45 @@ msgstr "Sisällysluettelotiedostoa %s ei voi avata"
 msgid "Cannot open index file: %s"
 msgstr "Indeksitiedostoa %s ei voi avata!"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "nimeämätön"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML-ohjekirjaa ei voi avata: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Näyttää ohjeen selatessasi kirjoja vasemmalla."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(kirjanmerkit)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Lisää tämä sivu kirjanmerkkeihin"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Poista nykyinen sivu kirjanmerkeistä"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Sisältä"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Etsi"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Näytä kaikki"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5421,19 +5433,19 @@ msgstr ""
 "Näytä sisällysluettelosta kaikki kohdat, jotka sisältävät annetun "
 "osatekstin. Haku on merkkikoosta riippumaton."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Näytä kaikki indeksissä"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Sama merkkikoko"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Vain kokonaiset sanat"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -5441,147 +5453,147 @@ msgid ""
 msgstr ""
 "Hae ohjekirjojen sisällöstä kaikki tapaukset, jossa on yllä antamasi teksti"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Näytä/piilota suunnistustaulu"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Takaisin"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Eteenpäin"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Mene ylös asiakirjahierarkiassa"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Avaa HTML-asiakirja"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Tulosta tämä sivu"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Näytä asetusikkuna"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Valitse näytettävä sivu:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Ohjeen aiheet"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Etsitään..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Täsmääviä sivuja ei vielä löydetty"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Löytyi %i täsmäävää"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Ohje)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d / %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu / %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Hae kaikista kirjoista"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Ohjeselaimen valinnat"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Tavallinen fontti:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Kiinteälevyinen fontti:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Kirjasinkoko:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "kirjasinkoko"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normaali kirjasin<br>ja <u>alleviivattu</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursivoitu kirjasin.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Lihavoitu kirjasin.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Lihavoitu kursivoitu kirjasin.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Kiinteäkokoinen kirjasin.<br> <b>lihavoitu</b> <i>kursivoitu</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>lihavoitu kursivoitu <u>alleviivattu</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Ohjeen tulostus"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Tyhjää sivua ei voi tulostaa."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-tiedostot (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Ohjekirjat (*.htb)|*.htb|Ohjekirjat (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Ohjeprojekti (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Tiivistetty HTML-ohjetiedosto (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu / %lu"
@@ -5653,32 +5665,6 @@ msgid ""
 msgstr ""
 "Sivun asetusten kanssa oli ongelma: voit joutua asettamaan oletustulostimen."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "HTML %s-koodattua asiakirjaa ei voi näyttää"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets ei voi avata näyttöä prosessille ”%s”: poistutaan."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Suodatin"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Hakemistot"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Tiedostot"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Valinta"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Leikepöydän avaus ei onnistunut."
@@ -5720,60 +5706,60 @@ msgstr "Värin valintaikkuna epäonnistui virheellä %0lx."
 msgid "Failed to create cursor."
 msgstr "Osoittimen luonti epäonnistui."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "DDE-palvelimen ”%s” rekisteröinti epäonnistui"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "DDE-serverin ”%s” poisto rekisteröinnistä epäonnistui"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Ei voitu yhdistää palvelimeen ”%s” asiassa %s"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 #, fuzzy
 msgid "DDE poke request failed"
 msgstr "DDE-kirjoituspyyntö epäonnistui"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 #, fuzzy
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE-serverin ohjeistuspiiriä ei aikaansaatu"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE ohjeistuspiirin (advise loop) keskeytys ei onnistunut"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "DDE:n ohjeistustiedotuksen lähetys epäonnistui"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "DDE-merkkijonoa ei voitu luoda"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "ei DDE-virhettä."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "synkronisen ohjeistustapahtuman pyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "tapahtuman vastaus aiheutti DDE_FBUSY-bitin asettumisen."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "synkronisen datasiirron pyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5783,7 +5769,7 @@ msgstr ""
 "DDEML funktio kutsuttiin ilman edeltävää DDE-initialisointia, \n"
 "tai epäkelpo instanssin tunniste annetiin DDEML funktiolle."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 #, fuzzy
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
@@ -5795,46 +5781,46 @@ msgstr ""
 "tehdä DDE tapahtuman tai APPCMD_CLIENTONLY on yrittänyt \n"
 "tehdä palvelimen tapahtuman."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "synkronisen ohjelmapyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 #, fuzzy
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML ei voinut varmistaa parametria."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 #, fuzzy
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML-sovellus on luonut pitkän kilpailutilanteen."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "muistin varaus epäonnistui."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "asiakkaan yritys aloittaa keskustelu epäonnistui."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "tapahtuma epäonnistui."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 #, fuzzy
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "synkronisen datakirjoitustapahtuman pyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "sisäinen kutsu ”PostMessage”-funktion epäonnistui. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "vaikeuksia uudelleen palaamisessa."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5844,15 +5830,15 @@ msgstr ""
 "joka pysäytettiin asiakkaan taholla, tai palvelin\n"
 "keskeytti ennen tapahtuman valmistumista."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "sisäinen virhe tapahtui DDEML:ssä."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "ohjeistustapahtuman lopettamisen pyynnön sallittu aika ylittyi."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5862,12 +5848,12 @@ msgstr ""
 "Kun sovellus on palannut XTYP_XACT_COMPLETE vastakutsusta, \n"
 "tapahtuman tunnus tälle vastakutsulle ei päde enää."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Tuntematon DDE-virhe %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5875,7 +5861,7 @@ msgstr ""
 "Puhelinsoittomahdollisuutta ei ole koska RAS (remote access service)\n"
 "ei ole asennettu tälle koneelle. Ole hyvä asenna se."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5884,65 +5870,65 @@ msgstr ""
 "Tälle koneelle asennetun RAS (remote access server) komponentin versio on "
 "liian vanha, ole hyvä ja päivitä se (vaadittua funktiota %s ei löytynyt)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS-virheilmoitusta ei saatu."
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "tuntematon virhe (virhekoodi %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Aktiivista puhelinyhteyttä ei löydy: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Monta aktiivista puhelinvalintaikkunaa auki, valitsen yhden satunnaisesti."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Soittoyhteyttä %s ei voitu luoda"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Palveluntarjoajien nimeä ei saatu: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Yhdistäminen epäonnistui: ei soitettavissa olevaa palveluntarjoajaa."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Valitse palveluntarjoaja jolle soitetaan"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Valitse palveluntarjoaja, johon haluat kytkeytyä"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Yhdistäminen epäonnistui: käyttäjätunnus/salasana puutui."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Osoitekirjatiedoston sijaintia ei löydy"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Puhelinyhteyden ”%s” keskeytys ei onnistunut."
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Puhelua ei voi lopettaa - ei aktiivista yhteyttä."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Puhelinyhteyden ”%s” keskeytys ei onnistunut."
@@ -5962,19 +5948,18 @@ msgstr "Osoittimen luonti epäonnistui."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Hakemiston ”%s” tiedostojen luettelointi epäonnistui"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Ajastimen luonti epäonnistui"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (virhe %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Kuvan lisäys kuvalistaan epäonnistui."
 
@@ -5988,7 +5973,7 @@ msgstr "Metatiedostoa ei voitu ladata tiedostosta ”%s”."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Standardin etsi/korvaa ikkunan luonti epäonnistui (virhekoodi %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Värin valintaikkuna epäonnistui virheellä %0lx."
@@ -6032,17 +6017,17 @@ msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 "Hakemiston \"%s\" muutoksia ei voida tarkkailla, koska sitä ei ole olemassa."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Ajastimen luonti epäonnistui"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL:n alustus epäonnistui"
 
@@ -6050,7 +6035,7 @@ msgstr "OpenGL:n alustus epäonnistui"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6058,7 +6043,7 @@ msgstr ""
 "MS HTML Ohjetoiminnot eivät ole saatavilla koska MS HTML Help kirjastoa ei "
 "ole asennettu tälle koneelle. Ole hyvä ja asenna se."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML Ohjeen alustus epäonnistui."
 
@@ -6067,7 +6052,7 @@ msgstr "MS HTML Ohjeen alustus epäonnistui."
 msgid "Can't delete the INI file '%s'"
 msgstr "INI-tiedoston ”%s” poisto epäonnistui"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, fuzzy, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Ei voi hakea tietoja list-kontrollin jäsenestä indeksissä %d."
@@ -6189,7 +6174,7 @@ msgstr "Ei voi rekisteröidä leikepöytämuotoa ”%s”."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Leikepöydän muotoa ”%d” ei ole olemassa."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Ohita"
 
@@ -6274,75 +6259,75 @@ msgstr ""
 "toimintaan. Avaimen poistaminen jättää järjestelmän\n"
 "epävakaaseen tilaan: toiminto keskeytetty."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Avainta ”%s” ei voi poistaa"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Arvon ”%s” poisto avaimesta ”%s” ei onnistu"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Ei voida lukea arvoa avaimesta ”%s”"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Ei voida asettaa arvoa ”%s”"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "”%s”:n arvoa ei voida lukea"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Avaimen ”%s” arvoja ei voi luetella"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Avaimen ”%s” aliavaimia ei voi luetella"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, fuzzy, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "Viety rekisteriavain: tiedosto ”%s” on jo olemassa eikä sitä korvata."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Tukemattoman tyypin %d arvoja ei voida viedä."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, fuzzy, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ohitetaan arvo ”%s” avaimessa ”%s”."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6350,41 +6335,41 @@ msgstr ""
 "Rich Edit tekstimuokkaus on mahdotonta, käytetään tavanomaista "
 "tekstimuokkausta.Asenna riched32.dll uudestaan."
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Säikeen käynnistys epäonnistui: virhe TLS-kirjoituksessa."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Säikeen prioriteetin asetus epäonnistui"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Säiettä ei voi luoda"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Säiettä ei voi päättää"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Ei voi odottaa säikeen keskeytystä"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Säikeen %x keskeytys epäonnistui"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Säikeen %x jatko epäonnistui"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Säikeen osoittimen haku epäonnistui"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6392,7 +6377,7 @@ msgstr ""
 "Säiemoduulin käynnistys epäonnistui: indeksin varaus säikeen muistiin "
 "mahdotonta"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6422,12 +6407,12 @@ msgstr "Prosessia %d ei voitu lopettaa."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Lukkotiedostoa ”%s” ei voitu lukita"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "käännös %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bittinen versio"
 
@@ -6439,47 +6424,47 @@ msgstr "Anonyymin putken luonti epäonnistui"
 msgid "Failed to redirect the child process IO"
 msgstr "Lapsiprosessin I/O:n uudelleenohjaus epäonnistui"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Komennon ”%s” käynnistäminen epäonnistui"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Tiedoston mpr.dll lataus epäonnistui."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Tyyppinimeä ei voi lukea: ”%s”"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Ei voitu ladata kuvaketta tiedostosta ”%s”."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Säikeen prioriteetin asetus epäonnistui"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Ei voitu ajaa kohdetta ”%s”\n"
@@ -6513,7 +6498,7 @@ msgid "Check to make the font italic."
 msgstr "Valitse tehdäksesi kirjasimesta kursivoidun."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Alleviivattu"
@@ -6619,490 +6604,490 @@ msgstr "Tiedosto %s ei ole olemassa."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Tietoja: %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Tietoja..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Asetukset..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Palvelut"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Kätke %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Kätke Appi"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Kätke muut"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Näytä kaikki"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Lopeta %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Lopeta Appi"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip:iä ei tueta zlib:in tässä versiossa"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Sarakkeen kuvausta ei voitu alustaa."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "K&irjasinkoko:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "UusiNimi"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Tyyli"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Paino"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "&Kirjasinperhe:"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Moderni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "heikko"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Tasaa teksti oikealle."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Moderni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Valikko"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Ikkuna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Ikkuna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Ikkuna"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Valinnainen koko"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "Mac (kreikkalainen)"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "Selaa"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "Toista"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "oletus"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "huomenna"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Oikealle"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Luettelomerkkityyli"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "&Merkkikoodi:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "K&irjasinkoko:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Tasaa oikealle"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Kysymys"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Oikealle"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Oikealle"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Liitä valinta"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "&Ominaisuudet"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategorisoitu tila"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Aakkosnumeerinen tila"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 #, fuzzy
 msgid "False"
 msgstr "Tiedosto"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Tosi"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 #, fuzzy
 msgid "Unspecified"
 msgstr "Tasattu"
@@ -7117,49 +7102,49 @@ msgstr "Tulostusvirhe"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Virhe resurssissa: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Anna sivunumero väliltä %d ja %d:"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "Tietoja %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Luo hakemisto"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "Valitse kirjasinlaji"
@@ -7650,128 +7635,128 @@ msgstr "Lisää"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Muuta tyyli"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 #, fuzzy
 msgid "Change Object Style"
 msgstr "Muuta luettelotyyli"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Muuta luettelotyyli"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Numeroi luettelo uudelleen"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Lisää teksti"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Lisää kuva"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "Lisää teksti"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "Lisää teksti"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Liian monta EndStyle-kutsua!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "tiedostot"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "perus/ympyrä"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "perus/neliö"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Usean solun ominaisuudet"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Poista tyyli"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "Poista"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "Poista valinta"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Ominaisuudet"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "kuva"
 
@@ -7979,25 +7964,25 @@ msgstr "~"
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Poista teksti"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Poista"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Tekstiä ei voitu tallentaa."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Korvaa"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Kirjasin:"
 
@@ -9024,53 +9009,53 @@ msgstr "Luettelotyylit"
 msgid "Box styles"
 msgstr "Kaikki tyylit"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Kirjasin, josta symboli otetaan."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Osajoukko:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Näyttää Unicode-osajoukon"
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Merkkikoodi:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Merkkikoodi."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Lähettäjä:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Näytettävä alue."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Lisää"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Tavallinen teksti)"
 
@@ -9264,7 +9249,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Näyttöä ”%s” ei voitu avata."
@@ -9364,20 +9349,20 @@ msgstr "äänidatan muotoa ei tueta."
 msgid "Couldn't open audio: %s"
 msgstr "ääntä ei voi avata: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Säikeen järjestyspolitiikka ei löydettävissä."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Järjestyspolitiikan %d priorisointialue ei ole tiedossa."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Säikeen prioriteettiasetus jätetään huomiotta."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9385,60 +9370,60 @@ msgstr ""
 "Säikeen kytkentä epäonnistui, todennäköisesti muistivuoto - ole hyvä ja "
 "käynnistä ohjelma uudestaan"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Säikeen prioriteetin %d asetus epäonnistui."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Säikeen prioriteetin %d asetus epäonnistui."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Säikeen päättäminen epäonnistui."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Säiemoduulin käynnistys epäonnistui: säieavainta ei voi luoda"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Lapsiprosessin syötteen saanti on mahdotonta"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Prosessia %d ei voitu lopettaa."
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Ei voitu ajaa kohdetta ”%s”\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Haarauttaminen epäonnistui"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Säikeen prioriteetin %d asetus epäonnistui."
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Lapsiprosessin I/O:n uudelleenohjaus epäonnistui"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Isäntäkoneen nimeä ei onnistuttu saamaan"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Isäntäkoneen virallista nimeä ei onnistuttu saamaan"
 
@@ -9456,12 +9441,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "PID:iä ei voitu lukea lukkotiedostosta."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Virheellinen geometry-määritelmä ”%s”"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets ei voi avata näyttöä. Poistutaan."
 
@@ -9475,30 +9460,60 @@ msgstr "Näytön ”%s” sulkeminen epäonnistui"
 msgid "Failed to open display \"%s\"."
 msgstr "Näyttöä ”%s” ei voitu avata."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML-jäsennysvirhe: ”%s” rivillä %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Ei voi ladata resursseja tiedostosta ”%s”."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
+
+#~ msgid "Printing "
+#~ msgstr "Tulostetaan "
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Työhakemistoa ei saatu"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Valitse kelvollinen fontti."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "HTML %s-koodattua asiakirjaa ei voi näyttää"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets ei voi avata näyttöä prosessille ”%s”: poistutaan."
+
+#~ msgid "Filter"
+#~ msgstr "Suodatin"
+
+#~ msgid "Directories"
+#~ msgstr "Hakemistot"
+
+#~ msgid "Files"
+#~ msgstr "Tiedostot"
+
+#~ msgid "Selection"
+#~ msgstr "Valinta"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "muunnos 8-bittiseksi koodaukseksi epäonnistui"
@@ -9670,8 +9685,8 @@ msgstr "Ei voitu purkaa ”%s”:aa kohteeseen ”%s”."
 
 #, fuzzy
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-04-10 12:52+0200\n"
 "Last-Translator: Gérard DURAND <gerard-florence.durand@orange.fr>\n"
 "Language-Team: French <debian-l10n-french@lists.debian.org>\n"
@@ -16,11 +16,11 @@ msgstr ""
 "plural-forms: nplurals=2; plural=n > 1\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Tous les fichiers (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Tous les fichiers (*)|*"
 
@@ -37,24 +37,21 @@ msgid "Remaining time:"
 msgstr "Temps restant :"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Oui"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Non"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Ok"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Annuler"
@@ -105,7 +102,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Impossible de créer un port de terminaison d'E/S"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Impression"
 
@@ -142,7 +139,7 @@ msgstr "Propriétés de l'Objet"
 msgid "Printing"
 msgstr "Impression"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symboles"
 
@@ -211,7 +208,7 @@ msgstr "&Précédent"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Fenêtre"
 
@@ -740,11 +737,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "montrer ce message d'aide"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "créer des messages de journalisation verbeux"
 
@@ -766,84 +763,84 @@ msgstr "Thème « %s » non reconnu."
 msgid "Invalid display mode specification '%s'."
 msgstr "Spécification du mode d'affichage « %s » non valable."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "L'option « %s » ne peut pas être inversée"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Option longue « %s » inconnue"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Option « %s » inconnue"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caractères non attendus suivant l'option « %s »."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L'option « %s » nécessite une valeur."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Séparateur attendu après l'option « %s »."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "« %s » n'est pas une valeur numérique correcte pour l'option « %s »."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Option « %s » : « %s » ne peut pas être converti en date."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Paramètre « %s » inattendu"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ou %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "La valeur de l'option « %s » doit être précisée."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Paramètre nécessaire « %s » non fourni."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "double"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "date"
 
@@ -861,7 +858,7 @@ msgid "Can't &Undo "
 msgstr "Impossible d'&annuler "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Annuler"
@@ -871,7 +868,7 @@ msgid "&Redo "
 msgstr "&Refaire "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refaire"
@@ -904,12 +901,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "« %s » a trop de « .. » : ils sont ignorés."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "coché"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "décoché"
 
@@ -918,103 +915,103 @@ msgstr "décoché"
 msgid "undetermined"
 msgstr "indéterminé"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "aujourd'hui"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "hier"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "demain"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "premier"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "deuxième"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "troisième"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "quatrième"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "cinquième"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sixième"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "septième"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "huitième"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "neuvième"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "dixième"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "onzième"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "douzième"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "treizième"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "quatorzième"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "quinzième"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "seizième"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "dix-septième"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "dix-huitième"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "dix-neuvième"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vingtième"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "midi"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "minuit"
 
@@ -1082,45 +1079,82 @@ msgstr "Échec de l'exécution de curl, veuillez l'installer dans le PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Échec de l'envoi du rapport de bogue (code d'erreur %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Enregistrer Sous"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Ignorer les modifications et recharger la dernière version enregistrée ?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "sans nom"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Faut-il enregistrer les modifications vers %s ?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Enregistrer"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ne pas enregistrer"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Faut-il enregistrer les modifications vers %s ?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Le texte n'a pas pu être enregistré."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Le fichier « %s » n'a pas pu être ouvert en écriture."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Échec de l'enregistrement du document dans le fichier « %s »."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Le fichier « %s » n'a pas pu être ouvert en lecture."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Échec de la lecture du document depuis le fichier « %s »."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1129,57 +1163,57 @@ msgstr ""
 "Le fichier « %s » n'existe pas et n'a pas pu être ouvert.\n"
 "Il a été retiré de la liste des fichiers récemment utilisés."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Échec de la création de l'aperçu avant impression."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Aperçu avant impression"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Le format du fichier « %s » n'a pas pu être déterminé."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "sans nom %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Ouvrir un Fichier"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Erreur fichier"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Impossible d'ouvrir ce fichier."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Format de fichier inconnu."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Sélectionner un modèle de document"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Modèles"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Sélectionner une vue du document"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Vues"
 
@@ -1213,43 +1247,43 @@ msgstr "Erreur de lecture dans le fichier « %s »"
 msgid "Write error on file '%s'"
 msgstr "Erreur d'écriture dans le fichier « %s »"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "échec de la mise à jour du fichier « %s »"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Erreur de recherche dans le fichier « %s » (les fichiers importants ne sont "
 "pas gérés par stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Erreur de recherche dans le fichier « %s »"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Impossible de trouver la position courante dans le fichier « %s »"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Échec de la configuration des permissions du fichier temporaire"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "impossible de supprimer le fichier « %s »"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "impossible d'appliquer les changements au fichier « %s »"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "impossible de supprimer le fichier temporaire « %s »"
@@ -1274,31 +1308,31 @@ msgstr "impossible de lire le descripteur de fichier %d"
 msgid "can't write to file descriptor %d"
 msgstr "impossible d'écrire dans le descripteur de fichier %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 "impossible de forcer l'écriture sur disque du descripteur de fichier %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "recherche impossible sur le descripteur de fichier %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "impossible de trouver la position de recherche sur le descripteur de fichier "
 "%d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "impossible de trouver la taille du fichier dans le descripteur de fichier %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1326,113 +1360,113 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Erreur lors de la lecture des options de configuration."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Échec de la lecture des options de configuration."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fichier '%s' : caractère %c inattendu à la ligne %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr ""
 "fichier « %s », ligne %zu : « %s » est ignoré après l'en-tête de groupe."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fichier « %s », ligne %zu : symbole « = » attendu."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "fichier « %s », ligne %zu : valeur pour la touche non configurable « %s » "
 "ignorée."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "fichier « %s », ligne %zu : première occurrence de la clé %s à la ligne %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Le nom d'entrée de configuration ne peut pas commencer par « %c »."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "impossible d'ouvrir le fichier de configuration utilisateur."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "impossible d'écrire le fichier de configuration utilisateur."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Échec de la mise à jour du fichier de configuration utilisateur."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr ""
 "Erreur lors de l'enregistrement des données de configuration de "
 "l'utilisateur."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "impossible d'effacer le fichier de configuration utilisateur « %s »"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "l'entrée « %s » apparaît plus d'une fois dans le groupe « %s »"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentative de modifier la touche non configurable « %s » ignorée."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "anti-slash de fin ignoré dans '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "symbole \" inattendu à la position %d dans « %s »."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Échec de la copie du fichier « %s » vers « %s »"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Impossible d'obtenir les permissions du fichier « %s »"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Impossible d'écraser le fichier « %s »"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Erreur à la copie du fichier '%s' vers '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Impossible de configurer les permissions du fichier « %s »"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1441,40 +1475,40 @@ msgstr ""
 "Erreur lors du changement de nom de « %s » en « %s » : il existe déjà un "
 "fichier avec le nom de destination."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Le fichier « %s » n'a pas pu être renommé en « %s »"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Le fichier « %s » n'a pas pu être supprimé"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Le dossier « %s » n'a pas pu être créé"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Le dossier « %s » n'a pas pu être supprimé"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Impossible d'énumérer les fichiers « %s »"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Échec de l'obtention du répertoire courant"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Impossible de définir le répertoire de travail courant"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Fichiers (%s)"
@@ -1501,17 +1535,17 @@ msgstr "Échec de la création d'un nom de fichier temporaire"
 msgid "Failed to open temporary file."
 msgstr "Échec de l'ouverture d'un fichier temporaire."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Échec de la modification de la date du fichier « %s »"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Échec de la mise à jour de la date du fichier « %s »"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Échec de la récupération de la date du fichier « %s »"
@@ -1520,22 +1554,22 @@ msgstr "Échec de la récupération de la date du fichier « %s »"
 msgid "Browse"
 msgstr "Parcourir"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tous les fichiers (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s fichiers (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Charger le fichier %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Enregistrer le fichier %s"
@@ -1898,99 +1932,99 @@ msgstr "défaut"
 msgid "unknown-%d"
 msgstr "inconnu-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "souligné"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " barré"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " mince"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " extra léger"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " léger"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " moyen"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " semi-gras"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " gras"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " extra gras"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " lourd"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " extra lourd"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " italique"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "barré"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "fin"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "extra-léger"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "léger"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "moyen"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "semi-gras"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "gras"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "extra-gras"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "lourd"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "extra lourd"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "italique"
 
@@ -2071,7 +2105,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Échec de la configuration du mode de transfert FTP en %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2092,7 +2126,7 @@ msgstr "Mode passif non reconnu par le serveur FTP."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Taille d'image GIF incorrecte (%u, %d) for l'image #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Échec de l'allocation de couleur pour OpenGL"
 
@@ -2108,7 +2142,7 @@ msgstr "Personnaliser les Colonnes"
 msgid "&Customize..."
 msgstr "&Personnaliser..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Échec de l'ouverture de l'URL « %s » avec le navigateur par défaut"
@@ -2128,159 +2162,158 @@ msgstr "Échec du chargement de l'image %d depuis le flux."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Échec du chargement des icônes depuis les ressources '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP : impossible de sauvegarder une image non valable."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP : wxImage n'a pas sa propre wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP : impossible d'écrire l'entête du fichier (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP : impossible d'écrire l'entête du fichier (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP : impossible d'écrire la palette de couleurs RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP : impossible d'écrire les données."
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP : impossible d'allouer de la mémoire."
 
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr ""
 "En-tête DIB : largeur de l'image supérieure à 32 767 pixels pour le fichier."
 
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr ""
 "En-tête DIB : hauteur de l'image supérieure à 32 767 pixels pour le fichier."
 
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "En-tête DIB : nombre de bits par pixel inconnu dans le fichier."
 
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "En-tête DIB : codage inconnu dans le fichier."
 
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "En-tête DIB : le codage ne correspond pas au nombre de bits par pixel."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Erreur lors de la lecture d'une image DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO : erreur à la lecture du masque DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO : image trop grande pour une icône."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO : image trop large pour une icône."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO : erreur à l'écriture du fichier image !"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO : index de l'icône non valable."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "L'image et le masque sont de tailles différentes."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Aucune couleur n'est disponible dans l'image en cours de masquage."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Échec du chargement du bitmap « %s » depuis les ressources."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Échec du chargement de l'icône « %s » depuis les ressources."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Échec du chargement de l'image depuis le fichier « %s »."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Impossible d'enregistrer l'image dans le fichier « %s » : extension inconnue."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Aucun gestionnaire trouvé pour le type d'image."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Aucun gestionnaire d'image défini pour le type %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Le fichier image n'est pas du type %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Impossible de déterminer le format d'image pour une entrée non positionnable."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Format de données d'image inconnu."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Ceci n'est pas un %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Aucun gestionnaire d'image défini pour le type %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Le fichier image n'est pas du type %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Échec de la vérification de format du fichier image « %s »."
@@ -2383,41 +2416,41 @@ msgstr "PNM : le fichier semble tronqué."
 msgid " (in module \"%s\")"
 msgstr " (dans le module « %s »)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF : erreur au chargement de l'image."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Index d'image TIFF non valable."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF : La taille de l'image est anormalement grande."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF : allocation de mémoire impossible."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF : erreur à la lecture de l'image."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unité %d de résolution TIFF inconnue et ignorée"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF : erreur à la sauvegarde de l'image."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF : erreur à l'écriture de l'image."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2426,11 +2459,11 @@ msgstr ""
 "L'argument %d de la ligne de commande n'a pas pu être converti en Unicode et "
 "sera ignoré."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "L'initialisation a échoué dans post init, abandon."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Impossible d'établir la localisation pour la langue « %s »."
@@ -2524,7 +2557,7 @@ msgstr "Erreur de compression LZMA : %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Erreur de compression LZMA pendant l'écriture : %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Symbole « { » non assorti dans une entrée pour le type mime %s."
@@ -2544,7 +2577,7 @@ msgstr "La dépendance « %s » du module « %s » n'existe pas."
 msgid "Module \"%s\" initialization failed"
 msgstr "L'initialisation du module « %s » a échoué"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Message"
 
@@ -3046,7 +3079,7 @@ msgstr "Erreur d'impression"
 msgid "Print"
 msgstr "Imprimer"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Mise en page"
 
@@ -3081,19 +3114,15 @@ msgstr "Impression de la page %d sur %d"
 msgid " (copy %d of %d)"
 msgstr " (copie %d sur %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Impression en cours "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Première page"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Page précédente"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Page suivante"
 
@@ -3137,16 +3166,16 @@ msgstr "Page %d de %d"
 msgid "Page %d"
 msgstr "Page %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "erreur inconnue"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expression rationnelle « %s » non valable : %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
@@ -3159,21 +3188,21 @@ msgstr ""
 "Le moteur de rendu « %s » a une version %d.%d incompatible et n'a pas pu "
 "être chargé."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Non disponible sur cette plateforme"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Enregistrement de mot de passe pour \"%s\" en erreur : %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Lecture de mot de passe pour \"%s\" en erreur : %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Suppression du mot de passe pour \"%s\" en erreur : %s."
@@ -3182,11 +3211,11 @@ msgstr "Suppression du mot de passe pour \"%s\" en erreur : %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Impossible de contrôler les canaux d'E/S"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Ne pas enregistrer"
 
@@ -3267,10 +3296,10 @@ msgid "Clear"
 msgstr "Effacer"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Fermer"
 
@@ -3282,7 +3311,7 @@ msgstr "&Convertir"
 msgid "Convert"
 msgstr "Convertir"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copier"
@@ -3291,7 +3320,7 @@ msgstr "&Copier"
 msgid "Copy"
 msgstr "Copier"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cou&per"
@@ -3300,13 +3329,13 @@ msgstr "Cou&per"
 msgid "Cut"
 msgstr "Couper"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Supprimer"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Supprimer"
@@ -3393,7 +3422,7 @@ msgstr "Disque dur"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Aide"
 
@@ -3413,7 +3442,7 @@ msgstr "Indenter"
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Index"
 
@@ -3482,7 +3511,7 @@ msgstr "&Nouveau"
 msgid "New"
 msgstr "Nouveau"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Non"
 
@@ -3499,12 +3528,12 @@ msgstr "&Ouvrir..."
 msgid "Open..."
 msgstr "Ouvrir..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Coller"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Coller"
@@ -3534,7 +3563,7 @@ msgid "Print..."
 msgstr "&Imprimer..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Propriétés"
 
@@ -3566,10 +3595,6 @@ msgstr "Remplacer..."
 msgid "Revert to Saved"
 msgstr "Changer en enregistré"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Enregistrer"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Enregistrer &sous..."
@@ -3578,7 +3603,7 @@ msgstr "Enregistrer &sous..."
 msgid "Save As..."
 msgstr "Enregistrer sous..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Tout sélectionner"
@@ -3685,7 +3710,7 @@ msgstr "&Haut"
 msgid "Up"
 msgstr "Haut"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Oui"
 
@@ -3773,44 +3798,44 @@ msgstr "Enregistrer le document courant"
 msgid "Save current document with a different filename"
 msgstr "Enregistrer le document courant avec un nouveau nom"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "La conversion vers le jeu de caractères « %s » ne fonctionne pas."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "inconnu"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "le bloc d'entête de tar est incomplet"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 "erreur de la somme de contrôle lors de la lecture du bloc d'entête de tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "donnée incorrectes dans l'entête étendu de tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "l'entrée tar n'est pas ouverte"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fin de fichier inattendue"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ne rentre pas dans l'entête tar pour l'entrée « %s »"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "la taille fournie pour l'entrée tar est incorrecte"
 
@@ -3819,7 +3844,7 @@ msgstr "la taille fournie pour l'entrée tar est incorrecte"
 msgid "'%s' is probably a binary buffer."
 msgstr "« %s » est probablement un tampon binaire."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Le fichier n'a pas pu être chargé."
 
@@ -3833,47 +3858,47 @@ msgstr "Échec de la lecture du fichier texte \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "impossible d'écrire le tampon « %s » sur le disque."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Échec de l'obtention de l'heure locale du système"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay a échoué."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "« %s » n'est pas un catalogue valable de messages."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catalogue de message non valable."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Écher de l'analyse des formes plurielles  : « %s »"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "utilisation du catalogue « %s » de « %s »."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "La ressource « %s » n'est pas un catalogue messages valable."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Impossible d'énumérer les traductions"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Pas d'application configurée pour les fichiers HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Échec de l'ouverture de l'URL « %s » avec le navigateur par défaut."
@@ -3906,7 +3931,7 @@ msgstr "'%s' contient un(des) caractère(s) invalide(s)"
 msgid "Error: %s (%d)"
 msgstr "Erreur : %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Pas assez de place disque pour télécharger."
 
@@ -3914,21 +3939,21 @@ msgstr "Pas assez de place disque pour télécharger."
 msgid "libcurl could not be initialized"
 msgstr "libcurl n'a pas pu être initialisé"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Conversion des chaînes non gérée"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Erreur à l'exécution du JavaScript : %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Cette plateforme ne supporte pas la transparence d'arrière plan."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Impossible de transférer les données à la fenêtre"
 
@@ -3981,8 +4006,8 @@ msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 "Classe d'objet non valable en tant que source d'événement (Non-wxEvtHandler)"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Le type doit être énumérable - conversion longue"
 
@@ -4032,82 +4057,82 @@ msgstr "Les objets doivent avoir un attribut id"
 msgid "Doubly used id : %d"
 msgstr "Identifiant utilisé deux fois : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propriété « %s » inconnue"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Une collection non vide doit comprendre des noeuds « éléments »"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "chaîne de gestion des événements non valable, point manquant"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "impossible de réinitialiser le flux de déchargement de zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "impossible de réinitialiser le flux de chargement de zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Ignorant l'enregistrement mal formé de données supplémentaires, le fichier "
 "ZIP peut être corrompu"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "suppose qu'il s'agit d'un zip recombiné"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "fichier zip non valable"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "impossible de trouver le répertoire principale dans le zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "erreur à la lecture du répertoire principale du zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "erreur à la lecture de l'en-tête local du zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "mauvais décalage de fichier zip dans l'entrée"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "longueur du fichier enregistré absente de l'entête du Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "méthode de compression zip non gérée"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lecture du flux zip (entrée %s) : mauvaise longueur"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lecture du flux zip (entrée %s) : mauvaise crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "erreur à l'écriture de l'entrée zip '%s' : fichier trop gros sans ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "erreur à l'écriture de l'entrée zip « %s » : mauvaise crc ou longueur"
@@ -4194,32 +4219,32 @@ msgstr "Graphismes par "
 msgid "Translations by "
 msgstr "Traductions par "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "À propos de %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licence"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Développeurs"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Rédacteurs de la documentation"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistes"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Traducteurs"
 
@@ -4270,43 +4295,42 @@ msgid "Password:"
 msgstr "Mot de passe :"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "vrai"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "faux"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Ligne %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Compacter"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Étendre"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d éléments)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Colonne %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4317,8 +4341,7 @@ msgid "Left"
 msgstr "Gauche"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4413,7 +4436,7 @@ msgid "Home directory"
 msgstr "Dossier personnel"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Bureau"
 
@@ -4426,8 +4449,7 @@ msgstr "Nom de répertoire illégal."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Erreur"
 
@@ -4611,16 +4633,16 @@ msgstr "Voir les fichiers en vue détaillée"
 msgid "Go to parent directory"
 msgstr "Aller au dossier parent"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Le fichier « %s » existe déjà, faut-il vraiment l'écraser ?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Choisir un fichier existant."
 
@@ -4714,7 +4736,7 @@ msgstr "Taille du point de la police."
 msgid "Whether the font is underlined."
 msgstr "Si la police est soulignée."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Aperçu :"
@@ -4732,53 +4754,52 @@ msgstr "Cliquer pour annuler la sélection de la police."
 msgid "Click to confirm the font selection."
 msgstr "Cliquer pour confirmer la sélection de la police."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Choisir la police"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "Copier plus d'un bloc sélectionné dans le bloc-note n'est pas supporté."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Dossier d'aide « %s » non trouvé."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Fichier d'aide « %s » non trouvé."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "La ligne %lu du fichier carte « %s » a une syntaxe incorrecte et a été "
 "sautée."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 "Aucune table de correspondance valablee n'a été trouvée dans le fichier « %s "
 "»."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Aucune entrée trouvée."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Aide Index"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Entrées pertinentes :"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Entrées trouvées"
 
@@ -4883,59 +4904,59 @@ msgstr "Impossible de lancer l'impression."
 msgid "Printing page %d..."
 msgstr "Impression de la page %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Options de l'imprimante"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Imprimer dans un fichier"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configurer..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Imprimante :"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "État :"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tout"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Pages"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Pages à imprimer"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "De :"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "À :"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Copies :"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Fichier PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Configuration de l'impression"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Imprimante"
 
@@ -4943,25 +4964,25 @@ msgstr "Imprimante"
 msgid "Default printer"
 msgstr "Imprimante par défaut"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Taille de la page"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Portrait"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Paysage"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientation"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Options"
 
@@ -4973,52 +4994,52 @@ msgstr "Imprimer en couleur"
 msgid "Print spooling"
 msgstr "File d'attente d'impression"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Commande pour l'imprimante :"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Options de l'imprimante :"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Marge gauche (mm) :"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Marge de haut de page (mm) :"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Marge droite (mm) :"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Marge de bas de page (mm) :"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Imprimante..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Pa&sser"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Terminé."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Chercher"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Impossible de trouver l'onglet pour l'identifiant"
 
@@ -5054,11 +5075,11 @@ msgstr "&Finir"
 msgid "< &Back"
 msgstr "< &Retour"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "liste des traducteurs"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5068,11 +5089,11 @@ msgstr ""
 "charge et peut entraîner des problèmes de gestion et de scintillement des "
 "entrées. Envisagez de désactiver GTK_IM_MODULE ou de définir sur « ibus »."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Impossible d'initialiser GTK+, l'AFFICHAGE est-il correctement réglé ?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Échec de la modification du dossier courant en « %s »"
@@ -5098,11 +5119,11 @@ msgstr "Échec d'ajout de police utilisateur \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Échec d'enregistrement de configuration utilisant des polices privées."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Erreur fatale"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5115,7 +5136,7 @@ msgstr ""
 "le \"backend\" X11 en définissant\n"
 "variable d’environnement GDK_BACKEND=x11 avant de démarrer votre programme."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5128,7 +5149,7 @@ msgstr ""
 "GDK_BACKEND=x11 avant\n"
 "de démarrer votre programme."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Fils MDI"
 
@@ -5144,16 +5165,12 @@ msgstr "Erreur lors de l'impression : "
 msgid "Page Setup"
 msgstr "Mise en Page"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Échec de l'insertion de texte dans le contrôle."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 "Récupérer la sortie du script JavaScript n'est pas supportée sous WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5162,7 +5179,7 @@ msgstr ""
 "reconnaitre la composition d'écran, il faut installer GTK+ 2.12 ou plus "
 "récent."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5170,17 +5187,13 @@ msgstr ""
 "La composition d'écran n'est pas reconnue par ce système, il faut l'activer "
 "dans le Gestionnaire de Fenêtre."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Ce programme a été compilé avec une version trop ancienne de GTK+, "
 "recompiler avec GTK+ 2.12 ou plus récent."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Choisir une police valable."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5279,45 +5292,45 @@ msgstr "Impossible d'ouvrir le fichier de table des matières : %s"
 msgid "Cannot open index file: %s"
 msgstr "Impossible d'ouvrir le fichier d'index : %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "pas de nom"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Impossible d'ouvrir le manuel d'aide HTML : %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Affiche l'aide pendant que le parcours des livres sur la gauche."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(marque-pages)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Ajouter la page courante aux marque-pages"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Retirer la page courante des marque-pages"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Table des matières"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Trouver"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Tout montrer"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5325,19 +5338,19 @@ msgstr ""
 "Afficher tous les éléments de l'index qui contiennent une sous-chaîne "
 "donnée. Recherche non sensible à la casse."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Montrer tous les éléments de l'index"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Sensible à la casse"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Mots complets seulement"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5345,147 +5358,147 @@ msgstr ""
 "Rechercher dans le contenu du/des manuel(s) d'aide toutes les occurrences du "
 "texte tapé ci-dessus"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Montrer/cacher le panneau de navigation"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Revenir"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Continuer"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Monter au niveau supérieur dans la hiérarchie du document"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Ouvrir un document HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Imprimer cette page"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Dialogue d'options de l'affichage"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Choisir la page à afficher :"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Sujets Aide"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Recherche..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Aucune page correspondante n'a encore été trouvée"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i correspondances trouvées"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Aide)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d sur %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu sur %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Chercher dans tous les manuels"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Aide Options Navigateur"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Police normale :"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Police de taille fixe :"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Taille de la police :"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "taille de police"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal<br>et <u>souligné</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Italique.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Gras.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Gras italique.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Police de taille fixe. <br> <b>gras</b> <i>italique</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>gras italique <u>souligné</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Aide Impression"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Impossible d'imprimer une page vide."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fichiers HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Livres d'aide (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projet d'aide HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fichier HTML compilé (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i de %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u sur %u"
@@ -5566,32 +5579,6 @@ msgstr ""
 "Un problème est apparu lors de la mise en page : la configuration d'une "
 "imprimante par défaut peut être nécessaire."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Échec de l'affichage du document HTML avec le codage %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets n'a pas pu ouvrir d'affichage pour %s : abandon."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtre"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Dossiers"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Fichiers"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Sélection"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Échec de l'ouverture du presse-papiers."
@@ -5633,62 +5620,62 @@ msgstr "Échec du dialogue de sélection de couleur avec l'erreur %0lx."
 msgid "Failed to create cursor."
 msgstr "Échec de la création d'un curseur."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Échec de l'enregistrement du serveur DDE « %s »"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Échec du désenregistrement du serveur DDE « %s »"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "Échec de la création d'une connexion au serveur « %s » sur le sujet « %s »"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Échec de la demande de transfert DDE"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 "Échec de l'établissement d'une boucle d'instructions avec le serveur DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 "Échec de la terminaison de la boucle d'instructions avec le serveur DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Échec de l'envoi d'une notification d'instructions au DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Échec de la création de la chaîne DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "erreur - pas de DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "une demande de transaction synchrone d'instructions a expiré."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "la réponse à la transaction a provoqué la spécification du bit DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "une demande de transaction synchrone de données a expiré."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5699,7 +5686,7 @@ msgstr ""
 "DdeInitialize, ou un identifiant non valable a été fourni à la fonction\n"
 "DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5710,43 +5697,43 @@ msgstr ""
 "d'effectuer une transaction DDE, ou une application initialisée en tant\n"
 "que APPCMD_CLIENTONLY a tenté d'effectuer des transactions serveur."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "une demande de transaction synchrone d'exécutions a expiré."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "un paramètre n'a pas pu être validé par la DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "une application DDEML a créé une situation de concurrence prolongée."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "une allocation de mémoire a échoué."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "une tentative d'un client pour établir une conversation a échoué."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "une transaction a échoué."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "une demande de transaction synchrone de stockage a expiré."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "un appel interne à la fonction PostMessage a échoué. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problème de double entrée."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5755,15 +5742,15 @@ msgstr ""
 "une transaction a été tentée du côté serveur lors d'une conversation déjà\n"
 "terminée par le client, ou le serveur a achevé la transaction avant la fin."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "une erreur interne s'est produite dans le DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "une demande pour terminer une transaction d'instructions a expiré."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5773,12 +5760,12 @@ msgstr ""
 "Quand l'application sort d'un rappel XTYP_XACT_COMPLETE, l'identifiant de\n"
 "transaction pour ce rappel n'est plus valable."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Erreur DDE inconnue : %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5786,7 +5773,7 @@ msgstr ""
 "Les fonctions d'appel ne sont pas disponibles car le service d'accès à "
 "distance (RAS) n'est pas installé sur cet ordinateur. L'installer."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5795,64 +5782,64 @@ msgstr ""
 "La version du service d'accès distant (RAS) installée sur cette machine est "
 "trop ancienne. Le mettre à niveau (la fonction suivante manque : %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Échec de la récupération du texte du message d'erreur RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "erreur inconnue (code d'erreur %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Impossible de trouver une connexion active : %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Plusieurs connexions actives trouvées, sélection unique aléatoire."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Échec de l'établissement d'une connexion : %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Échec de l'obtention des noms des FAI : %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Échec de la connexion : pas de FAI à appeler."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Choisir le FAI à appeler"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Choisir à quel FAI se connecter"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Échec de la connexion : nom d'utilisateur ou mot de passe manquant."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Impossible de trouver l'emplacement du fichier du manuel des adresses"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Échec de l'initialisation de la connexion modem : %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Impossible de raccrocher - pas de connexion active."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Échec de la terminaison de la connexion : %s"
@@ -5872,18 +5859,17 @@ msgstr "Échec de l'allocation de %lu Ko de mémoire pour les données bitmap."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Impossible d'énumérer les fichiers dans le répertoire « %s »"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Impossible d'obtenir le nom du dossier"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(erreur %d : %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Impossible d'ajouter une image à la liste des images."
 
@@ -5899,7 +5885,7 @@ msgstr ""
 "Échec de la création de la boîte de dialogue standard rechercher/remplacer "
 "(code d'erreur %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Échec du dialogue de fichier avec le code d'erreur %0lx."
@@ -5942,16 +5928,16 @@ msgstr "Impossible d'établir un scrutateur pour « %s »"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Impossible de surveiller les changements du dossier inexistant « %s »."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 et au-dessus n'est pas reconnu par le pilote OpenGL."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "N'a pas pu créer le contexte OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Échec de l'initialisation d'OpenGL"
 
@@ -5959,7 +5945,7 @@ msgstr "Échec de l'initialisation d'OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "N'a pas pu enregistrer le chargeur de police DirectWrite."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5967,7 +5953,7 @@ msgstr ""
 "Les fonctions de l'aide MS HTML ne sont pas disponibles car la bibliothèque "
 "MS HTML Help n'est pas présente sur cette machine. Il faut l'installer."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Échec de l'initialisation de l'aide MS HTML."
 
@@ -5976,7 +5962,7 @@ msgstr "Échec de l'initialisation de l'aide MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "Impossible d'effacer le fichier INI « %s »"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6099,7 +6085,7 @@ msgstr "Impossible d'enregistrer le format de presse-papiers « %s »."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format « %d » de presse-papiers inexistant."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Sauter"
 
@@ -6185,59 +6171,59 @@ msgstr ""
 "du système ; sa suppression laisserait ce système inutilisable :\n"
 "opération abandonnée."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Impossible d'effacer la clé « %s »"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Impossible d'effacer la valeur « %s » de la clé « %s »"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Impossible de lire la valeur de la clé « %s »"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Impossible de spécifier la valeur de « %s »"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "La valeur de registre \"%s\" n'est pas numérique (mais de type %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "La valeur de registre \"%s\" n'est pas binaire (mais de type %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "La valeur de registre \"%s\" n'est pas du texte (mais de type %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Impossible de lire la valeur de « %s »"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Impossible d'énumérer les valeurs de la clé « %s »"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Impossible d'énumérer les sous-clés de la clé « %s »"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6245,17 +6231,17 @@ msgstr ""
 "Exportation de la clé de registre : le fichier « %s » existe déjà et ne sera "
 "pas écrasé."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Impossible d'exporter les valeurs de type non reconnu %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Valeur « %s » de la clé « %s » ignorée."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6263,41 +6249,41 @@ msgstr ""
 "Impossible de créer un contrôle d'édition riche, utilisation d'un contrôle "
 "de texte simple à la place. Réinstaller riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Impossible de lancer le processus : erreur lors de l'écriture de TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Impossible de spécifier la priorité du processus"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Impossible de créer le processus"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Impossible d'arrêter le processus"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Impossible d'attendre la fin du processus"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Impossible de suspendre le thread %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Impossible de reprendre le thread %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Impossible d'obtenir le pointeur du processus actuel"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6305,7 +6291,7 @@ msgstr ""
 "Échec de l'initialisation du module du processus : impossible d'allouer un "
 "index dans le stockage local des processus"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6338,12 +6324,12 @@ msgstr "Échec du chargement de la ressource « %s »."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Échec du verrouillage de la ressource « %s »."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "version %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", édition 64-bit"
 
@@ -6355,49 +6341,49 @@ msgstr "Échec de la création d'un tube (pipe) anonyme"
 msgid "Failed to redirect the child process IO"
 msgstr "Échec de la redirection des entrées et sorties du processus fils"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Échec de l'exécution de la commande « %s »"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Échec du chargement de mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Impossible de lire le nom de type de « %s » !"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Impossible de charger l'icône depuis « %s »."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 "Impossible de trouver le niveau d’émulation de la vue Web dans le Registre"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Impossible de définir la vue Web avec un niveau d’émulation moderne"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 "Impossible de réinitialiser l’affichage Web avec un niveau d’émulation "
 "standard"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Ne peut lancer un script JavaScript sans document HTML valide"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Ne peut pas accéder à l'objet JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "échec de l'évaluation"
 
@@ -6430,7 +6416,7 @@ msgid "Check to make the font italic."
 msgstr "Cocher pour mettre la police en italique."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Souligné"
@@ -6497,15 +6483,33 @@ msgstr "<N'importe quel Télétype>"
 msgid "File type:"
 msgstr "Type de fichier :"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Fenêtre"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Aide"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimiser"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Tout amener au-dessus"
 
@@ -6522,493 +6526,493 @@ msgstr "Le fichier de police \"%s\" n'existe pas."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Le fichier de police \"%s\" ne peut pas être utilisé s'il n'est pas dans le "
 "répertoire de polices \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "À propos de %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "À propos..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Préférences..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Services"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Cacher %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Application"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Cacher les Autres"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Tout Montrer"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Quitter %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Application"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Impression non supportée par le système de contrôle web"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "L'impression n'a pas pu être initialisée"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Taille de Point"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nom"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Style"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Poids"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Famille"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ButtonText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "GrayText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Surlignage"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Barre de défilement"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Infobulle"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "InfobulleTexte"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Fenêtre"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Noir"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Marron"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Bleu marine"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Pourpre"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Bleu sarcelle"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Gris"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Vert"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Olive"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Brun"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Bleu"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuchia"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Rouge"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Orange"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Argent"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Citron"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Aqua"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Jaune"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Blanc"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Par défaut"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Flèche"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Flèche Droite"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Vide"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Carton"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Caractère"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Croix"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Main"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Bouton gauche"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Loupe"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Bouton du milieu"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Pas d'entrée"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Brosse à peinture"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Crayon"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Point Gauche"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Point Droite"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Point d'Interrogation"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Bouton droit"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Dimensionnement NE-SO"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Dimensionnement N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Dimensionnement NW-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Dimensionnement O-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Dimensionnement"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Vaporisateur"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Attente"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Scrutateur"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Flèche d'attente"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Créer une sélection :"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Propriété"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valeur"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Mode Catégories"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Mode Alphabétique"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Faux"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Vrai"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Non spécifié"
 
@@ -7022,12 +7026,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Une valeur incorrecte a été saisie. Presser ESC pour annuler l'édition."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Erreur dans la ressource : %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7036,36 +7040,36 @@ msgstr ""
 "Échec du type d'operation « %s » : la propriété désignée par « %s » est du "
 "type « %s », et NON « %s »."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Base inconnue %d. La base 10 sera utilisée."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "La valeur doit être %s ou plus."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "La valeur doit être entre %s et %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "La valeur doit être %s ou moins."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Pas %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Choisir un dossier :"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Choisir un fichier"
 
@@ -7532,117 +7536,117 @@ msgstr "Intérieur"
 msgid "Outset"
 msgstr "Extérieur"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Modifier le style"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Modifier le Style de l'Objet"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Modifier les Propriétés"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Modifier la liste de styles"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renuméroter la liste"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Insérer du texte"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Insérer une image"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Insérer un objet"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Insérer un champ"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Trop d'appels à EndStyle !"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "fichiers"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standard/circulaire"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standard/contour circulaire"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standard/carré"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standard/triangle"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Propriétés de la boîte"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Propriétés de Plusieurs Cellules"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Propriétés de Cellule"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Définir le Style de Cellule"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Supprimer la ligne"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Supprimer la colonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Ajouter une ligne"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Ajouter une colonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Propriétés du Tableau"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Propriétés de l'Image"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "image"
 
@@ -7850,24 +7854,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Glisser"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Supprimer le texte"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Retirer le tiret"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Le texte n'a pas pu être enregistré."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Remplacer"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Police :"
 
@@ -8836,53 +8840,53 @@ msgstr "Styles de liste"
 msgid "Box styles"
 msgstr "Styles de boîte"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "La police de laquelle prendre le symbole."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Sous-ensemble:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Affiche un échantillon d'Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Code caractère :"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Le code caractère."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "De :"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "L'intervalle à afficher."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insérer"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Texte normal)"
 
@@ -9074,7 +9078,7 @@ msgstr "Impossible d'obtenir les évènements depuis kqueue"
 msgid "Media playback error: %s"
 msgstr "Erreur du lecteur de média : %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Échec de la préparation à la lecture « %s »."
@@ -9175,22 +9179,22 @@ msgstr "Format des données sonores non reconnu."
 msgid "Couldn't open audio: %s"
 msgstr "Impossible d'ouvrir le fichier audio : %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Impossible de récupérer la charte de planification des processus."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Impossible d'obtenir une gamme de priorités pour la stratégie de "
 "planification %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "La priorité donnée au processus est ignorée."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9198,62 +9202,62 @@ msgstr ""
 "Échec de l'adjonction d'un processus : fuite potentielle de mémoire "
 "détectée, redémarrer le programme"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Échec de l'établissement du niveau de concurrence de processus à %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Échec de la configuration de la priorité %d du processus."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Échec de la terminaison d'un processus."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Échec de l'initialisation du module du processus : échec de la création de "
 "la clé du processus"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Impossible d'obtenir l'entrée du processus fils"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Impossible d'écrire sur l'entrée du processus enfant"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Échec de l'exécution de « %s »\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Échec du clonage"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Échec de la définition de la priorité du processus"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Échec de la redirection des entrées et sorties du processus fils"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Échec de l'établissement du tube (pipe) non bloquant, le prgramme pourrait "
 "s'arrêter inopinément."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Impossible d'obtenir le nom d'hôte"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Impossible d'obtenir le nom d'hôte officiel"
 
@@ -9272,12 +9276,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "Échec de la lecture du tube (pipe) de réveil"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Spécification géométrique « %s » non valable"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets n'a pas pu ouvrir d'affichage : abandon."
 
@@ -9291,30 +9295,59 @@ msgstr "Échec de la fermeture de l'écran « %s »."
 msgid "Failed to open display \"%s\"."
 msgstr "Échec de l'ouverture de l'écran « %s »."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Erreur d'analyse XML : « %s » à la ligne %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Impossible de charger les ressources depuis « %s »."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Impossible d'ouvrir le fichier de ressources « %s »."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Impossible de charger les ressources du fichier « %s »."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Échec de la création de %s « %s »."
+
+#~ msgid "Printing "
+#~ msgstr "Impression en cours "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Échec de l'insertion de texte dans le contrôle."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Choisir une police valable."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Échec de l'affichage du document HTML avec le codage %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets n'a pas pu ouvrir d'affichage pour %s : abandon."
+
+#~ msgid "Filter"
+#~ msgstr "Filtre"
+
+#~ msgid "Directories"
+#~ msgstr "Dossiers"
+
+#~ msgid "Files"
+#~ msgstr "Fichiers"
+
+#~ msgid "Selection"
+#~ msgstr "Sélection"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "échec de la conversion dans un codage 8 bits"
@@ -9486,8 +9519,8 @@ msgstr "Échec de la création de %s « %s »."
 #~ "valeur :"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/gl_ES.po
+++ b/locale/gl_ES.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2013-11-01 21:34+0100\n"
 "Last-Translator: Nuria Andión <nandiez@gmail.com>\n"
 "Language-Team: Proxecto Trasno <proxecto@trasno.net>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Generator: Poedit 1.5.7\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Todos os ficheiros (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Todos os ficheiros (*)|*"
 
@@ -38,24 +38,21 @@ msgid "Remaining time:"
 msgstr "Tempo restante:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Si"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Non"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Aceptar"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
@@ -105,7 +102,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Fallo ao crear un porto de E/S"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Saída de impresión"
 
@@ -142,7 +139,7 @@ msgstr "Propiedades do obxecto"
 msgid "Printing"
 msgstr "Imprimindo"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Símbolos"
 
@@ -211,7 +208,7 @@ msgstr "&Anterior"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Xanela"
 
@@ -773,11 +770,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Ctrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "amosar esta mensaxe de axuda"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "xerar mensaxes de rexistro detalladas"
 
@@ -799,84 +796,84 @@ msgstr "Tema '%s' non compatíbel."
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificación de modo de visor incorrecta: '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "A opción '%s' non se pode contrarrestar"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opción longa '%s' descoñecida"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opción descoñecida '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracteres inesperados despois da opción '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A opción '%s' require un valor."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Esperábase un separador despois da opción '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' non é un valor numérico correcto para a opción '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opción '%s': '%s' non se pode converter en data."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parámetro '%s' inesperado"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ou %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Debe especificarse o valor para a opción '%s'."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Non se especificou o parámetro requirido '%s'."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Uso: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "cadea"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "núm"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dobre"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -894,7 +891,7 @@ msgid "Can't &Undo "
 msgstr "Non se puido &desfacer "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfacer"
@@ -904,7 +901,7 @@ msgid "&Redo "
 msgstr "&Refacer "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refacer"
@@ -935,12 +932,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ten '..' adicional, ignórase."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -950,103 +947,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "subliñado"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "hoxe"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "onte"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "mañá"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primeiro"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "segundo"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "terceiro"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "cuarto"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "quinto"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sexto"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sétimo"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "oitavo"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "noveno"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "décimo"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "décimo primeiro"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "décimo segundo"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "décimo terceiro"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "décimo cuarto"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "décimo quinto"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "décimo sexto"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "décimo sétimo"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "décimo oitavo"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "décimo noveno"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vixésimo"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "mediodía"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "media noite"
 
@@ -1114,44 +1111,81 @@ msgstr "Erro ao executar curl, por favor, instáleo no PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Erro ao enviar o informe de depuración (código de erro %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Gardar como"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Omitir os cambios e cargar a última versión gardada?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "sen nome"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Quere gardar os cambios en %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Gardar"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Non gardar"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Quere gardar os cambios en %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Non se puido gardar o texto."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Non foi posíbel abrir o ficheiro \"%s\" para escritura."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Erro ao gardar a imaxe de mapa de bits no ficheiro \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Non foi posíbel abrir o ficheiro \"%s\" para lectura."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1160,57 +1194,57 @@ msgstr ""
 "O ficheiro '%s' non existe e non se puido abrir.\n"
 "Foi eliminado da lista de ficheiros recentes."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Fallo na previsualización de impresión."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Previsualización de impresión"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Non se puido determinar o formato do ficheiro '%s'."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "sen nome%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Abrir ficheiro"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Erro de ficheiro"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Non se puido abrir este ficheiro."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "O formato deste ficheiro é descoñecido."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Seleccione un patrón de documento"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Patróns"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Seleccionar unha vista de documento"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Vistas"
 
@@ -1244,43 +1278,43 @@ msgstr "Erro de lectura no ficheiro '%s'"
 msgid "Write error on file '%s'"
 msgstr "Erro de escritura no ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "erro ao baleirar a memoria do ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Erro de busca no ficheiro '%s' (os ficheiros grandes non son compatíbeis con "
 "stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Erro de busca no ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Non se puido atopar a posición actual no ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Erro ao estabelecer os permisos do ficheiro temporal"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "non se puido eliminar o ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "non se poden remitir os cambios ao ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "non se puido eliminar o ficheiro temporal '%s'"
@@ -1305,27 +1339,27 @@ msgstr "non é posíbel ler dende o descritor de ficheiro %d"
 msgid "can't write to file descriptor %d"
 msgstr "non é posíbel escribir no descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "non é posíbel baleirar o descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "non é posíbel buscar no descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "non se pode atopar a posición do descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "non se atopa lonxitude do ficheiro no descritor %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1351,108 +1385,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Erro ao ler as opcións de configuración."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Erro ao ler as opcións da configuración."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "ficheiro '%s': caracter inesperado %c na liña %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "ficheiro '%s', liña %d: '%s' ignorada despois de cabeceira de grupo."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "ficheiro '%s', liña %d: '=' esperado."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "ficheiro '%s', liña %d: valor para clave inmutábel '%s' ignorado."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "ficheiro '%s', liña %d: clave '%s' foi atopada por primeira vez na liña %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "O nome da entrada de configuración non pode comezar por '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "non se puido abrir o ficheiro de configuración de usuario."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "non se puido escribir o ficheiro de configuración do usuario."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Erro ao gardar os datos de configuración do usuario."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "non se puido eliminar o ficheiro de configuración de usuario '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a entrada '%s' aparece máis de unha vez no grupo '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "intento de cambiar a clave inmutábel '%s', ignorado."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "ignorouse a barra invertida sobrante en '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inesperado na posición %d en '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Fallo ao copiar o ficheiro '%s' a '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Non é posíbel obter permisos para o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "É imposíbel sobreescribir o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Fallo ao copiar o ficheiro '%s' a '%s'"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Foi imposíbel estabelecer os permisos para o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1461,40 +1495,40 @@ msgstr ""
 "Non se puido cambiar o nome do ficheiro de '%s' a '%s' porque o ficheiro de "
 "destino xa existe. "
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Non se puido renomear o ficheiro '%s' a '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Non foi posíbel eliminar o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Non se puido crear o cartafol '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Non se puido eliminar o cartafol '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Non se puideron enumerar os ficheiros '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Erro ao obter o cartafol de traballo"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Non se atopou o cartafol de traballo actual"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Ficheiros (%s)"
@@ -1521,17 +1555,17 @@ msgstr "Erro ao crear un nome de ficheiro temporal"
 msgid "Failed to open temporary file."
 msgstr "Erro ao abrir o ficheiro temporal."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Erro ao modificar o ficheiro de tempos para '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Erro ao tocar o ficheiro '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Erro ao obter tempos de ficheiro para '%s'"
@@ -1540,22 +1574,22 @@ msgstr "Erro ao obter tempos de ficheiro para '%s'"
 msgid "Browse"
 msgstr "Explorar"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Todos os ficheiros (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s ficheiros (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Cargar o ficheiro %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Gardar o ficheiro %s"
@@ -1918,105 +1952,105 @@ msgstr "predeterminado"
 msgid "unknown-%d"
 msgstr "descoñecido-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "subliñado"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " riscado"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " clara"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " clara"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " grosa"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " grosa"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " grosa"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " cursiva"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "riscado"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "clara"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "clara"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "grosa"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "grosa"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "grosa"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "cursiva"
 
@@ -2099,7 +2133,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Fallo ao estabelecer o modo de tranferencia FTP como %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2120,7 +2154,7 @@ msgstr "O servidor FTP non é compatíbel co modo pasivo."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Tamaño de marco de GIF incorrecto (%u, %d) para o marco #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Erro ao asignar cor para OpenGL"
 
@@ -2136,7 +2170,7 @@ msgstr "Columnas personalizadas"
 msgid "&Customize..."
 msgstr "&Personalizar..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Erro ao abrir URL \"%s\" no navegador predeterminado."
@@ -2156,158 +2190,157 @@ msgstr "Non foi posíbel cargar a imaxe %d do fluxo."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Non foi posíbel cargar a icona \"%s\" dos recursos."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Non se puido gardar imaxe non válida."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage non ten a súa propia wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Non se puido escribir a cabeceira (Bitmap) do arquito."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Non se puido escribir a cabeceira (BitmapInfo) do ficheiro."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: No se puido escribir o mapa de cor RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Non se puideron escribir os datos."
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Non se puido asignar memoria."
 
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr "Cabeceira DIB: Ancho da imaxe > 32767 píxeles por ficheiro."
 
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr "Cabeceira DIB: Altura da imaxe > 32767 píxeles por ficheiro."
 
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "Cabeceira DIB: Número de bits por píxel descoñecido no ficheiro."
 
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Cabeceira DIB: Codificación descoñecida en ficheiro."
 
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 "Cabeceira DIB: A codificación non coincide co número de bits por píxel."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Erro ao ler a imaxe DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Erro ao ler máscara DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: A imaxe é alta de máis para unha icona."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: A imaxe é ancha de máis para unha icona."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Erro ao escribir o ficheiro de imaxe!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índice de iconas incorrecto."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "A imaxe e a máscara teñen tamaños diferentes."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Non se enmascarou ningunha cor non utilizada na imaxe."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Non foi posíbel cargar o mapa de bits \"%s\" dos recursos."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Non foi posíbel cargar a icona \"%s\" dos recursos."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Non foi posíbel cargar a imaxe dende o ficheiro \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Non se puido gardar a imaxe no ficheiro '%s': extensión descoñecida."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Non se atopou un manexador para o tipo de imaxe."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Non se definiu ningún manexador para o tipo %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "O ficheiro de imaxe non é do tipo %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Non é posíbel determinar automaticamente o formato da imaxe debido a unha "
 "entrada non localizábel."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Formato de datos de imaxe descoñecido."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Isto non é un %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Non se definiu ningún manexador para o tipo %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "A imaxe non é do tipo %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Erro ao comprobar o formato do ficheiro de imaxe \"%s\"."
@@ -2410,41 +2443,41 @@ msgstr "PNM: O ficheiro semella truncado."
 msgid " (in module \"%s\")"
 msgstr " (en módulo \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Erro ao cargar a imaxe."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Índice de imaxe TIFF incorrecto."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: A imaxe ten un tamaño anormalmente grande."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Non se puido asignar memoria."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Erro ao ler a imaxe."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "A unidade de resolución de TIFF %d descoñecida foi ignorada"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Erro ao gardar a imaxe."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Erro ao escribir na imaxe."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2453,11 +2486,11 @@ msgstr ""
 "O argumento %d da liña de comandos non se puido converter a Unicode e "
 "ignorarase."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Erro ao inicializar post init, cancelando."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Non se pode configurar o idioma \"%s\"."
@@ -2555,7 +2588,7 @@ msgstr "erro de compresión"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' non emparellado nunha entrada para o tipo mime %s."
@@ -2575,7 +2608,7 @@ msgstr "A dependencia \"%s\" do módulo \"%s\" non existe."
 msgid "Module \"%s\" initialization failed"
 msgstr "Fallou a inicialización do módulo \"%s\""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Mensaxe"
 
@@ -3077,7 +3110,7 @@ msgstr "Erro de impresión"
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Configuración de páxina"
 
@@ -3112,19 +3145,15 @@ msgstr "Imprimindo páxina %d de %d"
 msgid " (copy %d of %d)"
 msgstr " (copiar %d de %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Imprimindo "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Primeira páxina"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Páxina anterior"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Seguinte páxina"
 
@@ -3168,16 +3197,16 @@ msgstr "Páxina %d de %d"
 msgid "Page %d"
 msgstr "Páxina %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "erro descoñecido"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expresión regular incorrecta '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Non se atopou correspondencia para a expresión regular: %s"
@@ -3189,21 +3218,21 @@ msgstr ""
 "O renderizador \"%s\" ten unha versión incompatíbel, %d.%d e non se puido "
 "cargar."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Fallou a extración de '%s' a '%s'."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Fallou a extración de '%s' a '%s'."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Fallou a extración de '%s' a '%s'."
@@ -3212,11 +3241,11 @@ msgstr "Fallou a extración de '%s' a '%s'."
 msgid "Failed to monitor I/O channels"
 msgstr "Non se puido monitorizar as canles I/O"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Gardar"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Non gardar"
 
@@ -3300,10 +3329,10 @@ msgid "Clear"
 msgstr "Borrar"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Pechar"
 
@@ -3315,7 +3344,7 @@ msgstr "&Con&verter"
 msgid "Convert"
 msgstr "Converter"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
@@ -3324,7 +3353,7 @@ msgstr "&Copiar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cor&tar"
@@ -3333,13 +3362,13 @@ msgstr "Cor&tar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Eliminar"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Eliminar"
@@ -3428,7 +3457,7 @@ msgstr "Disco duro"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "A&xuda"
 
@@ -3448,7 +3477,7 @@ msgstr "Sangrar"
 msgid "&Index"
 msgstr "&Índice"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Índice"
 
@@ -3517,7 +3546,7 @@ msgstr "&Novo"
 msgid "New"
 msgstr "Novo"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Non"
 
@@ -3534,12 +3563,12 @@ msgstr "&Abrir..."
 msgid "Open..."
 msgstr "Abrir..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Pegar"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Pegar"
@@ -3569,7 +3598,7 @@ msgid "Print..."
 msgstr "Imprimir..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Propiedades"
 
@@ -3603,10 +3632,6 @@ msgstr "Substituír"
 msgid "Revert to Saved"
 msgstr "Volver á versión gardada"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Gardar"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Gardar &como..."
@@ -3616,7 +3641,7 @@ msgstr "Gardar &como..."
 msgid "Save As..."
 msgstr "Gardar &como..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Seleccionar &todo"
@@ -3723,7 +3748,7 @@ msgstr "&Arriba"
 msgid "Up"
 msgstr "Arriba"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Si"
 
@@ -3814,43 +3839,43 @@ msgstr "Gardar o documento actual"
 msgid "Save current document with a different filename"
 msgstr "Gardar o documento actual cun nome de ficheiro diferente"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Non funciona a conversión ao xogo de caracteres '%s'."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "descoñecido"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "bloque de cabeceira incompleto en tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "erro na suma de comprobación ao ler o bloque de cabeceira de tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "datos incorrectos na cabeceira extendida de tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "non se abríu a entrada tar"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fin de ficheiro inesperado"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s non se axeitou á cabeceira de ficheiro tar na entrada '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tamaño de entrada tar incorrecto"
 
@@ -3859,7 +3884,7 @@ msgstr "tamaño de entrada tar incorrecto"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' é probábelmente un búfer binario."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Non foi posíbel cargar o ficheiro."
 
@@ -3873,47 +3898,47 @@ msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "non se pode escribir o búfer '%s' no disco."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Erro ao obter a hora local do sistema"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "Fallou wxGetTimeOfDay."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' non é un catálogo de mensaxes correcto."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catálogo de mensaxes incorrecto."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Erro ao analizar formas plurais: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "empregando catálogo '%s' de '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "O recurso '%s' non é un catálogo de mensaxes correcto."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Non se puideron enumerar traducións"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Non hai aplicación predeterminada para ficheiros HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Erro ao abrir URL \"%s\" no navegador predeterminado."
@@ -3946,7 +3971,7 @@ msgstr "'%s' debe conter só caracteres alfabéticos."
 msgid "Error: %s (%d)"
 msgstr "Erro: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3955,21 +3980,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Non se puido inicializar a descrición da columna."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Conersiones de cadena no soportadas"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Esta plataforma non admite a transparencia de fondo."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Non se puideron transferir os datos á xanela"
 
@@ -4022,8 +4047,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Clase de obxecto inaceptábel como orixe do evento (non-wxEvtHandler)"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "O tipo debe ter un conversor enum - long"
 
@@ -4073,79 +4098,79 @@ msgstr "Os obxectos deben ter un atributo id"
 msgid "Doubly used id : %d"
 msgstr "ID usado dúas veces: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propiedade descoñecida %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Unha colección non baleara debe consistir en nodos do tipo \"element\""
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "cadea manexadora de evento incorrecta, falta o punto"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "non é posíbel reinicializar o fluxo de compresión de zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "non é posíbel reinicializar o fluxo de descompresión de zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "supoñendo que isto é un ficheiro zip con varias partes concatenadas"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "ficheiro zip incorrecto"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "non é posíbel atopar o cartafol central en zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "erro ao ler o cartafol central de zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "erro ao ler a cabeceira local de zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "desprazamento incorrecto de ficheiro zip á entrada"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "a lonxitude do ficheiro almacenado non está na cabeceira de zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "método de compresión Zip non compatíbel"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lendo o fluxo de zip (entrada %s): lonxitude incorrecta"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lendo o fluxo de zip (entrada %s): crc incorrecto"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "erro ao escribir a entrada de zip '%s': crc ou lonxitude incorrectos"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "erro ao escribir a entrada de zip '%s': crc ou lonxitude incorrectos"
@@ -4232,32 +4257,32 @@ msgstr "Gráficos de"
 msgid "Translations by "
 msgstr "Traducións de "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versión"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Sobre %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licencia"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Desenvolvedores"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autores da documentación"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Tradutores/as"
 
@@ -4309,44 +4334,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Falso"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (ou %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Engadir columna"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4357,8 +4381,7 @@ msgid "Left"
 msgstr "Esquerda"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4456,7 +4479,7 @@ msgid "Home directory"
 msgstr "Cartafol inicial"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Escritorio"
 
@@ -4469,8 +4492,7 @@ msgstr "Nome de cartafol inaceptábel."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Erro"
 
@@ -4654,16 +4676,16 @@ msgstr "Ver os ficheiros coma unha lista detallada"
 msgid "Go to parent directory"
 msgstr "Ir ao cartafol superior"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "O ficheiro '%s' xa existe, desexa sobreescribilo?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Escolla un ficheiro existente."
 
@@ -4757,7 +4779,7 @@ msgstr "O tamaño de letra."
 msgid "Whether the font is underlined."
 msgstr "Se a letra está subliñada."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Previsualización:"
@@ -4775,50 +4797,49 @@ msgstr "Clique para cancelar a selección de tipo de letra."
 msgid "Click to confirm the font selection."
 msgstr "Prema para confirmar a selección de tipo de letra."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Elixa un tipo de letra"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Non se atopou o cartafol de axuda \"%s\"."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Non se atopou o ficheiro de axuda \"%s\"."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "A liña %lu do arquivo de mapa \"%s\" ten unha sintaxe incorrecta e foi "
 "omitida."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Non se atoparon asociacións no ficheiro \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Non se atoparon entradas."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Índice da axuda"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Entradas significativas:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Entradas atopadas"
 
@@ -4922,59 +4943,59 @@ msgstr "Non se puido comezar a impresión."
 msgid "Printing page %d..."
 msgstr "Imprimindo a páxina %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opcións da impresora"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Imprimir a un ficheiro"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configuración..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Impresora:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Estado:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Todos"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Páxinas"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Rango de impresión"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Dende:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Para:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Copias:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Ficheiro PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Configuración da impresión"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Impresora"
 
@@ -4982,25 +5003,25 @@ msgstr "Impresora"
 msgid "Default printer"
 msgstr "Impresora predeterminada"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Tamaño do papel"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Vertical"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Horizontal"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientación"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcións"
 
@@ -5012,52 +5033,52 @@ msgstr "Imprimir a cor"
 msgid "Print spooling"
 msgstr "Cola de impresión"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Comando de impresión:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opcións da impresora:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Marxe esquerda (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Marxe superior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Marxe dereita (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Marxe inferior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Impresora..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Omitir"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Descoñecido"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Feito."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Buscar"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Non se atopou lapela para id"
 
@@ -5093,22 +5114,22 @@ msgstr "&Finalizar"
 msgid "< &Back"
 msgstr "< &Atrás"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "traducción - créditos"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Non se puido inicializar GTK+, está instalado DISPLAY correctamente?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Erro ao crear o cartafol \"%s\""
@@ -5134,12 +5155,12 @@ msgstr "Erro ao cargar documento dende o ficheiro \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Erro ao actualizar o ficheiro de configuración de usuario."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Erro moi grave"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5147,7 +5168,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5155,7 +5176,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Fillo MDI"
 
@@ -5171,15 +5192,11 @@ msgstr "Erro ao imprimir:"
 msgid "Page Setup"
 msgstr "Configuración de páxina"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Erro ao obter o cartafol de traballo."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5188,7 +5205,7 @@ msgstr ""
 "compatíbel coa composición de pantalla. Por favor, instale GTK+ 2.12 ou "
 "posterior."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5196,17 +5213,13 @@ msgstr ""
 "Este sistema non admite a composición, por favor, actívea no seu xestor de "
 "xanelas."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Este programa compilouse cunha versión moi antiga de GTK+. Por favor, "
 "utilice GTK+ 2.12 ou posterior."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Escolla un tipo de letra correcto."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5305,45 +5318,45 @@ msgstr "Non se pode abrir o ficheiro de contido: %s"
 msgid "Cannot open index file: %s"
 msgstr "Non se puido abrir o ficheiro de índice: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "sen nome"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Non se puido abrir o libro de axuda HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Amosa a axuda cando explora os libros da esquerda."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(marcadores)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Engadir a páxina actual aos marcadores"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Eliminar a páxina actual dos marcadores"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Contidos"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Buscar"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Amosar todo"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5351,19 +5364,19 @@ msgstr ""
 "Amosar todo os elementos do índice que conteñen esta subcadea. A busca non é "
 "sensíbel a maiúsculas/minúsculas."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Amosar todos os elementos do índice"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Sensíbel a maiúsculas/minúsculas"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Só palabras completas"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5371,147 +5384,147 @@ msgstr ""
 "Busca nos contidos do(s) libro(s) de axuda todas as aparicións do texto que "
 "escribiu enriba"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Amosar/agochar o panel de navegación"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Volver"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Continuar"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Subir un nivel na xerarquía do documento"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Abrir documento HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Imprimir esta páxina"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Amosar o diálogo de opcións"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Por favor, elixa a páxina que quere amosar:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Temas da axuda"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Buscando..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Aínda non se atopou ningunha páxina que concorde"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Atopáronse %i coincidencias"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Axuda)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Buscar en todos os libros"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opcións do navegador de axuda"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Letra normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Tipo de letra estabelecido:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Tamaño da letra:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "tamaño de letra"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal<br>e <u>subliñado</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiva.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Grosa.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Cursiva grosa.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Tamaño estabelecido.<br> <b>grosa</b> <i>cursiva</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>cursiva grosa<u>subliñado</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Axuda de impresión"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Non se pode imprimir unha páxina en branco."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Ficheiros HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libros de axuda (*.htb)|*.htb|Libros de axuda (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Proxecto de Axuda HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Ficheiro de Axuda HTML Comprimido (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i de %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu de %lu"
@@ -5592,32 +5605,6 @@ msgstr ""
 "Houbo un problema mentres se configuraba a páxina: cómpre estabelecer unha "
 "impresora predeterminada."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Erro ao amosar o documento HTML coa codificación %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets non puido abrir a visualización para '%s': saíndo."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtro"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Cartafoles"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Ficheiros"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selección"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Fallo ao abrir o portapapeis."
@@ -5659,58 +5646,58 @@ msgstr "Fallou o diálogo de selección de cor co erro %0lx."
 msgid "Failed to create cursor."
 msgstr "Fallo ao crear un cursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Erro ao rexistrar servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Non foi posíbel cancelar o rexistro do servidor '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Erro ao crear a conexión co servidor '%s' co tema '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Erro na soicitude de envío de DDE"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Erro ao estabelecer un bucle de aviso co servidor DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Non se puido terminar o bucle de aviso co servidor DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Erro ao enviar notificación de recomendación de DDE "
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Erro ao crear cadea DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "non hai erro DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "expirou unha solicitude de transacción síncrona de recomendación."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a resposta á transacción causou que se activase o bit de DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "expirou unha solicitude de transacción síncrona de datos."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5721,7 +5708,7 @@ msgstr ""
 "ou un identificador de instancia incorrecto\n"
 "pasouse a unha función DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5733,43 +5720,43 @@ msgstr ""
 "ou un aplicativo inicializado como APPCMD_CLIENTONLY tentou\n"
 "realizar transaccións de servidor."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "expirou unha solicitude de transacción de execución síncrona."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "erro ao validar un parámetro polo DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "un aplicativo DDEML creou unha situación de posíbel inconsistencia."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "erro ao asignar memoria."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "fallou o intento de estabelecemento de conversación dun cliente."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "erro nunha transacción."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "expirou unha solicitude de transacción síncrona de asignación."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "erro nunha chamada interna á función PostMessage."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema de reentrada."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5779,15 +5766,15 @@ msgstr ""
 "que foi finalizada polo cliente, ou o servidor finalizou\n"
 "antes de completar a transacción."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "ocorreu un erro interno no DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "expirou unha solicitude de fin de transacción de aviso."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5797,12 +5784,12 @@ msgstr ""
 "Unha vez que o aplicativo volva dende unha chamada XTYP_XACT_COMPLETE,\n"
 "o identificador da transacción para esa chamada deixa de ser válido."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Erro DDE descoñecido %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5810,7 +5797,7 @@ msgstr ""
 "As funcións de marcado non están dispoñíbeis porque o servidor de acceso "
 "remoto (SAR) non está instalado nesta máquina. Por favor, instáleo."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5820,64 +5807,64 @@ msgstr ""
 "de máis. Por favor, actualícea (a seguinte función requerida non está "
 "dispoñíbel: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Erro ao recuperar texto de mensaxe de erro RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "erro descoñecido (código de erro %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Non se atopa conexión telefónica activa: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Atopáronse varias conexións activas e elixíuse unha ao chou."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Erro ao estabelecer conexión telefónica: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Erro ao obter nomes de ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Erro de conexión: non hai ISP ao que chamar."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Elixir ISP ao que conectar"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Por favor, elixa o provedor de Internet ao que desexa conectarse"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Erro ao conectar: falta o nome de usuario/contrasinal."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Non se puido atopar a localización do ficheiro de axenda"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Erro ao iniciar conexión telefónica: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Non se pode colgar - non hai conexión telefónica."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Non se puido terminar a conexión telefónica: %s"
@@ -5897,18 +5884,17 @@ msgstr "Erro ao asignar %luKb de memoria aos datos do mapa de bits."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Non se puideron enumerar os ficheiros do cartafol '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Non se puido obter o nome do cartafol"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (erro %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Non se puido engadir unha imaxe á lista de imaxes."
 
@@ -5922,7 +5908,7 @@ msgstr "Erro ao cargar metaficheiro do ficheiro \"%s\"."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Erro ao crear o diálogo estándar buscar/substituír (código de erro %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Houbo un erro no ficheiro de diálogo co código %0lx."
@@ -5963,17 +5949,17 @@ msgstr "Non foi posíbel estabelecer monitorización para '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Non se poden monitorizar os cambios no cartafol inexistente \"%s\"."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Non se puido crear un temporizador"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Erro ao inicializar OpenGL"
 
@@ -5981,7 +5967,7 @@ msgstr "Erro ao inicializar OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5990,7 +5976,7 @@ msgstr ""
 "instalada nesta máquina a biblioteca de Axuda HTML de MS. Por favor, "
 "instálea."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Erro ao inicializar a axuda HTML de MS."
 
@@ -5999,7 +5985,7 @@ msgstr "Erro ao inicializar a axuda HTML de MS."
 msgid "Can't delete the INI file '%s'"
 msgstr "Non se puido eliminar o ficheiro INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6120,7 +6106,7 @@ msgstr "Non se puido rexistrar o formato do portapapeis '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O formato '%d' do portapapeis non existe."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Omitir"
 
@@ -6205,59 +6191,59 @@ msgstr ""
 "se se borra pode deixar o sistema inutilizábel:\n"
 "operación cancelada."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Non se puido eliminar a clave '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Non se puido eliminar o valor '%s' da clave '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Non se puido ler o valor da clave '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Non se puido estabelecer o valor de '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Non se puido ler o valor de '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Non se puido enumerar os valores da clave '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Non se puido enumerar as subclaves da clave '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6265,17 +6251,17 @@ msgstr ""
 "Exportando a clave do rexistro: o ficheiro \"%s\" xa existe e non se vai "
 "sobreescribir."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Non se pode exportar o valor do tipo non admitido %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorando o valor \"%s\" da clave \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6283,41 +6269,41 @@ msgstr ""
 "Non é posíbel crear un control do editor visual, no seu lugar usouse un "
 "control de texto simple. Por favor, instale riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Non se pode iniciar o fío de execución: erro ao escribit TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Non se pode especificar a prioridade dos fíos de execución"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Non se pode crear o fío de execución"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Non se puido finalizar o fío de execución"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Non se pode agardar pola finalización do fío de execución"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Non se pode suspender o fío de execución %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Non se pode retomar o fío de execución %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Non se atopou o punteiro do fío de execución actual"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6325,7 +6311,7 @@ msgstr ""
 "Erro ao inicar o módulo de fíos de execución: imposíbel asignar índice no "
 "almacén local de fíos"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6357,12 +6343,12 @@ msgstr "Erro ao cargar recurso \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Erro ao bloquear recurso \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "compilar %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", edición de 64 bits"
 
@@ -6374,47 +6360,47 @@ msgstr "Erro ao crear canalización anónima"
 msgid "Failed to redirect the child process IO"
 msgstr "Erro ao redirecionar E/S do proceso fillo"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Fallou a execución do comando '%s'"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Erro ao cargar mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Non se pode ler a clase de '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Non se puido cargar a icona dende '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Non se pode especificar a prioridade dos fíos de execución"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Erro ao executar '%s'\n"
@@ -6448,7 +6434,7 @@ msgid "Check to make the font italic."
 msgstr "Marcar para letra cursiva."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subliñado"
@@ -6516,17 +6502,32 @@ msgstr "<Any Teletype>"
 msgid "File type:"
 msgstr "Teletipo"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Xanela"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Axuda"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimizar"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Achegar"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6543,487 +6544,487 @@ msgstr "O ficheiro %s non existe."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Sobre %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Sobre"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferencias..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Agochar %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Aplicativo"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Agochar outros"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Amosar todo"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Saír de %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Aplicativo"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip non é compatíbel con esta versión de zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Non se puido inicializar a descrición da columna."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Tamaño do punto"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nome da faz"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Peso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Bordo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "clara"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Aliñar texto á dereita."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Bordo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menú"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Xanela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Xanela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Xanela"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Tamaño personalizado"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "Mac grego"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "Explorar"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "Refacer"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "predeterminado"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "mañá"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Clara"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Estilo de viñetas"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "&Código de caracter:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Tamaño do punto"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Aliñar á Dereita"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Pregunta"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Clara"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Clara"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Seleccionar:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Propiedade"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Modo categorizado"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Modo alfabético"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Certo"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Non especificado"
 
@@ -7036,12 +7037,12 @@ msgstr "Erro de propiedade"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Introduciu un valor non válido. Pulse ESC para cacear a edición."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Erro no recurso: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7050,36 +7051,36 @@ msgstr ""
 "O tipo de operación \"%s\" fallou: A propiedade coa etiqueta \"%s\" é de "
 "tipo \"%s\", NON \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "O valor debe ser %s ou superior."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "O valor debe estar entre %s e %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "O valor debe ser %s ou inferior."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Non %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Elixir un cartafol:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Elixir un ficheiro"
 
@@ -7559,117 +7560,117 @@ msgstr "Inserido"
 msgid "Outset"
 msgstr "Externo"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Cambiar estilo"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Cambiar estilo de obxecto"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Cambiar propiedades"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Cambiar estilo de lista"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renumerar lista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Inserir texto"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Inserir imaxe"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Inserir obxecto"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Inserir campo"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Demasiadas chamadas a EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "ficheiros"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "estándar/círculo"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "estándar/contorno circular"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "estándar/cadrado"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "estándar/rombo"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "estándar/triángulo"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Propiedades da caixa"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Propiedades múltiples de cela"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Propiedades de &cela"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Estabelecer estilo de celas"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Eliminar fila"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Eliminar columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Engadir fila"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Engadir columna"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Propiedades de táboa"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Propiedades do debuxo"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "imaxe"
 
@@ -7877,24 +7878,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Arrastrar"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Eliminar texto"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Eliminar viñeta"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Non se puido gardar o texto."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Substituír"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Tipo de letra:"
 
@@ -8864,53 +8865,53 @@ msgstr "Estilos de lista"
 msgid "Box styles"
 msgstr "Estilos de caixa"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "O tipo de letra do que tomar o símbolo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subconxunto:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Amosa un subconxunto de Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Código de caracter:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "O código do caracter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Dende:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "O rango para amosar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Inserir"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
@@ -9100,7 +9101,7 @@ msgstr "Non se puideron tomar eventos do kqueue"
 msgid "Media playback error: %s"
 msgstr "Erro na reprodución multimedia: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Erro ao preparar reprodución \"%s\"."
@@ -9200,22 +9201,22 @@ msgstr "Os datos de son están nun formato non compatíbel."
 msgid "Couldn't open audio: %s"
 msgstr "Non se puido abrir o audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 "Non se pode recuperar a política de planificación de fíos de execución."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Non se pode obter un rango de prioridade para a política de planificación %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Ignorouse a configuración de prioridade de fíos de execución."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9223,62 +9224,62 @@ msgstr ""
 "Erro ao conectar cun fío de execución, detectada perda potencial de memoria. "
 "Por favor, reinicie o programa"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Erro ao estabelecer nivel de concurrencia de fíos de execución en %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Non se puido estabelecer a prioridade de fíos de execución %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Non se puido terminar un fío de execución."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Erro ao inicar o módulo de fíos de execución: non se puido crear clave de "
 "fíos"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Non é posíbel obter a entrada do proceso fillo"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Non se pode escribir na entrada estándar do proceso fillo"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Erro ao executar '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Erro ao facer fork"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Erro ao estabelecer prioridade de procesos"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Erro ao redirecionar proceso fillo de entrada/saída"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Non foi posíbel configurar canalización non bloqueante, o programa pode "
 "ficar trabado."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Non se puido obter o nome de máquina"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Non se puido obter o nome oficial da máquina"
 
@@ -9294,12 +9295,12 @@ msgstr "Erro ao cambiar canalización de activación a modo non bloqueante"
 msgid "Failed to read from wake-up pipe"
 msgstr "Erro ao ler dende a canalización de activación"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificación de xeometría incorrecta: '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets non puido abrir a visualización. Saíndo."
 
@@ -9313,30 +9314,59 @@ msgstr "Erro ao pechar a presentación \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Erro ao abrir a presentación \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Erro de análise de XML: '%s' na liña %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Non se poden cargar os recursos de '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Non se pode abrir o ficheiro de recursos '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Non se poden cargar os recursos dende o ficheiro '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Fallou a extración de '%s' a '%s'."
+
+#~ msgid "Printing "
+#~ msgstr "Imprimindo "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Erro ao obter o cartafol de traballo."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Escolla un tipo de letra correcto."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Erro ao amosar o documento HTML coa codificación %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets non puido abrir a visualización para '%s': saíndo."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Cartafoles"
+
+#~ msgid "Files"
+#~ msgstr "Ficheiros"
+
+#~ msgid "Selection"
+#~ msgstr "Selección"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "fallou a conversión á codificación de 8 bits"
@@ -9500,8 +9530,8 @@ msgstr "Fallou a extración de '%s' a '%s'."
 #~ msgstr "O renderizador de datos non pode xerar valor; tipo de valor:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/hi.po
+++ b/locale/hi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2008-07-28 23:09+0530\n"
 "Last-Translator: Priyank Bolia <priyank.bolia@gmail.com>\n"
 "Language-Team: हिन्दी (Hindi) <dysxhi@yahoo.co.in>\n"
@@ -20,11 +20,11 @@ msgstr ""
 "X-Poedit-Language: Hindi\n"
 "X-Poedit-Country: INDIA\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "सभी फ़ाइलें (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "सभी फ़ाइलें (*)|*"
 
@@ -44,24 +44,21 @@ msgid "Remaining time:"
 msgstr "शेष समय : "
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "हाँ"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "नहीं"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "ठीक"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "निरस्त"
@@ -113,7 +110,7 @@ msgid "Unable to create I/O completion port"
 msgstr "एमडीआई मूल खाके का निर्माण करने में असफ़ल।"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "मुद्रण"
@@ -158,7 +155,7 @@ msgstr "गुणधर्म (&P)"
 msgid "Printing"
 msgstr "मुद्रण हो रहा है "
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "प्रतीकों"
 
@@ -227,7 +224,7 @@ msgstr "पिछला (&P)"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "खिड़की (&W)"
 
@@ -796,11 +793,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "इस सहायता संदेश को दिखाएँ"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "वर्णनात्मक लॉग संदेशो का जनन करें"
 
@@ -822,84 +819,84 @@ msgstr "असमर्थित थीम '%s' ।"
 msgid "Invalid display mode specification '%s'."
 msgstr "अवैध जयामिति विशिष्टतायें '%s'"
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "अज्ञात लंबा विकल्प '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "अज्ञात विकल्प '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "विकल्प के पश्चात अप्रत्याशित संप्रतीक '%s'।"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "'%s' विकल्प को एक वैल्यू की आवश्यकता है।"
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "'%s' के बाद एक पृथककारी चिह्न की आशा की जाती है।"
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' एक सही सांख्यानिक मूल्य '%s' विकल्प के लिए नहीं है।"
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "विकल्प '%s': '%s' को एक तिथि में नहीं बदला जा सका।"
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "अप्रत्याशित पैरामीटर '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (या %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' विकल्प के लिए इस मूल्य को निर्दिष्ट करना अनिवार्य है।"
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "आवश्यक पैरामीटर '%s' को निर्दिष्ट नहीं किया गया था।"
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "उपयोगिता: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "तिथि"
 
@@ -917,7 +914,7 @@ msgid "Can't &Undo "
 msgstr "पहिले जैसा नहीं किया जा सकता है (&U)"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "पहिले जैसा करें (&U)"
@@ -927,7 +924,7 @@ msgid "&Redo "
 msgstr "पुनःकरें (&R)"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "पुनःकरें (&R)"
@@ -954,12 +951,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' में अतिरिक्त '..' है, ध्यान नहीं दिया गया।"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -969,103 +966,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "रेखांकित"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "आज"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "बीताहुआकल"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "कल"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "प्रथम"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "सेकन्ड"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "तीसरा"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "चौथा"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "पाँचवाँ"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "छठवाँ"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "सातवाँ"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "आठवाँ"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "नौवाँ"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "दसवाँ"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "ग्यारहवाँ"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "बारहवाँ"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "तेरहवाँ"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "चौदहवाँ"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "पन्द्रहवाँ"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "सोलहवाँ"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "सत्रहवाँ"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "अठारहवाँ"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "उन्नीसवाँ"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "बीसवाँ"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "दोपहर"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "अर्धरात्रि"
 
@@ -1133,45 +1130,82 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "दोषमार्जन विवरण को अपलोड करने में असफ़ल (त्रुटि कूट %d)।"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 #, fuzzy
 msgid "Save As"
 msgstr "जैसा सुरक्षित करें"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "बिनानामदियाहुआ"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "क्या आप %s प्रलेख पर परिवर्तनों को सुरक्षित करना चाहते है?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "सुरक्षित करें (&S)"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "सुरक्षित न करें"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "क्या आप %s प्रलेख पर परिवर्तनों को सुरक्षित करना चाहते है?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "इस पाठ को सुरक्षित किया जा सका।"
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "wxWidgets '%s' के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "बिट्मैप आकॄति को \"%s\" फ़ाइल पर सुरक्षित करने में असफ़ल।"
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "फ़ाइल को लोड नहीं किया जा सका।"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1180,58 +1214,58 @@ msgstr ""
 "'%s' यह निर्देशिका विद्यमान नहीं है और इसे खोला नहीं जा सका।\n"
 "इसे हाल ही में उपयोग में लायी गयी हुई फ़ाइलों की सूची में से हटा दिया गया है।"
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "पाइप का निर्माण असफ़ल रहा"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "मुद्रण पूर्वालोकन"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "बिनानामदियाहुआ %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "फ़ाइल खोलें"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "फ़ाइल त्रुटि"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "क्षमा करें, इस फ़ाइल को खोला नहीं जा सका।"
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "क्षमा करें, इस फ़ाइल का प्रारूप अज्ञात है।"
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "एक प्रलेख टेम्पलेट का चयन करें"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "टेम्पलेट्स"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "एक प्रलेख व्यू का चयन करें"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "अवलोकन"
 
@@ -1265,41 +1299,41 @@ msgstr "'%s' फ़ाइल पर पठन त्रुटि"
 msgid "Write error on file '%s'"
 msgstr "'%s' फ़ाइल पर लेखन त्रुटि"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "'%s' फ़ाइल को फ़्लैश करने में असफ़लता"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' फ़ाइल पर खोज त्रुटि"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr " '%s' फ़ाइल में वर्तमान स्थिति नहीं खोजी जा सकती है"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "अस्थायी फ़ाइल अनुमतियों को स्थापित करने में असफ़ल"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "'%s' फ़ाइल को हटाया नहीं जा सकता है"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "'%s' फ़ाइल पर परिवर्तनों को प्रतिबद्धित नहीं किया जा सकता है"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "'%s' अस्थायी फ़ाइल को हटाया नहीं जा सकता है"
@@ -1324,27 +1358,27 @@ msgstr "फ़ाइल विवरणकर्ता %d से पढ़ा नह�
 msgid "can't write to file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d पर लिखा नहीं जा सकता है"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d को फ़्लैश नहीं किया जा सकता है"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d पर खोज नहीं की जा सकती है"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "फ़ाइल विवरणकर्ता %d पर स्थिति को खोजा नहीं जा सकता है"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "%d फ़ाइल विवरणकर्ता पर फ़ाइल की लंबाई को पाया नहीं जा सकता है"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "निश्चय नहीं किया जा सकता है कि %d विवरणकर्ता पर फ़ाइल की समाप्ति पहुँच गयी है"
@@ -1368,148 +1402,148 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "संरचना के विकल्पों को पढ़नें में त्रुटि।"
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "संरचना के विकल्पों को पढ़नें में त्रुटि।"
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "फ़ाइल '%s': अप्रत्याशित %c शब्द %d पंक्ति पर।"
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "फ़ाइल '%s', पंक्ति %d: समूह शीर्ष के उपरान्त '%s' पर ध्यान नहीं दिया गया।"
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "फ़ाइल '%s', पंक्ति %d: '=' की आशा की जाती है।"
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "फ़ाइल '%s', पंक्ति %d: निर्विकल्प कुँजी '%s' के लिए मूल्य पर ध्यान नहीं दिया गया।"
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "फ़ाइल '%s', पंक्ति %d: '%s' कुँजी को सर्वप्रथम %d पंक्ति पर पाया गया था।"
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "संरचना प्रविष्टी नाम '%c' से आरम्भ नहीं हो सकता है।"
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "विश्वव्यापी संरचना फ़ाइल को खोला नहीं जा सकता है।"
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "उपयोगकर्ता संरचना फ़ाइल को लिखा नहीं जा सकता है।"
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "प्रयोक्ता की संरचना के विकल्पों को सुरक्षित करने में त्रुटि।"
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "'%s' उपयोगकर्ता संरचना फ़ाइल को मिटाय नहीं जा सकता है"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "'%s' प्रविष्टी '%s' समूह में एक से अधिक बार आयी है"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "निर्विकल्प कुँजी '%s' को परिवर्तित करने के प्रयास पर ध्यान नहीं दिया गया। "
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "अप्रत्याशित \" %d पर '%s' में ।"
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "'%s' फ़ाइल की '%s' पर प्रतिलिपि बनाने में असफ़ल"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "'%s' फ़ाइले के लिए अनुमतियों को प्राप्त करना असम्भव"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "'%s' फ़ाइल को पुनः आरम्भ से लिखना असम्भव"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "'%s' फ़ाइल की '%s' पर प्रतिलिपि बनाने में असफ़ल"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "'%s' फ़ाइल के लिए अनुमतियों को स्थापित करना असम्भव"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' निर्देशिका का निर्माण नहीं किया जा सकता था"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "'%s' फ़ाइलों की परिगणना नहीं की जा सकती है"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "फ़ाइलें (%s)"
@@ -1536,17 +1570,17 @@ msgstr "एक अस्थायी फ़ाइल नाम का निर्�
 msgid "Failed to open temporary file."
 msgstr "अस्थायी फ़ाइल को खोलने में असफ़ल।"
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr " '%s' के लिए फ़ाइल टाइम्स को परिवर्तित करने में असफ़ल"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "'%s' फ़ाइल को छूने में असफ़ल"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s' के लिए फ़ाइल टाइम्स को पुनःप्राप्त करने में असफ़ल"
@@ -1555,22 +1589,22 @@ msgstr "'%s' के लिए फ़ाइल टाइम्स को पुन�
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "सभी फ़ाइलें (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s फ़ाइलें (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "%s फ़ाइल को लोड करें"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "%s फ़ाइल को सुरक्षित करें"
@@ -1945,108 +1979,108 @@ msgstr "डिफ़ाल्ट"
 msgid "unknown-%d"
 msgstr "अज्ञात-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "रेखांकित"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 #, fuzzy
 msgid " strikethrough"
 msgstr " स्ट्राइक थुःरु"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "हल्का"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr "हल्का"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "गहरा"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr "गहरा"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "गहरा"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr "तिरछा"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 #, fuzzy
 msgid "strikethrough"
 msgstr "स्ट्राइक थुःरु (S)"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "हल्का"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "हल्का"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "सामान्य"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "गहरा"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "गहरा"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "गहरा"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "तिरछा"
 
@@ -2127,7 +2161,7 @@ msgstr "यह एफ़टीपी सर्वर निश्चेष्ट �
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "एफ़टीपी स्थानान्तरण विधा को %s पर स्थापित करने में असफ़ल।"
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "आस्की (ASCII)"
 
@@ -2148,7 +2182,7 @@ msgstr "यह एफ़टीपी सर्वर निश्चेष्ट �
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "कर्सर का निर्माण करने में असफ़ल।"
@@ -2165,7 +2199,7 @@ msgstr ""
 msgid "&Customize..."
 msgstr ""
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "'%s' को %s के लिए खोलने में असफ़ल"
@@ -2185,157 +2219,156 @@ msgstr "%d आकॄति को '%s' फ़ाइल से लोड करन�
 msgid "Failed to load icons from resource '%s'."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "बीएमपी: अवैध आकॄति को सुरक्षित नहीं किया जा सका।"
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "बीएमपी: डब्लूएक्सइमेज के पास स्वंम का डब्लूएक्सपैलेट नहीं है।"
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "बीएमपी: इस फ़ाइल के (बिट्मैप) शीर्षक को नहीं लिखा जा सका।"
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "बीएमपी: इस फ़ाइल के (बिट्मैपइन्फ़ो) शीर्षक को नहीं लिखा जा सका।"
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "बीएमपी: आरजीबी रंग मानचित्र को नहीं लिखा जा सका।"
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "बीएमपी: सूचना को नहीं लिखा जा सका।"
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "बीएमपी: स्मॄति का आवंटन नहीं हो सका।"
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "डीआईबी शीर्ष: फ़ाइल के लिए आकॄति की चौड़ाई > ३२७६७ पिक्सेल।"
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "डीआईबी शीर्ष: फ़ाइल के लिए आकॄति की ऊचाँई > ३२७६७ पिक्सेल।"
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "डीआईबी शीर्ष: फ़ाइल में अज्ञात बिट्गहराई।"
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "डीआईबी शीर्ष: फ़ाइल में अज्ञात एन्कोडिंग।"
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "डीआईबी शीर्ष: एन्कोडिंग बिटगहराई से मेल नहीं खाती है।"
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "बीएमपी: स्मॄति का आवंटन नहीं हो सका।"
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "डीआईबी शीर्ष: फ़ाइल के लिए आकॄति की चौड़ाई > ३२७६७ पिक्सेल।"
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "डीआईबी शीर्ष: फ़ाइल के लिए आकॄति की ऊचाँई > ३२७६७ पिक्सेल।"
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "डीआईबी शीर्ष: फ़ाइल में अज्ञात बिट्गहराई।"
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "डीआईबी शीर्ष: फ़ाइल में अज्ञात एन्कोडिंग।"
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "डीआईबी शीर्ष: एन्कोडिंग बिटगहराई से मेल नहीं खाती है।"
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "आकॄति डीआईबी को पढ़ने में त्रुटि।"
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "आईसीओ: मास्क डीआईबी को पढ़ने में त्रुटि।"
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "आईसीओ: आकॄति एक आईकॉन के लिए बहुत बड़ी है।"
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "आईसीओ: आकॄति एक आईकॉन के लिए बहुत चौड़ी है।"
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "आईसीओ: आकॄति फ़ाइल को लिखने में त्रुटि!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: अवैध आईकॉन इंडेक्स।"
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "आकृति और मास्क के आकार भिन्न है।"
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 #, fuzzy
 msgid "No unused colour in image being masked."
 msgstr "आकृति में कोई बिना उपयोग किया हुआ रंग छुपाया गया"
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "%d आकॄति को '%s' फ़ाइल से लोड करने में असफ़ल।"
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "आकॄति को '%s' फ़ाइले में सुरक्षित नहीं किया जा सकता है: अज्ञात उपनाम।"
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "आकृति प्रकार के लिए कोई हैन्डलर नहीं मिला।"
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "आकृति फ़ाइल %ld प्रकार की नहीं है।"
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "डाटा प्रारूप में त्रुटि"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "पीसीएक्स: यह एक पीसीएक्स फ़ाइल नहीं है।"
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s प्रकार के लिए कोई आकृति हैन्डलर परिभाषित नहीं।"
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "आकृति फ़ाइल %s प्रकार की नहीं है।"
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "बिट्मैप आकॄति को \"%s\" फ़ाइल पर सुरक्षित करने में असफ़ल।"
@@ -2439,52 +2472,52 @@ msgstr "पीएनएम: फ़ाइल लगता है टूट गई �
 msgid " (in module \"%s\")"
 msgstr "टिफ़्फ़ माड्यूल: %s"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "टीआईएफ़एफ़: आकॄति को लोड करने में त्रुटि।"
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "अवैध टीआईएफ़एफ़ आकॄति इंडेक्स।"
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "टीआईएफ़एफ़: स्मॄति का आवंटन महीं किया जा सका।"
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "टीआईएफ़एफ़: आकॄति को पढ़ने में त्रुटि।"
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "टीआईएफ़एफ़: आकॄति को सुरक्षित करने में त्रुटि।"
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "टीआईएफ़एफ़: आकॄति को लिखने में त्रुटि।"
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2582,7 +2615,7 @@ msgstr "संकुचन त्रुटि"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "माइम प्रकार %s के लिए एक प्रविष्टी में बेमेल '{' ।"
@@ -2602,7 +2635,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "%s संदेश"
@@ -3136,7 +3169,7 @@ msgstr "मुद्रण त्रुटि"
 msgid "Print"
 msgstr "मुद्रण"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "पॄष्ट स्थापना"
 
@@ -3173,20 +3206,16 @@ msgstr "%d पृष्ट को मुद्रित किया जा र�
 msgid " (copy %d of %d)"
 msgstr "पृष्ट %d / %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "मुद्रण हो रहा है "
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "अगला पृष्ट"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "पिछला पॄष्ट"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "अगला पृष्ट"
 
@@ -3233,16 +3262,16 @@ msgstr "पृष्ट %d / %d"
 msgid "Page %d"
 msgstr "पृष्ट %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "अज्ञात त्रुटि"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "'%s' अवैध सामान्य व्यंजक: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "'%s' को सामान्य व्यंजक में मिलाने में असफ़ल: %s"
@@ -3252,21 +3281,21 @@ msgstr "'%s' को सामान्य व्यंजक में मिल
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "\"%s\" रेन्डर्र का %d.%d संस्मरण असुसंगत है और लोड नहीं किया जा सका।"
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
@@ -3275,11 +3304,11 @@ msgstr "'%s' का निष्कर्षण '%s' में असफ़ल र�
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "सुरक्षित करें"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "सुरक्षित न करें"
 
@@ -3366,10 +3395,10 @@ msgid "Clear"
 msgstr "साफ़ करें (&C)"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "समाप्त"
 
@@ -3383,7 +3412,7 @@ msgstr "विषय-वस्तु"
 msgid "Convert"
 msgstr "विषय-वस्तु"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "प्रतिलिपि बनाएँ (&C)"
@@ -3393,7 +3422,7 @@ msgstr "प्रतिलिपि बनाएँ (&C)"
 msgid "Copy"
 msgstr "प्रतिलिपि बनाएँ (&C)"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "काटें (&t)"
@@ -3403,13 +3432,13 @@ msgstr "काटें (&t)"
 msgid "Cut"
 msgstr "काटें (&t)"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "मिटाएँं (&D)"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "मिटाएँं"
@@ -3504,7 +3533,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "सहायता (&H)"
 
@@ -3524,7 +3553,7 @@ msgstr "जगह छोड़ कर लिखें"
 msgid "&Index"
 msgstr "अनुक्रमणिका (&I)"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "इंडेक्स"
 
@@ -3598,7 +3627,7 @@ msgstr "नया (&N)"
 msgid "New"
 msgstr "नया (&N)"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "नहीं (&N)"
 
@@ -3616,12 +3645,12 @@ msgstr "खोलें (&O)..."
 msgid "Open..."
 msgstr "खोलें (&O)..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "चिपकाएँ (&P)"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "चिपकाएँ"
@@ -3655,7 +3684,7 @@ msgid "Print..."
 msgstr "मुद्रण (&P)..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "गुणधर्म (&P)"
 
@@ -3691,10 +3720,6 @@ msgstr "बदलें"
 msgid "Revert to Saved"
 msgstr "संरक्षित पर लौटे"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "सुरक्षित करें (&S)"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "इस जैसा सुरक्षित करें (&A)..."
@@ -3704,7 +3729,7 @@ msgstr "इस जैसा सुरक्षित करें (&A)..."
 msgid "Save As..."
 msgstr "इस जैसा सुरक्षित करें (&A)..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "सभी का चयन (&A)"
@@ -3824,7 +3849,7 @@ msgstr "ऊपर (&U)"
 msgid "Up"
 msgstr "ऊपर"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "हाँ (&Y)"
 
@@ -3917,43 +3942,43 @@ msgstr "वर्तमान प्रलेख को सुरक्षित
 msgid "Save current document with a different filename"
 msgstr "वर्तमान प्रलेख को अलग नाम से सुरक्षित करें"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "'%s' शब्दसमुच्चय में रूपांतरण ने कार्य नहीं किया।"
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "अज्ञात"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "अनपेक्षित फ़ाइल अंत"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3962,7 +3987,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' सम्भवता एक बायनरी बफ़र है।"
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "फ़ाइल को लोड नहीं किया जा सका।"
 
@@ -3976,49 +4001,49 @@ msgstr "%d आकॄति को '%s' फ़ाइल से लोड करन�
 msgid "can't write buffer '%s' to disk."
 msgstr "'%s' बफ़र को डिस्क पर नहीं लिखा जा सकता है।"
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "स्थानीय तंत्र समय प्राप्त करने में असफ़ल"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay असफ़ल रहा।"
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "प्ल्यूलर-फ़ार्मों का पदभंजन नहीं किया जा सका:'%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' से '%s' तक सूचीपत्र का उपयोग किया जा रहा है।"
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' एक वैध संदेश सूचीपत्र नहीं है।"
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "थ्रेड को समाप्त नहीं किया जा सका"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "'%s' को %s के लिए खोलने में असफ़ल"
@@ -4051,7 +4076,7 @@ msgstr "'%s' में सिर्फ़ आल्फ़ाबेटिक अक्�
 msgid "Error: %s (%d)"
 msgstr "त्रुटि: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4060,21 +4085,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "फ़ाइल को लोड नहीं किया जा सका।"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "श्रेणीयों का रूपांतरण समर्थित नहीं है"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "डाटा को खिड़की पर स्थानान्तरित किया जा सका"
 
@@ -4127,8 +4152,8 @@ msgstr "घोषित आरटीटीआई पैरामीटरों 
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "घटना स्रोत की भांति अवैध ऑबजेक्ट वर्ग (Non-wxEvtHandler)"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "प्रकार के पास ईनम - लंबा रूपांतरण अवश्य होना चाहिए"
 
@@ -4179,79 +4204,79 @@ msgstr "ऑबजेक्टों के पास एक पहचान-स�
 msgid "Doubly used id : %d"
 msgstr "दोहरी उपयोग में लायी गयी पहचानसंख्या : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "अज्ञात विशेषतायें %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "एक भरे हुए संग्रह को 'तत्व' नोडो से मिलकर बना होना चाहिए"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "गलत घटना हैन्डलर स्ट्रीनिंग, विलुप्त डॉट"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "जेडलिब् डीफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "जेडलिब् इनफ़्लेट धारा का आरम्भीकरण नहीं किया जा सकता है"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "अवैध जीज़िप फ़ाइल"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "केन्द्र निर्देशिका को जीज़िप में खोजा नहीं जा सका"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "जीज़िप केन्द्र निर्देशिका को पढ़नें में त्रुटि"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "जीज़िप स्थानीय शीर्ष को पढ़नें में त्रुटि"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "सुरक्षित फ़ाइल की लंबाई जीज़िप शीर्ष में नहीं है"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "असमर्थित जीज़िप संकुचन विधि"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "जीज़िप धारा को पढ़ा जा रहा है (प्रविष्टी  %s): गलत लंबाई"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "जीज़िप धारा को पढ़ा जा रहा है (प्रविष्टी %s): निकृष्ट सीआरसी"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "जीज़िप प्रविष्टी '%s' के लेखन में त्रुटि: निकृष्ट सीआरसी या गलत लंबाई"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "जीज़िप प्रविष्टी '%s' के लेखन में त्रुटि: निकृष्ट सीआरसी या गलत लंबाई"
@@ -4337,33 +4362,33 @@ msgstr "आलेख कला के द्वारा"
 msgid "Translations by "
 msgstr "द्वारा अनुवाद"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "संस्मरण"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "के बारे में"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "लाइसेंस"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "विकासक"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "प्रलेख लेखक"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "कलाकार"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "अनुवादक"
 
@@ -4414,44 +4439,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "फ़ाइल"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (या %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4462,8 +4486,7 @@ msgid "Left"
 msgstr "बायें"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4559,7 +4582,7 @@ msgid "Home directory"
 msgstr "गृह निर्देशिका"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "डेस्कटॉप"
 
@@ -4572,8 +4595,7 @@ msgstr "अवैध निर्देशिका नाम।"
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "त्रुटि"
 
@@ -4757,16 +4779,16 @@ msgstr "फ़ाइलों को एक विस्तॄत अवलोक�
 msgid "Go to parent directory"
 msgstr "मूल निर्देशिका पर जाएँ"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' फ़ाइल पहिले से विद्यमान है, क्या आप वास्तव में इसके ऊपर फ़िर से लिखना चाहते है?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "संपुष्टी दें"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "कॄपया एक विद्यमान फ़ाइल का चयन करें।"
 
@@ -4861,7 +4883,7 @@ msgstr "फ़ॉन्ट बिन्दु का आकार।"
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "पूर्वालोकन:"
@@ -4879,48 +4901,47 @@ msgstr ""
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "फ़ॉन्ट का चयन करें"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "सहायता निर्देशिका \"%s\" नहीं मिली।"
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "सहायता फ़ाइल \"%s\" नहीं मिली।"
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "कोई प्रविष्टियां नहीं मिली।"
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "सहायता इंडेक्स"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "संबंधित प्रविष्टियां:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "प्रविष्टियां मिली"
 
@@ -5028,59 +5049,59 @@ msgstr "मुद्रण को आरम्भ नहीं किया ज�
 msgid "Printing page %d..."
 msgstr "%d पृष्ट को मुद्रित किया जा रहा है..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "प्रिंटर के विकल्प"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "फ़ाइल पर मुद्रित करें"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "स्थापना..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "प्रिंटर:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "अवस्था:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "सभी"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "अनेक पृष्ट"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "मुद्रण सीमा"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "प्रेषणकर्ता:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "प्राप्तकर्ता:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "प्रतिलिपियां:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "पोस्टस्क्रिप्ट फ़ाइल"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "मुद्रण स्थापना"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "मुद्रक"
 
@@ -5088,25 +5109,25 @@ msgstr "मुद्रक"
 msgid "Default printer"
 msgstr "डिफ़ाल्ट मुद्रक"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "पृष्ट आकार"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "पोर्ट्रेट"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "लैडस्केप"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "अभिविन्यास"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "विकल्प"
 
@@ -5118,53 +5139,53 @@ msgstr "मुद्रण रंगों में"
 msgid "Print spooling"
 msgstr "मुद्रण स्पूलिंग"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "प्रिंटर निर्देश:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "प्रिंटर के विकल्प:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "बायाँ हाशिया (मिलीमीटर):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "ऊपरी हाशिया (मिलीमीटर):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "दायाँ हाशिया (मिलीमीटर):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "तल मार्जिन (मिलीमीटर):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "प्रिंटर..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 #, fuzzy
 msgid "&Skip"
 msgstr "छोड़ दे"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "अज्ञात"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "किया गया।"
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "खोजें"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "आईडी के लिए टैब को नहीं पाया जा सका"
 
@@ -5200,22 +5221,22 @@ msgstr "समाप्त करें (&F)"
 msgid "< &Back"
 msgstr "< पीछे (&B)"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "अनुवाद श्रेय"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "\"%s\" निर्देशिका का निर्माण करने में असफ़ल।"
@@ -5241,12 +5262,12 @@ msgstr "%d आकॄति को '%s' फ़ाइल से लोड करन�
 msgid "Failed to register font configuration using private fonts."
 msgstr "उपयोगकर्ता संरचना फ़ाइल को अपडेट करने में असफ़ल।"
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "घातक त्रुटि"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5254,7 +5275,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5262,7 +5283,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "एमडीआई चाइल्ड"
 
@@ -5280,36 +5301,27 @@ msgstr "कॄपया प्रतीक्षा करें जबतक �
 msgid "Page Setup"
 msgstr "पॄष्ट स्थापना"
 
-#: ../src/gtk/textctrl.cpp:1273
-#, fuzzy
-msgid "Failed to insert text in the control."
-msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "कॄपया एक वैध फ़ॉन्ट का चयन करें।"
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5408,64 +5420,64 @@ msgstr "विषयवस्तु फ़ाइल को नहीं खोल�
 msgid "Cannot open index file: %s"
 msgstr "इंडेक्स फ़ाइल को खोला नहीं जा सका: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "कोईनामनहीं"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "एचटीएमएल सहायता प्रलेख को नहीं खोला जा सका: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "सहायता दिखाएँ जब आप सरसरी नजर से बायें में किताबें देखे।"
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(बुकमार्क)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "वर्तमान पृष्ट को बुकमार्कों में जोड़ें"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "बुकमार्कों से वर्तमान पृष्ट को हटाएँ"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "विषय-वस्तु"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "खोज"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "सभी को दिखाएँ"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 "सभी इंडेक्स आयट्मों को दिखाएँ जिनमें दी गयी उपश्रेणी शामिल हो।खोज छोटा-बड़ा संवेदी है।"
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "इंडेक्स में सभी आयट्मों को दिखाएँ"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "छोटा-बड़ा संवेदी"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "सिर्फ़ पूर्ण शब्द "
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -5474,147 +5486,147 @@ msgstr ""
 "सहायक पुस्तक(पुस्तकों) के विषयवस्तु में आपके द्वारा बताया हुआ उपरोक्त पाठ  जितनी बार आया "
 "हो खोजें "
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "नैवीगेशन पैनल को दिखाएँ/छुपाएँ"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "पीछे जाएँ"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "आगे जाएँ"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "प्रलेख पदानुक्रम में एक स्तर ऊपर जाएँ"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "एचटीएमएल प्रलेख को खोलें"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "इस पृष्ट को मुद्रित करें"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "विकल्पों का संवाद दिखाएँ"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "कॄपया एक विद्यमान फ़ाइल का चयन करें:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "सहायता विषयवस्तु"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "खोजा जा रहा है..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "कोई मिलता-जुलता पृष्ट अभी तक नहीं मिला"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i मेल मिलें"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(सहायता)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i का %i"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i का %i"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "सभी पुस्तकों में खोजें"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "सहायता ब्राउजर के विकल्प"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "सामान्य फ़ॉन्ट: "
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "नियत फ़ॉन्ट:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "फ़ॉन्ट आकार:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "फ़ॉन्ट आकार"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "सामान्य फ़ेस<br>और <u>रेखांकित</u>। "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>इटैलिक फ़ेस।</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>गहरा फ़ेस।</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>गहरा इटैलिक फ़ेस।</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "नियत आकार फ़ेस<br> <b>गहरा</b> <i>इटैलिक</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>गहरा इटैलिक <u>रेखांकित</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "सहायता मुद्रण"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "खाली पृष्ट को मुद्रित नहीं किया जा सकता है।"
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "एचटीएमएल फ़ाइलें (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "सहायता पुस्तकें (*.htb)|*.htb|सहायता पुस्तकें (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "एचटीएमएल सहायता परियोजना (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "संकुचित एचटीएमएल सहायता फ़ाइल (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i का %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i का %i"
@@ -5687,32 +5699,6 @@ msgstr ""
 "पॄष्ट स्थापना के दौरान एक समस्या थी: आपको एक डिफ़ाल्ट प्रिंटर को स्थापित करने की "
 "आवश्यकता है।"
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "एचटीएमएल प्रलेख को %s एन्कोडिंग में दिखाने में असफ़ल"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets '%s' के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "फ़िल्टर"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "निर्देशिकाओं"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "फ़ाइलें"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "चयन"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "क्लिपबोर्ड को खोलने में असफ़ल।"
@@ -5754,58 +5740,58 @@ msgstr "'%s' निर्देश का निष्पादन त्रु�
 msgid "Failed to create cursor."
 msgstr "कर्सर का निर्माण करने में असफ़ल।"
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "'%s' डीडीई सर्वर को पंजीकॄत करने में असफ़ल"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "'%s' डीडीई सर्वर को अपंजीकॄत करने में असफ़ल"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "'%s' सर्वर से '%s' विषय पर कनेक्शन जोड़ने में असफ़ल"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "डीडीई पोक निवेदन असफ़ल रहा"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "डीडीई सर्वर के साथ एक परामर्श लूप को स्थापित करने में असफ़ल"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "डीडीई सर्वर के साथ परामर्श लूप को समाप्त करने में असफ़ल"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "डीडीई परामर्श घोषणा को प्रेषित करने में असफ़ल"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "डीडीई श्रेणी का निर्माण करने में असफ़ल"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "कोई डीडीई नहीं त्रुटि।"
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "एक तुल्यकालिक परामर्श कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "इस कार्य संपादन को दिये हुए उत्तर ने DDE_FBUSY बिट् को स्थापित कर दिया।"
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "एक तुल्यकालिक डाटा कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5815,7 +5801,7 @@ msgstr ""
 "एक डीडीईएमएल संक्रिया को बिना डीडीईआरम्भीकरण संक्रिया को पुकारे हुएपुकारा गया है,\n"
 "या फ़िर एक डीडीईएमएल संक्रिया को एक अवैध दॄष्टांत आइडेन्टीफ़ायरदिया गया है।"
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5827,43 +5813,43 @@ msgstr ""
 "या एक कार्यक्रम जिसका आरम्भीकरण APPCMD_CLIENTONLY की भांति किया गया था, \n"
 "सर्वर कार्यसंपादनों को करने का प्रयास कर चुका है।"
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "एक तुल्यकालिक निष्पादन कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "डीडीईएमएल द्वारा एक पैरामीटर का सत्यापन करना असफ़ल रहा।"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "एक डीडीईएमएल कार्यक्रम ने एक बहुत लंबी रेस दशा का निर्माण कर दिया है।"
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "एक स्मृति आवंटन असफ़ल रहा।"
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "एक ग्राहक का एक संवाद स्थापित करने का प्रयास असफ़ल रहा।"
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "एक कार्यसंपादन असफ़ल रहा।"
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "एक तुल्यकालिक पोक कार्यसंपादन हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage चलन को एक आंतरिक कॉल असफ़ल रही। "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "पुनःअन्दर आने की समस्या।"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5873,16 +5859,16 @@ msgstr ""
 "या फ़िर सर्वर ने एक कार्यसंपादन के खत्म होने के पहिले अचानक समाप्त कर दिया  था,\n"
 "एक सर्वर की तरफ़ से एक कार्यसंपादन का प्रयास किया गया था।"
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "डीडीईएमएल में एक आंतरिक त्रुटि उत्पन्न हो गयी है।"
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "एक परामर्श कार्यसंपादन को समाप्त करने हेतु एक निवेदन की समय-सीमा समाप्त हो चुकी है।"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5892,12 +5878,12 @@ msgstr ""
 "जब यह कार्यक्रम एक XTYP_XACT_COMPLETE कॉलबैक से वापस आ चुका होगा,\n"
 "इस कॉलबैक के लिए यह कार्य संपादन पहचानकर्ता मान्य नहीं रह जायेगा।"
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "अज्ञात डीडीई त्रुटि %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5905,7 +5891,7 @@ msgstr ""
 "डायल-अप क्रियाऐं अनुपलब्ध है क्योंकि इस मशीन पर सुदूर पहुँच सेवा (आरऐएस)संसाधित नहीं है। "
 "कॄपया इसे संसाधित करें।"
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5914,64 +5900,64 @@ msgstr ""
 "इस मशीन पर संसाधित सुदूर पहुँच सेवा (आरऐएस) का यह संस्मरण अति प्राचीन है, कृपया इसे "
 "अपग्रेड करें(निम्न आवश्यक चलन विलुप्त है:  %s)।"
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "आरऐएस त्रुटि संदेश के पाठ को पुनःप्राप्त करने में असफ़ल"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "अज्ञात त्रुटि (त्रुटि कूट %08x)।"
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "सक्रिय डायल-अप कनेक्शन को खोजा नहीं जा सका: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "अनेकों सक्रिय डायल-अप कनेक्श मिलें, बेतरतीब से एक का चयन किया जा रहा है।"
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "डायल-अप कनेक्शन को स्थापित करने में असफ़ल: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "आईएसपी नामों को प्राप्त करने में असफ़ल: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "कनेक्ट करने में असफ़ल: डायल करने के लिए कोई आईएसपी नहीं।"
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "डायल करने के लिए आईएसपी का चयन करें"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "कॄपया उस आईएसपी का चयन करें जिससे आप जुड़ना चाहते है"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "कनेक्ट करने में असफ़ल: विलुप्त उपयोगकर्तानाम/कूटशब्द।"
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "पता पुस्तिका फ़ाइल के स्थान को नहीं खोजा जा सका"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "डायल-अप कनेक्शन को समाप्त करने में असफ़ल: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "संबंध-विच्छेद नहीं किया जा सका - कोई सक्रिय डायल-अप कनेक्शन नहीं।"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "डायल-अप कनेक्शन को समाप्त करने में असफ़ल: %s"
@@ -5991,19 +5977,18 @@ msgstr "बिट्मैप डाटा के लिए %lu केबी स
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' निर्देशिका में फ़ाइलों की परिगणना नहीं की जा सकती है"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr "(त्रुटि %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "आकॄतियों की सूची में एक आकॄति को जोड़ा नहीं जा सका।"
 
@@ -6017,7 +6002,7 @@ msgstr "%d आकॄति को '%s' फ़ाइल से लोड करन�
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "मानक खोज/बदलाव संवाद का निर्माण करने में असफ़ल (त्रुटि कूट %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
@@ -6060,17 +6045,17 @@ msgstr "'%s' फ़ाइल को छूने में असफ़ल"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "एक समय-सचेतक का निर्माण नहीं किया जा सका"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "ओपनजीएल का आरम्भीकरण करने में असफ़ल।"
 
@@ -6078,7 +6063,7 @@ msgstr "ओपनजीएल का आरम्भीकरण करने �
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6086,7 +6071,7 @@ msgstr ""
 "एमएस एचटीएमएल सहायता क्रियाऐं अनुपलब्ध है क्योंकि एमएस एचटीएमएल सहायता लायबरी इस "
 "मशीन परसंसाधित नहीं है। कॄपया इसे संसाधित करें।"
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "एमएस एचटीएमएल सहायता का आरम्भीकरण करने में असफ़ल।"
 
@@ -6095,7 +6080,7 @@ msgstr "एमएस एचटीएमएल सहायता का आर�
 msgid "Can't delete the INI file '%s'"
 msgstr " '%s' आईएनआई फ़ाइल को हटाया नहीं जा सकता है"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "%d सूची नियंत्रण आयट्म के बारे में सूचना प्राप्त नहीं की जा सकी।"
@@ -6217,7 +6202,7 @@ msgstr "'%s' क्लिपबोर्ड प्रारूप को पं�
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "क्लिपबोर्ड प्रारूप '%d' विद्यमान नहीं है।"
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "छोड़ दे"
 
@@ -6302,75 +6287,75 @@ msgstr ""
 "इसको हटाने से आपका तंत्र कार्य ना करने की अवस्था में रह जायेगा:\n"
 "संक्रिया को निरस्त किया गया।"
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "'%s' कुँजी को हटाया नहीं जा सकता है"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "'%s' मूल्य को '%s' कुँजी से हटाया नहीं जा सकता है"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "'%s' कुँजी के मूल्य को पढ़ा नहीं जा सकता है"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s' के मूल्य की स्थापना नहीं की जा सकती है"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s' के मूल्य को पढ़ा नहीं जा सकता है"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "'%s' कुँजी के मूल्यों की परिगणना नहीं की जा सकती है"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "'%s' कुँजी की उपकुँजियों की परिगणना नहीं की जा सकती है"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "%d असमर्थित प्रकार के मूल्यों की प्रतिलिपि नहीं बनायी जा सकती है।"
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6378,47 +6363,47 @@ msgstr ""
 "एक रिच ऐडीट कन्ट्रोल का निर्माण असम्भव है, इसके बज़ाय सामान्य पाठ कन्ट्रोल का उपयोग "
 "किया जा रहा है। कृपया riched32.dll को पुनः संसाधित करें"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "थ्रेड को आरम्भ नहीं किया जा सकता है: टीएलएस लेखन में त्रुटि"
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "थ्रेड की वरीयता की स्थापना नहीं की जा सकती है"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "थ्रेड का निर्माण नहीं किया जा सकता है"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "थ्रेड को समाप्त नहीं किया जा सका"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "थ्रेड समाप्ति की प्रतीक्षा नहीं की जा सकती है"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "%x थ्रेड को अधर में नहीं छोड़ा जा सकता है"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "%x थ्रेड को समान-बिन्दु से पुनः आरम्भ नहीं किया जा सकता है"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "वर्तमान थ्रेड सूचक को प्राप्त नहीं किया जा सका"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "थ्रेड माड्यूल आरम्भीकरण असफ़ल रहा: स्थानीय थ्रेड भंडार में इंडेक्स का आवंटन असम्भव"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6449,12 +6434,12 @@ msgstr "%d आकॄति को '%s' फ़ाइल से लोड करन�
 msgid "Failed to lock resource \"%s\"."
 msgstr "'%s' फ़ाइल को लॉक करने में असफ़ल"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "विण्डो एक्स पी (निर्माण %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6466,47 +6451,47 @@ msgstr "एक अज्ञात पाइप का निर्माण क�
 msgid "Failed to redirect the child process IO"
 msgstr "बाल प्रोसेस आईओ को दिशानिर्देश देने में असफ़ल"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' निर्देश का निष्पादन असफ़ल रहा"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll को लोड करने में असफ़ल।"
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' से टाइपनाम को पढ़ा नहीं जा सका!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' से आइकॉन को लाया नहीं जा सकता है।"
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "थ्रेड की वरीयता की स्थापना नहीं की जा सकती है"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "'%s' का निष्पादन करने में असफ़ल\n"
@@ -6540,7 +6525,7 @@ msgid "Check to make the font italic."
 msgstr ""
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "रेखांकित"
@@ -6608,17 +6593,32 @@ msgstr "<कोई टेलीटाइप>"
 msgid "File type:"
 msgstr "टेलीटाइप"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "खिड़की (&W)"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "सहायता"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "छोटा करें (&n)"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "बड़ा करें (&I)"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6635,492 +6635,492 @@ msgstr " %s फ़ाइल विद्यमान नहीं है।"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "के बारे में"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "के बारे में (&A)"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "प्राथमिकता (&P)"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "सहायता: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "चयन"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "सभी को दिखाएँ"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "छोड़ दे (&Q)"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "चयन"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "फ़ॉन्ट आकार (&P):"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "नयानाम"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "शैली"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "भार (&W):"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "फ़ॉन्ट वंश:"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "आधुनिक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "हल्का"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "पाठ को दायें पंक्तिबद्ध करें।"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "आधुनिक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "विकल्प सूची"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "खिड़की (&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "खिड़की (&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "खिड़की (&W)"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "फ़ॉन्ट आकार"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "पुनःकरें (&R)"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "डिफ़ाल्ट"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "कल"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "दायें"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "बुल्लेट शैली"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "संप्रतीक कूट (&C):"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "फ़ॉन्ट आकार (&P):"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "दायें पंक्तिबद्ध करें"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "प्रश्न"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "दायें"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "दायें"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "चयन चिपकाएँ"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 #, fuzzy
 msgid "False"
 msgstr "फ़ाइल"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr ""
 
@@ -7134,49 +7134,49 @@ msgstr "मुद्रण त्रुटि"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "%d से %d के मध्य में एक पृष्ट संख्या बताएँ:"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "टिप्पणी (&N)"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "निर्देशिका का निर्माण करें"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "फ़ॉन्ट का चयन करें"
@@ -7668,130 +7668,130 @@ msgstr "डाले"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "शैली बदले"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 #, fuzzy
 msgid "Change Object Style"
 msgstr "सूची शैली बदले"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "सूची शैली बदले"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "सूची पुनः संख्यांकन करें"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "पाठ डाले"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "आकृति डाले"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "पाठ डाले"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "पाठ डाले"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "फ़ाइलें"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 #, fuzzy
 msgid "standard/circle"
 msgstr "मानक"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 #, fuzzy
 msgid "standard/square"
 msgstr "मानक"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "शैली हटाएँ"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "मिटाएँं"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "चयन मिटाएँ"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "गुणधर्म (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "आकृति"
 
@@ -7999,25 +7999,25 @@ msgstr "~"
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "पाठ मिटाएँ"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "निकाल दें"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "इस पाठ को सुरक्षित किया जा सका।"
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "बदलें"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "फ़ॉन्ट: (&F)"
 
@@ -9050,53 +9050,53 @@ msgstr "सूची शैलियाँ"
 msgid "Box styles"
 msgstr "सभी शैलियाँ"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "उप समुच्चय (&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "एक यूनिकोड उप समुच्चय दिखाएँ।"
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "संप्रतीक कूट (&C):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "का संप्रतीक कूट।"
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "से (&F):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "यूनिकोड"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "डाले"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(सामान्य पाठ)"
 
@@ -9290,7 +9290,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "प्रदर्श युक्ति \"%s\" को खोलने में असफ़ल।"
@@ -9390,20 +9390,20 @@ msgstr "साउन्ड डाटा एक असमर्थित प्�
 msgid "Couldn't open audio: %s"
 msgstr "आडियो को नहीं खोला जा सका: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "थ्रेड समय-सारणी नीति को प्राप्त नहीं किया जा सकता है।"
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "%d नीति की समय-सारणी के लिए वरीयता सीमा को नहीं प्राप्त किया जा सका"
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "थ्रेड वरीयता समायोजना पर ध्यान नहीं दिया गया।"
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9411,60 +9411,60 @@ msgstr ""
 "एक थ्रेड में शामिल होने में असफ़ल, अत्याधिक स्मॄति रिसाव पाया गया -कॄपया इस कार्यक्रम को "
 "पुनः आरम्भ करें"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "एक थ्रेड को समाप्त करने में असफ़ल।"
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "थ्रेड माड्यूल आरम्भीकरण असफ़ल रहा: थ्रेड कुँजी का निर्माण नहीं किया जा सका"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "बाल प्रोसेस इनपुट का प्राप्त करना असम्भव"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "%d प्रोसेस को खत्म करने में असफ़ल"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' का निष्पादन करने में असफ़ल\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "फ़ार्क असफ़ल रहा"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "%d थ्रेड वरीयता को स्थापित करने में असफ़ल।"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "बाल प्रोसेस इनपुट/आउटपुट को दिशानिर्देश देने में असफ़ल"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "होस्टनाम को प्राप्त नहीं किया जा सका"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "अधिकारिक होस्टनाम को प्राप्त नहीं किया जा सका"
 
@@ -9482,12 +9482,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "लॉक फ़ाइल से पीआईडी को पढ़ने में असफ़ल।"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "अवैध जयामिति विशिष्टतायें '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
 
@@ -9501,30 +9501,60 @@ msgstr "डिस्प्ले \"%s\" को बन्द करने मे�
 msgid "Failed to open display \"%s\"."
 msgstr "प्रदर्श युक्ति \"%s\" को खोलने में असफ़ल।"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "एक्सएम एल पदभंजन त्रुटि: '%s' %d पंक्ति पर"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "'%s' फ़ाइल से स्रोत संसाधनों को नहीं लाया जा सकता है।"
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s' का निष्कर्षण '%s' में असफ़ल रहा।"
+
+#~ msgid "Printing "
+#~ msgstr "मुद्रण हो रहा है "
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "कार्यशील निर्देशिका को प्राप्त करने में असफ़ल"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "कॄपया एक वैध फ़ॉन्ट का चयन करें।"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "एचटीएमएल प्रलेख को %s एन्कोडिंग में दिखाने में असफ़ल"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets '%s' के लिए अवलोकन को खोल नहीं पाया: बाहर निकल रहा है।"
+
+#~ msgid "Filter"
+#~ msgstr "फ़िल्टर"
+
+#~ msgid "Directories"
+#~ msgstr "निर्देशिकाओं"
+
+#~ msgid "Files"
+#~ msgstr "फ़ाइलें"
+
+#~ msgid "Selection"
+#~ msgstr "चयन"
 
 #, fuzzy
 #~ msgid "failed to retrieve execution result"
@@ -9656,8 +9686,8 @@ msgstr "'%s' का निष्कर्षण '%s' में असफ़ल र�
 #~ msgstr "मुद्रण को आरम्भ नहीं किया जा सका।"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/hr.po
+++ b/locale/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-08-05 00:46+0200\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: \n"
@@ -15,15 +15,15 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 3.0\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Sve datoteke (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Sve datoteke (*)|*"
 
@@ -40,24 +40,21 @@ msgid "Remaining time:"
 msgstr "Preostalo vrijeme:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Da"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "U redu"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Odustani"
@@ -107,7 +104,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Nije moguće stvoriti završni priključak ulaza/izlaza"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Ispis"
 
@@ -144,7 +141,7 @@ msgstr "Svojstva objekta"
 msgid "Printing"
 msgstr "Ispisivanje"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simboli"
 
@@ -213,7 +210,7 @@ msgstr "&Prethodno"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Prozor"
 
@@ -742,11 +739,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "prikaži ovu obavijest pomoći"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "stvori opširne log-poruke"
 
@@ -768,84 +765,84 @@ msgstr "Nepodržana tema „%s”."
 msgid "Invalid display mode specification '%s'."
 msgstr "Nevaljana specifikacija modusa prikaza „%s”."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Nije moguće negirati opciju „%s”"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nepoznata dugačka opcija „%s”"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nepoznata opcija „%s”"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Neočekivani znakovi slijede opciju „%s”."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opcija „%s” zahtijeva vrijednost."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Potreban je razdvojnik nakon opcije „%s”."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "„%s” nije ispravna numerička vrijednost za opciju „%s”."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opcija „%s”: Nije moguće konvertirati „%s” u datum."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Neočekivani parametar „%s”"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ili %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Vrijednost opcije „%s” mora biti određena."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Obavezan parametar „%s” nije bio određen."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Upotreba: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dvostruko"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "datum"
 
@@ -863,7 +860,7 @@ msgid "Can't &Undo "
 msgstr "&Poništavanje nije moguće "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Poništi"
@@ -873,7 +870,7 @@ msgid "&Redo "
 msgstr "&Ponovi "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ponovi"
@@ -903,12 +900,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "„%s” ima dodatne „..”, zanemareno."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "aktivirano"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "neaktivirano"
 
@@ -917,103 +914,103 @@ msgstr "neaktivirano"
 msgid "undetermined"
 msgstr "neodređeno"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "danas"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "jučer"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "sutra"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "prvi"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "drugi"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "treći"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "četvrti"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "peti"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "šesti"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sedmi"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "osmi"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "deveti"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "deseti"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "jedanaesti"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dvanaesti"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "trinaesti"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "četrnaesti"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "petnaesti"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "šesnaesti"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "sedamnaesti"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "osamnaesti"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "devetnaesti"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "dvadeseti"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "podne"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "ponoć"
 
@@ -1081,44 +1078,81 @@ msgstr "Neuspjelo izvršavanje curl-a, instaliraj ga u PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Neuspjeli prijenos izvještaja o ispravljanju grešaka (kôd greške %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Spremi kao"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Zanemari promjene i ponovo učitaj posljednju spremljenu verziju?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "neimenovano"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Želiš li spremiti promjene u %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Spremi"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nemoj spremiti"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Želiš li spremiti promjene u %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Nije bilo moguće spremiti tekst."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Nije bilo moguće otvoriti datoteku „%s” za pisanje."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Neuspjelo spremanje dokumenta u datoteku „%s”."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Nije bilo moguće otvoriti datoteku „%s” za čitanje."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Neuspjelo čitanje dokumenta iz datoteke „%s”."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1127,57 +1161,57 @@ msgstr ""
 "Datoteka „%s” ne postoji i ne može se otvoriti.\n"
 "Uklonjena je iz popisa nedavno otvorenih datoteka."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Izrada pregleda ispisa neuspjela."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Pregled ispisa"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Nije bilo moguće ustanoviti format datoteke „%s”."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "neimenovano%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " – "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Otvori datoteku"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Greška datoteke"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Nažalost nije moguće otvoriti ovu datoteku."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Nažalost je format datoteke nepoznat."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Odaberi jedan predložak"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Predlošci"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Odaberi jedan pogled"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Prikazi"
 
@@ -1211,41 +1245,41 @@ msgstr "Greška u čitanju datoteke „%s”"
 msgid "Write error on file '%s'"
 msgstr "Zapiši grešku za datoteku „%s”"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "neuspjelo pražnjenje datoteke „%s”"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Traži grešku u datoteci „%s” (stdio ne podržava velike datoteke)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Traži grešku u datoteci „%s”"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nije moguće naći trenutačni položaj u datoteci „%s”"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Neuspjelo postavljanje privremenih datotečnih prava"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nije moguće ukloniti datoteku „%s”"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nije moguće potvrditi promjene za datoteku „%s”"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nije moguće ukloniti privremenu datoteku „%s”"
@@ -1270,27 +1304,27 @@ msgstr "nije moguće čitanje iz deskriptora datoteka %d"
 msgid "can't write to file descriptor %d"
 msgstr "nije moguće zapisivanje u deskriptor datoteka %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nije moguće isprazniti deskriptor datoteka %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nije moguće traženje na deskriptor datoteka %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nije moguće dobiti poziciju traženja na deskriptoru datoteka %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "nije moguće naći duljinu datoteke na deskriptoru datoteka %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "nije moguće odrediti dosezanje kraja datoteke na deskriptoru %d"
@@ -1316,109 +1350,109 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Greška prilikom čitanja opcija konfiguracije."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Neuspjelo čitanje opcija koniguracije."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "datoteka „%s”: neočevani znak %c u %zu. retku."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "datoteka „%s”, redak %zu: „%s” zanemareno nakon zaglavlja grupe."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "datoteka „%s”, redak %zu: „=” očekivano."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "datoteka „%s”, redak %zu: vrijednost nepromijenjivog ključa „%s” je "
 "zanemaren."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "datoteka „%s”, redak %zu: ključ „%s” je najprije nađen u %d. retku."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfiguracijsko ulazno ime ne može početi s „%c”."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "nije moguće otvoriti datoteku korisničke konfiguracije."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "nije moguće zapisivanje datoteke korisničke konfiguracije."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Neuspjelo aktualiziranje datoteke korisničke konfiguracije."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Greška prilikom spremanja podataka korisničke konfiguracije."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "nije moguće izbrisati datoteku konfiguracije „%s”"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "unos „%s” se pojavljuje višestruko u grupi „%s”"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "pokušaj mijenjanja nepromjenljivog ključa „%s” je zanemaren."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "obrnuta kosa crta na kraju je zanemarena u „%s”"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "neočekivani \" na poziciji %d u „%s”."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Neuspjelo kopiranje datoteke „%s” u „%s”"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nije moguće dobiti dozvolu za datoteku „%s”"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nije moguće prepisati datoteku „%s”"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Greška prilikom kopiranja datoteke „%s” u „%s”."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nije moguće postaviti korisnička prava za datoteku „%s”"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1427,40 +1461,40 @@ msgstr ""
 "Neuspjelo preimenovanje datoteke „%s” u „%s”, jer odredišna datoteka već "
 "postoji."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Datoteku „%s” nije bilo moguće preimenovati „%s”"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Nije bilo moguće ukloniti datoteku „%s”"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nije bilo moguće stvoriti mapu „%s”"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nije bilo moguće izbrisati mapu „%s”"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nije moguće numerirati datoteke „%s”"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Neuspjelo dohvaćanje radne mape"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Nije bilo moguće postaviti trenutačnu radnu mapu"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Datoteke (%s)"
@@ -1487,17 +1521,17 @@ msgstr "Neuspjelo stvaranje imena privremene datoteke"
 msgid "Failed to open temporary file."
 msgstr "Neuspjelo otvaranje privremene datoteke."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Neuspjelo mijenjanje vremena datoteke za „%s”"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Neuspjelo dodirivanje datoteke „%s”"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Neuspjelo dohvaćanje vremena datoteke za „%s”"
@@ -1506,22 +1540,22 @@ msgstr "Neuspjelo dohvaćanje vremena datoteke za „%s”"
 msgid "Browse"
 msgstr "Pregledaj"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Sve datoteke (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s datoteka (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Učitaj %s datoteku"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Spremi %s datoteku"
@@ -1884,99 +1918,99 @@ msgstr "zadano"
 msgid "unknown-%d"
 msgstr "nepoznato-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "podcrtano"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " precrtano"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " tanki"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " ekstra svjetli"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " svjetli"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " srednji"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " polu debeli"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " debeli"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " ekstra debeli"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " masni"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " ekstra masni"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kurziv"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "precrtano"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "tanki"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "ekstrasvjetli"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "svijetli"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normalni"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "srednji"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "poludebeli"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "debeli"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "ekstradebeli"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "masni"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "ekstramasni"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kurziv"
 
@@ -2057,7 +2091,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Neuspjelo postavljanje modusa za FTP prijenos na %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2078,7 +2112,7 @@ msgstr "FTP server ne podržava pasivni modus."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nepravilna veličina GIF okvira (%u, %d) za okvir #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Neuspjelo alociranje boje za OpenGL"
 
@@ -2094,7 +2128,7 @@ msgstr "Prilagodi stupce"
 msgid "&Customize..."
 msgstr "&Prilagodi …"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Neuspjelo otvaranje URL-a „%s” u zadanom pregledniku"
@@ -2114,156 +2148,155 @@ msgstr "Neuspjelo učitavanje slike %d iz tijeka."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Neuspjelo učitavanje ikona iz resursa „%s”."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nije bilo moguće spremiti nevaljanu sliku."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nema vlastitu wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nije bilo moguće zapisati zaglavlje (bitmap) datoteke."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nije bilo moguće zapisati zaglavlje (bitmapinfo) datoteke."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nije bilo moguće zapisati RGB mapu boja."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nije bilo moguće zapisati podatke."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nije bilo moguće alocirati memoriju."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Header: Širina slike > 32767 piksela za datoteku."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Header: Visina slike > 32767 piksela za datoteku."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB zaglavlje: Nepoznata bit-dubina u datoteci."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB zaglavlje: Nepoznato kodiranje u datoteci."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB zaglavlje: Kodiranje se ne poklapa s bit-dubinom."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: zaglavlje ima biClrUsed=%d kad je biBitCount=%d."
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Nije bilo moguće alocirati memoriju."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB Header: Širina slike > 32767 piksela za datoteku."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB Header: Visina slike > 32767 piksela za datoteku."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB zaglavlje: Nepoznata bit-dubina u datoteci."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB zaglavlje: Nepoznato kodiranje u datoteci."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB zaglavlje: Kodiranje se ne poklapa s bit-dubinom."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Greška u čitanju DIB slike."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Greška prilikom čitanja DIB maske."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Slika je pre visoka za ikonu."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Slika je pre široka za ikonu."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Greška prilikom pisanja datoteke slike!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Nevaljani indeks ikone."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Slika i maska imaju različite veličine."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Nema nekorištenih boja u slici koja se maskira."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Neuspjelo učitavanje bitmapa „%s” iz resursa."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Neuspjelo učitavanje ikone „%s” iz resursa."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Neuspjelo učitavanje slike iz datoteke „%s”."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nije moguće spremanje slikovne datoteke „%s”: nepoznati sufiks."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Nije nađen upravljač za vrstu slike."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nijedan upravljač slikama za vrstu %d nije određen."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Datoteka slike nije vrste %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Nije moguće automatski odrediti format slike za unos koji se ne može tražiti."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Nepoznati format slikovnih podataka."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Ovo nije %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nijedan upravljač slikama za vrstu %s nije određen."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Slika nije vrste %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Neuspjela provjera formata datoteke slike „%s”."
@@ -2366,41 +2399,41 @@ msgstr "PNM: Datoteka se čini odrezanom."
 msgid " (in module \"%s\")"
 msgstr " (u modulu „%s”)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Greška prilikom učitavanja slike."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Nevaljani indeks TIFF slike."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Slika je abnormalno velika."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nije moguće alocirati memoriju."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Greška prilikom čitanja slike."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Nepoznata TIFF jedinica rezolucije %d je zanemarena"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Greška prilikom spremanja slike."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Greška prilikom pisanja slike."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2409,11 +2442,11 @@ msgstr ""
 "Argument naredbenog retka %d nije bilo moguće konvertirati u Unicode i bit "
 "će zanemaren."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicijaliziranje u naknadnom inicijaliziranju nije uspjelo, prekid."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nije moguće postaviti lokalizaciju za „%s” jezik."
@@ -2510,7 +2543,7 @@ msgstr "Greška LZMA komprimiranja: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Greška LZMA komprimiranja prilikom nedovršavanja iznošaja: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nezatvorena „{” u jednom unosu za mime vrstu %s."
@@ -2530,7 +2563,7 @@ msgstr "Ovisnost „%s” o modulu „%s” ne postoji."
 msgid "Module \"%s\" initialization failed"
 msgstr "Inicijaliziranje modula „%s” nije uspjelo"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Poruka"
 
@@ -3032,7 +3065,7 @@ msgstr "Greška u ispisu"
 msgid "Print"
 msgstr "Ispiši"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Postavke stranice"
 
@@ -3067,19 +3100,15 @@ msgstr "Ispisivanje %d. stranice od %d"
 msgid " (copy %d of %d)"
 msgstr " (kopija %d od %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Ispisivanje "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Prva stranica"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Prethodna stranica"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Sljedeća stranica"
 
@@ -3123,16 +3152,16 @@ msgstr "%d. stranica od %d"
 msgid "Page %d"
 msgstr "Stranica %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "nepoznata greška"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Nevaljan regularni izraz „%s”: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Neuspjeo nalaženje poklapanja ragularnog izraza: %s"
@@ -3143,21 +3172,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Iscrtač „%s” ima nekompatibilnu verziju %d.%d i nije ga moguće učitati."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Nije dostupno za ovu platformu"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Spremanje lozinke za „%s” neuspjelo: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Čitanje lozinke za „%s” neuspjelo: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Brisanje lozinke za „%s” neuspjelo: %s."
@@ -3166,11 +3195,11 @@ msgstr "Brisanje lozinke za „%s” neuspjelo: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Neuspjelo praćenje ulaznih/izlaznih kanala"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Spremi"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Nemoj spremiti"
 
@@ -3251,10 +3280,10 @@ msgid "Clear"
 msgstr "Izbriši"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Zatvori"
 
@@ -3266,7 +3295,7 @@ msgstr "&Pretvori"
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiraj"
@@ -3275,7 +3304,7 @@ msgstr "&Kopiraj"
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Izr&eži"
@@ -3284,13 +3313,13 @@ msgstr "Izr&eži"
 msgid "Cut"
 msgstr "Izreži"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Izbriši"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Izbriši"
@@ -3377,7 +3406,7 @@ msgstr "Čvrsti disk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Pomoć"
 
@@ -3397,7 +3426,7 @@ msgstr "Uvlaka"
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3466,7 +3495,7 @@ msgstr "&Nova"
 msgid "New"
 msgstr "Novo"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Ne"
 
@@ -3483,12 +3512,12 @@ msgstr "&Otvori …"
 msgid "Open..."
 msgstr "Otvori …"
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Zalijepi"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Zalijepi"
@@ -3518,7 +3547,7 @@ msgid "Print..."
 msgstr "Ispiši …"
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Svojstva"
 
@@ -3550,10 +3579,6 @@ msgstr "Zamijeni …"
 msgid "Revert to Saved"
 msgstr "Vrati na spremljeno"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Spremi"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Spremi &kao …"
@@ -3562,7 +3587,7 @@ msgstr "Spremi &kao …"
 msgid "Save As..."
 msgstr "Spremi kao …"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Odaberi &sve"
@@ -3669,7 +3694,7 @@ msgstr "&Gore"
 msgid "Up"
 msgstr "Gore"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Da"
 
@@ -3757,43 +3782,43 @@ msgstr "Spremi trenutačni dokument"
 msgid "Save current document with a different filename"
 msgstr "Spremi trenutačni dokument pod drugim imenom"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konverzija u kodnu stranicu „%s” ne radi."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "nepoznato"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "nepotpuni zaglavni blok u tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "greška u ispitnom zbroju prilikom čitanja zaglavnog bloka"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "nevaljani podaci u proširenom tar zaglavlju"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar unos nije otvoren"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "neočekivani kraj datoteke"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ne paše tar zaglavlju za unos „%s”"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "nepravilna veličina, zadan za tar ulaz"
 
@@ -3802,7 +3827,7 @@ msgstr "nepravilna veličina, zadan za tar ulaz"
 msgid "'%s' is probably a binary buffer."
 msgstr "„%s” je vjerojatno jedan binaran međuspremnik."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Nije bilo moguće učitati datoteku."
 
@@ -3816,47 +3841,47 @@ msgstr "Neuspjelo čitanje tekstualne datoteke „%s”."
 msgid "can't write buffer '%s' to disk."
 msgstr "nije moguće zapisivanje međuspremnika „%s” na disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Neuspjelo dobivanje lokalnog vremena sustava"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay nije uspjelo."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "„%s” nije valjan katalog obavijesti."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Nevaljani katalog obavijesti."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Neuspjela obrada oblika množine: „%s”"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "koristi se katalog „%s” od „%s”."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Resurs „%s” nije valjani katalog obavijesti."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Nije bilo moguće numerirati prijevode"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Nije konfigurirana standardna aplikacija za HTML datoteke."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Neuspjelo otvaranje URL-a „%s” u zadanom pregledniku."
@@ -3889,7 +3914,7 @@ msgstr "„%s” sadržava nevažeće slovne znakove"
 msgid "Error: %s (%d)"
 msgstr "Greška: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Nema dovoljno memorije na disku za preuzimanje."
 
@@ -3897,20 +3922,20 @@ msgstr "Nema dovoljno memorije na disku za preuzimanje."
 msgid "libcurl could not be initialized"
 msgstr "libcurl nije bilo moguće inicijalizirati"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync not supported nije podržano"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Greška prilikom pokretanja JavaScripta: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Ova platforma ne podržava neprozirnost pozadine."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Nije bilo moguće prenijeti podatke u prozor"
 
@@ -3962,8 +3987,8 @@ msgstr "Parametar za stvaranje %s, nije nađen u prijavljenim RTTI parametrima"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Nevažeći razred objekta (Non-wxEvtHandler) kao izvor događaja"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Vrsta mora imati enum - long konverziju"
 
@@ -4013,82 +4038,82 @@ msgstr "Objekt mora imati id svojstvo"
 msgid "Doubly used id : %d"
 msgstr "Dvostruko korišten id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Nepoznato svojstvo %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Ne prazna kolekcija mora sadržavati „element” čvorove"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "nepravilan znakovni niz upravljača događaja, nedostaje točka"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nije moguće ponovo inicijalizirati zlib deflate tijek"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nije moguće ponovo inicijalizirati zlib inflate tijek"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Zanemaruje se pogrešno oblikovan dodatni zapis podataka, ZIP datoteka možda "
 "neće biti ispravna"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "pod pretpostavkom da se radi o višedjelnom lančanom zipu"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "nevaljana zip datoteka"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "nije moguće pronaći osnovnu mapu u zipu"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "greška prilikom čitanja osnovne mape zip-a"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "greška prilikom čitanja lokalnog zaglavlja zip-a"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "neispravni odmak zip datoteke na unos"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "spremljena dužina datoteke nije u Zip zaglavlju"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "nepodržana metoda Zip komprimiranja"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "čitanje zip tijeka (unos %s): loša duljina"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "čitanje zip tijeka (unos %s): loš crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "greška prilikom pisanja zip unosa „%s”: datoteka je prevelika bez ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "greška prilikom pisanja zip unosa „%s”: krivi izvor ili duljina"
@@ -4174,32 +4199,32 @@ msgstr "Ilustracija: "
 msgid "Translations by "
 msgstr "Prijevodi: "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Verzija "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "O programu %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licenca"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Programeri"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autori dokumentacije"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Ilustratori"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Prevoditelji"
 
@@ -4250,42 +4275,42 @@ msgid "Password:"
 msgstr "Lozinka:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "točno"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "netočno"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Redak %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Sklopi"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Rasklopi"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d stavki)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Stupac %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4296,7 +4321,7 @@ msgid "Left"
 msgstr "Lijevo"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4392,7 +4417,7 @@ msgid "Home directory"
 msgstr "Početna mapa (home)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -4405,8 +4430,7 @@ msgstr "Nevažeće ime mape."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Greška"
 
@@ -4591,16 +4615,16 @@ msgstr "Prikaži datoteke s detaljima"
 msgid "Go to parent directory"
 msgstr "Idi na matičnu mapu"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Datoteka „%s”već postoji. Sigurno je želiš prepisati?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Potvrdi"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Odaberi jednu postojeću datoteku."
 
@@ -4694,7 +4718,7 @@ msgstr "Veličina fonta."
 msgid "Whether the font is underlined."
 msgstr "Je li font podcrtan."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Pregled:"
@@ -4712,48 +4736,47 @@ msgstr "Klikni za odustajanje od odabira fonta."
 msgid "Click to confirm the font selection."
 msgstr "Klikni za potvrdu odabira fonta."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Odaberi font"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "Kopiranje više od jednog odabranog bloka u međuspremnik nije podržano."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Mapa pomoći „%s” nije pronađena."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Datoteka pomoći „%s” nije pronađena."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "%lu. redak datoteke „%s” ima nevaljanu sintaksu, preskočeno."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "U datoteci „%s” nisu pronađena valjana mapiranja."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Unosi nisu pronađeni."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indeks pomoći"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevantni unosi:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Pronađeni unosi"
 
@@ -4858,59 +4881,59 @@ msgstr "Nije bilo moguće pokrenuti ispis."
 msgid "Printing page %d..."
 msgstr "Ispisivanje %d. stranice …"
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opcije pisača"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Ispiši u datoteku"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Postavljanje …"
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Pisač:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Stanje:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Sve"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Stranice"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Opseg ispisa"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopije:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript datoteka"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Postavke ispisa"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Pisač"
 
@@ -4918,25 +4941,25 @@ msgstr "Pisač"
 msgid "Default printer"
 msgstr "Zadani pisač"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Veličina papira"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Uspravno"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Položeno"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Položaj"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcije"
 
@@ -4948,52 +4971,52 @@ msgstr "Ispiši u boji"
 msgid "Print spooling"
 msgstr "Pripremanje ispisa"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Naredba pisača:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opcije pisača:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Lijeva margina (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Gornja margina (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Desna margina (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Donja margina (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Pisač …"
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Preskoči"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Nepoznato"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Gotovo."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Traži"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Nije bilo moguće naći karticu za id"
 
@@ -5029,11 +5052,11 @@ msgstr "&Završi"
 msgid "< &Back"
 msgstr "< &Natrag"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Milo Ivir <mail@milotype.de>, 2019., 2021."
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5043,11 +5066,11 @@ msgstr ""
 "probleme u rukovanju s unosom i treperenjem. Deaktiviraj GTK_IM_MODULE ili "
 "postavi na „ibus”."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nije moguće inicijalizirati GTK+. Je li DISPLAY ispravno postavljen?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Mijenjanje trenutačne mape u „%s” nije uspjelo"
@@ -5074,11 +5097,11 @@ msgid "Failed to register font configuration using private fonts."
 msgstr ""
 "Neuspjela registracija konfiguracije fontova koristeći privatne fontove."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Kobna greška"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5090,7 +5113,7 @@ msgstr ""
 "postavljanjem\n"
 "varijable okruženja GDK_BACKEND=x11 prije pokretanja tvog programa."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5101,7 +5124,7 @@ msgstr ""
 "zaobići taj problem postavljanjem varijable okruženja GDK_BACKEND=x11 prije\n"
 "pokretanja programa."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
@@ -5117,15 +5140,11 @@ msgstr "Greška prilikom spisa: "
 msgid "Page Setup"
 msgstr "Postavke stranice"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Neuspjelo umetanje teksta u kontrolu."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "Dohvaćanje iznošaja JavaScript skripta nije podržano s WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5133,7 +5152,7 @@ msgstr ""
 "Na ovom računalu instalirani GTK+ je pre star za podržavanje dijeljenja "
 "ekrana, instaliraj GTK+ 2.12 ili noviju verziju."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5141,17 +5160,13 @@ msgstr ""
 "Dijeljenje nije podržano u ovom sustavu. Aktiviraj ga u tvom upravljaču "
 "prozora."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Ovaj je program kompiliran s pre starom verzijom GTK+, ponovo izgradi s GTK+ "
 "2.12 ili novijom verzijom."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Odaberi valjani font."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5250,45 +5265,45 @@ msgstr "Nije moguće otvoriti datoteku sadržaja: %s"
 msgid "Cannot open index file: %s"
 msgstr "Nije moguće otvoriti datoteku indeksa: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "bezimeno"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nije moguće otvoriti HTML knjigu pomoći: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Prikazuje pomoć prilikom pregledavanja knjiga na lijevo strani."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(knjižne oznake)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Dodaj trenutačnu stranicu u knjižne oznake"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Ukloni trenutačnu stranicu iz knjižnih oznaka"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Sadržaj"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Nađi"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Prikaži sve"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5296,19 +5311,19 @@ msgstr ""
 "Prikaži sve indicirane stavke koje sadržavaju zadani znakovni niz. Pretraga "
 "ne razlikuje veličinu slova."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Prikaži sve stavke u indeksu"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Razlikovanje veličine slova"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Samo cijele riječi"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5316,147 +5331,147 @@ msgstr ""
 "Pretraži sadržaj svih knjiga pomoći, i nađi sva pojavljivanja gore utipkanog "
 "teksta"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Prikaži/sakrij navigaciju"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Idi natrag"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Idi naprijed"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Idi jednu razinu prema gore u hijerarhiji dokumenata"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Otvori HTML datoteku"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Ispiši ovu stranicu"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Dijalog za opcije prikaza"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Odaberi stranicu za prikazivanje:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Pomoć za teme"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Traženje …"
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Dosada nije nađena odgovarajuće stranica"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Nađena su %i poklapanja"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(pomoć)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d od %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu od %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Traži u svim knjigama"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Pomoć za opcije preglednika"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normalni font:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Font fiksne širine:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Veličina fonta:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "veličina fonta"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normalni font<br>i <u>podcrtano</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kurziv.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Debeli.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Debeli kurziv.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Font fiksne širine.<br> <b>debeli</b> <i>kurziv</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>debeli kurziv <u>podcrtano</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Pomoć za ispis"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Nije moguće ispisati praznu stranicu."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML datoteke (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Pomoćne knjige (*.htb)|*.htb|Pomoćne knjige (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML pomoćni projekt (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimirana HTML datoteka pomoći (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i od %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u od %u"
@@ -5535,32 +5550,6 @@ msgstr ""
 "Došlo je do problema prilikom postavljanja stranice: možda moraš postaviti "
 "zadani pisač."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Neuspjeo prikaz HTML dokumenta %s kodiranjem"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets nije uspio otvoriti zaslon za „%s”: prekid."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtar"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Mape"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Datoteke"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Odabir"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Neuspjelo otvaranje međuspremnika."
@@ -5602,58 +5591,58 @@ msgstr "Dijalog za boju odabira nije uspjeo, zbog greške %0lx."
 msgid "Failed to create cursor."
 msgstr "Neuspjelo stvaranje pokazivača."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Neuspjelo registriranje DDE servera „%s”"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Neuspjelo odjavljivanje DDE servera „%s”"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Neuspjelo povezivanje na server „%s” na temu „%s”"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE poke upit nije uspjeo"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Neuspjelo stvoriti advise petlju s DDE serverom"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Neuspjelo prekidanje advise petlje s DDE serverom"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Neuspjelo slanje DDE advise napomena"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Neuspjelo stvaranje DDE znakovnog niza"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "bez DDE greške."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "vrijeme zahtjeva za sinkroniziranu preporučenu transakciju je isteklo."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odgovor transakciji je prouzročilo, da se postavio DDE_FBUSY bit."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "vrijeme zahtjeva za sinkroniziranu transakciju podataka je isteklo."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5665,7 +5654,7 @@ msgstr ""
 "ili je jedan nevažeći identifikator instance\n"
 "proslijeđen DDEML funkciji."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5677,43 +5666,43 @@ msgstr ""
 "ili aplikacija inicijalizirana kao APPCMD_CLIENTONLY\n"
 "pokušala je izvršiti transakcije servera."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "vrijeme zahtjeva za sinkroniziranu izvršnu transakciju je isteklo."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "jedan parametar nije validiran od DDEML-a."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "jedna DDEML aplikacija je stvorila produljeno stanje."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "alociranje memorije nije uspjelo."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "pokušaj klijenta da uspostavi razgovor nije uspjeo."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "jedna transakcija nije uspjela."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "vrijeme zahtjeva za sinkroniziranu guranu transakciju je isteklo."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "interni poziv na funkciju PostMessage nije uspjeo. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema prilikom ponovnog ulaženja."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5723,15 +5712,15 @@ msgstr ""
 "koji je prekinut od strane klijenta ili ga je server prekinuo\n"
 "prije završetka transakcije."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "dogodila se interna greška u DDEML-u."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "vrijeme zahtjeva za prekidom preporučene transakcije je isteklo."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5741,12 +5730,12 @@ msgstr ""
 "Nakon što se aplikacija vrati iz povratnog poziva XTYP_XACT_COMPLETE,\n"
 "identifikator transakcije za taj povratni poziv više nije valjan."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Nepoznata DDE greška %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5754,7 +5743,7 @@ msgstr ""
 "Funkcije nazivanja nisu dostupne jer usluga daljinskog pristupa (RAS) nije "
 "instalirana na ovom računalu. Instaliraj ga."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5763,64 +5752,64 @@ msgstr ""
 "Na ovom računalu instalirana verzija usluge daljninskog pristupa (RAS) je "
 "pre stara, nadogradi je (nedostaje potrebna funkcija: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Neuspjelo dohvaćanje teksta iz RAS poruke o greškama"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "nepoznata greška (kod greške %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nije moguće naći aktivnu vezu pozivanja: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Pronađeno je nekoliko aktivnih veza, jedna je nasumce odabrana."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Neuspjelo stvaranje aktivne veze pozivanja: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Neuspjelo dobivanje ISP imena: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Neuspjelo povezivanje: nema ISP za biranje."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Odaberi ISP za biranje"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Odaberi davatelja internetskih usluga s kojim se želiš povezati"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Neuspjelo povezivanje: nedostaje korisničko ime/lozinka."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Nije moguće naći mjesto datoteke adresara"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Neuspjelo inicijaliziranje povezivanja: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nije moguće prekinuti poziv – nema aktivne veze pozivanja."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Neuspjelo prekidanje veze pozivanja: %s"
@@ -5840,18 +5829,17 @@ msgstr "Neuspjelo alociranje %lu Kb memorije za podatke bitmapa."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nije moguće numerirati datoteke u mapi „%s”"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Nije bilo moguće dobiti ime mape"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(greška %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Nije bilo moguće dodati sliku u popis slika."
 
@@ -5866,7 +5854,7 @@ msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Neuspjelo stvaranje standardnog traži/zamijeni dijaloga (kodna greška %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Greška u dijalogu, sa šifrom greške %0lx."
@@ -5909,16 +5897,16 @@ msgstr "Nije moguće postaviti sat za „%s”"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nije moguće praćenje promjena za nepostojeću mapu „%s”."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL driver ne podržava OpenGL 3.0 i novije."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Nije bilo moguće stvoriti OpenGL sadržaj"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Neuspjelo inicijaliziranje OpenGL-a"
 
@@ -5927,7 +5915,7 @@ msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 "Nije bilo moguće registrirati prilagođeni DirectWrite učitavač fontova."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5935,7 +5923,7 @@ msgstr ""
 "Funkcije za MS HTML pomoć nisu dostupne, jer biblioteka za MS HTML pomoć "
 "nije instalirana na ovom računalu. Instaliraj je."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Neuspjelo inicijaliziranje MS HTML pomoći."
 
@@ -5944,7 +5932,7 @@ msgstr "Neuspjelo inicijaliziranje MS HTML pomoći."
 msgid "Can't delete the INI file '%s'"
 msgstr "Nije moguće izbrisati INI datoteku „%s”"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nije bilo moguće pronaći informacije o kontrolnoj stavci popisa %d."
@@ -6064,7 +6052,7 @@ msgstr "Nije bilo moguće registrirati format međuspremnika „%s”."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format međuspremnika „%d” ne postoji."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Preskoči"
 
@@ -6149,76 +6137,76 @@ msgstr ""
 "Brisanjem će tvoj sustav postati nestabilan:\n"
 "operacija je prekinuta."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nije moguće izbrisati ključ „%s”"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nije moguće izbrisati vrijednost „%s” ključa „%s”"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nije moguće čitanje vrijednosti od ključa „%s”"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nije moguće postavljanje vrijednosti od „%s”"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Registarska vrijednost „%s” nije numerička (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Registarska vrijednost „%s” nije binarna (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Registarska vrijednost „%s” nije tekst (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nije moguće čitanje vrijednosti od „%s”"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nije moguće numeriranje vrijednosti ključa „%s”"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nije moguće numeriranje podključeva ključa „%s”"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Izvoz ključa registra: datoteka „%s” već postoji i neće biti prepisana."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nije moguće izvesti vrijednost nepodržane vrste %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Zanemarivanje vrijednosti „%s” tipke „%s”."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6226,41 +6214,41 @@ msgstr ""
 "Stvaranje uređivača bogatog teksta nije moguće, koristi se jednostavni "
 "uređivač. Instaliraj riched32.dll ponovo"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nije moguće započeti tijek: greška prilikom pisanja TLS-a."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Nije moguće postaviti prioritet komponente procesa"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Nije moguće stvoriti komponentu procesa"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Nije bilo moguće prekinuti komponentu procesa"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Nije moguće čekati na prekid komponente procesa"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nije moguće odgoditi komponentu procesa %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nije moguće nastaviti komponentu procesa %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Nije bilo moguće dobiti trenutačni označivač komponente procesa"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6268,7 +6256,7 @@ msgstr ""
 "Neuspjela inicijalizacija modula komponente procesa: nije moguće alocirati "
 "indeks u komponenti procesa lokalnog spremišta"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6300,12 +6288,12 @@ msgstr "Neuspjelo učitavanje resursa „%s”."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Neuspjelo zaključavanje resursa „%s”."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "gradnja %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bitno izdanje"
 
@@ -6317,46 +6305,46 @@ msgstr "Neuspjelo stvaranje anonimnog cjevovoda"
 msgid "Failed to redirect the child process IO"
 msgstr "Neuspjelo preusmjeravanje podređenog procesa ulaza/izlaza"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Izvršenje naredbe %s"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Neuspjelo učitavanje mpr.dll-a."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nije moguće čitati ime vrste od „%s”!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nije moguće učitati ikone iz „%s”."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "Neuspjelo pronalaženje razine emulacije web prikaza u registru"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Neuspjelo postavljanje web-prikaza na modernu razinu emulacije"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "Neuspjelo obnavljanje web-prikaza na standardnu razinu emulacije"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "JavaScript skripta se ne može pokrenuti bez valjanog HTML dokumenta"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Nije moguće dobiti JavaScript objekt"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "neuspjela evaluacija"
 
@@ -6389,7 +6377,7 @@ msgid "Check to make the font italic."
 msgstr "Aktiviraj za korištenje kurzivnog fonta."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podcrtano"
@@ -6456,15 +6444,33 @@ msgstr "<Bilo koji strojopisni>"
 msgid "File type:"
 msgstr "Vrsta datoteke:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Window"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Smanji"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zumiraj"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Postavi sve naprijed"
 
@@ -6481,463 +6487,463 @@ msgstr "Font-datoteka „%s” ne postoji."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Font-datoteka „%s” se ne može koristiti, jer se ne nalazi u mapi fontova "
 "„%s”."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "O programu %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "O programu …"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Postavke …"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Usluge"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Sakrij %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Sakrij aplikaciju"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Sakrij ostalo"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Prikaži sve"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Zatvori %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Zatvori aplikaciju"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Sustavsko upravljanje internetom ne podržava ispis"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Nije bilo moguće inicijalizirati operaciju za ispis"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Veličina u tipografskim točkama"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Ime fonta"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Debljina"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Obitelj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "Radna površina aplikacije"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "Aktivni rub"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "Aktivni podnaslov"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "Ploha gumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "Isticanje gumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "Sjena gumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "Tekst gumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "Tekst podnaslova"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "Upravljač tamno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "Upravljač svjetlo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "Sivi tekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Istakni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Istakni tekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "Rub neaktivnih"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "Podnaslov neaktivnih"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "Tekst podnaslova neaktivnih"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Izbornik"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Traka klizača"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Opis alata"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "Tekst opisa alata"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Window"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "Okvir prozora"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "Tekst prozora"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Prilagođeno"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Crna"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Kestenjasta"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Mornarsko plava"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Ljubičasta"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Plavozelena"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Siva"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Zelena"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Maslinasta"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Smeđa"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Plava"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuksija"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Crvena"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Narančasta"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Srebrna"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Limun"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Plavkasta"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Žuta"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Bijela"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Zadano"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Strelica"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Strelica-Desno"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Prazno"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Meta"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Znak"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Križić"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Ruka"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "Okomita crta"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Lijevi gumb"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Povećalo"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Srednji gumb"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Bez unosa"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Kist za bojenje"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Olovka"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Ukaži na lijevo"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Ukaži na desno"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Strelica-Upitnik"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Desni gumb"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Skaliranje SI-JZ"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Skaliranje S-J"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Skaliranje SZ-JI"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Skaliranje Z-I"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Skaliranje"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Sprej-limenka"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Čekaj"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Sat"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Strelica-Čekaj"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Stvori odabir:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Svojstvo"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Vrijednost"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Modus kategorizacije"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Slovni modus"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Netočno"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Točno"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Neodređeno"
 
@@ -6951,12 +6957,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Uneseni su nevaljane vrijednosti. Pritisni ESC za odustajanje od uređivanja."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Greška u resursu: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6965,36 +6971,36 @@ msgstr ""
 "Operacija vrste „%s” nije uspjela: Svojstvo s oznakom „%s” je vrste „%s”, NE "
 "„%s”."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Nepoznata osnova %d. Koristit će se osnova 10."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vrijednost mora biti %s ili veće."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Vrijednost mora biti između %s i %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vrijednost mora biti %s ili manje."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Nije %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Odaberi mapu:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Odaberi datoteku"
 
@@ -7461,117 +7467,117 @@ msgstr "Sužavanje"
 msgid "Outset"
 msgstr "Širenje"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Promijeni stil"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Promijeni stil objekta"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Promijeni svojstva"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Promijeni stil popisa"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Ponovi numeriranje"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Umetni tekst"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Umetni sliku"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Umetni objekt"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Umetni polje"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Previše EndStyle poziva!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "datoteke"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standardno/krug"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standardno/krug-kontura"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standardno/kvadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standardno/romb"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standardno/trokut"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Svojstva okvira"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Višestruka svojstva ćelije"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Svojstva ćelije"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Postavi stil ćelija"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Izbriši red"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Izbriši stupac"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Dodaj red"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Dodaj stupac"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Svojstva tablice"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Svojstva slike"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "slika"
 
@@ -7779,24 +7785,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Povuci"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Izbriši tekst"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Ukloni znak nabrajanja"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Nije bilo moguće spremiti tekst."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Zamijeni"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Font:"
 
@@ -8765,53 +8771,53 @@ msgstr "Stilovi popisa"
 msgid "Box styles"
 msgstr "Stil okvira"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Font, iz kojeg se preuzima simbol."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Podskupina:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Prikazuje Unicode podskupinu."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Slovni znak:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Kȏd slovnog znaka."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Prikazani opseg."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Umetni"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normalan tekst)"
 
@@ -8995,7 +9001,7 @@ msgstr "Nije moguće dobiti događaje iz kqueue"
 msgid "Media playback error: %s"
 msgstr "Greška u pokretanju medija: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Neuspjela priprema pokretanja „%s”."
@@ -9095,20 +9101,20 @@ msgstr "Zvukovni podaci imaju nepodržani format."
 msgid "Couldn't open audio: %s"
 msgstr "Nije bilo moguće otvoriti audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nije moguće pronaći pravila rasporeda komponente procesa."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nije moguće dobiti raspon prioriteta za pravilo rasporeda %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Postavka prioriteta komponente procesa je zanemarena."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9116,61 +9122,61 @@ msgstr ""
 "Neuspjelo povezivanje komponente procesa, otkrivena ja moguća nedostatna "
 "memorija – ponovo pokreni program"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Neuspjelo postavljanje razine podudarnosti komponente procesa na %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Neuspjelo postavljanje prioriteta komponente procesa %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Neuspjelo prekidanje komponente procesa."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Neuspjela inicijalizacija modula komponente procesa: neuspjela izrada ključa "
 "komponente procesa"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Nije moguće dobiti unos podređenog procesa"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Nije moguće pisanje u stdin podređenog procesa"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Neuspjelo izvršavanje „%s”\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Račvanje nije uspjelo"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Neuspjelo postavljanje prioriteta procesa"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Neuspjelo preusmjeravanje unosa/iznošaja podređenog procesa"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Neuspjelo postavljanje ne-blokirajućeg cjevovoda. Program će možda zastati."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Nije moguće dobiti ime hosta"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Nije moguće dobiti službeno ime hosta"
 
@@ -9186,12 +9192,12 @@ msgstr "Neuspjelo prebacivanje wake up cjevovoda u ne-blokirajući modus"
 msgid "Failed to read from wake-up pipe"
 msgstr "Neuspjelo čitanje iz wake-up cjevovoda"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Nevaljana specifikacija geometrije „%s”"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nije uspio otvoriti zaslon. Prekid."
 
@@ -9205,27 +9211,56 @@ msgstr "Neuspjelo zatvaranje prikaza „%s”"
 msgid "Failed to open display \"%s\"."
 msgstr "Neuspjelo otvaranje ekrana „%s”."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Greška u XML obradi: „%s” u %d. retku"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nije moguće učitati resurse iz „%s”."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nije moguće otvoriti datoteku resursa „%s”."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nije moguće učitati resurse iz datoteke „%s”."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Stvaranje %s „%s” nije uspjelo."
+
+#~ msgid "Printing "
+#~ msgstr "Ispisivanje "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Neuspjelo umetanje teksta u kontrolu."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Odaberi valjani font."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Neuspjeo prikaz HTML dokumenta %s kodiranjem"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nije uspio otvoriti zaslon za „%s”: prekid."
+
+#~ msgid "Filter"
+#~ msgstr "Filtar"
+
+#~ msgid "Directories"
+#~ msgstr "Mape"
+
+#~ msgid "Files"
+#~ msgstr "Datoteke"
+
+#~ msgid "Selection"
+#~ msgstr "Odabir"

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2009-07-26 20:12+0100\n"
 "Last-Translator: Oaron <oaron1@gmail.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -11,11 +11,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Minden fájlt (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Minden fájlt (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "A hátralevő idő : "
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Igen"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nem"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Ok"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Mégsem"
@@ -104,7 +101,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Nem sikerült lérehozni egér mutatót."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "Nyomtatás"
@@ -148,7 +145,7 @@ msgstr "&Tulajdonságok"
 msgid "Printing"
 msgstr "Nyomtatás"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 #, fuzzy
 msgid "Symbols"
 msgstr "&Stílus:"
@@ -218,7 +215,7 @@ msgstr "&Előző"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Ablak"
 
@@ -783,11 +780,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "ctrl"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "mutassa meg ezt az üzenetet a súgóban"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "készíts bőbeszédű naplóbejegyzéseket "
 
@@ -809,84 +806,84 @@ msgstr "A(z) '%s' bőr nem támogatott."
 msgid "Invalid display mode specification '%s'."
 msgstr "Hibás megjelenítési mód meghatározás: '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Ismeretlen hosszú opció '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Ismeretlen opció '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Váratlan '%s' paraméter"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A(z) '%s' beállítás egy értéket kér."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "A(z) '%s' választási lehetőség után elválasztó jelet vártam."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' nem megfelelő számérték a(z) '%s' beállításához."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "A(z) '%s' beállítása: '%s' nem alakítható át dátummá."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Váratlan '%s' paraméter"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (vagy %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "A(z) '%s' beállítás értékét meg kell adni."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "A szükséges '%s' paraméter nincs megadva."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Használat: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "dátum"
 
@@ -904,7 +901,7 @@ msgid "Can't &Undo "
 msgstr "Nem lehet &Visszavonni"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Visszavonás"
@@ -914,7 +911,7 @@ msgid "&Redo "
 msgstr "&Újra"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Újra"
@@ -943,12 +940,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' után felesleges '..'-t találtam, elhanyagoltam."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -958,103 +955,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "aláhúzott"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "ma"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "tegnap"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "holnap"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "első"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "második"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "harmadik"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "negyedik"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "ötödik"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "hatodik"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "hetedik"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "nyolcadik"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "kilencedik"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "tizedik"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "tizenegyedik"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "tizenkettedik"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "tizenharmadik"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "tizennegyedik"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "tizenötödik"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "tizenhatodik"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "tizenhetedik"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "tizennyolcadik"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "tizenkilencedik"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "huszadik"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "dél"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "éjfél"
 
@@ -1125,44 +1122,81 @@ msgstr "Nem sikerült a curl-t végrehajtani, kérem tegye elérhetővé a PATH-
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Nem sikerült létrehozni a hibakereső jelentéstt (hibakód : %d) "
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Mentés Másként"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "névtelen"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Elmentsem a(z) %s dokument változásait?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Mentés"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ne mentsd el"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Elmentsem a(z) %s dokument változásait?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "A szöveget nem tudom elmenteni."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Nem tudtam elmenteni a bittérképet a(z)  '%s' fájlba."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1171,58 +1205,58 @@ msgstr ""
 "A(z) '%s' fájl nem létezik és nem nyitható meg.\n"
 "A legutóbb használt fájlok listájáról is el van távolítva."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "A cső létrehozása nem sikerült"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Nyomtatási kép"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "névtelen%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Fájl Megnyitás"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Fájl hiba"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Sajnálom, nem tudtam megnyitni ezt a fájlt."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Sajnálom, ezt a fájl formátumot nem ismerem."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Válasszon dokumentum mintát"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Minták"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Válasszon dokumentum nézetet"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Nézetek"
 
@@ -1256,42 +1290,42 @@ msgstr "Olvasási hiba a(z) '%s' fájlban"
 msgid "Write error on file '%s'"
 msgstr "Irási hiba a(z) '%s' fájlban"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "nem sikerült kiüríteni a(z) '%s' fájl pufferét"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Keresési hiba a(z) '%s' fájlban (a nagy fájlokat nem támogatja a stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Keresési hiba a(z) '%s' fájlban"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nem találom a(z) '%s' fájlban a jelenlegi pozíciót"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Nem tudtam az átmeneti fájl engedélyeit beállítani."
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nem tudom eltávolítani a(z) '%s' fájlt"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nem tudom érvényre juttatni a(z) '%s' fájl változásait"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nem tudom eltávolítani a(z) '%s' átmeneti fájlt"
@@ -1316,28 +1350,28 @@ msgstr "nem tudok olvasni a(z) %d leíróval megadott fájból"
 msgid "can't write to file descriptor %d"
 msgstr "nem tudok írni a(z) %d leíróval megadott fájba"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nem tudom kiüríteni a(z) %d leíróval megadott fájl pufferét"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nem tudok keresni a(z) %d leíróval megadott fájlban"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nem találom a keresési pozíciót a(z) %d leíróval megadott fájlban"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "nem tudom meghatározni a fájl hosszát a(z) %d leíróval megadott fájlban"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1363,153 +1397,153 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Hiba a konfigurációs beállítások olvasásakor."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Hiba a konfigurációs beállítások olvasásakor."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "'%s' fájl: a(z) %c nem várt jel a(z) %d sorban."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "'%s' fájl, %d. sor: '%s' -t elhanyagoltam a csoport fejléce után."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "'%s' fájl, %d. sor: '=' -t vártam."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "file '%s', line %d: a változtathatatlan '%s' kulcs új értékét elhanyagoltam."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "'%s' fájl, %d. sor: a(z) '%s' kulcsot először a(z) %d sorban találtam meg."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurációs bejegyzés nem kezdődhet '%c'-vel."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "nem tudom megnyitni a felhasználó konfigurációs fájlját."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "nem tudom írni a felhasználó konfigurációs fájlját."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Hiba a felhasználói konfigurációs beállítások elmentésekor."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "nem tudom törölni a(z) '%s' felhasználói konfigurációs fájlt"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a(z) '%s' elem egynél többször jelenik meg a(z) '%s' csoportban"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 "elhanyagoltam a változtathatatlan '%s' kulcs megváltoztatására tett "
 "kísérletét."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "váratlan \" a(z) %d pozícióban, a(z) '%s' fájlban."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Nem sikerült lemásolni a(z) '%s' fájlt  '%s'-be."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nem kapom meg a '%s' fájl engedélyeit."
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nem sikerült felülírni ni a(z) '%s' fájlt."
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Nem sikerült lemásolni a(z) '%s' fájlt  '%s'-be."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nem lehet beállítani a  '%s' fájl engedélyeit."
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nem sikerült létrehozni a(z) '%s' könyvtárat"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nem tudom megszámolni a(z) '%s'  fájlokat"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Nem sikerült létrehozni a munkakönyvtárat."
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Nem sikerült létrehozni a munkakönyvtárat."
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Fájlok (%s)"
@@ -1536,17 +1570,17 @@ msgstr "Nem sikerült létrehozni átmeneti fájlnevet."
 msgid "Failed to open temporary file."
 msgstr "Nem tudtam megnyitni az átmeneti fájlt."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Nem sikerült módosítani a(z) időket '%s'-re."
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Nem sikerült megérinteni a(z) '%s't."
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Nem sikerült helyrehozni a fájl időket '%s'-re."
@@ -1555,22 +1589,22 @@ msgstr "Nem sikerült helyrehozni a fájl időket '%s'-re."
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Minden fájlt (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s fájl (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "A(z) %s fájl betöltése"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "A(z) %s fájl elmentése"
@@ -1944,109 +1978,109 @@ msgstr "alapértelmezés"
 msgid "unknown-%d"
 msgstr "ismeretlen-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "aláhúzott"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "vékony"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 #, fuzzy
 msgid " light"
 msgstr "vékony"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "félkövér"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 #, fuzzy
 msgid " bold"
 msgstr "félkövér"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "félkövér"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 #, fuzzy
 msgid " italic"
 msgstr "dőlt"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "vékony"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "vékony"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normál"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "félkövér"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "félkövér"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "félkövér"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "dőlt"
 
@@ -2128,7 +2162,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Nem tudtam a(z) '%s' FTP átviteli módot beállítani."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2149,7 +2183,7 @@ msgstr "Az FTP kiszolgáló nem támogatja a passzív módot."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Nem sikerült lérehozni egér mutatót."
@@ -2168,7 +2202,7 @@ msgstr "Jelkészlet méret"
 msgid "&Customize..."
 msgstr "Jelkészlet méret"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
@@ -2188,158 +2222,157 @@ msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nem tudtam elmenteni a hibás képet."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: a wxImage-nek nincs saját wxPalette-je."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nem tudtam kiírni a fájl (bittérkép) fejet."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nem tudtam kiírni a fájl (bittérkép info) fejet."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nem tudtam kiírni az RGB színtérképet."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nem tudtam kiírni az adatokat."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nem sikerült memóriát foglalni."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB fej: A képszélesség a fájl-ban  > 32767 pixel."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB fej: A képmagasság a fájl-ban  > 32767 pixel."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB fej: Ismeretlen bitmélység a fájl-ban."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB fej: Ismeretlen kódolás a fájl-ban."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB fej: A kódolás nem felel meg a bitmélységnek."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Nem sikerült memóriát foglalni."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB fej: A képszélesség a fájl-ban  > 32767 pixel."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB fej: A képmagasság a fájl-ban  > 32767 pixel."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB fej: Ismeretlen bitmélység a fájl-ban."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB fej: Ismeretlen kódolás a fájl-ban."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB fej: A kódolás nem felel meg a bitmélységnek."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Hiba a DIB kép olvasásakor."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Hiba a DIB maszk olvasásakor."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: A kép túl magas az ikon számára."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: A kép túl széles az ikon számára."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Hiba a kép írásakor!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Hibás icon index."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "A kép és a maszk mérete különböző."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "A képben nincs maszkolva nem használt szín."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Nem tudtam betölteni a(z) %d képet a  '%s' fájlból."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Nem tudom elmenteni a képet a(z) '%s' fájlba: nincs ilyen kiterjesztés."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Ilyen típusú képhez nem találtam kezelőt."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d  típusú képhez nincs kezelő meghatározva."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "A kép nem %d típusú."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "adatformátum hiba"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: ez nem PCX fájl."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s  típusú képhez nincs kezelő meghatározva."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "A kép nem %d típusú."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Nem tudtam elmenteni a bittérképet a(z)  '%s' fájlba."
@@ -2442,52 +2475,52 @@ msgstr "PNM: A fájl csonkítottnak tűnik."
 msgid " (in module \"%s\")"
 msgstr "tiff modul: %s"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Hiba a kép betöltésekor."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Hibás TIFF kép index."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nem tudtam memóriát foglalni."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Hiba a kép olvasásakor."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Hiba a kép elmentésekor."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Hiba a kép írásakor."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Az inicializálás utolsó fázisa nem sikerült, kilépek."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2585,7 +2618,7 @@ msgstr "tömörítési hiba"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Páratlan '{' a(z) %s mime típus egyik elemében."
@@ -2605,7 +2638,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr "Nem sikerült inicializálni a \"%s\" modult"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "%s üzenet"
@@ -3110,7 +3143,7 @@ msgstr "Nyomtatási hiba"
 msgid "Print"
 msgstr "Nyomtatás"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Oldal beállítás "
 
@@ -3146,20 +3179,16 @@ msgstr "A(z) %d. oldalt nyomtatom..."
 msgid " (copy %d of %d)"
 msgstr "%d. oldal (%d-ből)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Nyomtatás"
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "Következő oldal"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Előző oldal"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Következő oldal"
 
@@ -3206,16 +3235,16 @@ msgstr "%d. oldal (%d-ből)"
 msgid "Page %d"
 msgstr "%d. oldal"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "ismeretlen hiba"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Hibás szabályos kifejezés '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Nem sikerült megtalálni '%s'-t  a(z) '%s' szabályos kifejezésben."
@@ -3226,21 +3255,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "A \"%s\" renderer  verziója %d.%d nem megfelelő és ezért nem lehet betölteni."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
@@ -3249,11 +3278,11 @@ msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Mentés"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Ne mentsd el"
 
@@ -3340,10 +3369,10 @@ msgid "Clear"
 msgstr "&Törlés"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Bezárás"
 
@@ -3357,7 +3386,7 @@ msgstr "Tartalom"
 msgid "Convert"
 msgstr "Tartalom"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Másolás"
@@ -3367,7 +3396,7 @@ msgstr "&Másolás"
 msgid "Copy"
 msgstr "&Másolás"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Kivágás"
@@ -3377,13 +3406,13 @@ msgstr "&Kivágás"
 msgid "Cut"
 msgstr "&Kivágás"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Törlés"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 #, fuzzy
 msgid "Delete"
@@ -3480,7 +3509,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Súgó"
 
@@ -3500,7 +3529,7 @@ msgstr "Bekezdés"
 msgid "&Index"
 msgstr "&Tartalom mutató"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Tartalom mutató"
 
@@ -3574,7 +3603,7 @@ msgstr "Ú&j "
 msgid "New"
 msgstr "Ú&j "
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nem"
 
@@ -3592,12 +3621,12 @@ msgstr "&Megnyitás..."
 msgid "Open..."
 msgstr "&Megnyitás..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Beillesztés"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 #, fuzzy
 msgid "Paste"
@@ -3632,7 +3661,7 @@ msgid "Print..."
 msgstr "&Nyomtatás..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Tulajdonságok"
 
@@ -3668,10 +3697,6 @@ msgstr "&Helyettesítés"
 msgid "Revert to Saved"
 msgstr "Cseréld vissza az elmentettre"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Mentés"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Mentés másként..."
@@ -3681,7 +3706,7 @@ msgstr "&Mentés másként..."
 msgid "Save As..."
 msgstr "&Mentés másként..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Válassz ki &minden fájlt"
@@ -3800,7 +3825,7 @@ msgstr "&Fel"
 msgid "Up"
 msgstr "Fel"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Igen"
 
@@ -3899,44 +3924,44 @@ msgstr "Válasszon dokumentum nézetet"
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "A  '%s' jelkészletté alakítás nem működik."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "ismeretlen"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 #, fuzzy
 msgid "unexpected end of file"
 msgstr "Váratlanul véget ért a fájl az erőforrás értelmezése során. "
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3945,7 +3970,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' valószínűleg bináris fájl."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "A fájlt nem tudtam betölteni."
 
@@ -3959,49 +3984,49 @@ msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 msgid "can't write buffer '%s' to disk."
 msgstr "nem tudom a mágneslemezre írni a(z) '%s' puffert."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Nem kaptam meg a helyi rendszer időt."
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay hibát eredményezett."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' érvénytelen üzenet katalógus."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' érvénytelen üzenet katalógus."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Nem tudom értelmezni a(z)  '%s' többes számú alakotat"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "a(z) '%s' katalógust használom (a(z) '%s' közül)."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' érvénytelen üzenet katalógus."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Nem tudtam befejezni a szálat"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
@@ -4034,7 +4059,7 @@ msgstr "'%s' csak betűket tartalmazhat."
 msgid "Error: %s (%d)"
 msgstr "Hiba: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4043,21 +4068,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "A fájlt nem tudtam betölteni."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Szöveg átalakítást nem támogatok"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Nem tudtam adatot átvinni az ablakba"
 
@@ -4109,8 +4134,8 @@ msgstr "Nem találtam"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Hibás objektum osztály (Nem-wxEvtHandler) szerepel esemény forrásként"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "A típust enum-ról long-ra kell alakítani"
 
@@ -4161,79 +4186,79 @@ msgstr "Az objektumoknak id jellemzúvel is rendelkezniük kell"
 msgid "Doubly used id : %d"
 msgstr "Másodszor használt azonosító : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Ismeretlen tulajdonság %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Egy nem-üres gyűjteménynek 'elem' csomópontokból kell állnia"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "hibás eseménykezelő szöveg, a pont hiányzik"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Nem tudom megkezdenii a zlib folyam kifejtését."
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Nem tudom elindítani a zlib folyam tömörítését."
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "azt hiszem ez egy több-részes zip egymás után pakolva"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "Hibás zip fájl."
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "nem találom a fő könyvtárat a zip-ben"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "hiba a zip fő könyvtár olvasásakor"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "hiba a zip lokális fejrészének olvasásakor"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "hibás zip-fájl offset"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "a Zip fejrészben nincs meg a tárolt fájl hossza"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "nem támogatott Zip tömörítési módszer"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "a zip folyam olvasása ( a(z) %s adat): hibáshossz"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "a zip folyam olvasása ( a(z) %s adat): hibás crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "hiba a(z) '%s' zip adat írásakor: hibás crc vagy hossz"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "hiba a(z) '%s' zip adat írásakor: hibás crc vagy hossz"
@@ -4319,33 +4344,33 @@ msgstr ""
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Jogosultságok"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "&Névjegy..."
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr ""
 
@@ -4397,44 +4422,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Fájl"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (vagy %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4445,8 +4469,7 @@ msgid "Left"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 #, fuzzy
@@ -4547,7 +4570,7 @@ msgid "Home directory"
 msgstr "Saját könyvtár"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Asztal"
 
@@ -4560,8 +4583,7 @@ msgstr "Hibás könyvtár név."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Hiba"
 
@@ -4747,16 +4769,16 @@ msgstr "A fájlok bemutatása részletezve"
 msgid "Go to parent directory"
 msgstr "Menj a szülő könyvtárba"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "A(z) '%s file már létezik, valóban  felül akarja írni?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Megerősítés"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Kérem válasszon egy létező fájlt."
 
@@ -4851,7 +4873,7 @@ msgstr "A jelkészlet mérete."
 msgid "Whether the font is underlined."
 msgstr "Hogy aláhúzza-e a betűket."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Előkép:"
@@ -4869,48 +4891,47 @@ msgstr "Kattints ide a betűtípus választás törléséhez"
 msgid "Click to confirm the font selection."
 msgstr "Kattints ide a betűtípus választás megerősítéséhez"
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Válasszon betűtípust"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "a(z) '%s' domén konfigurációs fájlját nem találom."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Nem találtam elemet."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Súgó tartalomjegyzék"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "A megfelelő tagok:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "A talált bejegyzések"
 
@@ -5019,59 +5040,59 @@ msgstr "Nem tudom elindítani a nyomtatást."
 msgid "Printing page %d..."
 msgstr "A(z) %d. oldalt nyomtatom..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Nyomtató lehetőségek"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Nyomtatás fájlba"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Beállítás..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Nyomtató:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Állapot:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Mindet"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Oldalak"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Nyomtatási tartomány"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Tól:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Ig:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Másolat(ok):"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript fájl"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Nyomtatási beállítások"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Nyomtató"
 
@@ -5079,25 +5100,25 @@ msgstr "Nyomtató"
 msgid "Default printer"
 msgstr "Az alapértelmezett nyomtató"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Papír méret"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Álló"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Tájkép"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Irányultság"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Lehetőségek"
 
@@ -5109,54 +5130,54 @@ msgstr "Színes nyomtatás"
 msgid "Print spooling"
 msgstr "Nyomtatás sorbaállítással"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Nyomtató parancs:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Nyomtató lehetőségek:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Bal margó (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Felső margó (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Jobb margó (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Alsó margó (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Nyomtató..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 #, fuzzy
 msgid "&Skip"
 msgstr "Ugrás"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 #, fuzzy
 msgid "Unknown"
 msgstr "ismeretlen"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Kész."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Keresés"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Nem találok lapválasztót az azonosítóhoz"
 
@@ -5192,22 +5213,22 @@ msgstr "Be&fejez"
 msgid "< &Back"
 msgstr "< &Vissza"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Nem sikerült létrehozni a(z) \"%s\" könyvtárat"
@@ -5233,12 +5254,12 @@ msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Nem tudom frissíteni a felhasználó konfigurációs fájlját."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Végzetes hiba"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5246,7 +5267,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5254,7 +5275,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI gyermek"
 
@@ -5272,36 +5293,27 @@ msgstr "Hiba történt a semaforra várakozás során"
 msgid "Page Setup"
 msgstr "Oldal beállítás"
 
-#: ../src/gtk/textctrl.cpp:1273
-#, fuzzy
-msgid "Failed to insert text in the control."
-msgstr "Nem sikerült létrehozni a munkakönyvtárat."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Kérem válasszon egy érvényes jelkészletet."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5400,45 +5412,45 @@ msgstr "Nem tudom megnyitni a(z) %s tartalom fájlt"
 msgid "Cannot open index file: %s"
 msgstr "Nem tudom a(z) %s index fájlt megnyitni"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "névtelen"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nem tudom megnyitni a(z) %s súgó könyvet"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(könyvjelzők)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Add hozzá ezt a lapot a könyvjelzőkhöz"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Töröld ezt az oldalt a könyvjelzők közül"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Tartalom"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Keres"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Mutatsd mindet"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5446,19 +5458,19 @@ msgstr ""
 "Írja ki az összes index bejegyzést, ami tartalmazza az adott bejegyzést. A "
 "keresés kis/nagy betűre nem érzékeny."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Mutasd meg a tartalom mutató valamennyi elemét"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Kis/nagybetűk különbözőek"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Csak egész szavak"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -5467,147 +5479,147 @@ msgstr ""
 "Keresd meg a fentebb beírt szöveg valamennyi előfordulását a súgó "
 "könyv(ek)ben"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Bemutatja/elrejti az irányító elemeket"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Menj vissza"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Menj előre"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Menj a dokumentum hierarchia eggyel magasabb szintjére"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Nyisd meg a HTML dokumentumot"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Nyomtasd ezt az oldalt"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Képernyő beállítási párbeszédablak"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Kérem válassza ki a látni kívánt oldalt:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Súgó témakörök"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Keresek..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Még nem találtam egy megfelelő oldalt"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i megfelelőt találtam"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Súgó)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i. (össz %i)"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i. (össz %i)"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Keresés az összes könyvben"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Súgó Böngésző beállítások"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normál jelkészlet:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Nem skálázható jelkészlet:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Jelkészlet mérete:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "Jelkészlet méret"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normál btű<br>and <u>aláhúzva</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Dőlt betű.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Félkövér betű.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Félkövér dőlt betű.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Rögzített méretű betű.<br> <b>bold</b> <i>dőlt</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>félkövér dőlt <u>aláhúzott</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Súgó nyomtatás"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Nem tudok üres oldalt nyomtatni."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML fájlok (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Súgó könyvek (*.htb)|*.htb|Súgó könyvek (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Tömörített HTML súgó file (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i. (össz %i)"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i. (össz %i)"
@@ -5680,32 +5692,6 @@ msgstr ""
 "Az oldal beállításakor hiba történt: lehet hogy az alapértelmezett nyomtatót "
 "kellene beállítania."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Nem sikerült a HTML dokumentumot %s kódolással megjeleníteni"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "a wxWidgets nem tudott képernyőt nyitni '%s' számára: kilépés."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Szűrő"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Könyvtárak"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Fájlok"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Kiválasztott"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Nem tudtam megnyitni a vágólapot."
@@ -5747,59 +5733,59 @@ msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
 msgid "Failed to create cursor."
 msgstr "Nem sikerült lérehozni egér mutatót."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Nem tudtam regisztrálni a(z) '%s' DDE kiszolgálót"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Nem tudtam a(z) '%s' DDE kiszolgáló regisztrációját megszüntetni."
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 "Nem sikerült kapcsolatot létrehozni a '%s' kiszolgálóval a '%s' témában"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE adatbeírás nem sikerült"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Nem sikerült létrehozni tanácsadói kapcsolatot a DDE kiszolgálóval"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Nem tudtam befejezni a tanácskozási ciklust a DDE kiszolgálóval."
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Nem sikerült DDE tanácsot küldeni."
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Nem sikerült létrehozni a DDE láncot"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "nincs DDE hiba."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "a szinkron tanácskérési tranzakció nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a tranzakció eredményeként a DDE_FBUSY bit beállítódott."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "a szinkron adatkérési tranzakció nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5811,7 +5797,7 @@ msgstr ""
 "vagy érvénytelen instance azonosítót \n"
 "adott át a DDEML függvénynek."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5823,43 +5809,43 @@ msgstr ""
 "vagy  APPCMD_CLIENTONLY-ként inicializált alkalmazás\n"
 "próbált meg kiszolgáló tranzakciót végezni."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "a szinkron végrehajtás kérési tranzakció nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "a paramétert nem sikerült érvényesíttetni a DDEML-lel."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "a DDEML alkalmazás meghosszabított versenyhelyzetet teremtett."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "a memória lefoglalása nem sikerült."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "nem sikerült az ügyfél próbálkozása a párbeszéd létrehozására."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "sikertelen tranzakció."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "a szinkron adatlerakás kérési tranzakció nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "egy belső PostMessage függvényhívás nem sikerült. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "újrabelépési probléma."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5869,16 +5855,16 @@ msgstr ""
 "amelyiket az ügyfél már befejezett, vagy a kiszolgáló\n"
 "a tranzakció befejezése előtt kilépett."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "belső hiba történt a DDEML-ben."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "a  tanácskozási tranzakció befejezésének kérése nem fejeződött be időre."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5888,12 +5874,12 @@ msgstr ""
 "Ha az alkalmazás visszatért egy XTYP_XACT_COMPLETE visszahívásból,\n"
 "a tranzakció azonosítója erre a hívásra már nem érvényes."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Ismeretlen DDE hiba %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5901,7 +5887,7 @@ msgstr ""
 "A tárcsázó funkciók nem használhatók, mert a távoli elérés szolgáltatás "
 "(RAS) nincs installálva ezen a gépen. Kérem installálja."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5910,69 +5896,69 @@ msgstr ""
 "Az ezen a gépre installált távoli hozzáférési lehetőség  (RAS) túl régi, "
 "kérem frissítsen (A(z) %s szükséges funkció hiányzik)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Nem sikerült értelmezni a RAS hibaüzenet szövegét."
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "ismeretlen hiba (hiba kód %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nem találom a(z) %s aktív telefonos kapcsolatot"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Több aktív telefonkapcsolatot találtam, az egyiket véletlenszerűen "
 "kiválasztom."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Nem sikerült létrehozni a telefonos kapcsolatot: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Nem kaptam meg a(z) %s ISP(szolgáltató) neveket"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 "Nem sikerült létrehozni a kapcsolatot: nincs tárcsázható szolgáltató (ISP)."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Válassza ki a tárcsázandó szolgáltatót (ISPt)!"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Kérem válassza ki, melyik szolgáltatóhoz (ISP) akar kapcsolódni."
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr ""
 "Nem sikerült létrehozni a kapcsolatot: hiányzik a felhasználói név vagy a "
 "jelszó."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Nem találom a címjegyzék fájl helyét"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Nem tudtam befejezni a(z) %s telefon kapcsolatot."
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nem tudom letenni - nincs aktív telefonkapcsolat."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Nem tudtam befejezni a(z) %s telefon kapcsolatot."
@@ -5992,19 +5978,18 @@ msgstr "Nem sikerült %luKb tárterületet foglalni a memóriatérkép adatoknak
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nem tudom megszámolni a(z) '%s' könyvtárban a fájlokat"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Nem tudtam időzítőt létrehozni"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr "(hiba %ld: %s) "
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Nem tudok egy képet a képek listájához hozzáadni."
 
@@ -6020,7 +6005,7 @@ msgstr ""
 "Nem sikerült létrehozni a keresés-helyettesítés párbeszéd ablakot (hibakód : "
 "%d) "
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot, hibakód: %ul"
@@ -6063,17 +6048,17 @@ msgstr "Nem sikerült megérinteni a(z) '%s't."
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Nem tudtam időzítőt létrehozni"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Nem tudom elindítani az OpenGLt."
 
@@ -6081,7 +6066,7 @@ msgstr "Nem tudom elindítani az OpenGLt."
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6089,7 +6074,7 @@ msgstr ""
 "A MS HTML funkciók nem használhatók, mert a MS HTML Help könyvtár nincs "
 "installálva ezen a gépen. Kérem installálja."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Nem sikerült elindítani az MS HTML súgót."
 
@@ -6098,7 +6083,7 @@ msgstr "Nem sikerült elindítani az MS HTML súgót."
 msgid "Can't delete the INI file '%s'"
 msgstr "Nem tudom törölni a '%s' INI fájt"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nem kaptam információt a lista vezérlő %d eleméről."
@@ -6220,7 +6205,7 @@ msgstr "Nem tudtam regisztrálni a(z) '%s' vágólap formátumot."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "A(z) '%d' vágólap formátum nem létezik."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Ugrás"
 
@@ -6306,76 +6291,76 @@ msgstr ""
 "annak törlése használhatatlanná teszi az Ön rendszerét:\n"
 "a műveletet nem hajtom végre."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nem tudom törölni a(z) '%s' kulcsot"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nem tudom törölni a '%s' értéket a '%s' kulcsból"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nem tudom olvasni a(z) '%s' kulcs értékét"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nem tudom a(z) '%s' értéket beállítani"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nem tudom olvasni a(z) '%s' értékét"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nem tudtam megszámlálni a(z) '%s' kulcs értékeit"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nem tudtam megszámlálni a(z) '%s' kulcs alkulcsait"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Registry kulcs exportálás: a fájl \"%s\" már létezik és nem írom felül."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nem tudom a nem támogatott %d típusú értékeket exportálni."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Nem írom be a \"%s\" értéket a \"%s\" kulcsba."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6383,41 +6368,41 @@ msgstr ""
 "Nem tudok formázott szövegkontrollt készíteni, egyszerű szövegkontrollt "
 "használok helyette. Kérem installálja újra a riched32.dll fájlt"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nem tudom elindítani a szálat: hiba a TLS írásakor."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Nem tudom a szál prioritását beállítani"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Nem tudom létrehozni a szálat"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Nem tudtam befejezni a szálat"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Nem tudom megvárni a szál befejeződését"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nem tudom felfüggeszteni a(z) %x szálat"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nem tudom folytatni a(z) %x szálat"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Nem kaptam meg a mutatót a jelenlegi szálhoz"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6425,7 +6410,7 @@ msgstr ""
 "A szál modul inicializálása nem sikerült: nem lehet indexet foglalni a szál "
 "helyi tárolájában"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6458,12 +6443,12 @@ msgstr "Nem tudtam betölteni a metafájlt a(z)  '%s' fájlból."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Nem sikerült lelakatolni a(z) '%s' lakat fájlt."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (build %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6475,47 +6460,47 @@ msgstr "Nem sikerült lérehozni a névtelen csövet."
 msgid "Failed to redirect the child process IO"
 msgstr "Nem tudtam átirányítani a gyermek processz be/kimenetét"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Nem sikerült végrehajtani a(z) '%s' parancsot"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Nem tudtam betölteni az mpr.dll-t."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nem tudom elolvasni '%s' típusának nevét."
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nem tudom betölteni az ikont '%s'-ből."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Nem tudom a szál prioritását beállítani"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Nem sikerült végrehajtani '%s'-t\n"
@@ -6555,7 +6540,7 @@ msgid "Check to make the font italic."
 msgstr "Kattints ide a betűtípus választás törléséhez"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 #, fuzzy
 msgid "Underlined"
@@ -6635,17 +6620,32 @@ msgstr "Teletype"
 msgid "File type:"
 msgstr "Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Ablak"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Súgó"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimalizál"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "&Nagyítás"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6662,492 +6662,492 @@ msgstr "A(z) '%s' file nem létezik."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "&Névjegy..."
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "&Névjegy"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "&Előválasztás"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Súgó: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Kiválasztott"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Mutatsd mindet"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "&Kilépés"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Kiválasztott"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "A zlib ezen változata nem támogatja gzip-et"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Nem tudom elindítani a megjelenítést."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "Jelkészlet &pontmérete:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "ÚjNév"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 #, fuzzy
 msgid "Style"
 msgstr "&Stílus:"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "Hang&súly:"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "Jelkészlet család:"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "vékony"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Ablak"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Ablak"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Ablak"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Jelkészlet méret"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "&Újra"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "alapértelmezés"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "holnap"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Vékony"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Jelkészlet &pontmérete:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Jobbra igazíts"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Kérdés"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Vékony"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Vékony"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Kiválasztott"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "&Tulajdonságok"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 #, fuzzy
 msgid "False"
 msgstr "Fájl"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 #, fuzzy
 msgid "Unspecified"
 msgstr "Jóváhagyva"
@@ -7162,49 +7162,49 @@ msgstr "Nyomtatási hiba"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Adjon meg egy oldalszámot %d és %d között:"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "&Névjegy..."
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Hozzon létre könyvtárat"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "Válasszon betűtípust"
@@ -7691,128 +7691,128 @@ msgstr "Bekezdés"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "Bekezdés"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "Bekezdés"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 #, fuzzy
 msgid "files"
 msgstr "Fájlok"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Bejegyzés törlése"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "&Törlés"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "Kiválasztott"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Tulajdonságok"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr ""
 
@@ -8025,27 +8025,27 @@ msgstr ""
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 #, fuzzy
 msgid "Delete Text"
 msgstr "Bejegyzés törlése"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Töröld"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "A szöveget nem tudom elmenteni."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 #, fuzzy
 msgid "Replace"
 msgstr "&Helyettesítés"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 #, fuzzy
 msgid "&Font:"
 msgstr "Jelkészlet család:"
@@ -9116,56 +9116,56 @@ msgstr ""
 msgid "Box styles"
 msgstr "&Következő >"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 #, fuzzy
 msgid "&From:"
 msgstr "Tól:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 #, fuzzy
 msgid "Unicode"
 msgstr "&Kikezdés"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 #, fuzzy
 msgid "Insert"
 msgstr "Bekezdés"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 #, fuzzy
 msgid "(Normal text)"
 msgstr "Normál jelkészlet:"
@@ -9366,7 +9366,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
@@ -9466,20 +9466,20 @@ msgstr "A hang adat ismeretlen formátumban van."
 msgid "Couldn't open audio: %s"
 msgstr "Nem tudtam megnyitni a(z) '%s' audiot"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nem találom a szál ütemezés előírásait."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nincs prioritási tartomány a(z) %d ütemezési előíráshoz."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "A szál prioritás beállítását elhanyagoltam."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9487,62 +9487,62 @@ msgstr ""
 "Nem tudtam a szálhoz csatlakozni, valószínűleg memória lyukat találtam - "
 "kérem indítsa újra a programot"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Nem tudtam befejezni a szálat."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "A szál modul inicializálása nem sikerült: nem sikerült a szálhoz kulcsot "
 "készíteni"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Nem kapom meg a gyermek processz bemenetét."
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Nem tudtam megölni a '%d' folyamatot."
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Nem sikerült végrehajtani '%s'-t\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "A folyamat elágaztatása nem sikerült"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Nem tudtam a(z) %d szál prioritást beállítani."
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Nem tudtam átirányítani a gyermek processz be/kimenetét."
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Nem ismerem a gazdagép nevét"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Nem ismerem a gazdagép hivatalos nevét"
 
@@ -9560,12 +9560,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "Nem sikerült elolvasni a PID-t a lakat fájlból."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Hibás geometriai meghatározás: '%s'."
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "A wxWidgets nem tudott képernyőt nyitni. Kilépés."
 
@@ -9579,30 +9579,60 @@ msgstr "Nem sikerült lezárni a vágólapot."
 msgid "Failed to open display \"%s\"."
 msgstr "Nem tudtam megnyitni '%s'-t %s-ként."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML értelmezési hiba: '%s' a(z) %d sorban"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nem tudom betölteni az erőforrást a(z) '%s' fájlból."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
+
+#~ msgid "Printing "
+#~ msgstr "Nyomtatás"
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Nem sikerült létrehozni a munkakönyvtárat."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Kérem válasszon egy érvényes jelkészletet."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Nem sikerült a HTML dokumentumot %s kódolással megjeleníteni"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "a wxWidgets nem tudott képernyőt nyitni '%s' számára: kilépés."
+
+#~ msgid "Filter"
+#~ msgstr "Szűrő"
+
+#~ msgid "Directories"
+#~ msgstr "Könyvtárak"
+
+#~ msgid "Files"
+#~ msgstr "Fájlok"
+
+#~ msgid "Selection"
+#~ msgstr "Kiválasztott"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "nem sikerült 8 bites kódolásúvá alakítani"
@@ -9748,8 +9778,8 @@ msgstr "Nem sikerült kifejteni  '%s'-t '%s'-be"
 #~ msgstr "Nem tudom elindítani a nyomtatást."
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/id.po
+++ b/locale/id.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2020-06-26 21:31+0700\n"
 "Last-Translator: Hertatijanto Hartono <dvertx@gmail.com>\n"
 "Language-Team: ID <doplank@gmx.com>\n"
@@ -16,11 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Poedit-Bookmarks: 912,-1,-1,-1,-1,-1,-1,-1,-1,1004\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Semua berkas (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Semua berkas (*)|*"
 
@@ -37,24 +37,21 @@ msgid "Remaining time:"
 msgstr "Waktu tersisa:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ya"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Tidak"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancel"
@@ -104,7 +101,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Gagal membuat penyelesaian port I/O"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Hasil cetakan"
 
@@ -141,7 +138,7 @@ msgstr "Properti Obyek"
 msgid "Printing"
 msgstr "Mencetak"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simbol"
 
@@ -210,7 +207,7 @@ msgstr "&Sebelumnya"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Jendela"
 
@@ -740,11 +737,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "tampilkan pesan bantuan ini"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "hasilkan pesan log lengkap"
 
@@ -766,84 +763,84 @@ msgstr "Tema '%s' tidak didukung."
 msgid "Invalid display mode specification '%s'."
 msgstr "Spesifikasi mode tampilan %s tidak sah."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Opsi '%s' tidak boleh negatif"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Pilihan panjang '%s' tidak dikenal"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Pilihan '%s' tidak diketahui"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Karakter tidak diharapkan setelah opsi '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Pilihan '%s' memerlukan suatu nilai."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Pemisah diharapkan setelah pilihan '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' bukan suatu nilai numerik yang benar untuk pilihan '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Pilihan '%s': '%s' tidak bisa dikonversi ke suatu tanggal."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parameter ‘%s’ tidak diharapkan"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (atau %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Nilai untuk pilihan '%s' harus dispesifikasikan."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Parameter '%s' yang dibutuhkan tidak dispesifikasikan."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Penggunaan: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "angka"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "ganda"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "tanggal"
 
@@ -861,7 +858,7 @@ msgid "Can't &Undo "
 msgstr "Tidak Bisa &Urungkan "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Urungkan"
@@ -871,7 +868,7 @@ msgid "&Redo "
 msgstr "&Kerjakan Lagi "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Kerjakan Lagi"
@@ -900,12 +897,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' mempunyai '..' ekstra, diabaikan."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "tercentang"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "tidak dicentang"
 
@@ -914,103 +911,103 @@ msgstr "tidak dicentang"
 msgid "undetermined"
 msgstr "tidak diketahui"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "hari ini"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "kemarin"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "esok"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "pertama"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "kedua"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "ketiga"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "keempat"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "kelima"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "keenam"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "ketujuh"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "kedelapan"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "kesembilan"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "kesepuluh"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "kesebelas"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "keduabelas"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "ketigabelas"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "keempatbelas"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "kelimabelas"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "keenambelas"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "ketujuhbelas"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "kedelapanbelas"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "kesembilanbelas"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "keduapuluh"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "siang"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "tengah malam"
 
@@ -1076,44 +1073,81 @@ msgstr "Gagal mengeksekusi curl, tolong install di PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Gagal mengupload laporan debut (kode error %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Simpan Sebagai"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Batalkan semua perubahan dan buka ulang simpanan versi terakhir?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "tanpa nama"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Apakah anda ingin menyimpan perubahan ke %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Simpan"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Jangan Save"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Apakah anda ingin menyimpan perubahan ke %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Teks tidak bisa disimpan."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Berkas \"%s\" tidak dapat dibuka untuk ditulisi."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Gagal menyimpan dokumen ke berkas \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Berkas \"%s\" tidak dapat dibuka untuk dibaca."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1122,57 +1156,57 @@ msgstr ""
 "Berkas '%s' tidak ada dan tidak bisa dibuka.\n"
 "Itu telah dihapus dari daftar berkas yang baru terpakai."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Membuat pratinjau cetakan gagal."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Pratinjau Pencetakan"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Format berkas '%s' tidak dapat ditentukan."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "tanpa nama%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Buka Berkas"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Galat berkas"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Maaf, gagal membuka file ini."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Maaf, format dari berkas ini tidak diketahui."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Pilih template dokumen"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Template"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Pilih tampilan dokumen"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Tampilan"
 
@@ -1206,42 +1240,42 @@ msgstr "Kesalahan membaca pada file '%s'"
 msgid "Write error on file '%s'"
 msgstr "Kesalahan menulis pada file '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "gagal mem-flush berkas '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Galat pencarian pada berkas '%s' (berkas besar tidak didukung oleh stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Galat pencarian pada file '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Gagal menemukan posisi saat ini dalam berkas '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Gagal menetapkan permisi file sementara"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "gagal menghapus file '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "gagal menerapkan perubahan ke berkas '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "gagal menghapus berkas sementara '%s'"
@@ -1266,27 +1300,27 @@ msgstr "gagal membaca dari file descriptor %d"
 msgid "can't write to file descriptor %d"
 msgstr "gagal menulis ke file descriptor %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "gagal mem-flush file descriptor %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "gagal melakukan seek pada file descriptor %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "gagal memperoleh posisi seek pada file descriptor %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "gagal menentukan panjang berkas pada file descriptor %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "gagal menentukan apakah akhir berkas telah dicapai pada descriptor %d"
@@ -1312,107 +1346,107 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Galat saat membaca opsi config."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Gagal membaca opsi konfigurasi."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "berkas '%s': karakter %c tidak diharapkan pada baris %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "berkas '%s', baris %zu: '%s' diabaikan setelah header grup."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "berkas '%s', baris %zu: '=' diharapkan."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "berkas '%s', baris %zu: nilai untuk kunci immutable '%s' diabaikan."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "berkas '%s', baris %zu: kunci '%s' pertama ditemukan pada baris %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Nama entri konfigurasi tidak bisa diawali dengan '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "gagal membuka berkas konfigurasi pemakai."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "gagal menulis berkas konfigurasi pemakai."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Gagal memperbaharui berkas konfigurasi."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Galat saat menyimpan data konfigurasi pengguna."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "gagal menghapus berkas konfigurasi pemakai '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "entri '%s' muncul lebih dari sekali dalam grup '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "mengabaikan usaha untuk mengubah kunci immutable '%s'."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "backslash yang mengekor diabaikan dalam '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" tidak diharapkan pada posisi %d dalam '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Gagal menyalin berkas '%s' ke '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Tidak mungkin memperoleh permisi file '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Tidak mungkin menimpa file '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Gagal menyalin berkas dari '%s' ke ‘%s’."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Tidak mungkin mengubah permisi file '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1420,40 +1454,40 @@ msgid ""
 msgstr ""
 "Gagal mengubah nama berkas '%s' ke '%s' karena berkas tujuan sudah ada."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Berkas '%s' tidak dapat diubah nama menjadi '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Berkas '%s' tidak dapat dihapus"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Direktori '%s' tidak bisa dibuat"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Direktori '%s' tidak dapat dihapus"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Gagal mengenumerasi berkas '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Gagal memperoleh direktori kerja"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Gagal mengatur lokasi direktori ini"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Berkas (%s)"
@@ -1480,17 +1514,17 @@ msgstr "Gagal menciptakan suatu nama file sementara"
 msgid "Failed to open temporary file."
 msgstr "Gagal membuka file sementara."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Gagal untuk memodifikasi waktu file untuk '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Gagal membuat file kosong '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Gagal mengambil waktu file untuk '%s'"
@@ -1499,22 +1533,22 @@ msgstr "Gagal mengambil waktu file untuk '%s'"
 msgid "Browse"
 msgstr "Ramban"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Semua berkas (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "berkas %s (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Memuat berkas %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Simpan berkas %s"
@@ -1877,105 +1911,105 @@ msgstr "default"
 msgid "unknown-%d"
 msgstr "%d-tidak dikenal"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "bergarisbawah"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " teks coret"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " ringan"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " ringan"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " tebal"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " tebal"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " tebal"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " miring"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "teks coret"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "ringan"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "ringan"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "tebal"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "tebal"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "tebal"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "miring"
 
@@ -2057,7 +2091,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Gagal menetapkan mode transfer FTP ke %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2078,7 +2112,7 @@ msgstr "Server FTP tidak mendukung mode passive."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Ukuran frame GIF salah (%u, %d) untuk frame #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Gagal mengalokasikan warna untuk OpenGL"
 
@@ -2094,7 +2128,7 @@ msgstr "Kustomisasi Kolom"
 msgid "&Customize..."
 msgstr "&Kustomisasi..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Gagal membuka URL \"%s\" pada browser."
@@ -2114,155 +2148,154 @@ msgstr "Gagal memuat citra %d dari stream."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Gagal memuat ikon dari sumber “%s”."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Gagal menympan citra tidak sah."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage tidak mempunyai wxPallete."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Gagal menulis header berkas (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Gagal menulis header berkas (BitmapInfo)"
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Gagal menulis peta warna RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Gagal menulis data."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Gagal mengalokasikan memori."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Header: Lebar citra > 32767 pixel untuk berkas."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Header DIB: Tinggi citra > 32767 pixel untuk berkas."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Header: bitdepth dalam berkas tidak diketahui."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Header DIB: Pengkodean dalam file tidak diketahui."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Header DIB: Pengkodean tidak sesuai dengan bitdepth."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Gagal mengalokasikan memori."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB Header: Lebar citra > 32767 pixel untuk berkas."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Header DIB: Tinggi citra > 32767 pixel untuk berkas."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB Header: bitdepth dalam berkas tidak diketahui."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Header DIB: Pengkodean dalam file tidak diketahui."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Header DIB: Pengkodean tidak sesuai dengan bitdepth."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Galat ketika membaca citra DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Kesalahan dalam membaca mask DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Citra terlalu tinggi untuk suatu ikon."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Citra terlalu lebar untuk suatu ikon."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Kesalahan dalam menulis berkas citra!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Indeks ikon tidak sah."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Citra dan mask mempunyai ukuran yang berbeda."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Tidak tersedia warna pada citra yang di mask."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Gagal memuat bitmap \"%s\" dari sumber."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Gagal memuat ikon \"%s\" dari sumber."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Gagal memuat citra dari berkas \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Gagal menyimpan citra ke berkas '%s': ekstensi tidak diketahui."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Tidak ditemukan handler untuk tipe citra tsb."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Tidak ada handler citra untuk tipe %d yang didefinisikan."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Berkas citra bukan bertipe %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Gagal menentukan format citra bagi masukan yang tak bisa dirambah."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Format citra data tidak dikenal."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Ini bukan %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Tidak ada handler citra untuk tipe %s yang didefinisikan."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Citra bukan dari tipe %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Gagal mengecek format citra \"%s\"."
@@ -2363,43 +2396,43 @@ msgstr "PNM: Kelihatannya file terpotong."
 msgid " (in module \"%s\")"
 msgstr " (dalam modul \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Galat memuat citra."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Indeks citra TIFF tidak sah."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Ukuran citra terlalu besar."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Gagal mengalokasikan memori."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Galat membaca citra."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ukuran resolusi TIFF %d yang tidak dikenal diabaikan"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Galat menyimpan citra."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Galat menulis citra."
 
 # verifikasi terjemahan s/d 2156
 # 20131008
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2407,11 +2440,11 @@ msgid ""
 msgstr ""
 "Perintah Command Line %d tidak dapat diubah ke Unicode dan akan dibiarkan."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Inisialisasi gagal saat init, membatalkan."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Gagal mengatur bahasa ke \"%s\"."
@@ -2507,7 +2540,7 @@ msgstr "galat kompresi"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' tanpa pasangan dalam entri mime type %s."
@@ -2527,7 +2560,7 @@ msgstr "Ketergantungan \"%s\" dari modul \"%s\" tidak ada."
 msgid "Module \"%s\" initialization failed"
 msgstr "Modul \"%s\" gagal terpasang"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Pesan"
 
@@ -3029,7 +3062,7 @@ msgstr "Galat Mencetak"
 msgid "Print"
 msgstr "Print"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Pengaturan halaman"
 
@@ -3064,19 +3097,15 @@ msgstr "Mencetak halaman %d dari %d"
 msgid " (copy %d of %d)"
 msgstr " (salinan %d dari %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Mencetak "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Halaman pertama"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Halaman sebelumnya"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Halaman berikut"
 
@@ -3120,16 +3149,16 @@ msgstr "Halaman %d dari %d"
 msgid "Page %d"
 msgstr "Halaman %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "galat tidak dikenal"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Regular expression tidak sah '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Gagal mencari ekspresi yang cocok: %s"
@@ -3141,21 +3170,21 @@ msgstr ""
 "Perender \"%s\" memiliki versi yang tidak kompatibel %d.%d dan tidak dapat "
 "dimuat."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Penyimpanan password untuk “%s/%s” gagal: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Membaca password untuk \"%s/%s\" gagal: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Menghapus password untuk \"%s/%s\" gagal: %s."
@@ -3164,11 +3193,11 @@ msgstr "Menghapus password untuk \"%s/%s\" gagal: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Gagal memonitor saluran I/O"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Simpan"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Jangan Save"
 
@@ -3252,10 +3281,10 @@ msgid "Clear"
 msgstr "Clear"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Tutup"
 
@@ -3267,7 +3296,7 @@ msgstr "&Ubah"
 msgid "Convert"
 msgstr "Ubah"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Salin"
@@ -3276,7 +3305,7 @@ msgstr "&Salin"
 msgid "Copy"
 msgstr "Salin"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Po&tong"
@@ -3285,13 +3314,13 @@ msgstr "Po&tong"
 msgid "Cut"
 msgstr "Potong"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Hapus"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Delete"
@@ -3380,7 +3409,7 @@ msgstr "Harddisk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Bantuan"
 
@@ -3400,7 +3429,7 @@ msgstr "Inden"
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3469,7 +3498,7 @@ msgstr "&Baru"
 msgid "New"
 msgstr "Baru"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Tidak"
 
@@ -3486,12 +3515,12 @@ msgstr "&Buka..."
 msgid "Open..."
 msgstr "Buka..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Tempel"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Tempel"
@@ -3521,7 +3550,7 @@ msgid "Print..."
 msgstr "Cetak..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Properti"
 
@@ -3555,10 +3584,6 @@ msgstr "Timpa"
 msgid "Revert to Saved"
 msgstr "Kembali ke yang tersimpan"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Simpan"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Simpan Seb&agai..."
@@ -3568,7 +3593,7 @@ msgstr "Simpan Seb&agai..."
 msgid "Save As..."
 msgstr "Simpan Seb&agai..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Pilih Semu&a"
@@ -3675,7 +3700,7 @@ msgstr "&Naik"
 msgid "Up"
 msgstr "Up"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ya"
 
@@ -3766,43 +3791,43 @@ msgstr "Simpan dokumen ini"
 msgid "Save current document with a different filename"
 msgstr "Simpan dokumen ini dengan nama berkas berbeda"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konversi ke charset '%s' tidak dimungkinkan."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "tidak dikenal"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "galat berkas tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "gagal checksum berkas tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "data tidak valid pada header tar yang diperluas"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "entri tar tidak terbuka"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "akhir berkas yang tak diharapkan"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s tidak pas dengan header tar untuk entri '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "salah ukuran pada isian tar"
 
@@ -3811,7 +3836,7 @@ msgstr "salah ukuran pada isian tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' kemungkinan suatu penyangga biner."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Berkas tidak bisa dimuat."
 
@@ -3825,47 +3850,47 @@ msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "gagal menulis buffer '%s' ke disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Gagal memperoleh waktu lokal sistem"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay gagal."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' bukan suatu katalog pesan yang sah."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Kesalahan katalog pesan."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Gagal mengurai Plural-Forms: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "menggunakan katalog '%s' dari '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Sumber '%s' bukan pesan katalog yang valid."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Gagal menghitung terjemahan"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Aplikasi standar untuk membuka berkas HTML tidak tersedia."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Gagal membuka URL \"%s\" pada browser."
@@ -3898,7 +3923,7 @@ msgstr "'%s' mengandung karakter ilegal"
 msgid "Error: %s (%d)"
 msgstr "Kesalahan: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3907,20 +3932,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Deskripsi kolom tidak dapat diinisialisasi."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Platform ini tidak mendukung transparansi background."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Gagal mentransfer data ke jendela"
 
@@ -3972,8 +3997,8 @@ msgstr "Membuat Parameter %s tidak dideklarasikan di RTTI Parameter"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Kelas Obyek Ilegal (Non-wxEvtHandler) sebagai Event Source"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Tipe harus memiliki konversi enum - long"
 
@@ -4023,79 +4048,79 @@ msgstr "Obyek harus memiliki atribut id"
 msgid "Doubly used id : %d"
 msgstr "User id ganda : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Properti %s tidak dikenal"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Suatu koleksi tak kosong mesti terdiri dari node 'elemen'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "string event handler salah, kurang titik"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "gagal menyiapkan zlib deflate stream"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "gagal menyiapkan zlib inflate stream"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "mengasumsikan ini adalah berbagai berkas zip yang disambung"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "berkas zip tidak valid"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "gagal menemukan sentral direktori pada zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "galat membaca sentral direktori zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "galat membaca berkas zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "salah offset di berkas zip terhadap entri"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "stored file length not in Zip header"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "metode kompresi zip tidak didukung"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "membaca berkas zip (entri %s): ukuran buruk"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "membaca berkas zip (entri %s): crc buruk"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "galat membuat berkas zip '%s': crc rusak"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "galat membuat berkas zip '%s': crc rusak"
@@ -4181,32 +4206,32 @@ msgstr "Grafis oleh "
 msgid "Translations by "
 msgstr "Diterjemahkan oleh "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versi "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Tentang %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Lisensi"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Pengembang"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Penulis Dokumentasi"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artis"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Penerjemah"
 
@@ -4257,43 +4282,42 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "true"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "false"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Baris %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Perkecil"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Perluas"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d obyek)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Kolom %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4304,8 +4328,7 @@ msgid "Left"
 msgstr "Kiri"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4402,7 +4425,7 @@ msgid "Home directory"
 msgstr "Direktori rumah"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -4415,8 +4438,7 @@ msgstr "Nama direktori tidak sah."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Kesalahan"
 
@@ -4599,16 +4621,16 @@ msgstr "Tampilkan berkas dalam tampilan rinci"
 msgid "Go to parent directory"
 msgstr "Ke direktori atasnya"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Berkas '%s' sudah ada, apakah benar anda ingin menimpanya?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Konfirmasi"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Silahkan pilih file yang ada."
 
@@ -4702,7 +4724,7 @@ msgstr "Ukuran point font."
 msgid "Whether the font is underlined."
 msgstr "Apakah font bergarisbawah."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Pratinjau:"
@@ -4720,49 +4742,48 @@ msgstr "Klik untuk membatalkan font yang dipilih."
 msgid "Click to confirm the font selection."
 msgstr "Klik untuk mengkonfirmasi pemilihan font."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Pilih font"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Direktori bantuan \"%s\" tidak ditemukan."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Berkas bantuan \"%s\" tidak ditemukan."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "Baris %lu dari berkas peta \"%s\" mempunyai sintaks yang salah, dilewati."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Tidak ada mapping yang sesuai di berkas ini \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Tidak ada entri yang ditemukan."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indeks Bantuan"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Entri yang relevan:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Entri ditemukan"
 
@@ -4866,59 +4887,59 @@ msgstr "Gagal memulai pencetakan."
 msgid "Printing page %d..."
 msgstr "Mencetak halaman %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opsi pencetak"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Cetak ke Berkas"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Pengaturan..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Mesin cetak:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Semua"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Halaman"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Jangkauan Cetakan"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Dari:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Kepada:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Salinan:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Berkas PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Pengaturan Cetakan"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Printer"
 
@@ -4926,25 +4947,25 @@ msgstr "Printer"
 msgid "Default printer"
 msgstr "Printer default"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Ukuran kertas"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Tegak"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Memanjang"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientasi"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opsi"
 
@@ -4956,52 +4977,52 @@ msgstr "Cetak berwarna"
 msgid "Print spooling"
 msgstr "Antrian pencetakan"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Perintah pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opsi pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Batas kiri (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Batas atas (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Batas kanan (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Batas bawah (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Pencetak..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Lewati"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Tidak dikenal"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Selesai."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Cari"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Gagal menemukan tab untuk id"
 
@@ -5037,22 +5058,22 @@ msgstr "&Selesai"
 msgid "< &Back"
 msgstr "< &Mundur"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "penerjemah"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Gagal menginisiasi GTK+, apakah DISPLAY sudah benar?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Gagal pindah ke direktori \"%s\""
@@ -5078,12 +5099,12 @@ msgstr "Gagal untuk membaca dokumen dari berkas \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Gagal memperbaharui berkas konfigurasi."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Galat berkas"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5091,7 +5112,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5099,7 +5120,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
@@ -5115,15 +5136,11 @@ msgstr "Galat ketika mencetak: "
 msgid "Page Setup"
 msgstr "Pengaturan Halaman"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Gagal menyisipkan teks ke dalam kontrol."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5131,7 +5148,7 @@ msgstr ""
 "GTK+ terpasang dimesin ini dan terlalu tua untuk mendukung fitur screen "
 "compositing, mohon memasang GTK+ 2.12 atau versi ke atasnya."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5139,17 +5156,13 @@ msgstr ""
 "Komposisi tidak didukung oleh sistem ini, tolong hidupkan pada WIndow "
 "Manager anda."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Program ini telah dibuat dengan GTK+ lama, mohon dibuat kembali dengan GTK+ "
 "2.12 atau lebih baru."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Silahkan pilih font yang sah."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5248,45 +5261,45 @@ msgstr "Gagal membuka isi berkas: %s"
 msgid "Cannot open index file: %s"
 msgstr "Gagal membuka berkas indeks: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "tanpa nama"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Gagal membuka buku bantuan HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Tampilkan bantuan saat melihat buku di jendela sebelah kiri."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(tanda taut)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Tambahkan halaman ini ke penanda taut"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Hilangkan halaman saat ini dari bookmark"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Isi"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Temukan"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Tampilkan semua"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5294,19 +5307,19 @@ msgstr ""
 "Tampilkan semua obyek indeks yang berisi substring tersebut. Pencarian tidak "
 "membedakan pemakaian huruf besar dan kecil."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Tampilkan semua butir dalam indeks"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Membedakan huruf besar dan kecil"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Hanya seluruh kata"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5314,147 +5327,147 @@ msgstr ""
 "Cari isi dari konten bantuan untuk semua pemunculan dari teks yang "
 "diketikkan diatas"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Tampilkan/sembunyikan panel navigasi"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Kembali"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Ke depan"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Ke satu tingkat diatas dalam hirarki dokumen"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Buka dokumen HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Cetak halaman ini"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Tampilkan dialog opsi"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Silakan pilih lembar yang mau ditampilkan:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Topik Bantuan"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Mencari..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Tidak ditemukan halaman yang sesuai"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Menemukan %i sesuai"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Bantuan)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d dari %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu dari %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Cari di semua buku"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opsi Bantuan Browser"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Font normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Huruf tetap:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Ukuran huruf:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "ukuran font"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Huruf normal<br>dan <u>digarisbawahi</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Contoh miring.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Contoh tebal.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Contoh miring tebal.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Font ukuran tetap.<br> <b>tebal</b> <i>miring</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>miring tebal <u>digarisbawahi</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Bantuan Pencetakan"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Gagal mencetak halaman kosong."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Berkas HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Buku bantuan (*.htb)|*.htb|Buku bantuan (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Proyek Bantuan HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Berkas Bantuan HML Terkompresi (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i dari %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u dari %u"
@@ -5535,32 +5548,6 @@ msgstr ""
 "Ada masalah pada saat mengatur halaman: mungkin perlu ditetapkan pencetak "
 "default."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Gagal menampilkan dokumen HTML dalam pengkodean %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets tidak bisa membuka tampilan untuk '%s': keluar."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Penyaring"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Direktori"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Berkas"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Seleksi"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Gagal membuka clipboard."
@@ -5602,58 +5589,58 @@ msgstr "Dialog pemilihan warna gagal dengan galat %0lx."
 msgid "Failed to create cursor."
 msgstr "Gagal membuat kursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Gagal meregister server DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Gagal melepas register server DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Gagal menciptakan koneksi ke server '%s' untuk topik '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Permintaan poke DDE gagal"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Gagal mengadakan advise loop dengan server DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Gagal menghentikan advise loop dengan server DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Gagal mengirimkan pemberitahuan DDE advise"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Gagal menciptakan string DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "tidak ada kesalahan DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "permintaan untuk transaksi advise sinkron telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "tanggapan terhadap transaksi menyebabkan bit DDE_FBUSY ditetapkan."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "permintaan untuk transaksi data sinkron telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5664,7 +5651,7 @@ msgstr ""
 "atau suatu identifikasi instan yang tidak sah\n"
 "disampaikan ke suatu fungsi DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5676,43 +5663,43 @@ msgstr ""
 "atau aplikasi yang diinisialisasi sebagai APPCMD_CLIENTONLY telah \n"
 "berusaha melaksanakan transaksi server."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "permintaan untuk transaksi eksekusi sinkron telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parameter gagal divalidasi oleh DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "aplikasi DDEML telah menciptakan kondisi race berkesinambungan."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "alokasi memori gagal."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "usaha dari klien untuk memulai percakapan telah gagal."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "transaksi gagal."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "permintaan untuk transaksi poke sinkron telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "panggilan internal ke fungsi PostMessage telah gagal. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "masalah reentransi kembali."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5722,15 +5709,15 @@ msgstr ""
 "yang dihentikan oleh klien, atau server\n"
 "dihentikan sebelum menyelesaikan transaksi."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "kesalahan internal muncul dalam DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "permintaan untuk mengakhiri transaksi advise telah habis waktunya."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5740,12 +5727,12 @@ msgstr ""
 "Saat aplikasi kembali dari callback XTYP_XACT_COMPLETE,\n"
 "pengenal transaksi untuk callback tersebut tidak lagi sah."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Galat DDE %08x tidak dikenal"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5753,7 +5740,7 @@ msgstr ""
 "Fungsi dial up tidak tersedia karena remote access service (RAS) tidak "
 "terinstall pada mesin ini. Silahkan menginstall."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5762,64 +5749,64 @@ msgstr ""
 "Versi remote access service (RAS) terinstall di mesin ini terlalu tua, "
 "silahkan perbarui (fungsi yang dibutuhkan berikut ini hilang: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Gagal mengambil teks dari pesan kesalahan RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "galat tidak dikenal (kode kesalahan %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Gagal menemukan koneksi dialup yang aktif: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Dijumpai beberapa koneksi dialup aktif, pilih satu secara acak."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Gagal membentuk koneksi dialup: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Gagal memperoleh nama ISO: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Gagal koneksi: tidak ada ISP untuk didial."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Pilih ISP yang akan dihubungi"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Silahkan pilih ingin koneksi ke ISP mana"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Gagal koneksi: kurang nama user/kata kunci."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Gagal menemukan lokasi dari berkas buku alamat"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Gagal memulai koneksi dialup: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Gagal memutus - tidak ada koneksi dialup yang aktif."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Gagal menghentikan koneksi dialup: %s"
@@ -5839,18 +5826,17 @@ msgstr "Gagal mengalokasikan %luKB dari memori untuk data bitmap."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Gagal mengenumerasi berkas di direktori '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Gagal mendapatkan nama direktori"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (galat %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Gagal menambahkan citra ke daftar citra."
 
@@ -5864,7 +5850,7 @@ msgstr "Gagal memuat metafile dari berkas \"%s\"."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Gagal menciptakan dialog standar temukan/ganti (kode kesalahan %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialog berkas gagal dengan kode galat %0lx."
@@ -5905,16 +5891,16 @@ msgstr "Gagal mengatur pengamatan untuk '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Gagal memantau perubahan pada direktori yang tidak ada \"%s\"."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 atau lebih baru tidak didukung oleh driver OpenGL."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Gagal menciptakan konteks OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Gagal menginisialisasi OpenGL"
 
@@ -5922,7 +5908,7 @@ msgstr "Gagal menginisialisasi OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5930,7 +5916,7 @@ msgstr ""
 "Fungsi MS HTML Help tidak tersedia karena pustaka MS HTML Help tidak "
 "terinstal di mesin ini. Silahkan instal."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Gagal menginisialisasi MS HTML Help."
 
@@ -5939,7 +5925,7 @@ msgstr "Gagal menginisialisasi MS HTML Help."
 msgid "Can't delete the INI file '%s'"
 msgstr "Gagal menghapus berkas INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Gagal mengambil informasi tentang obyek list control %d."
@@ -6059,7 +6045,7 @@ msgstr "Gagal meregister format clipboard '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format clipboard '%d' tidak ada."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Lewati"
 
@@ -6144,76 +6130,76 @@ msgstr ""
 "menghapusnya akan menyebabkan sistem anda tidak stabil:\n"
 "operasi dibatalkan."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Gagal menghapus kunci '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Gagal menghapus nilai '%s' dari kunci '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Gagal membaca nilai dari kunci '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Gagal menetapkan nilai dari '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Nilai registri “%s” bukan numerik (melainkan tipe %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Nilai registri \"%s\" bukan biner (melainkan tipe %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Nilai registri “%s” bukan teks (melainkan tipe %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Gagal membaca nilai dari '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Gagal mengenumerasi nilai dari kunci '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Gagal mengenumerasi subkunci dari kunci '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Mengekspor kunci registri: berkas \"%s\" sudah ada dan tidak akan ditimpa."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Gagal mengekspor nilai dari tipe %d yang tidak didukung."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Mengabaikan nilai \"%s\" dari kunci \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6221,41 +6207,41 @@ msgstr ""
 "Tidak mungkin menciptakan suatu kontrol rich edit, menggunakan kontrol text "
 "sederhana sebagai gantinya. Silahkan install ulang riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Gagal memulai thread: kesalahan menulis TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Gagal menetapkan prioritas thread"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Gagal menciptakan thread"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Gagal menghentikan thread"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Gagal menunggu penghentian thread"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Gagal menunda thread %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Gagal meneruskan thread %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Gagal memperoleh penunjuk thread saat ini"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6263,7 +6249,7 @@ msgstr ""
 "Inisialisasi modul thread gagal: tidak mungkin mengalokasikan indeks dalam "
 "penyimpanan thread lokal"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6294,12 +6280,12 @@ msgstr "Gagal memuat sumber \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Gagal menyunci sumber \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "versi %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", edisi 64-bit"
 
@@ -6311,47 +6297,47 @@ msgstr "Gagal menciptakan pipa anonymous"
 msgid "Failed to redirect the child process IO"
 msgstr "Gagal mengarahkan kembali proses IO child"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Eksekusi perintah '%s' gagal"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Gagal memuat mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Gagal membaca typename dari '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Gagal memuat ikon dari '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Gagal menetapkan prioritas thread"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Gagal mengeksekusi '%s'\n"
@@ -6385,7 +6371,7 @@ msgid "Check to make the font italic."
 msgstr "Centang untuk membuat font miring."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Garis dibawahi"
@@ -6453,17 +6439,32 @@ msgstr "<Sebarang Teletype>"
 msgid "File type:"
 msgstr "Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Window"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Help"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi%nimalkan"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Perbesar"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6480,493 +6481,493 @@ msgstr ": berkas tidak ada!"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Tentang %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Tentang..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferensi..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Layanan"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Sembunyi: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Aplikasi"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Sembunyikan Lainnya"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Tampilkan Semua"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Keluar %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Aplikasi"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip tidak didukung oleh versi zlib ini"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Deskripsi kolom tidak dapat diinisialisasi."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Ukuran Point"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nama Face"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Gaya"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Berat"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Keluarga"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "RuangKerjaApp"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "TepiAktif"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "JudulAktif"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "TampakMukaTombol"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "KilauTombol"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "BayanganTombol"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "TeksTombol"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "TeksJudul"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "KendaliGelap"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "KendaliTerang"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "TeksAbu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Kilau"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "KilauTeks"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "TepiTakAktif"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "JudulTakAktif"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "TeksJudulTakAktif"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "BatangScroll"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Tooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "TeksTooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Window"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Kustom"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Hitam"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Ungu Kemerahan"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Biru Tua"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Ungu"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Hijau Kebiruan"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Abu-abu"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Hijau"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Coklat Muda"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Coklat"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Biru"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Merah Muda"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Merah"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Jingga"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Perak"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Kunig Kehijauan"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Biru Muda"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Kuning"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Putih"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Standar"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Panah"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Panah Kanan"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Kosong"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Sasaran"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Karakter"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Silang"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Tangan"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "Batang-I"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Tombol Kiri"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Kaca Pembesar"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Tombol Kanan"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Dilarang Masuk"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Kuas"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Pensil"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Tunjuk Kiri"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Tunjuk Kanan"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Panah Tanda Tanya"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Tombol Kanan"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Sizing NE-SW"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Ubah Utara-Selatan"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Sizing NW-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Sizing W-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Sizing"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Kaleng Cat"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Tunggu"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Jam"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Panah Tunggu"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Buat seleksi:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Properti"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Nilai"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Mode Terkategorisasi"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Mode Alfabet"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "False"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "True"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Tidak dijabarkan"
 
@@ -6980,12 +6981,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Kamu telah mengisi nilai yang salah. Tekan ESC untuk membatalkan suntingan."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Galat pada sumber %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6994,36 +6995,36 @@ msgstr ""
 "Tipe operasi \"%s\" gagal: Label properti \"%s\" seharusnya tipe \"%s\", "
 "BUKAN \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Nilai harus %s atau lebih besar."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Nilai harus di antara %s dan %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Nilai harus %s atau lebih kecil."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Bukan %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Pilih direktori:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Pilih berkas"
 
@@ -7490,117 +7491,117 @@ msgstr "Inset"
 msgid "Outset"
 msgstr "Outset"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Ubah Gaya"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Ubah Gaya Obyek"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Ubah Properti"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Ubah Gaya Daftar"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Nomori Ulang Daftar"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Sisipkan Teks"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Sisipkan Citra"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Sisipkan Obyek"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Sisipkan Kolom"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Terlalu banyak pemanggilan EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "berkas"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standar/lingkaran"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standar/lingkaran-ikhtisar"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standar/bujur sangkar"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standar/intan"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standar/segitiga"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Properti Kotak"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Properti Multi Sel"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Properti Sel"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Atur Gaya Sel"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Hapus Baris"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Hapus Kolom"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Tambah Baris"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Tambah Kolom"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Properti Tabel"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Properti Citra"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "citra"
 
@@ -7808,24 +7809,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Geser"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Hapus Teks"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Hapus Bullet"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Teks tidak bisa disimpan."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Timpa"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Font:"
 
@@ -8794,53 +8795,53 @@ msgstr "Daftar gaya"
 msgid "Box styles"
 msgstr "Gaya kotak"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Pilih font untuk mengambil simbol."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subset:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Tampilkan subset Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Kode karakter:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Kode karakter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Dari:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Jangkauan yang akan diperlihatkan."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Teks normal)"
 
@@ -9028,7 +9029,7 @@ msgstr "Gagal mendapatkan even dari kqueue"
 msgid "Media playback error: %s"
 msgstr "Galat media pemutar: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Gagal memutar \"%s\"."
@@ -9128,20 +9129,20 @@ msgstr "Data suara tidak didukung."
 msgid "Couldn't open audio: %s"
 msgstr "Gagal membuka audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Gagal mengambil kebijakan penjadwalan thread."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Gagal memperoleh jangkauan prioritas untuk kebijakan penjadwalan %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Setelan prioritas thread diabaikan."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9149,60 +9150,60 @@ msgstr ""
 "Gagal bergabung ke thread, terdeteksi potensi kebocoran memori - silahkan "
 "jalankan ulang program"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Gagal mengatur thread concurrency level pada %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Gagal menetapkan prioritas thread %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Gagal menghentikan thread."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Inisialisasi modul thread gagal: gagal menciptakan kunci thread"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Tidak mungkin memperoleh masukan dari proses anak"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Gagal menulis ke stdin proses anak"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Gagal mengeksekusi '%s'\n"
 
 # sort by translation
 # checked up to here 20131006-1302
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Fork gagal"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Gagal menetapkan prioritas proses"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Gagal mengarahkan kembali proses masukan/keluaran child"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Gagal mengatur no-blocking pipe, program mungkin akan mengalami galat."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Gagal memperoleh nama host"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Gagal memperoleh nama host resmi"
 
@@ -9218,12 +9219,12 @@ msgstr "Gagal mengubah wake up pipe ke mode non-blocking"
 msgid "Failed to read from wake-up pipe"
 msgstr "Gagal membaca dari wake-up pipe"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Spesifikasi geometri '%s' tidak sah"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets tidak bisa membuka tampilan. Keluar."
 
@@ -9237,30 +9238,59 @@ msgstr "Gagal menutup \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Gagal membuka \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Kesalahan parsing XML: '%s' pada baris %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Gagal memuat sumber daya dari '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Gagal membuka berkas sumber daya '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Gagal memuat sumber daya dari berkas '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Gagal membuat %s \"%s\"."
+
+#~ msgid "Printing "
+#~ msgstr "Mencetak "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Gagal menyisipkan teks ke dalam kontrol."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Silahkan pilih font yang sah."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Gagal menampilkan dokumen HTML dalam pengkodean %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets tidak bisa membuka tampilan untuk '%s': keluar."
+
+#~ msgid "Filter"
+#~ msgstr "Penyaring"
+
+#~ msgid "Directories"
+#~ msgstr "Direktori"
+
+#~ msgid "Files"
+#~ msgstr "Berkas"
+
+#~ msgid "Selection"
+#~ msgstr "Seleksi"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "konversi ke enkoding 8-bit gagal"
@@ -9426,8 +9456,8 @@ msgstr "Gagal membuat %s \"%s\"."
 #~ msgstr "Gagal merender nilai penanggalan; tipe nilai: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/it.po
+++ b/locale/it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets revised 07.06.2022 by bovirus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-06-07 09:53+0200\n"
 "Last-Translator: bovirus <bovirus@gmail.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Tutti i file (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Tutti i file (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "Tempo rimanente :"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Si"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "No"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Annulla"
@@ -102,7 +99,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Impossibile creare porta completamento I/O"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Stampa"
 
@@ -139,7 +136,7 @@ msgstr "Proprietà oggetto"
 msgid "Printing"
 msgstr "Stampa"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simboli"
 
@@ -208,7 +205,7 @@ msgstr "&Precedente"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Finestra"
 
@@ -737,11 +734,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "visualizza questo messaggio di aiuto"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "genera messaggi registro eventi dettagliati"
 
@@ -763,84 +760,84 @@ msgstr "Tema '%s' non supportato."
 msgid "Invalid display mode specification '%s'."
 msgstr "Specifica della modalità video '%s' non valida."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "L'opzione '%s' non può essere negata"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opzione lunga '%s' sconosciuta"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opzione '%s' sconosciuta"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caratteri non attesi dopo l'opzione '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "L'opzione '%s' richiede un valore."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Atteso separatore dopo l'opzione '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' non è un valore numerico corretto per l'opzione '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opzione '%s': impossibile convertire '%s' in una data."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametro '%s' non atteso"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (o %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "L'opzione '%s' richiede un parametro."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Il parametro '%s' è obbligatorio."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilizzo: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "doppio"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -858,7 +855,7 @@ msgid "Can't &Undo "
 msgstr "Impossibile &annullare "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Annulla"
@@ -868,7 +865,7 @@ msgid "&Redo "
 msgstr "&Ripeti "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ripeti"
@@ -899,12 +896,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ha troppi '..', ignorati."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "verificato"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "non verificato"
 
@@ -913,103 +910,103 @@ msgstr "non verificato"
 msgid "undetermined"
 msgstr "non determinato"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "oggi"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "ieri"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "domani"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primo"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "due"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tre"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "quattro"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "cinque"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sei"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sette"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "otto"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "nove"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "dieci"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "undici"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dodici"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "tredici"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "quattordici"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "quindici"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "sedici"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "diciassette"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "diciotto"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "diciannove"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "venti"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "mezzogiorno"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "mezzanotte"
 
@@ -1079,44 +1076,81 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Impossibile inviare la segnalazione di errore (codice di errore %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Salva come"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Vuoi annullare le modifiche e ricaricare l'ultima versione salvata?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "senzanome"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vuoi salvare le modifiche in %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Salva"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Non salvare"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vuoi salvare le modifiche in %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Il testo non può essere salvato."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Impossibile aprire il file \"%s\" per la scrittura."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Impossibile salvare il documento nel file \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Impossibile aprire il file \"%s\" per la lettura."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Impossibile leggere il documento dal file \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1125,57 +1159,57 @@ msgstr ""
 "Il file file '%s' non esiste e non può essere aperto.\n"
 "È stato rimosso dall'elenco dei file recentemente usati."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Creazione anteprima di stampa fallita."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Anteprima di stampa"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Impossibile determinare il formato del file '%s'."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "senzanome%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Apri file"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Errore file"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Impossibile aprire il file."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Formato del file sconosciuto."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Scegli un modello di documento"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Modelli"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Scegli una visualizzazione del documento"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Visualizzazioni"
 
@@ -1209,43 +1243,43 @@ msgstr "Errore di lettura nel file '%s'"
 msgid "Write error on file '%s'"
 msgstr "Errore di scrittura nel file '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "impossibile forzare la scrittura su disco del file '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Errore durante la ricerca nel file '%s' (stdio non supporta file di queste "
 "dimensioni))"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Errore durante la ricerca nel file '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Impossibile determinare la posizione attuale del file '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Impossibile impostare i permessi del file temporaneo"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "impossibile eliminare il file '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "impossibile applicare i cambiamenti al file '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "impossibile eliminare il file temporaneo '%s'"
@@ -1270,28 +1304,28 @@ msgstr "impossibile leggere dal descrittore di file %d"
 msgid "can't write to file descriptor %d"
 msgstr "impossibile scrivere sul descrittore di file %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "impossibile forzare la scrittura su disco del descrittore di file %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "impossibile eseguire una seek sul descrittore di file %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "impossibile determinare la posizione attuale del descrittore di file %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "impossibile determinare la dimensione del file del descritore %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1319,108 +1353,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Errore durante la lettura del file di configurazione."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Impossibile leggere opzioni configurazione."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "file '%s': carattere %c non atteso alla linea %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "file '%s', linea %zu: ignorato '%s' dopo intestazione gruppo."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "file '%s', linea %zu: atteso '='."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "file '%s', linea %zu: valore per la chiave non configurabile '%s' ignorato."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "file '%s', linea %zu la chiave '%s' è già stata trovata alla linea %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Il nome di una voce di configurazione non può iniziare con '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "impossibile aprire il file di configurazione utente."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "impossibile scrivere il file di configurazione utente."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Impossibile aggiornare il file di configurazione utente."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Errore durante il salvataggio del file di configurazione."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "impossibile eliminare il file di configurazione utente '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "la voce '%s' è presente più volte nel gruppo '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativo di modificare la chiave non modificabile '%s' ignorato."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "barra retroversa finale ignorata in '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" non atteso alla posizione %d in '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Impossibile copiare copiare il file '%s' in '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Impossibile determinare i permessi per il file '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Impossibile sovrascrivere il file '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Impossibile copiare copiare il file '%s' in '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Impossibile impostare i permessi per il file '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1429,40 +1463,40 @@ msgstr ""
 "Impossibile rinominare il file '%s' in '%s' perché la destinazione esiste "
 "già."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Il file '%s' non può essere rinominato '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Il file '%s' non può essere rimosso"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Impossibile creare la cartella '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "La cartella '%s' non può essere eliminata"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Impossibile elencare i file '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Impossibile determinare la cartella di lavoro"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Impossibile impostare la cartella di lavoro"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "File (%s)"
@@ -1489,17 +1523,17 @@ msgstr "Impossibile creare il nome per il file temporaneo"
 msgid "Failed to open temporary file."
 msgstr "Impossibile aprire un file temporaneo."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Impossibile modificare le date del file '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Impossibile eseguire 'touch' sul file '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Impossibile ottenere le date del file '%s'"
@@ -1508,22 +1542,22 @@ msgstr "Impossibile ottenere le date del file '%s'"
 msgid "Browse"
 msgstr "Sfoglia"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tutti i file (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s file (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Carica file %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Salva il file %s"
@@ -1886,99 +1920,99 @@ msgstr "predefinito"
 msgid "unknown-%d"
 msgstr "sconosciuto-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "sottolineato"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " barrato"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " sottile"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " extra leggero"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " leggero"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " medio"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " semi grassetto"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " grassetto"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " extra grassetto"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " pesante"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " extra pesante"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " corsivo"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "barrato"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "sottile"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "extra leggero"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "leggero"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normale"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "medio"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "semi grassetto"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "grassetto"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "extra grassetto"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "pesante"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "extra pesante"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "corsivo"
 
@@ -2063,7 +2097,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Impossibile impostare la modalità di trasferimneto FTP %s.."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2084,7 +2118,7 @@ msgstr "Il server FTP non supporta la modalità di trasferimento passiva."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Dimensione frame GTK non valida (%u, %d) per il frame #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Impossibile allocare colore per OpenGL"
 
@@ -2100,7 +2134,7 @@ msgstr "Personalizzazione colonne"
 msgid "&Customize..."
 msgstr "&Personalizza..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Impossibile aprire l'URL \"%s\" nel browser predefinito"
@@ -2120,158 +2154,157 @@ msgstr "Impossibile caricare immagine %d dallo stream."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Impossibile caricare icona per la risorsa '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Impossibile salvare un'immagine non valida."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: l'oggetto wxImage non ha una propria wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Impossibile scrivere l'header (Bitmap) del file."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Impossibile scrivere l'header (BitmapInfo) del file."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Impossibile scrivere la mappa dei colori RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Impossibile scrivere i dati."
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr "BMP: l'intestazione ha biClrUsed=%d quando biBitCount=%d."
-
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Impossibile allocare la memoria."
 
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr ""
 "Intestazione DIB: la larghezza dell'immagine nel file è > di 32767 pixel."
 
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr "Intestazione DIB: l'altezza dell'immagine nel file è > di 32767 pixel."
 
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "Intestazione DIB: numero di bit per pixel nel file sconosciuto."
 
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Inetstazione DIB: Codifica del file sconosciuta."
 
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 "Intestazione DIB: la codifica non corrisponde al numero di bit per pixel."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr "BMP: l'intestazione ha biClrUsed=%d quando biBitCount=%d."
+
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Errore durante la lettura dell'immagine DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: errore durante la lettura della maschera DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: immagine troppo alta per essere un'icona."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: immagine troppo larga per essere un'icona."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Errore durante la scrittura dell'immagine!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: indice dell'icona non valido."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "L'immagine e la maschera hanno dimensioni diverse."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Nessun colore inutilizzato nell'immagine da mascherare."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Impossibile caricare bitmap \"%s\" dalle risorse."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Impossibile caricare icona \"%s\" dalle risorse."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Impossibile caricare il file immagine \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Impossibile salvare l'immagine nel file '%s': estensione sconosciuta."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Funzionalità non disponibili per questo formato di immagine."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Funzionalità non disponibili per il formato di immagine %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Il file immagine non è di tipo %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Impossibile determinare il formato immagine per input non selezionabile."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Formato dati immagine sconosciuto."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Questo non è un %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Funzionalità non disponibili per il formato di immagine %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "L'immagine non è di tipo %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Impossibile verificare formato immagine file \"%s\"."
@@ -2374,41 +2407,41 @@ msgstr "PNM: Il file sembra troncato."
 msgid " (in module \"%s\")"
 msgstr " (nel modulo \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: errore nel caricamento dell'immagine."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Indice dell'immagine TIFF non valido."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: dimensione immaggine esageratamenet grande."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: impossibile allocare la memoria."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: errore durante la lettura dell'immagine."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Risoluzione TIFF sconosciuta - unità %d ignorata"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: errore nel salvataggio dell'immagine."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: errore durante la scrittura dell'immagine."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2417,11 +2450,11 @@ msgstr ""
 "L'argomento %d della linea di comando non può essere convertito in Unicode e "
 "verrà ignorato."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Inizializzazione fallita in \"post init\", esco."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Impossibile impostare locale a lingua \"%s\"."
@@ -2517,7 +2550,7 @@ msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 "Errore di compressione LZMA durante lo svuotamento della destinazione: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' spaiata in una voce per il tipo MIME %s."
@@ -2538,7 +2571,7 @@ msgstr "La dipendenza \"%s\" del modulo \"%s\" non esiste."
 msgid "Module \"%s\" initialization failed"
 msgstr "Inizializzazione del modulo \"%s\" fallita"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Messaggio"
 
@@ -3040,7 +3073,7 @@ msgstr "Errore durante la stampa"
 msgid "Print"
 msgstr "Stampa"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Impostazioni pagina"
 
@@ -3075,19 +3108,15 @@ msgstr "Stampa pagina %d di %d"
 msgid " (copy %d of %d)"
 msgstr " (copia %d di %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Stampa "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Prima pagina"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Pagina precedente"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Pagina successiva"
 
@@ -3131,16 +3160,16 @@ msgstr "Pagina %d di %d"
 msgid "Page %d"
 msgstr "Pagina %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "errore sconosciuto"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Espressione regolare '%s' non valida: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Impossibile trovare una corrispondenza per l'espressione regolare: %s"
@@ -3152,21 +3181,21 @@ msgstr ""
 "Il renderer \"%s\" ha una versione %d.%d che non è compatibile, quindi non è "
 "stato caricato."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Non disponibile per questa piattaforma"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Salvataggio password per \"%s\" non riuscito: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Lettura della password per \"%s\" non riuscita: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Eliminazione fallita password per \"%s\": %s."
@@ -3175,11 +3204,11 @@ msgstr "Eliminazione fallita password per \"%s\": %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Impossibile monitorare canali I/O"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Salva"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Non salvare"
 
@@ -3261,10 +3290,10 @@ msgid "Clear"
 msgstr "Azzera"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Chiudi"
 
@@ -3276,7 +3305,7 @@ msgstr "&Converti"
 msgid "Convert"
 msgstr "Converti"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copia"
@@ -3285,7 +3314,7 @@ msgstr "&Copia"
 msgid "Copy"
 msgstr "Copia"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Ta&glia"
@@ -3294,13 +3323,13 @@ msgstr "Ta&glia"
 msgid "Cut"
 msgstr "Taglia"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Elimina"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Elimina"
@@ -3387,7 +3416,7 @@ msgstr "Disco fisso"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Aiuto"
 
@@ -3407,7 +3436,7 @@ msgstr "Indenta"
 msgid "&Index"
 msgstr "&Indice"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indice"
 
@@ -3476,7 +3505,7 @@ msgstr "&Nuovo"
 msgid "New"
 msgstr "Nuovo"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&No"
 
@@ -3493,12 +3522,12 @@ msgstr "&Apri..."
 msgid "Open..."
 msgstr "Apri..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Incoll&a"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Incolla"
@@ -3528,7 +3557,7 @@ msgid "Print..."
 msgstr "Stampa..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Proprietà"
 
@@ -3560,10 +3589,6 @@ msgstr "Sostituisci..."
 msgid "Revert to Saved"
 msgstr "Ritorna alla versione salvata"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Salva"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Salva con n&ome..."
@@ -3572,7 +3597,7 @@ msgstr "Salva con n&ome..."
 msgid "Save As..."
 msgstr "Salva come..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Seleziona tutto"
@@ -3679,7 +3704,7 @@ msgstr "&Su"
 msgid "Up"
 msgstr "Su"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Si"
 
@@ -3767,43 +3792,43 @@ msgstr "Salva il documento attuale"
 msgid "Save current document with a different filename"
 msgstr "Salva il documento con un nome differente"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "La conversione nella codifica '%s' non funziona."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "blocco di intestazione errato nel file tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "checksum errato durante la lettura dell'intestazione del file TAR"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "dati errati nell'intestazione estesa del file TAR"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "voce del file TAR non aperta"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fine del file non attesa"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s non ha trovato l'intestazione del file tar per l'elemento '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "valore della dimensione errato per una voce del file TAR"
 
@@ -3812,7 +3837,7 @@ msgstr "valore della dimensione errato per una voce del file TAR"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' probabilmente è un buffer binario."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Impossibile caricare il file."
 
@@ -3826,47 +3851,47 @@ msgstr "Impossibile leggere il file di testo \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "impossibile scrivere su disco il buffer '%s'."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Impossibile ottenere l'ora locale di sistema"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay fallita."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' non è un catalogo di messaggi valido."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Messaggio catalogo non valido."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Impossibile analizzare forme plurali: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "utilizzato catalogo '%s' in '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "La risorsa '%s' non è un catalogo di messaggi valido."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Impossibile enumerare la traduzione"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Nessuna applicazione predefinita configurata per i file HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Impossibile aprire URL '%s' nel browser predefinito."
@@ -3899,7 +3924,7 @@ msgstr "'%s' contiene caratteri non validi"
 msgid "Error: %s (%d)"
 msgstr "Errore: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Spazio su disco insufficiente per il download."
 
@@ -3907,20 +3932,20 @@ msgstr "Spazio su disco insufficiente per il download."
 msgid "libcurl could not be initialized"
 msgstr "libcurl non può essere inizializzato"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync non supportata"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Errore durante l'esecuzione del file JavaScript: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "La piattaforma non supporta la trasparenza sfondo."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Impossibile trasferire i dati verso la finestra"
 
@@ -3974,8 +3999,8 @@ msgstr "Create Parameter %s non trovato nella dichiarazione dei parametri RTTI"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Object Class (Non-wxEvtHandler) come Event Source non consentito"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Tipo deve avere enumeratore - convertito a long"
 
@@ -4025,82 +4050,82 @@ msgstr "L'oggetto deve avere un ID ed un attributo"
 msgid "Doubly used id : %d"
 msgstr "Doppio utilizzo di id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Proprietà %s sconosciuta"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Una collezione non vuota deve contenere nodi 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "gestore evento stringa non corretto - manca punto"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "impossibile reinizializzare il flusso zlib di compressione"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "impossibile reinizializzare il flusso di decompressione zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Ignorando il record di dati extra non valido, il file ZIP potrebbe essere "
 "danneggiato"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "si assume che queste siano più parti di un archivio ZIP concatenato"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "file ZIP non valido"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "impossibile trovare il catalogo all'interno del file ZIP"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "errore durante la lettura del catalogo del file ZIP"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "errore durante la lettura dell'intestazione ZIP locale"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "offset scorretto per il file nell'archivio ZIP"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "la lunghezza del file non è memorizzata nell'intestazione del file ZIP"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "metodo di compressione non supportato per il file ZIP"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lunghezza errata durante la lettura del file %s dal file ZIP"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lettura stream zip (elemento %s): CRC errato"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "errore durante la scrittura del file '%s': file troppo grande senza ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "errore durante la scrittura del file '%s': CRC o lunghezza errati"
@@ -4186,32 +4211,32 @@ msgstr "Grafica di "
 msgid "Translations by "
 msgstr "Tradotto da "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versione "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Info su %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licenza"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Sviluppatori"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autori documentazione"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artisti"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Traduttori"
 
@@ -4262,42 +4287,42 @@ msgid "Password:"
 msgstr "Password:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "vero"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "falso"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Colonna %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Riduci"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Espandi"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elementi)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Colonna %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4308,7 +4333,7 @@ msgid "Left"
 msgstr "Sinistra"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4405,7 +4430,7 @@ msgid "Home directory"
 msgstr "Cartella home"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -4418,8 +4443,7 @@ msgstr "Nome cartella non valido."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Errore"
 
@@ -4603,18 +4627,18 @@ msgstr "Visalizza file - dettagli"
 msgid "Go to parent directory"
 msgstr "Cartella superiore"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 "File '%s' già esistente. \n"
 "Vuoi sovrascriverlo?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Conferma"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Segli un file esistente."
 
@@ -4708,7 +4732,7 @@ msgstr "Il corpo della font."
 msgid "Whether the font is underlined."
 msgstr "Sottolineato."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Anteprima:"
@@ -4726,50 +4750,49 @@ msgstr "Clic per annullare la selezione del font."
 msgid "Click to confirm the font selection."
 msgstr "Clic per confermare la selezione del font."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Carattere"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "Non è supportata la copia di più di un blocco selezionato negli Appunti."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Cartella \"%s\" della Guida non trovata."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "File della Guida \"%s\" non trovato."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "La riga %lu del file mappa \"%s\" è stata scartata in quanto scorretta."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Il file \"%s\" non contiene mappature valide."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Voci non trovate."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indice"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Voci pertinenti:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Trovati"
 
@@ -4874,59 +4897,59 @@ msgstr "Impossibile avviare la stampa."
 msgid "Printing page %d..."
 msgstr "Stampa pagina %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opzioni stampante"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Stampa su file"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configurazione..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Stampante:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Stato:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tutto"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Pagine"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Intervallo stampa"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Da:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Per:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Copie:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "File PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Impostazioni di stampa"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Stampante"
 
@@ -4934,25 +4957,25 @@ msgstr "Stampante"
 msgid "Default printer"
 msgstr "Stampante predefinita"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Dimensione foglio"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Verticale"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Orizzontale"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientamento"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opzioni"
 
@@ -4964,52 +4987,52 @@ msgstr "Stampa a colori"
 msgid "Print spooling"
 msgstr "Coda di stampa"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Comando stampante:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opzioni stampante:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Margine sinistro (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Margine superiore (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Margine destro (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Margine inferiore (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Stampante..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Salta"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Sconosciuta"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Completato."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Cerca"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Impossibile trovare l'etichetta per l'id"
 
@@ -5045,11 +5068,11 @@ msgstr "&Fine"
 msgid "< &Back"
 msgstr "< &Indietro"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "ringraziamenti traduttore"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5060,11 +5083,11 @@ msgstr ""
 "Prendi in considerazione la disimpostazione di GTK_IM_MODULE o "
 "l'impostazione su \"ibus\"."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Impossibile inzializzare GTK+, DISPLAY impostato correttamente?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Impossibile modificare la cartella attuale a \"%s\""
@@ -5091,11 +5114,11 @@ msgid "Failed to register font configuration using private fonts."
 msgstr ""
 "Impossibile registrare la configurazione della font usando le font private."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Errore fatale"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5108,7 +5131,7 @@ msgstr ""
 "impostando\n"
 "prima di avviare il programma la variabile di ambiente GDK_BACKEND=x11."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5119,7 +5142,7 @@ msgstr ""
 "Potresti essere in grado di aggirare questo problema impostando prima di "
 "avviare il programma la variabile di ambiente GDK_BACKEND=x11."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Figlio MDI"
 
@@ -5135,17 +5158,13 @@ msgstr "Errore durante la stampa: "
 msgid "Page Setup"
 msgstr "Impostazioni pagina"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Impossibile inserire il testo nella casella di testo."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 "Il recupero della dell'output dello script JavaScript non è supportato con "
 "WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5154,7 +5173,7 @@ msgstr ""
 "composizione schermo. \n"
 "Installa GTK+ 2.12 o versione superiore."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5162,17 +5181,13 @@ msgstr ""
 "Composizione non supportata da questo sistema. \n"
 "Abilitala nel tuo gestore finestra."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Questo programma è stato compilato con una versione troppo vecchia di GTK+.\n"
 "Ricompila con GTK+ 2.12 o versione superiore."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Scegli un font valido."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5273,45 +5288,45 @@ msgstr "Impossibile aprire il file sommario: %s"
 msgid "Cannot open index file: %s"
 msgstr "Impossibile aprire il file indice: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "senzanome"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Impossibile aprire il libro di help HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Visualizza la guida mentre sfogli i manuali sulla sinistra."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(segnalibri)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Aggiungi la pagina attuale ai segnalibri"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Rimuovi la pagina attuale dai segnalibri"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Sommario"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Trova"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Visualizza tutto"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5319,19 +5334,19 @@ msgstr ""
 "Visualizza tutte le voci dell'indice contenenti un dato testo.\n"
 "La ricerca non distingue maiuscole e minuscole."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Visualizza tutti le voci dell'indice"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Maiuscole/minuscole"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Solo parole intere"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5339,147 +5354,147 @@ msgstr ""
 "Cerca i contenuti nelle Guida/e per tutte le occorrenze del testo digitato "
 "di seguito"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Visualizza/nascondi la barra di navigazione"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Indietro"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Avanti"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Livello superiore nella gerarchia di documenti"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Apri un documento HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Stampa questa pagina"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Visualizza riquadro di dialogo per le opzioni"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Scegli la pagina da visualizzare:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Contenuti"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Ricerca..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Pagina corrispondente non ancora trovata"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Trovate %i corrispondenze"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Aiuto)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d di %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu di %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Cerca in tutti i libri"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opzioni del browser della Guida"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Carattere normale:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Font a corpo fisso:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Corpo:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "corpo"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normale <br>e <u>sottolineato</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Corsivo.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Grassetto.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Grassetto corsivo.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Larghezza fissa.<br> <b>grassetto</b> <i>corsivo</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>grassetto corsivo <u>sottolineato</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Stampa"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Impossibile stampare una pagina vuota."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "File HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libro Guida (*.htb)|*.htb|Libro Guida (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Progetto HTML Help (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Guida HTML (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i di %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u di %u"
@@ -5560,32 +5575,6 @@ msgstr ""
 "Si è verificato un problema: potrebbe essere necessario impostare una "
 "stampante predefinita."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Impossibile visualizzare la pagina HTML con la codifica %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets non può aprire il display per '%s': abbandona."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtra"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Cartelle"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "File"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selezione"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Impossibile aprire gli Appunti."
@@ -5627,61 +5616,61 @@ msgstr "Finestra selezione colore fallita con errore %0lx."
 msgid "Failed to create cursor."
 msgstr "Impossibile creare il cursore."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Impossibile registrare il server DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Impossibile de-registrare il server DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Impossibile creare la connessione al server '%s' sull'argomento '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Richiesta DDE (poke) fallita"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Impossibile stabilire un ciclo advise con il server DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Impossibile terminare il ciclo advise con il server DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Impossibile inviare una notifica advise DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Impossibile creare la stringa DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "nessun errore DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "una richiesta di transazione sincrona (advise) ha superato il tempo massimo."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 "la risposta alla transazione ha causato l'impostazione del bit DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "una richiesta di transazione sincrona (data) ha superato il tempo massimo."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5692,7 +5681,7 @@ msgstr ""
 "oppure è stato passato ad una funzione DDEML\n"
 "un identificatore di istanza non valido."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5704,45 +5693,45 @@ msgstr ""
 "oppure un'applicazione inizializzata come APPCMD_CLIENTONLY\n"
 "ha cercato di effettuare una transazione server."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "una richiesta di transazione sincrona (execute) ha superato il tempo massimo."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "un parametro ha fallito la validazione da parte del DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "un'applicazione DDEML ha creato una 'race condition' prolungata."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "allocazione di memoria è fallita."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "tentativo del client di stabilire una connessione fallito."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "una transazione è fallita."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "una richiesta di transazione sincrona (poke) ha superato il tempo massimo."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "una chiamata interna alla funzione PostMessage è fallita. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema di rientranza."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5752,17 +5741,17 @@ msgstr ""
 "già terminata dal client, oppure il server\n"
 "è terminato prima di portare a termine la transazione."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "è avvenuto un errore interno nel DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "una richiesta di terminazione di transazione (advise) ha superato il tempo "
 "massimo."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5773,12 +5762,12 @@ msgstr ""
 "Una volta che l'applicazione è uscita da una callback XTYP_XACT_COMPLETE,\n"
 "l'identificatore di transazione per questa callback non è più valido."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Errore DDE %08x sconosciuto"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5787,7 +5776,7 @@ msgstr ""
 "di Accesso Remoto (RAS) non è installato su questo computer. Installa il "
 "servizio."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5797,65 +5786,65 @@ msgstr ""
 "vecchia.\n"
 "Aggiornala (la funzione richiesta %s è assente)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 "Impossibile ottenere il testo del messaggio di errore di Accesso Remoto (RAS)"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "errore sconosciuto (codice %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Impossibile trovare la connessione attiva: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Trovate più connessioni attive, ne verrà scelta una a caso."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Impossibile connettersi: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Impossibile ottenere i nomi degli ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Connessione impossibile: numero dell'ISP mancante."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Scegli l'ISP da chiamare"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Scegli l'ISP a cui connettersi"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Connessione impossibile: mancano nome utente/password."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Impossibile trovare il file degli indirizzi"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Impossibile inizializzare connessione dialup: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Impossibile disconnettersi - nessuna connessione attiva."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Impossibile terminare la connessione: %s"
@@ -5875,18 +5864,17 @@ msgstr "Impossibile allocare %luKb di memoria per i dati bitmap."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Impossibile elencare i file nella cartella '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Impossibile ottenere nome cartella"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(errore %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Impossibile aggiungere un'immagine all'elenco."
 
@@ -5902,7 +5890,7 @@ msgstr ""
 "Impossibile creare riquadro di ricerca/sostituzione standard (codice di "
 "errore %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Finestra dialogo file fallita con codice errore %0lx."
@@ -5945,16 +5933,16 @@ msgstr "Impossibile impostare controllo per '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Impossibile monitorare la cartella \"%s\" per le modifiche."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "Il driver OpenGL non supporta OpenGL 3.0 o superiore."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Impossibile creare contesto OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Impossibile inizializzare OpenGL"
 
@@ -5963,7 +5951,7 @@ msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 "Impossibile registrare il caricatore di font DirectWrite personalizzato."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5971,7 +5959,7 @@ msgstr ""
 "Funzionalità Guida HTML MS non disponibili perchè la relativa libreria non è "
 "installata in questo computer. Installa la libreria."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Impossibile inizializzare MS HTML Help."
 
@@ -5980,7 +5968,7 @@ msgstr "Impossibile inizializzare MS HTML Help."
 msgid "Can't delete the INI file '%s'"
 msgstr "Impossibile eliminare il file INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Impossibile ottenere informazioni sull'elemento %d del list control."
@@ -6100,7 +6088,7 @@ msgstr "Impossibile registrare il formato '%s' degli appunti."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Il formato '%d' degli appunti non esiste."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Salta"
 
@@ -6191,59 +6179,59 @@ msgstr ""
 "La cancellazione renderebbe il sistema inutilizzabile:\n"
 "Operazione abbandonata."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Impossibile eliminare la chiave '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Impossibile eliminare il valore '%s' dalla chiave '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Impossibile leggere il valore della chiave '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Impossibile impostare il valore di '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Il valore registro \"%s\" non è di tipo numerico (ma di tipo %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Il valore registro \"%s\" non è di tipo binario (ma di tipo %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Il valore registro \"%s\" non è di tipo testo (ma di tipo %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Impossibile leggere il valore di '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Impossibile elencare i valori della chiave '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Impossibile elencare le sotto chiavi della chiave '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6251,17 +6239,17 @@ msgstr ""
 "Durante l'esportazione della chiave di registro: il file \"%s\" esiste e non "
 "verrà sovrascritto."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Impossibile esportare valori del tipo non supportato %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Il valore \"%s\" della chiave \"%s\" è stato ignorato."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6270,41 +6258,41 @@ msgstr ""
 "testo semplice.\n"
 "Reinstalla riched32.dll."
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Impossibile avviare il thread: errore nella scrittura del TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Impossibile impostare la priorità del thread"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Impossibile creare il thread"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Impossibile terminare il thread"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Impossibile attendere la fine del thread"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Impossibile sospendere il thread %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Impossibile riprendere il thread %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Impossibile ottenere un puntatore al thread attuale"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6312,7 +6300,7 @@ msgstr ""
 "Inizializzazione del modulo dei thread fallita: impossibile allocare "
 "l'indice nella memoria locale del thread"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6344,12 +6332,12 @@ msgstr "Impossibile caricare risorsa \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Impossibile bloccare risorsa \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", versione 64-bit"
 
@@ -6361,52 +6349,52 @@ msgstr "Impossibile creare una pipe anonima"
 msgid "Failed to redirect the child process IO"
 msgstr "Impossibile redirigere l'input/output del processo figlio"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Esecuzione del comando '%s' fallita"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Impossibile caricare mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Impossibile leggere l'identificatore di tipo da '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Impossibile caricare l'icona da '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 "Impossibile trovare il livello di emulazione della visualizzazione web nel "
 "registro"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 "Impossibile impostare la visualizzazione web al livello di emulazione moderno"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 "Impossibile ripristinare la visualizzazione web al livello di emulazione "
 "standard"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 "Impossibile eseguire lo script JavaScript senza un documento HTML valido"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Impossibile ottenere l'oggetto JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "impossibile valutare"
 
@@ -6439,7 +6427,7 @@ msgid "Check to make the font italic."
 msgstr "Seleziona per rendere il font corsivo."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Sottolineato"
@@ -6506,15 +6494,33 @@ msgstr "<Qualunque teletype>"
 msgid "File type:"
 msgstr "Tipo file:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Finestra"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Aiuto"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimizza"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Porta tutto in primo piano"
 
@@ -6531,463 +6537,463 @@ msgstr "Il file font '%s' non esiste."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Impossibile usare il file della font \"%s\" poiché non si trova all'interno "
 "della cartella delle font \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Info su %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Info..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferenze..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Servizi"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Nascondi %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Nascondi applicazione"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Nascondi altri"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Visualizza tutto"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Esci da %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Esci dall'applicazione"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "La stampa non è supportata dal controllo web del sistema"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Impossibile inizializzare l'operazione di stampa"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Dimensione punti"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nome faccia"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stile"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Peso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Famiglia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "SpazioLavoroApp"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "Bordo attivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "Titolo attivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ApparenzaPulsante"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "EvidenziazionePulsante"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "OmbreggiaturaPulasnte"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "TestoPulsante"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "TitoloTesto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlloScuro"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlloChiaro"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "Testo grigio"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Evidenzia"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Testo evidenziato"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "Bordo non attivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "TitoloNonAttivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "TestoTitoloNonAttivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Barra scorrimento"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Suggerimento"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "Testo suggerimento"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Finestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "FrameFinestra"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "TestoFinestra"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Personalizzata"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Nero"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Marrone"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Navy"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Viola"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Teal"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Grigio"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Oliva"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Marrone"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Blu"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fucsia"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Rosso"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Arancio"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Argento"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Lime"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Acqua"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Giallo"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Bianco"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Predefinito"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Freccia"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Freccia destra"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Vuoto"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Occhio di bue"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Carattere"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Incrocio"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Mano"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Pulsante sinistro"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Ingrandimento"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Pulsante centrale"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Nessun elemento"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Pennello"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Matita"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Punto a sinistra"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Punta a destra"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Freccia domanda"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Pulsante destro"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Posizionamento NE-SO"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Posizionamento N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Posizionamento NO-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Posizionamento O-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Posizionamento"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Bombola spray"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Attendi"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Monitora"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Freccia attesa"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Effettua una selezione:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Proprietà"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valore"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Modo categorizzato"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Modo alfabetico"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Vero"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Non specificato"
 
@@ -7002,50 +7008,50 @@ msgstr ""
 "È stato inserito un valore non valido. \n"
 "Premi 'ESC' per annullare la modifica."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Errore nella risorsa: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
-"Tipo operazione \"%s\" fallita: etichetta proprietà: \"%s\" è del tipo \"%s"
-"\", NON \"%s\"."
+"Tipo operazione \"%s\" fallita: etichetta proprietà: \"%s\" è del tipo "
+"\"%s\", NON \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Base sconosciuta %d. Verrà usata la base 10."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Il valore deve essere %s o superiore."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Il valore deve essere tra %s e %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Il valore deve essere %s o inferiore."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Non %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Scegli una cartella:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Scegli un file"
 
@@ -7512,117 +7518,117 @@ msgstr "Aggiunta"
 msgid "Outset"
 msgstr "Rimozione"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Modifica stile"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Modifica stile oggetto"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Modifica proprietà"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Modifica stile elenco"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Rinumera l'elenco"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Inserisci testo"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Inserisci immagine"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Inserisci oggetto"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Inserisci campo"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Troppe chiamate a EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "file"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standard/cerchio"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standard/cerchio con contorno"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standard/quadrato"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standard/diamante"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standard/triangolo"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Proprietà riquadro"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Proprietà celle multiple"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Proprietà cella"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Imposta stile cella"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Elimina riga"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Elimina colonna"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Aggiungi riga"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Aggiungi colonna"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Proprietà tabella"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Proprietà immagine"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "immagine"
 
@@ -7830,24 +7836,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Trascina"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Elimina testo"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Rimuovi punto elenco"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Il testo non può essere salvato."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Sostituisci"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Font:"
 
@@ -8818,53 +8824,53 @@ msgstr "Stili elenco"
 msgid "Box styles"
 msgstr "Stili riquadro"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Il font da cui prendere il simbolo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Sottoinsieme:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Visualizza un sottoinsieme Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Codice carattere:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Il codice del carattere."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Da:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Intervallo da visualizzare."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Inserisci"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Testo normale)"
 
@@ -9052,7 +9058,7 @@ msgstr "Impossibile ottenere eventi da kqueue"
 msgid "Media playback error: %s"
 msgstr "Errore riproduzione: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Impossibile preparare riproduzione \"%s\"."
@@ -9152,22 +9158,22 @@ msgstr "Formato dei dati sonori non supportato."
 msgid "Couldn't open audio: %s"
 msgstr "Impossibile inizializzare l'audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Impossibile determinare la strategia di pianificazione."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Impossibile ottenere un intervallo di priorità per la strategia di "
 "pianificazione %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Priorità del thread ignorata."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9175,61 +9181,61 @@ msgstr ""
 "Impossibile esegure la join su di un thread, possibile memoria persa (leak) "
 "- esegui nuovamente il programma"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Impossibile impostare livello concorrenza a %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Impossibile assegnare la priorità %d al thread."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Impossibile terminare il thread."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Inizializzazione del modulo dei thread fallita: errore nella creazione della "
 "chiave dei thread"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Impossibile ottenere l'input del processo figlio"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Impossibile scrivere nello stdin del processo figlio"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Impossibile eseguire '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Fork fallita"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Impossibile impostare la priorità"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Impossibile redirigere l'input/output del processo figlio"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Impossibile impostare pipe non bloccante, il programma potrebbe bloccarsi."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Impossibile ottenere il nome dell'host"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Impossibile ottenere il nome ufficiale dell'host"
 
@@ -9245,12 +9251,12 @@ msgstr "Impossibile commutare coda risveglio in modalità non bloccante"
 msgid "Failed to read from wake-up pipe"
 msgstr "Impossibile leggere dalla coda di risveglio"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Specifica della posizione e/o dimensioni '%s' non valida"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets non può aprire il display. Uscita."
 
@@ -9264,30 +9270,59 @@ msgstr "Impossibile chiudere il display \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Impossibile aprire il display \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Errore durante l'analisi XML: %s alla riga %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Impossibile caricare le risorse da '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Impossibile aprire il file risorse '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Impossibile caricare le risorse dal file '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Creazione di %s \"%s\" fallita."
+
+#~ msgid "Printing "
+#~ msgstr "Stampa "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Impossibile inserire il testo nella casella di testo."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Scegli un font valido."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Impossibile visualizzare la pagina HTML con la codifica %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets non può aprire il display per '%s': abbandona."
+
+#~ msgid "Filter"
+#~ msgstr "Filtra"
+
+#~ msgid "Directories"
+#~ msgstr "Cartelle"
+
+#~ msgid "Files"
+#~ msgstr "File"
+
+#~ msgid "Selection"
+#~ msgstr "Selezione"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "la conversione in una codifica ad 8 bit è fallita"
@@ -9452,8 +9487,8 @@ msgstr "Creazione di %s \"%s\" fallita."
 #~ msgstr "Data renderizzazione non può rendere valore; tipo valore:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2011-03-02 18:30+0900\n"
 "Last-Translator: Suzumizaki-Kimitaka(鈴見咲君高) <suzumizaki@free."
 "japandesign.ne.jp>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "すべてのファイル (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "すべてのファイル (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "残り時間:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "はい"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "いいえ"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "キャンセル"
@@ -102,7 +99,7 @@ msgid "Unable to create I/O completion port"
 msgstr "I/O完了ポートを作成できません"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "印刷出力"
 
@@ -145,7 +142,7 @@ msgstr "プロパティー (&P)"
 msgid "Printing"
 msgstr "印刷"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "記号"
 
@@ -215,7 +212,7 @@ msgstr "前 (&P)"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "ウィンドウ (&W)"
 
@@ -782,11 +779,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Ctrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "このヘルプメッセージを表示します"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "冗長なログメッセージを生成します。"
 
@@ -808,84 +805,84 @@ msgstr "テーマ '%s' は未対応です。"
 msgid "Invalid display mode specification '%s'."
 msgstr "画面モード '%s' は正しい指定ではありません。"
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "ディレクトリー '%s' を作成できませんでした"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "未定義の詳細オプション名 '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "未定義の簡易オプション名 '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "オプション '%s' に想定外の文字が続いています。"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "オプション '%s' には値の指定が必要です。"
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "オプション '%s' の後には区切り文字が必要です。"
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' はオプション '%s' に使えない数値です。"
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "オプション '%s': '%s' という表現は日付に変換できません。"
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "想定外の変数 '%s' があります"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (または %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "オプション '%s' とその値は必ず指定してください。"
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "必須引数 '%s' が与えられていません。"
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "文字列"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "数値"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "double値"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "日付"
 
@@ -903,7 +900,7 @@ msgid "Can't &Undo "
 msgstr "戻せません (&U)"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "元に戻す (&U)"
@@ -913,7 +910,7 @@ msgid "&Redo "
 msgstr "再実行 (&R)"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "再実行 (&R)"
@@ -941,12 +938,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' に余分な '..' がありました。無視します。"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -956,103 +953,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "下線"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "今日"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "昨日"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "明日"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "1日"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "2日"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "3日"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "4日"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "5日"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "6日"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "7日"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "8日"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "9日"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "10日"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "11日"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "12日"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "13日"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "14日"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "15日"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "16日"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "17日"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "18日"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "19日"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "20日"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "正午"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "0時"
 
@@ -1120,101 +1117,138 @@ msgstr "curl を実行できません。PATHの参照先にインストールし
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "デバッグレポートのアップロードができませんでした (エラーコード %d)。"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Save As"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "変更を破棄して最後に保存したものを読み直しますか?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "名称未指定"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "変更結果を %s へ保存しますか?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "保存 (&S)"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "保存しない"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "変更結果を %s へ保存しますか?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "テキストが保存できませんでした。"
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "ファイル '%s' に書き込もうとしましたが開くことができません"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "文書をファイル \"%s\" に保存できませんでした。"
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "ファイル '%s' を読み取ろうとしましたが開くことができません"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, fuzzy, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr "最近使ったファイルのリストから削除されています。"
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "印刷プレビューを作成できませんでした。"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "印刷プレビュー"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "ファイル '%s' の様式を決定できませんでした。"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "名称未指定%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "ファイルを開く"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "ファイルエラー"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "ファイルを開くことができませんでした。"
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "このファイルの形式は未対応です。"
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "文書の雛形を選んでください"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "雛形"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "文書ビューの選択"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "ビュー"
 
@@ -1248,41 +1282,41 @@ msgstr "ファイル '%s' の読み取りエラー"
 msgid "Write error on file '%s'"
 msgstr "ファイル '%s' への書き出しエラー"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "ファイル '%s' のフラッシュができませんでした"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "ファイル '%s' のシークエラー(stdioでは大きなファイルに対応できません)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "ファイル '%s' のシークエラー"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "ファイル '%s' の現在位置を見つけられません"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "一時ファイルのパーミッションを設定できませんでした。"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ファイル '%s' を削除できません"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "変更をファイル '%s' に反映できません。"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "一時ファイル '%s' を削除できません"
@@ -1307,27 +1341,27 @@ msgstr "記述子 %d のファイルから読み取ることができません"
 msgid "can't write to file descriptor %d"
 msgstr "記述子 %d のファイルへ書き出すことができません。"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "記述子 %d のファイルをフラッシュできません"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "記述子 %d のファイル上をシークできません"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "記述子 %d のファイルからシーク位置を取得できません"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "記述子 %d のファイルから長さを取得できません"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "記述子 %d のファイルがEOFに達したかどうかを判断できません"
@@ -1351,107 +1385,107 @@ msgstr "ファイル \"%s\" への上書きが拒否されたため変更内容�
 msgid "Error reading config options."
 msgstr "設定オプションの読み取りエラー"
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "設定オプションを読み取ることができませんでした。"
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "ファイル '%s': 想定外の文字 %c が %d 行目にありました。"
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "ファイル '%s' %d行目: グループヘッダの後にある '%s' は無視されます。"
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "ファイル '%s' %d行目: '=' がありません｡"
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "ファイル '%s'  %d行目: 不変キー '%s' への値は無視されます。"
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "ファイル '%s' %d行目: キー '%s' はすでに %d行目に出てきました。"
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "設定項目名は '%c' で始めることができません。"
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "ユーザー設定ファイルを開くことができません。"
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "ユーザー設定ファイルを書き出すことができません。"
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "ユーザー設定ファイルを更新できませんでした。"
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "ユーザー設定データの保存中にエラーが発生しました。"
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "ユーザー設定ファイル '%s' を削除できません"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "項目 '%s' が二回以上グループ '%s' に現れています"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "不変キー '%s' への変更要求を無視しました。"
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' の末尾にある / は無視されました"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "%d文字目に想定外の\"があります '%s'。"
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "ファイル '%s' を '%s' へコピーできませんでした。"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "ファイル '%s' へのパーミッションは取得不可能です"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "ファイル '%s' の上書きは不可能です"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "ファイル '%s' を '%s' へコピーできませんでした。"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "ファイル '%s' へのパーミッションは設定不可能です"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1460,41 +1494,41 @@ msgstr ""
 "ファイル '%s' を '%s' に改名できませんでした。改名先のファイルがすでに存在し"
 "ています。"
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "ファイル '%s' を開くことができません。"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "ファイル '%s' を開くことができません。"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "ディレクトリー '%s' を作成できませんでした"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "ディレクトリー '%s' を削除できませんでした"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "ファイルを列挙できません '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "作業ディレクトリーを取得できませんでした。"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "作業ディレクトリーを取得できませんでした。"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "ファイル (%s)"
@@ -1521,17 +1555,17 @@ msgstr "一時ファイルの名前を作成できませんでした。"
 msgid "Failed to open temporary file."
 msgstr "一時ファイルを開くことができませんでした。"
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "'%s' のファイル時刻を変更できませんでした"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "ファイル '%s' の属性を変更できませんでした。"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s' のファイル時刻を取得できませんでした。"
@@ -1540,22 +1574,22 @@ msgstr "'%s' のファイル時刻を取得できませんでした。"
 msgid "Browse"
 msgstr "ファイルの選択"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "すべてのファイル (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s 形式 (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "%s ファイルの読み取り"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "%s ファイルを保存"
@@ -1924,106 +1958,106 @@ msgstr "規定"
 msgid "unknown-%d"
 msgstr "未知-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "下線"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " 打ち消し線"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " 軽量"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " 軽量"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " 太字"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " 太字"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " 太字"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " イタリック"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 #, fuzzy
 msgid "strikethrough"
 msgstr "打ち消し線 (&S)"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "軽量"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "軽量"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "通常"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "太字"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "太字"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "太字"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "イタリック"
 
@@ -2104,7 +2138,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP転送モードを %s に変更できませんでした。"
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2125,7 +2159,7 @@ msgstr "そのFTPサーバーはPASSIVEモードに対応していません。"
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF フレームの大きさ (%u, %d) が不適切です (フレーム #%u)"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL に色を割り当てることができませんでした。"
 
@@ -2141,7 +2175,7 @@ msgstr "列の編集"
 msgid "&Customize..."
 msgstr "列の編集 (&C) ..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "デフォルトブラウザでURL \"%s\" を開けませんでした。"
@@ -2161,156 +2195,155 @@ msgstr "画像 %d をストリームから読み取れませんでした。"
 msgid "Failed to load icons from resource '%s'."
 msgstr "画像 %d をストリームから読み取れませんでした。"
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: 不正な画像で保存できませんでした。"
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage は自身の wxPalette を保有していません。"
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Bitmapヘッダの書き出しに失敗しました。"
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: BitmapInfoヘッダの書き出しに失敗しました。"
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB色索引を書き出せませんでした。"
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: データ書き出しに失敗しました。"
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: メモリ割り当てに失敗しました。"
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB ヘッダー: 画像の幅が32767ピクセルを超えています。"
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB ヘッダー: 画像の高さが32767ピクセルを超えています。"
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB ヘッダー: 未知のビット深さがファイルに含まれています。"
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB ヘッダー: 未知のエンコーディングがファイルに含まれています。"
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB ヘッダー: エンコーディングがビット深さに対応していません。"
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: メモリ割り当てに失敗しました。"
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB ヘッダー: 画像の幅が32767ピクセルを超えています。"
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB ヘッダー: 画像の高さが32767ピクセルを超えています。"
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB ヘッダー: 未知のビット深さがファイルに含まれています。"
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB ヘッダー: 未知のエンコーディングがファイルに含まれています。"
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB ヘッダー: エンコーディングがビット深さに対応していません。"
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "画像のDIB読み取りエラー。"
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: マスクDIBの読み取り中にエラーを検出しました。"
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: 縦に長すぎます。アイコンに変換できません。"
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: 幅が大きすぎます。アイコンに変換できません。"
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: 画像ファイルの書き出し中にエラーが発生しました。"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: アイコンの索引が不正のようです。"
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "画像とマスクが異なる大きさになっています。"
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "マスクされるべき未使用色が画像にありません。"
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "画像 %d をストリームから読み取れませんでした。"
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "画像 %d をストリームから読み取れませんでした。"
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "ファイル \"%s\" からメタファイルを読み取れませんでした。"
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "画像を保存できません。'%s' は未対応の拡張子を持っています。"
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "イメージタイプのハンドラーが見つかりません。"
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d 型のイメージハンドラーが定義されていません。"
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "画像ファイルは %ld 形式ではないようです。"
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "未知のデータ様式です"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: PCXファイルではないようです。"
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s 型のイメージハンドラーが定義されていません。"
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "画像ファイルは %s 形式ではないようです。"
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "ファイル \"%s\" にビットマップイメージを保存できませんでした。"
@@ -2412,52 +2445,52 @@ msgstr "PNM: ファイルが欠けているようです。"
 msgid " (in module \"%s\")"
 msgstr "(モジュール \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: 画像の読み取りエラーを検出しました。"
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "TIFF 画像索引が不正です。"
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: 画像の大きさが極端に大きいようです。"
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: メモリ割り当てに失敗しました。"
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: 画像の読み取りエラーを検出しました。"
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "未知の解像度単位 %d を無視しました"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: 画像の書き出しエラーを検出しました。"
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: 画像の書き出しエラーを検出しました。"
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "コマンドライン引数 %d はユニコードに変換できません。無視されます。"
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "PostInit の初期化に失敗しました。中断します。"
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "ロケールを言語 \"%s\" に設定できません。"
@@ -2554,7 +2587,7 @@ msgstr "圧縮エラー"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "MIME型 %s の項目に閉じていない '{' がありました。"
@@ -2574,7 +2607,7 @@ msgstr "依存先の \"%s\" (モジュール \"%s\" 内) は存在しません�
 msgid "Module \"%s\" initialization failed"
 msgstr "モジュール \"%s\" の初期化に失敗しました"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "%s からの通知"
@@ -3077,7 +3110,7 @@ msgstr "印刷エラー"
 msgid "Print"
 msgstr "印刷"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "ページの設定"
 
@@ -3114,20 +3147,16 @@ msgstr "%d ページを印刷中 ..."
 msgid " (copy %d of %d)"
 msgstr "%dページ (%dページ中)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "印刷"
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "次のページ"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "前のページ"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "次のページ"
 
@@ -3174,16 +3203,16 @@ msgstr "%dページ (%dページ中)"
 msgid "Page %d"
 msgstr "%dページ"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "想定外のエラーです"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "不正な正規表現です '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "正規表現に合致する部分が見つかりませんでした: %s"
@@ -3195,21 +3224,21 @@ msgstr ""
 "レンダラー \"%s\" は非互換バージョン %d.%d で実装されているため読み取ることが"
 "できません。"
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s' を '%s' に展開できませんでした。"
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s' を '%s' に展開できませんでした。"
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s' を '%s' に展開できませんでした。"
@@ -3218,11 +3247,11 @@ msgstr "'%s' を '%s' に展開できませんでした。"
 msgid "Failed to monitor I/O channels"
 msgstr "I/O チャンネルの監視に失敗しました。"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "保存"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "保存しない"
 
@@ -3311,10 +3340,10 @@ msgid "Clear"
 msgstr "消去 (&C)"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "閉じる"
 
@@ -3327,7 +3356,7 @@ msgstr "変換 (&C)"
 msgid "Convert"
 msgstr "変換 (&C)"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "コピー (&C)"
@@ -3336,7 +3365,7 @@ msgstr "コピー (&C)"
 msgid "Copy"
 msgstr "コピー"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "切り取り (&T)"
@@ -3345,13 +3374,13 @@ msgstr "切り取り (&T)"
 msgid "Cut"
 msgstr "切り取り"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "削除 (&D)"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "削除"
@@ -3447,7 +3476,7 @@ msgstr "ハードディスク (&H)"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "ヘルプ (&H)"
 
@@ -3467,7 +3496,7 @@ msgstr "字下げ"
 msgid "&Index"
 msgstr "索引 (&I)"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "索引"
 
@@ -3541,7 +3570,7 @@ msgstr "新規作成 (&N)"
 msgid "New"
 msgstr "新規作成 (&N)"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "いいえ (&N)"
 
@@ -3559,12 +3588,12 @@ msgstr "開く (&O) ..."
 msgid "Open..."
 msgstr "開く (&O) ..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "貼り付け (&P)"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "貼り付け"
@@ -3598,7 +3627,7 @@ msgid "Print..."
 msgstr "印刷 (&P) ..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "プロパティー (&P)"
 
@@ -3633,10 +3662,6 @@ msgstr "置換"
 msgid "Revert to Saved"
 msgstr "保存した状態まで戻します"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "保存 (&S)"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "別名で保存(&A) ..."
@@ -3646,7 +3671,7 @@ msgstr "別名で保存(&A) ..."
 msgid "Save As..."
 msgstr "別名で保存(&A) ..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "すべて選択(&A)"
@@ -3762,7 +3787,7 @@ msgstr "上 (&U)"
 msgid "Up"
 msgstr "上へ"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "はい (&Y)"
 
@@ -3855,43 +3880,43 @@ msgstr "現在の文書を保存します"
 msgid "Save current document with a different filename"
 msgstr "現在の文書を別名で保存します"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "文字集合 '%s' への変換が機能していません。"
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "不明"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "不完全なtarヘッダブロックです"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "ヘッダーブロックを読み取り中にチェックサムの不整合が見つかりました"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "拡張tarヘッダに不正なデータがあります"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "TARの項目を開くことができません"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "想定外の状況でファイル末尾に達しました"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s は tar のヘッダとして認識できませんでした '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tar項目に不正な大きさが与えられています"
 
@@ -3900,7 +3925,7 @@ msgstr "tar項目に不正な大きさが与えられています"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' はおそらくバイナリーバッファーです。"
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "ファイルを読み取ることができません。"
 
@@ -3914,48 +3939,48 @@ msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
 msgid "can't write buffer '%s' to disk."
 msgstr "バッファー '%s' をディスクに書き出すことができません。"
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "ローカルのシステム時刻を取得できませんでした。"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay が失敗しました。"
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' は正しいメッセージカタログではありません。"
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "正しいメッセージカタログではありません。"
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "複数形を解析できません: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "カタログ '%s' を '%s' から利用します。"
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' は正しいメッセージカタログではありません。"
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "スレッドを終了できませんでした"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "HTMLファイルに対する既定のアプリケーション設定がありません。"
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "デフォルトブラウザでURL \"%s\" を開けませんでした。"
@@ -3988,7 +4013,7 @@ msgstr "'%s' はアルファベット以外を受け付けません。"
 msgid "Error: %s (%d)"
 msgstr "エラー:"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3997,21 +4022,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "列の記述を初期化できませんでした。"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "文字列変換は未対応です"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "ウィンドウへデータを転送できませんでした。"
 
@@ -4065,8 +4090,8 @@ msgstr "宣言された RTTI 変数の中には Create で指定されたもの�
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "wxEvtHandler ではないオブジェクトクラスがイベントソースになっています"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "型は列挙からlongへの変換が可能でなくてはなりません。"
 
@@ -4118,79 +4143,79 @@ msgstr "オブジェクトには id 属性が必須です。"
 msgid "Doubly used id : %d"
 msgstr "識別子が重複しています: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "未知のプロパティ %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "空でないコレクションは 'element' ノードを必須とします"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "点が付いていない不正なイベントハンドラー文字列です"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlibをdeflateストリームで再初期化できません"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlibをinflateストリームで再初期化できません"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "複数のzipファイルが結合されるよう意図されたデータです"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "不完全なzipファイルです"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "zip内にセントラルディレクトリー部が見つかりません。"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "zipのセントラルディレクトリーを読み取り中にエラーを検出しました"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "zipのローカルヘッダーを読み取り中にエラーを検出しました。"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "項目へのzipfileオフセットが不適当です"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "Zipヘッダーにファイルの長さが記されていません"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "この Zip 圧縮法には未対応です"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zipストリームの読み取り中 (項目 %s): 不正な長さ"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zipストリームの読み取り中 (項目 %s): CRC 不一致"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "zip項目 '%s' の書き出しエラー: CRCまたは長さが不正です"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "zip項目 '%s' の書き出しエラー: CRCまたは長さが不正です"
@@ -4277,32 +4302,32 @@ msgstr "デザイナー"
 msgid "Translations by "
 msgstr "翻訳 : "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "バージョン "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "%s について"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "許諾"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "開発者"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "説明書の著者"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "デザイン"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "翻訳者"
 
@@ -4354,44 +4379,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "偽"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (または %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4402,8 +4426,7 @@ msgid "Left"
 msgstr "左"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4500,7 +4523,7 @@ msgid "Home directory"
 msgstr "ホームディレクトリー"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "デスクトップ"
 
@@ -4513,8 +4536,7 @@ msgstr "不正なディレクトリー名です。"
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "エラー"
 
@@ -4697,16 +4719,16 @@ msgstr "詳細情報付きでファイル一覧を見る"
 msgid "Go to parent directory"
 msgstr "親ディレクトリーへ移動"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "ファイル %s はすでに存在します。上書きしてよろしいですか?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "確定"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "存在するファイルを選んでください。"
 
@@ -4800,7 +4822,7 @@ msgstr "フォントの大きさをポイントで記します。"
 msgid "Whether the font is underlined."
 msgstr "フォントに下線が付くかどうか。"
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "プレビュー:"
@@ -4818,49 +4840,48 @@ msgstr "クリックでフォントの選択をキャンセルします。"
 msgid "Click to confirm the font selection."
 msgstr "クリックでフォントの選択を確定します。"
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "フォントを選んでください"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "ヘルプディレクトリー \"%s\" が見つかりません。"
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "ヘルプファイル \"%s\" が見つかりません。"
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "%lu 行目 (マップファイル \"%s\" ) に文法不適合がありました。無視します。"
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "ファイル \"%s\" には適切なマップが含まれていません。"
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "項目が見つかりません。"
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "ヘルプの索引"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "関連項目:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "候補が見つかりました"
 
@@ -4967,59 +4988,59 @@ msgstr "印刷を始められませんでした。"
 msgid "Printing page %d..."
 msgstr "%d ページを印刷中 ..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "プリンターのオプション"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "ファイルへ印刷"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "設定 ..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "プリンター:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "状態:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "すべて"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "指定"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "印刷範囲"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "開始ページ:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "末尾ページ:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "部数:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript ファイル"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "印刷設定"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "プリンター"
 
@@ -5027,25 +5048,25 @@ msgstr "プリンター"
 msgid "Default printer"
 msgstr "既定のプリンター"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "用紙サイズ"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "縦置き"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "横置き"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "向き"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "オプション"
 
@@ -5057,52 +5078,52 @@ msgstr "カラー印刷"
 msgid "Print spooling"
 msgstr "印刷予約設定"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "プリンターへのコマンド:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "プリンターのオプション:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "余白-左 (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "余白-天 (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "余白-右 (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "余白-地 (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "プリンター ..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "スキップ (&S)"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "不明"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "完了しました。"
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "検索"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "識別子に対応したタブが見つかりませんでした。"
 
@@ -5138,22 +5159,22 @@ msgstr "完了 (&F)"
 msgid "< &Back"
 msgstr "< 戻る (&B)"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "翻訳者-謝辞"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+を初期化できません。 DISPLAY の設定が不適切の可能性があります。"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "ディレクトリー \"%s\" を作成できませんでした。"
@@ -5179,12 +5200,12 @@ msgstr "ファイル \"%s\" から文書を読み取れませんでした。"
 msgid "Failed to register font configuration using private fonts."
 msgstr "ユーザー設定ファイルを更新できませんでした。"
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "重大なエラー"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5192,7 +5213,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5200,7 +5221,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI子ウィンドウ"
 
@@ -5216,35 +5237,27 @@ msgstr "印刷中にエラー発生: "
 msgid "Page Setup"
 msgstr "ページの設定"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "そのコントロールにテキストを挿入できませんでした。"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "有効なフォントを選んでください。"
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5343,210 +5356,210 @@ msgstr "目次ファイルを開くことができません: %s"
 msgid "Cannot open index file: %s"
 msgstr "索引ファイルを開くことができません: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "名称未設定"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTMLヘルプブックを開くことができません: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "横に置く本のようにヘルプを表示します。"
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(ブックマーク)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "現在のページをブックマークに追加します"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "ブックマークから現在のページを削除します"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "目次"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "検索"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "すべて表示"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 "与えられた文字列を含む索引項目を表示します。大文字小文字は区別しません。"
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "索引に全項目を表示します"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "大文字小文字を区別"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "全体一致のみ"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "上で入力したテキストがある部分をヘルプブックの全体に渡って検索します"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "ナビゲーションパネルの表示/非表示を切り替えます"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "戻る"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "進む"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "文書構造のひとつ上へ"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "HTML文書を開く"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "このページを印刷"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "オプションダイアログを表示します"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "表示するページを選んでください:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "ヘルプトピック"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "検索中..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "一致するページがまだありません。"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i 件の該当部を発見"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(ヘルプ)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "すべてのブックを検索"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "ヘルプブラウザのオプション"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "通常のフォント:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "固定幅フォント:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "フォントの大きさ:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "フォントの大きさ"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "通常<br> と <u>下線付き</u>"
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>イタリック体。</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>太字。</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>太字でイタリック体。</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "固定幅。<br> <b>太字</b><i>イタリック</i>"
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>太字でイタリック体 <u>下線</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "ヘルプの印刷"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "空のページは印刷できません。"
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML ファイル (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "ヘルプブック (*.htb)|*.htb|ヘルプブック (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTMLヘルププロジェクト (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "圧縮HTMLヘルプ (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i / %i"
@@ -5625,33 +5638,6 @@ msgstr ""
 "ページの準備中に問題が検出されました: 既定のプリンターが未指定なら指定してく"
 "ださい。"
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "%s エンコーディングで HTML 文書を表示できませんでした。"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr ""
-"wxWidgets はディスプレイ '%s' を開くことができませんでした: 終了します。"
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "フィルター"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "ディレクトリー"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "ファイル"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "選択"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "クリップボードを開くことができませんでした。"
@@ -5693,58 +5679,58 @@ msgstr "色選択ダイアログがエラー %0lx で失敗しました。"
 msgid "Failed to create cursor."
 msgstr "カーソルを作成できませんでした。"
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "DDEサーバー '%s' を登録できませんでした。"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "DDE サーバ '%s' の登録を削除できませんでした。"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "サーバー '%s' へのトピック '%s' 接続を確立できませんでした。"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE の poke 要求が失敗しました"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE サーバーとのアドバイスループを確立できませんでした。"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE サーバ他とのアドバイスループを終了できませんでした。"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "DDE アドバイス通知を送信できませんでした。"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "DDE文字列を作成できませんでした。"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "DDE エラーはありませんでした。"
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "非同期 advise トランザクションの要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "トランザクションへの応答が DDE_FBUSY ビットの設定を引き起こしました。"
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "非同期 data トランザクションの要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5755,7 +5741,7 @@ msgstr ""
 "無効な実体識別子が DDEML 関数に渡されました。\n"
 "　"
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5767,43 +5753,43 @@ msgstr ""
 "APPCMD_CLIENTONLY で初期化されたものが\n"
 "サーバートランザクションの実現を試みようとしました。"
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "非同期 execute トランザクションの要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML の評価により引数の失敗が検出されました。"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML アプリケーションが競合状態の延長として作成されています｡"
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "メモリ割り当てに失敗しました。"
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "クライアントによる通信対話の確立が試みられましたが失敗しました。"
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "トランザクションが失敗しました。"
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "非同期 poke トランザクションの要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage関数の内部呼び出しが失敗しました。"
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "同期トランザクションが別の同期トランザクションを開始しようとしました。"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5813,15 +5799,15 @@ msgstr ""
 "クライアントによって終了されたかトランザクション成立前に\n"
 "終了してしまいました。"
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEMLの内部エラーが発生しました。"
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "advise トランザクション終了の要求が時間切れになりました。"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5831,12 +5817,12 @@ msgstr ""
 "XTYP_XACT_COMPLETE コールバックで識別子を使った後復帰した\n"
 "アプリケーションはその識別子を以後の呼び出しで使うことができません。"
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "想定外のDDE エラー 0x%08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5844,7 +5830,7 @@ msgstr ""
 "リモートアクセスサービス(RAS)がインストールされていないため、ダイヤルアップは"
 "機能しません。RASをインストールしてください。"
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5853,64 +5839,64 @@ msgstr ""
 "このコンピューターにインストールされているリモートアクセスサービス(RAS)は古す"
 "ぎるようです。新しいものを用意してください(機能 %s が必要です)。"
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS エラーメッセージのテキストを取得できませんでした。"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "想定外のエラーです (エラーコード 0x%08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "使用中のダイヤルアップ接続が見つかりません: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "複数のダイヤルアップ接続が有効です。乱数でひとつ選びます。"
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "ダイヤルアップ接続を確立できませんでした: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP名を取得できませんでした: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "接続失敗: ダイヤル先のISPがありません。"
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "ダイヤル先のISPを選んでください"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "接続したいISPを選んでください"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "接続に失敗: username/password が欠けています。"
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "住所録の位置を特定できません"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "ダイヤルアップ接続の初期化に失敗しました: %s "
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "接続を切るよう指示されましたが、有効なダイヤルアップ接続がありません。"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "ダイヤルアップ接続を終了できませんでした: %s"
@@ -5930,19 +5916,18 @@ msgstr "ビットマップデータ用のメモリ割り当て(%luKb)に失敗�
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "ディレクトリー '%s' のファイルは列挙できません"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "タイマーを作成できませんでした"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (エラー %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "イメージリストに画像を追加できませんでした。"
 
@@ -5956,7 +5941,7 @@ msgstr "ファイル \"%s\" からメタファイルを読み取れませんで�
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "標準の検索置換ダイアログを作成できませんでした (エラーコード %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "ファイルダイアログがエラー %0lx で失敗しました。"
@@ -5997,17 +5982,17 @@ msgstr "'%s' の監視を準備できませんでした。"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "監視対象のディレクトリー \"%s\" を開くことができませんでした。"
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "タイマーを作成できませんでした"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGLを初期化できませんでした。"
 
@@ -6015,7 +6000,7 @@ msgstr "OpenGLを初期化できませんでした。"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6023,7 +6008,7 @@ msgstr ""
 "Microsoft Help ライブラリーがインストールされていないので Microsoft HTML "
 "Help 機能が使えません。そのライブラリーをインストールしてください。"
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Microsoft HTML Help を初期化できませんでした。"
 
@@ -6032,7 +6017,7 @@ msgstr "Microsoft HTML Help を初期化できませんでした。"
 msgid "Can't delete the INI file '%s'"
 msgstr "INIファイル '%s' を削除できません"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "リストコントロールの項目 %d に関する情報を取得できませんでした。"
@@ -6155,7 +6140,7 @@ msgstr "クリップボードの様式 '%s' を登録できませんでした。
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "クリップボード様式 '%d' は存在しません。"
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "スキップ"
 
@@ -6240,59 +6225,59 @@ msgstr ""
 "これを削除するとシステムを不安定にします:\n"
 "処理を中断しました。"
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "キー '%s' を削除できません"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "値 '%s' をキー '%s' から削除できません"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "キー '%s' の値を読み取ることができません"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s' の値を設定できません"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s' の値を読み取ることができません"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "キー '%s' の値を列挙できません"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "キー '%s' のサブキーを列挙できません"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6300,17 +6285,17 @@ msgstr ""
 "レジストリーのエクスポート: ファイル \"%s\" はすでに存在します。上書きも行い"
 "ません。"
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "未対応型 %d の値はエクスポートできません。"
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "値 \"%s\" を無視します (キー \"%s\")。"
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6318,41 +6303,41 @@ msgstr ""
 "リッチエディットコントロールを作成できませんでした。代わりに簡素なテキストコ"
 "ントロールを使います。 riched32.dllを再インストールしてください。"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "スレッドを開始できませんでした: TLS への書き込みに失敗しています。"
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "スレッド優先度を設定できません"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "スレッドを作成できません"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "スレッドを終了できませんでした"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "スレッドの終了を待つことはできません"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "スレッド %x のサスペンドができません"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "スレッド %x のリジュームができません"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "現在のスレッドを示すポインタを取得できませんでした。"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6360,7 +6345,7 @@ msgstr ""
 "スレッドモジュールの初期化に失敗: スレッドローカルストレージに索引を割り当て"
 "られませんでした"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6391,12 +6376,12 @@ msgstr "リソース \"%s\" を読み取れませんでした。"
 msgid "Failed to lock resource \"%s\"."
 msgstr "リソース \"%s\" をロックできませんでした。"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (ビルド %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64ビットエディション"
 
@@ -6408,47 +6393,47 @@ msgstr "匿名パイプを作成できませんでした。"
 msgid "Failed to redirect the child process IO"
 msgstr "子プロセスの入出力をリダイレクトできませんでした。"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "コマンド '%s' を実行できませんでした。"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll を読み取れませんでした。"
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' の型名を読み出すことができません。"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' からアイコンを読み取れません。"
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "スレッド優先度を設定できません"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "'%s' の実行に失敗しました\n"
@@ -6482,7 +6467,7 @@ msgid "Check to make the font italic."
 msgstr "フォントをイタリックにするときにチェックしてください。"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "下線付き"
@@ -6550,17 +6535,32 @@ msgstr "<Teletypeのいずれか>"
 msgid "File type:"
 msgstr "Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "ウィンドウ (&W)"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "ヘルプ"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "最小化 (&N)"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "拡大(&I)"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6577,489 +6577,489 @@ msgstr "ファイル %s は存在しません。"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "%s について"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "詳細 (&A)"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "設定 (&P)"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "ヘルプ: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "選択"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "すべて表示"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "終了 (&Q)"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "選択"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "このバージョンの zlib は Gzip を処理できません"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "列の記述を初期化できませんでした。"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "大きさ(ポイント):"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "フォント名"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "スタイル"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "ウエイト"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "フォントファミリー"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "軽量"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "右寄せにします。"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "メニュー"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "ウィンドウ (&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "ウィンドウ (&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "ウィンドウ (&W)"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "任意の寸法指定"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "MacGreek"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "ファイルの選択"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "再実行"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "規定"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "明日"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "右"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "行頭文字のスタイル"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "文字コード (&C):"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "大きさ(ポイント):"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "右寄せ"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "お尋ねします"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "右"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "右"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "選択してください:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "プロパティー"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "値"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "種類順"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "名前順"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "偽"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "真"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "未指定"
 
@@ -7073,12 +7073,12 @@ msgstr "プロパティー"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "リソースにエラー: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7087,36 +7087,36 @@ msgstr ""
 "型の処理 \"%s\" に失敗:  \"%s\" とラベルされたプロパティーは \"%s\" 型で"
 "す。\"%s\" ではありません。"
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, fuzzy, c-format
 msgid "Value must be %s or higher."
 msgstr "%f 以上の値にしてください"
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "%f 以下の値にしてください"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, fuzzy, c-format
 msgid "Value must be %s or less."
 msgstr "%f 以下の値にしてください"
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "%sではない"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "ディレクトリーを選んでください:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "フォントを選んでください"
 
@@ -7609,129 +7609,129 @@ msgstr "挿入"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "スタイルの変更"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 #, fuzzy
 msgid "Change Object Style"
 msgstr "リストスタイルを変更します"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "リストスタイルを変更します"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "リスト連番の初期化"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "テキストの挿入"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "画像の挿入"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "テキストの挿入"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "テキストの挿入"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "EndStyle の呼び出しが多すぎます。"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "ファイル"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "標準/丸"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 #, fuzzy
 msgid "standard/circle-outline"
 msgstr "標準/丸"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "標準/四角"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "標準/ひし形"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "標準/三角"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "スタイルの削除"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "削除"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "選択範囲の削除"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "プロパティー (&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "画像一時ファイル"
 
@@ -7939,25 +7939,25 @@ msgstr "~"
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "テキストの削除"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "削除"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "テキストが保存できませんでした。"
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "置換"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "フォント (&F):"
 
@@ -8986,53 +8986,53 @@ msgstr "リストスタイル"
 msgid "Box styles"
 msgstr "すべてのスタイル"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "記号の取得元フォントを指定できます。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "部分表示 (&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "ユニコードの部分集合を表示します。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "文字コード (&C):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "文字コードです。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "取得元 (&F):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "ユニコード"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "表示する範囲を指定できます。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "挿入"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(通常のテキスト)"
 
@@ -9217,7 +9217,7 @@ msgstr "kqueue からのイベントを取得できませんでした"
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "ディスプレイ \"%s\" を開くことができませんでした。"
@@ -9317,20 +9317,20 @@ msgstr "未対応の様式が使われている音声データです。"
 msgid "Couldn't open audio: %s"
 msgstr "音声を開くことができませんでした: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "スレッドスケジュールポリシーを取得できません。"
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "スケジューリングポリシー %d への優先度範囲を取得できません。"
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "スレッド優先度の設定は無視されました。"
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9338,60 +9338,60 @@ msgstr ""
 "スレッド接合に失敗しました。メモリリーク発生の可能性があります。プログラムを"
 "再起動してください。"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "スレッド優先度を %d に設定できませんでした。"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "スレッド優先度を %d に設定できませんでした。"
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "スレッドを終了できませんでした。"
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "スレッドモジュールの初期化に失敗: スレッドキーを作成できませんでした"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "子プロセスの入力は取得不可能です。"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "プロセス %d の kill に失敗しました"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' の実行に失敗しました\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "フォークに失敗しました"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "スレッド優先度を %d に設定できませんでした。"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "子プロセスの入出力をリダイレクトできませんでした。"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "ホスト名を取得できません"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "公的なホスト名を取得できません"
 
@@ -9407,12 +9407,12 @@ msgstr "起動パイプをnon-blockingモードに切り替えることができ
 msgid "Failed to read from wake-up pipe"
 msgstr "起動パイプからの読み取りに失敗しました。"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "画面設定 '%s' は正しい指定ではありません"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets はディスプレイを開くことができませんでした。終了します。"
 
@@ -9426,30 +9426,60 @@ msgstr "ディスプレイ \"%s\" を閉じることができませんでした�
 msgid "Failed to open display \"%s\"."
 msgstr "ディスプレイ \"%s\" を開くことができませんでした。"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML 解析エラー: '%s' (%d行目)"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "ファイル '%s' からリソースを読み取れません。"
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "ファイル '%s' からリソースを読み取れません。"
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "ファイル '%s' からリソースを読み取れません。"
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s' を '%s' に展開できませんでした。"
+
+#~ msgid "Printing "
+#~ msgstr "印刷"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "そのコントロールにテキストを挿入できませんでした。"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "有効なフォントを選んでください。"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "%s エンコーディングで HTML 文書を表示できませんでした。"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr ""
+#~ "wxWidgets はディスプレイ '%s' を開くことができませんでした: 終了します。"
+
+#~ msgid "Filter"
+#~ msgstr "フィルター"
+
+#~ msgid "Directories"
+#~ msgstr "ディレクトリー"
+
+#~ msgid "Files"
+#~ msgstr "ファイル"
+
+#~ msgid "Selection"
+#~ msgstr "選択"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "8ビットエンコーディングへの変換に失敗しました"
@@ -9617,8 +9647,8 @@ msgstr "'%s' を '%s' に展開できませんでした。"
 #~ msgstr "日付レンダラーが値をレンダリングできません; 値の型:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-07-30 11:10+0200\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "ყველა ფაილი (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "ყველა ფაილი(*)|*"
 
@@ -39,24 +39,21 @@ msgid "Remaining time:"
 msgstr "დარჩენილი დრო:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "დიახ"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "არა"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "კარგი"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "გაუქმება"
@@ -106,7 +103,7 @@ msgid "Unable to create I/O completion port"
 msgstr "I/O დასრულების პორტის შექმნის შეცდომა"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "გამობეჭდვა"
 
@@ -143,7 +140,7 @@ msgstr "ობიექტის თვისებები"
 msgid "Printing"
 msgstr "დაბეჭდვა"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "სიმბოლოები"
 
@@ -212,7 +209,7 @@ msgstr "&წინა"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&ფანჯარა"
 
@@ -741,11 +738,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "დახმარების ამ შეტყობინების ჩვენება"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "დამატებითი შეტყობინებების გენერაცია"
 
@@ -767,84 +764,84 @@ msgstr "მხარდაუჭერელი თემა '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "ეკრანის რეჟიმის არასწორი სპეციფიკაცია: %s."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "პარამეტრი %s-ის გაუარყოფითება არ შეგიძლიათ"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "უცნობი გრძელი პარამეტრი %s"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "უცნობი პარამეტრი %s"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "პარამეტრის (%s) მომდევნო სიმბოლოები მოულოდნელია."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "პარამეტრს \"%s\" მნიშვნელობა სჭირდება."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "პარამეტრის (%s) შემდეგ აუცილებელი გამყოფის გარეშე."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "%s პარამეტრი \"%s\"-ის სწორ რიცხვობრივ მნიშვნელობას არ წარმოადგენს."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "პარამეტრი %s: %s-ის თარიღად გარდაქმნა შეუძლებელია."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "მოულოდნელი პარამეტრი: %s"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ან %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "პარამეტრს \"%s\" მნიშვნელობა სჭირდება."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "საჭირო პარამეტრის \"%s\" მნიშვნელობა მითითებული არაა."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "გამოყენება: %s\\"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "სტრ"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "რიცხვ"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "ორმაგი"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "თარიღი"
 
@@ -862,7 +859,7 @@ msgid "Can't &Undo "
 msgstr "&დაბრუნება შეუძლებელია "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&დაბრუნება"
@@ -872,7 +869,7 @@ msgid "&Redo "
 msgstr "&გამეორება "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&გამეორება"
@@ -901,12 +898,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' -ს ზედმეტი '..' აქვს. იგნორირებულია."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "ჩართულია"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "გამორთულია"
 
@@ -915,103 +912,103 @@ msgstr "გამორთულია"
 msgid "undetermined"
 msgstr "განუსაზღვრელია"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "დღეს"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "გუშინ"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "ხვალ"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "პირველი"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "წამი"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "მესამე"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "მეოთხე"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "მეხუთე"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "მეექვსე"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "მეშვიდე"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "მერვე"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "მეცხრე"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "მეათე"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "მეთერთმეტე"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "მეთორმეტე"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "მეცამეტე"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "მეთოთხმეტე"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "მეთხუთმეტე"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "მეთექვსმეტე"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "მეჩვიდმეტე"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "მეთვრამეტე"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "მეცხრამეტე"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "მეოცე"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "საღამო"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "შუაღამე"
 
@@ -1079,44 +1076,81 @@ msgstr "Curl-ის გაშვების შეცდომა. გთხო
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "გამართვის ანგარიშის ატვირთვის შეცდომა (შეცდომის კოდი: %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "შენახვა, როგორც"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "გავაუქმო ცვლილებები და ჩავტვირთო ბოლოს შენახული ვერსია?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "უსახელო"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "გნებავთ'%s' -ის ცვლილებების შენახვა?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&შენახვა"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "არ შეინახო"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "გნებავთ'%s' -ის ცვლილებების შენახვა?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "ტექსტის შენახვა შეუძლებელია."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "ფაილის (\"%s\") ჩასაწერად გახსნა შეუძლებელია."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "დოკუმენტის შენახვის შეცდომა: \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "ფაილის წასაკითხად გახსნის შეცდომა: %s."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "ფაილიდან \"%s\" დოკუმენტის წაკითხვის შეცდომა."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1125,57 +1159,57 @@ msgstr ""
 "ფაილი %s არ არსებობს და მისი გახსნა შეუძლებელია.\n"
 "წაიშალა ახლახანს გამოყენებული ფაილების სიიდან."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "საბეჭდი ესკიზის გადახედვის შექმნის შეცდომა."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "დასაბეჭდის გადახედვა"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "ფაილის (%s) ფორმატის განსაზღვრის შეცდომა."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "უსახელო%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "ფაილის გახსნა"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "ფაილის შეცდომა"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "ჩასაწერად გახსნა შეუძლებელია."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "უცნობი ფორმატი."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "აირციეთ დოკუმენტის შაბლონი"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "ნიმუშები"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "აირჩიეთ დოკუმენტის ხედი"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "ხედები"
 
@@ -1209,42 +1243,42 @@ msgstr "ფაილის წაკითხვის პრობლემა:
 msgid "Write error on file '%s'"
 msgstr "ფაილის ჩაწერის შეცდომა: %s"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "ფაილის პირდაპირ დისკზე ჩაწერის შეცდომა: %s"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "ფაილში გადახვევის შეცდომა: %s (stdio-ს დიდი ფაილების მხარდაჭერა არ გააჩნია)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "ფაილში გადახვევის შეცდომა: %s"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "ფაილში (%s) მიმდინარე მდებარეობის პოვნის შეცდომა"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "დროებითი ფაილის წვდომების დაყენების შეცდომა"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ფაილის წაშლის შეცდომა: %s"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "ფაილის ცვლილებების გადაცემის შეცდომა: %s"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "დროებითი ფაილის წაშლის შეცდომა: %s"
@@ -1269,27 +1303,27 @@ msgstr "ფაილის დესკრიპტორიდან წაკ�
 msgid "can't write to file descriptor %d"
 msgstr "ფაილის დესკრიპტორში ჩაწერის შეცდომა: %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "ფაილის დესკრიპტორში პირდაპირი ჩაწერის შეცდომა: %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "ფაილის დესკრიპტორში გადახვევის შეცდომა: %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "ფაილის დესკრიპტორში მდებარეობაზე გადახვევის შეცდომა: %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "ფაილის დესკრიპტორზე ფაილის სიგრძის მიღების შეცდომა: %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1316,108 +1350,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "კონფიგურაციის პარამეტრების წაკითხვის შეცდომა."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "კონფიგურაციის პარამეტრების წაკითხვის შეცდომა."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "ფაილი %s: მოულოდნელი სიმბოლო (%c) ხაზზე %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "ფაილი %s, ხაზი %zu: %s იგნორირებულია ჯგუფის თავსართის შემდეგ."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "ფაილი %s: ხაზი %zu: მოველოდი \"=\"."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "ფაილი '% s', ხაზი % zu: მნიშვნელობა უცვლელი გასაღებისთვის '%s' იგნორირებულია."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "ფაილი '%s', ხაზი %zu: გასაღები '%s ' პირველად იქნა ნაპოვნი ხაზი %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "კონფიგურაციის ჩანაწერის სახელი '%c'-ით ვერ დაიწყება."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "მომხმარებლის კონფიგურაციის ფაილის გახსნს შეცდომა."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "მომხმარებლის კონფიგურაციის ფაილის ჩაწერის შეცდომა."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "მომხმარებლის კონფიგურაციის ფაილის განახლების შეცდომა."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "მომხმარებლის კონფიგურაციის ფაილის შენახვის შეცდომა."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "მომხმარებლის კონფიგურაციის ფაილის წაშლი შეცდომა: %s"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "ჩანაწერი %s ერთზე მეტჯერაა ჯგუფში %s"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "მუდმივი გასაღების (%s) შეცვლის მცდელობა იგნორირებულია."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "\"%s\"-ში ხაზის ბოლოში მოყოლილი \\ იგნორირებულია"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "პოზიციაზე %d %s-ში მოულოდნელი \"."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "ფაილის %s-დან %s-მდე კოპირების შეცდომა"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "წვდომების მიღების შეცდომა ფაილისთვის: %s"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "თავზე გადაწერის შეცდომა ფაილისთვის:%s"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "ფაილის %s-დან %s-მდე კოპირების შეცდომა."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "წვდომის უფლებების დაყენება შეუძლებელია ფაილისთვის %s"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1426,40 +1460,40 @@ msgstr ""
 "ფაილის სახელის %s-დან %s-ზე გადარქმევის პრობლემა. სამიზნე ფაილი უკვე "
 "არსებობს."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "ფაილის სახელის (%s) გადარქმევის (%s-მდე) შეცდომა"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "ფაილის წაშლა შეუძლებელია: %s"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "საქაღალდის შექმნა შეუძლებელია (%s)"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "საქაღალდის წაშლის შეცდომა: %s"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "ფაილების ჩამოთვლა შეუძლებელია: %s"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "სამუშაო საქაღალდის მიღების შეცდომა"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "მიმდინარე სამუშაო საქაღალდის დაყენების შეცდომა"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "ფაილები (%s)"
@@ -1486,17 +1520,17 @@ msgstr "დროებითი ფაილის სახელის შე
 msgid "Failed to open temporary file."
 msgstr "დროებითი ფაილის გახსნის შეცდომა."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "ფაილის დროების ჩასწორების შეცდომა %s-სთვის"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "ფაილის შეხების შეცდომა: %s."
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "ფაილის დროების მიღების შეცდომა %s-სთვის"
@@ -1505,22 +1539,22 @@ msgstr "ფაილის დროების მიღების შეც
 msgid "Browse"
 msgstr "დათვალიერება"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "ყველა ფაილი (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s ფაილი (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "%s ფაილის ჩატვირთვა"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "%s ფაილის შენახვა"
@@ -1883,99 +1917,99 @@ msgstr "ნაგულისხმები"
 msgid "unknown-%d"
 msgstr "უცნობი-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "ხაზგასმული"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " ხაზგადასმული"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " თხელი"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " ძალიან თხელი"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " მსუბუქი"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " საშუალო"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " ნახევრად სქელი"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " სქელი"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " ძალიან სქელი"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " მძიმე"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " ძალიან მძიმე"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " დახრილი"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "ხაზგადასმული"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "თხელი"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "ძალიან თხელი"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "ღია"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "ნორმალური"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "საშუალო"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "ნახევრად სქელი"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "სქელი"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "ძალიან სქელი"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "მძიმე"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "ძალიან მძიმე"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "დახრილი"
 
@@ -2057,7 +2091,7 @@ msgstr "FTP სერვერთან დაკავშირების დ
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP -ის გადაწერის რეჟიმის %s-ზე დაყენების შეცდომა."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2078,7 +2112,7 @@ msgstr "FTP სერვერს პასიური რეჟიმის �
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF კადრის არასწორი ზომა (%u, %d) კადრი #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL-ის ფერის გამოყოფის შეცდომა"
 
@@ -2094,7 +2128,7 @@ msgstr "სვეტების მორგება"
 msgid "&Customize..."
 msgstr "&მორგება..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "URL-ის ნაგულისხმებ ბრაუზერში გახსნის შეცდომა: %s"
@@ -2114,157 +2148,156 @@ msgstr "გამოსახულების (%d) ნაკადიდან
 msgid "Failed to load icons from resource '%s'."
 msgstr "რესურსიდან ხატულების ჩატვირთვის შეცდომა: %s."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: არასწორი გამოსახულების შენახვის პრობლემა."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage -ს საკუთარი wxPalette არ გააჩნია."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: ფაილის (ბიტური რუკის) თავსართის ჩაწერის შეცდომა."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: ფაილის (BitmapInfo) თავსართის ჩაწერის შეცდომა."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB ფერების რუკის ჩაწერის შეცდომა."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: მონაცემების ჩაწერის შეცდომა."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: მეხსიერების გამოყოფის შეცდომა."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB თავსართი: გამოსახულების სიგანე > 32767 პიქსელი."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB თავსართი: გამოსახულების სიმაღლე > 32767 პიქსელი."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB თავსართი: უცნობი ბიტური სიღრმე."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB თავსართი: ფაილის უცნობი კოდირება."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB თავსართი: კოდირება ბიტურ სიღრმეს არ ემთხვევა."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: თავსართოცას აქვს biClrUsed=%d when biBitCount=%d."
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: მეხსიერების გამოყოფის შეცდომა."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB თავსართი: გამოსახულების სიგანე > 32767 პიქსელი."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB თავსართი: გამოსახულების სიმაღლე > 32767 პიქსელი."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB თავსართი: უცნობი ბიტური სიღრმე."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB თავსართი: ფაილის უცნობი კოდირება."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB თავსართი: კოდირება ბიტურ სიღრმეს არ ემთხვევა."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "გამოსახულებების DIB-ის წაკითხვის შეცდომა."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: ნიღბის DIB-ის წაკითხვის შეცდომა."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: გამოსახულება ხატულისთვის მეტისმეტად გრძელია."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: გამოსახულება ხატულისთვის მეტისმეტად განიერია."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: გამოსახულების ფაილის ჩაწერის შეცდომა!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ხატულის არასწორი ინდექსი."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "გამოსახულებას და ნიღაბს სხვადასხვა ზომები აქვთ."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "გამოსახულებაში გამოუყენებელი ფერის შენიღბვა არ ხდება."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "რესურსებიდან ბიტური რუკის (%s) ჩატვირთვის შეცდომა."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "რესურსებიდან ხატულის (%s) ჩატვირთვის შეცდომა."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "გამოსახულების ჩატვირთვის შეცდომა ფაილიდან %s."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "გამოსახულების ფაილში %s ჩაწერის შეცდომა: უცნობი გაფართოება."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "გამოსახულების ამ ტიპის დამმუშავებელი ვერ ვიპოვე."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "გამოსახულების დამმუშავებელი ტიპისთვის %d აღწერილი არაა."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "გამოსახულების ფაილი %d ტიპის არაა."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "გადაუხვევადი შეყვანისთვის გამოსახულების ფორმატის ავტომატური დადგენა "
 "შეუძლებელია."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "გამოსახულების ფაილის უცნობი ფორმატი."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "ეს %s არაა."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "გამოსახულების დამმუშავებელი ტიპისთვის %s აღწერილი არაა."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "გამოსახულების ტიპი \"%s\" არაა."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "გამოსახულების ფაილის (%s) ფორმატის შემოწმების შეცდომა."
@@ -2367,41 +2400,41 @@ msgstr "PNM: ფაილი შეკვეცილია."
 msgid " (in module \"%s\")"
 msgstr " (მოდულში \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: გამოსახულების ჩატვირთვის შეცდომა."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "TIFF გამოსახულების არასწორი ინდექსი."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: გამოსახულების ზომა არანორმალურად დიდია."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: მეხსიერების გამოყოფის შეცდომა."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: გამოსახულების კითხვის შეცდომა."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "TIFF-ის გაფართოების უცნობი ერთეული: %d. იგნორირებულია"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: გამოსახულების შენახვის შეცდომა."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: გამოსახულების ჩასწერის შეცდომა."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2410,11 +2443,11 @@ msgstr ""
 "ბრძანების ტრიქონის არგუმენტი %d უნიკოდში ვერ გარდაიქმნა და იგნორირებული "
 "იქნება."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "ინიციალიზაციის შეცდომა init-ისშემდეგ. მუშაობის დასრულება."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "ვერ ხერხდება ლოკალის ენის \"%s\"-ზე დაყენება."
@@ -2508,7 +2541,7 @@ msgstr "LZMA შეკუმშვის შეცდომა: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "LZMA შეკუმშვის შეცდომა გამოტანის დისკზე ჩაწერისას: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "დაუხურავი \"(\" ჩანაწერში mime ტიპისთვის %s."
@@ -2528,7 +2561,7 @@ msgstr "მოდულის (%2$s) დამოკიდებულება 
 msgid "Module \"%s\" initialization failed"
 msgstr "მოდულის ინიციალიზაციის შეცდომა: %s"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "შეტყობინება"
 
@@ -3030,7 +3063,7 @@ msgstr "ბეჭდვის შეცდომა"
 msgid "Print"
 msgstr "დაბეჭდვა"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "გვერდის პარამეტრები"
 
@@ -3065,19 +3098,15 @@ msgstr "მინდინარეობს %d-ე გვერდის და
 msgid " (copy %d of %d)"
 msgstr " (კოპირება %d %d-დან)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "დაბეჭდვა "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "პირველი გვერდი"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "წინა გვერდი"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "შემდეგი გვერდი"
 
@@ -3121,16 +3150,16 @@ msgstr "%d-ე გვერდი %d-დან"
 msgid "Page %d"
 msgstr "%d გვერდი"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "უცნობი შეცდომა"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "არასწორი რეგულარული გამოსახულება (%s): %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "რეგულარული გამოსახულების დამთხვევის შეცდომა: %s"
@@ -3140,21 +3169,21 @@ msgstr "რეგულარული გამოსახულების �
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "რენდერერის (%s) ვერსია (%d.%d) არათავსებადია და ვერ ჩაიტვირთება."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "მიუწვდომელია ამ პლატფორმისთვის"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "%s-ის პაროლის შენახვის შეცდომა: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "%s-ის პაროლის წაკითხვის შეცდომა: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "%s-ის პაროლის წაშლის შეცდომა: %s."
@@ -3163,11 +3192,11 @@ msgstr "%s-ის პაროლის წაშლის შეცდომა
 msgid "Failed to monitor I/O channels"
 msgstr "I/O არხების მონიტორინგის შეცდომა"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "შენახვა"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "არ შეინახო"
 
@@ -3248,10 +3277,10 @@ msgid "Clear"
 msgstr "გაწმენდა"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "დახურვა"
 
@@ -3263,7 +3292,7 @@ msgstr "&გარდაქმნა"
 msgid "Convert"
 msgstr "გარდაქმნა"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&კოპირება"
@@ -3272,7 +3301,7 @@ msgstr "&კოპირება"
 msgid "Copy"
 msgstr "დააკოპირე"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "ამ&ოჭრა"
@@ -3281,13 +3310,13 @@ msgstr "ამ&ოჭრა"
 msgid "Cut"
 msgstr "ამოჭრა"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&წაშლა"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "წაშლა"
@@ -3374,7 +3403,7 @@ msgstr "მყარიდისკი"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&დახმარება"
 
@@ -3394,7 +3423,7 @@ msgstr "შეწევა"
 msgid "&Index"
 msgstr "&ინდექსი"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "ინდექსი"
 
@@ -3463,7 +3492,7 @@ msgstr "&ახალი"
 msgid "New"
 msgstr "&ახალი"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&არა"
 
@@ -3480,12 +3509,12 @@ msgstr "&გახსნა..."
 msgid "Open..."
 msgstr "გახსნა..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&ჩასმა"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "ჩასმა"
@@ -3515,7 +3544,7 @@ msgid "Print..."
 msgstr "დაბეჭდვა..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&თვისებები"
 
@@ -3547,10 +3576,6 @@ msgstr "ჩანაცვლება..."
 msgid "Revert to Saved"
 msgstr "შენახულზე დაბრუნება"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&შენახვა"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "შეინახვა &როგორც..."
@@ -3559,7 +3584,7 @@ msgstr "შეინახვა &როგორც..."
 msgid "Save As..."
 msgstr "შენახვა, როგორც..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "ყველაფრის &მონიშვნა"
@@ -3666,7 +3691,7 @@ msgstr "&მაღლა"
 msgid "Up"
 msgstr "მაღლა"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&დიახ"
 
@@ -3754,43 +3779,43 @@ msgstr "მიმდინარე დოკუმენტის შენა�
 msgid "Save current document with a different filename"
 msgstr "მიმდინარე დოკუმენტის სხვა სახელით შენახვა"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "კოდირებაზე (%s) გადაყვანა არ მუშაობს."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "უცნობი"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "tar ფაილის თავსართის ბლოკი არასრულია"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "არასწორი საკონტროლო ჯამი tar-ის თავსართის ბლოკის კითხვისას"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "არასწორი მონაცემები tar-ის გაფართოებულ თავსართში"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar ფაილის ერთეული ღია არაა"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "ფაილის მოულოდნელი დასასრული"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ვერ ჩაეტია tar-ის თავსართში ჩანაწერისთვის %s"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tar-ის ჩანაწერისთვის მითითებული ზომა არასწორია"
 
@@ -3799,7 +3824,7 @@ msgstr "tar-ის ჩანაწერისთვის მითითებ
 msgid "'%s' is probably a binary buffer."
 msgstr "%s ალბათ ბინარული ბაფერია."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "ფაილის ჩატვირთვა შეუძლებელია."
 
@@ -3813,47 +3838,47 @@ msgstr "ტექსტური ფაილის კითხვის შე
 msgid "can't write buffer '%s' to disk."
 msgstr "ბაფერის (%s) დისკზე ჩაწერის პრობლემა."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "ლოკალური სისტემის დროის მიღების პრობლემა"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay =ის შეცდომა."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "%s შეტყობინებების სწორ კატალოგს არ წარმოადგენს."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "შეტყობინებების არასწორი კატალოგი."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "მრავლობითი ფორმების დამუშავების შეცდომა: %s"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "გამოიყენება კატალოგი (%s) %s-დან."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "რესურსი %s შეტყობინების სწორ კატალოგს არ წარმოადგენს."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "თარგმანების ჩამონათვლის შეცდომა"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "HTML ფაილებისთვის ნაგულისხმები აპლიკაცია გაწერილი არაა."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "URL-ის ნაგულისხმებ ბრაუზერში გახსნის შეცდომა: %s."
@@ -3886,7 +3911,7 @@ msgstr "'%s' არასწორ სიმბოლოებს შეიც�
 msgid "Error: %s (%d)"
 msgstr "შეცდომა: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "გადმოსაწერად დისკზე საკმარისი თავისუფალი ადგილი არაა."
 
@@ -3894,20 +3919,20 @@ msgstr "გადმოსაწერად დისკზე საკმა�
 msgid "libcurl could not be initialized"
 msgstr "libcurl-ის ინიციალიზაციის შეცდომა"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync მხარდაუჭერელია"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "JavaScript-ის შესრულების შეცდომა: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "ამ პლატფორმას ფონის გამჭვირვალობის მხარდაჭერა არ გააჩნია."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "მონაცემების ფანჯარაში გადაცემა შეუძლებელია"
 
@@ -3959,8 +3984,8 @@ msgstr "RTTI-ის აღწერილ პარამეტრებში �
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "მოვლენის წყაროდ მითითებული ობიექტის კლასი (Non-wxEvtHandler) არასწორია"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "ტიპს enum-long გარდაქმნა უნდა ჰქონდეს"
 
@@ -4012,81 +4037,81 @@ msgstr "ობიექტებს ატრიბუტი \"id\" აუცი
 msgid "Doubly used id : %d"
 msgstr "ორჯერ გამოყენებული id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "უცნობ თვისება %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "არაცარიელი კოლექციები 'ელემენტის' კვანძებისგან უნდა შედგებოდეს"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "მოვლენის დამმუშავებლის არასწორ სტრიქონი. წერტილი აკლია"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib-ის გაშლის ნაკადის თავიდან ინიციალიზაციის შეცდომა"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib-ის შეკუმშვის ნაკადის თავიდან ინიციალიზაციის შეცდომა"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "დამატებითი მონაცემების არასწორი ჩანაწერის იგნორი. შეიძლება ZIP ფაილი "
 "დაზიანებულია"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "ჩავთვლი, რომ ეს შეერთებული მრავალნაწილიანია zip ფაილია"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "არასწორი zip ფაილი"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "zp-ის ცენტრალური საქაღალდის პოვნა შეუძლებელია"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "zp-ის ცენტრალური საქაღალდის წაკითხვის შეცდომა"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "zip-ის ლოკალური თავსართის წაკითხვის შეცდომა"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "zip ფაილის არასწორი წანაცვლება"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "დამახსოვრებული ფაილის სიგრძე Zip თავსართში არაა"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "zip შეკუმშვის მხარდაუჭერელი მეთოდი"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zip ნაკადის წაკითხვა (ჩანაწერი %s): არასწორი სიგრძე"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zip ნაკადის წაკითხვა (ჩანაწერი %s): არასწორი CRC"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "zip ჩანაწერის (%s) ჩაწერის შეცდომა: ZIP64-ის გარეშე ფაილი ძალიან დიდია"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "zip ჩანაწერის (%s) ჩაწერის შეცდომა: არასწორი CRC ან სიგრძე"
@@ -4170,32 +4195,32 @@ msgstr "გრაფიკის ავტორი "
 msgid "Translations by "
 msgstr "თარგმანები "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "ვერსია "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "%s-ის შესახებ"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "ლიცენზია"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "პროგრამისტები"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "დოკუმენტაციის ავტორები"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "შემსრულებლები"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "მთარგმნელები"
 
@@ -4246,42 +4271,42 @@ msgid "Password:"
 msgstr "პაროლი:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "სიმართლე"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "მცდარი"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "მწკრივი %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "აკეცვა"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "გაფართოება"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d ჩანაწერი)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "სვეტი %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4292,7 +4317,7 @@ msgid "Left"
 msgstr "მარცხნივ"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4382,7 +4407,7 @@ msgid "Home directory"
 msgstr "საწყისი საქაღალდე"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "სამუშაო მაგიდა"
 
@@ -4395,8 +4420,7 @@ msgstr "საქაღალდის არასწორი სახელ�
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "შეცდომა"
 
@@ -4580,16 +4604,16 @@ msgstr "ფაილების დეტალური ხედის ნა
 msgid "Go to parent directory"
 msgstr "ზედა საქაღალდეზე გადასვლა"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "ფაილი %s უკვე არსებობს. გნებავთ გადავაწერო?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "დადასტურება"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "გთხოვთ აირჩიოთ არსებული ფაილი."
 
@@ -4683,7 +4707,7 @@ msgstr "ფონტის წერტილის ზომა."
 msgid "Whether the font is underlined."
 msgstr "არის თუ არა ფონტი ხასგაზმული."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "წინასწარი ნახვა:"
@@ -4701,48 +4725,47 @@ msgstr "წკაპი ფონტის არჩევის გაუქე
 msgid "Click to confirm the font selection."
 msgstr "წკაპი ფონტის არჩევანის დასადასტურებლად."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "აირჩიეთ ფონტი"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "მიმოცვლის ბაფერში ერთზე მეტი ბლოკის დამატება მხარდაუჭერელია."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "დახმარების საქაღალდე %s არ არსებობს."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "დახმარების ფაილი %s არ არსებობს."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "ფაილში %s სწორი მიბმები ვერ ვიპოვე."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "ჩანაწერების გარეშე."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "დახმარების ინდექსი"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "შესაბამისი ჩანაწერები:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "ნაპოვნი ჩანაწერები"
 
@@ -4847,59 +4870,59 @@ msgstr "ბეჭდვის დაწყება შეუძლებელ�
 msgid "Printing page %d..."
 msgstr "იბეჭდება გვერდი %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "პრინტერის მორგება"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "ფაილში ბეჭდვა"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "მორგება..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "პრინტერი:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "მდგომარეობა:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "ყველა"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "გვერდი"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "ბეჭდვის დიაპაზონი"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "ვისგან:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "სადამდე:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "ასლები:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript ფაილი"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "ბეჭდვის მორგება"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "პრინტერი"
 
@@ -4907,25 +4930,25 @@ msgstr "პრინტერი"
 msgid "Default printer"
 msgstr "ნაგულისხმები პრინტერი"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "გვერდის ზომა"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "პორტრეტი"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "ლანდშაფტი"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "ორიენტაცია"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "პარამეტრები"
 
@@ -4937,52 +4960,52 @@ msgstr "ფერადი ბეჭდვა"
 msgid "Print spooling"
 msgstr "ბეჭდვის რიგი"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "პრინტერის ბრძანება:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "პრინტერის პარამეტრები:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "მარცხენა ზღვარი (მმ):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "მარცხენა ზღვარი (მმ):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "მარცხენა ზღვარი (მმ):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "ქვედა ზღვარი (მმ):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "პრინტერი..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "გამო&ტოვება"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "უცნობი"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "მზადაა."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "_ძებნა"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "ჩანარდის პოვნა ID-სთვის შეუძლებელია"
 
@@ -5018,22 +5041,22 @@ msgstr "&დასრულება"
 msgid "< &Back"
 msgstr "< &უკან"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "თემური დოღონაძე"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+-ის ინიციალიზაციის შეცდომა. DISPLAY სწორადაა დაყენებული?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "მიმდინარე საქაღალდის %s-ზე შეცვლის შეცდომა"
@@ -5057,11 +5080,11 @@ msgstr "თქვენი ფონტის დამატების შე
 msgid "Failed to register font configuration using private fonts."
 msgstr "პირადი ფონტების გამოყენებით ფონტის რეგისტრაციის შეცდომა."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "ფატალური შეცდომა"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5069,7 +5092,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5077,7 +5100,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI შვილი"
 
@@ -5093,35 +5116,27 @@ msgstr "ბეჭდვის შეცდომა: "
 msgid "Page Setup"
 msgstr "გვერდის მორგება"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "კონტროლში ტექსტის ჩასმის პრობლემა."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "აირჩიეთ სწორი ფონტი."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5221,209 +5236,209 @@ msgstr "შემცველობის ფაილის გახსნი�
 msgid "Cannot open index file: %s"
 msgstr "ინდექსის ფაილის გახსნის შეცდომა: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "უსახელო"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML დახმარების წიგნის გახსნის შეცდომა: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "აჩვენებს დახმარებას მაშინ, როცა თქვენ მარცხნივ წიგნს ათვალიერებთ."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(სანიშნები)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "მიმდინარე გვერდის რჩეულებში დამატება"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "მიმდინარე გვერდის რჩეულებიდან წაშლა"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "შიგთავსი"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "ძიება"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "ყველას ჩვენება"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "ინდექსის ყველა ჩანაწერის ჩვენება"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "დიდი და პატარა ასოების განსხვავება"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "მხოლოდ მთლიანი სიტყვები"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "ნავიგაციის პანელის ჩართ/გამორთ"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "უკან დაბრუნება"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "წინ გადასვლა"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "დოკუმენტების იერარქიაში ერთი დონით მაღლა აწევა"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "HTML დოკუმენტის გახსნა"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "ამ გვერდის დაბეჭდვა"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "მორგების ფანჯრის ჩვენება"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "საჩვენებელი გვერდის არჩევა:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "დახმარების თემები"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "ძებნა..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "შესამაბისი გვერდი ჯერ ვერ ვიპოვე"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "ნაპოვნია %i დამთხვევა"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(დახმარება)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d %lu-დან"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu %lu-დან"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "ყველა წიგნში ძებნა"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "დახმარების ბრაუზერის მორგება"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "ნორმალური ფონტი:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "ფიქსირებული ფონტი:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "ფონტის ზომა:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "ფონტის ზომა"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "ნორმალური <br>და<u>გაზგასმული</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>დახრილი ტექსტი.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>სქელი ტექსტი.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>სქელი კურსივი ტექსტი.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "ფიქსირებული სახის ფონტი.<br> <b>სქელი</b> <i>კურსივი</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>სქელი კურსივი <u>გაზგასმული</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "ბეჭდვის დახმარება"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "ცარიელი გვერდის დაბეჭდვა შეუძლებელია."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML ფაილები (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "დახმარების წიგნები (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML დახმარების პროექტი (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "დახმარების შეკუმშული HTML ფაილი (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i %u-დან"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u %u-დან"
@@ -5494,32 +5509,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr ""
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets -მა ვერ გახსნა ეკრანი '%s'-სთვის: გასვლა."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "ფილტრი"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "საქაღალდეები"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "ფაილები"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "მონიშნული"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "მიმოცვლის ბაფერის გახსნის შეცდომა."
@@ -5561,58 +5550,58 @@ msgstr "ფერის არჩევის ფანჯრის ავარ
 msgid "Failed to create cursor."
 msgstr "კურსორის შექმნის შეცდომა."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "DDE სერვერის რეგისტრაციის შეცდომა: %s"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "DDE სერვერის რეგისტრაციის გაუქმების შეცდომა: %s"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE poke მოთხოვნის შეცდომა"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "DDE სტრიქონის შექმნის შეცდომა"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "\"DDE\"-ის შეცდომის გარეშე."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5620,7 +5609,7 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5628,140 +5617,140 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "მეხსიერების გამოყოფის შეცდომა."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "ტრანზაქციის შეცდომა."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "თავიდან შესვლის პრობლემა."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "\"DDEML\"-ის შიდა შეცდომა."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "DDE-ის უცნობი შეცდომა %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
 "old, please upgrade (the following required function is missing: %s)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS-ის შეცდომის შეტყობინების ტექსტის მიღების შეცდომა"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "უცნობი შეცდომა (შეცდომის კოდი %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "სატელეფონო კავშირის დამყარების შეცდომა: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP-ების სახელების მიღების პრობლემა: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "კავშირის შეცდომა: დასაკავშირებელი ISP-ის გარეშე."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "აირჩიეთ ISP, რომ დავურეკოთ"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "შეერთების შეცდომა: აკლია მომხმარებელი/პაროლი."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "მისამართების წიგნის ფაილის მდებარეობა ვერ ვიპოვე"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "სატელეფონო კავშირის ინიციალიზაციის შეცდომა: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "გათიშვა შეუძლებელია. ტელეფონით შეერთება არ არსებობს."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "სატელეფონო კავშირის გაუქმების შეცდომა: %s"
@@ -5781,18 +5770,17 @@ msgstr ""
 msgid "Cannot enumerate files in directory '%s'"
 msgstr ""
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "საქაღალდის სახელის მიღების შეცდომა"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(შეცდომა %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "გამოსახულების სიაში ჩამატება შეუძლებელია."
 
@@ -5806,7 +5794,7 @@ msgstr "ფაილიდან (%s) მეტაფაილის ჩატ�
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "ფაილის არჩევის ფანჯრის ავარია კოდით %0lx."
@@ -5847,16 +5835,16 @@ msgstr "%s-ის ყურების შეცდომა"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "OpenGL-ის კონტექსტის შექმნის შეცდომა"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL-ის ინიციალიზაციის შექმნის შეცდომა"
 
@@ -5864,13 +5852,13 @@ msgstr "OpenGL-ის ინიციალიზაციის შექმნ
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML Help-ის ინიციალიზაციის შეცდომა."
 
@@ -5879,7 +5867,7 @@ msgstr "MS HTML Help-ის ინიციალიზაციის შეც
 msgid "Can't delete the INI file '%s'"
 msgstr "INI ფაილი (%s) ვერ წავშალე"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -5999,7 +5987,7 @@ msgstr "მიმოცვლის ბაფერის ფორმატი�
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "მიმოცვლის ბაფერის ფორმატი არ არსებობს: %d."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "გამოტოვება"
 
@@ -6081,121 +6069,121 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "გასაღების წაშლის შეცდომა: %s"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "გასაღებიდან %2$s მნიშვნელობის (%1$s) წაშლია შეუძლებელია"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "%s-ის მნიშვნელობის წაკითხვის შეცდომა"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "%s-ის მნიშვნელობის დაყენების შეცდომა"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "%s-ის მნიშვნელობის წაკითხვის შეცდომა"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "ნაკადის გაშვების შეცდომა: TLS-ის ჩაწერის შეცდომა."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "ნაკადის პრიორიტეტის დაყენება შეუძლებელია"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "ნაკადის შექმნის შეცდომა"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "ნაკადის შეწყვეტა შეუძლებელია"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "ნაკადის შეწყვეტისთვის ლოდინი შეუძლებელია"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "ნაკადის (%lx) შეჩერების შეცდომა"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "ნაკადის (%lx) გაგრძელების შეცდომა"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "მიმდინარე ნაკადის მაჩვენებლის მიღების შეცდომა"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6225,12 +6213,12 @@ msgstr "რესურსის ჩატვირთვის შეცდო�
 msgid "Failed to lock resource \"%s\"."
 msgstr "რესურსის დაბლოკვის შეცდომა: %s."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "აგება %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-ბიტიანი გამოცემა"
 
@@ -6242,46 +6230,46 @@ msgstr "ანონიმური ფაიფის შექმნის შ
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "ბრძანების შესრულების შეცდომა: %s"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "\"mpr.dll\"-ის ჩატვირთვის შეცდომა."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr ""
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "%s-დან ხატულის ჩატვირთვის შეცდომა."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "JavaScript-ის ობიექტის მიღების შეცდომა"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "შეფასების შეცდომა"
 
@@ -6314,7 +6302,7 @@ msgid "Check to make the font italic."
 msgstr "ფონტის დასაკურსივებლად ჩართეთ."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "ხაზგასმული"
@@ -6381,15 +6369,33 @@ msgstr "<ნებისმიერი ტელეტაიპი>"
 msgid "File type:"
 msgstr "ფაილის ტიპი:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "ფანჯარა"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "დახმარება"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "ჩაკეცვა"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "გადიდება"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "ყველას წინ გამოტანა"
 
@@ -6406,461 +6412,461 @@ msgstr "ფონტის ფაილი არ არსებობს: %s."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "%s-ის შესახებ"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "შესახებ..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "მორგება..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "სერვისები"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "%s-ის დამალვა"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "აპლიკაციის დამალვა"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "სხვების დამალვა"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "ყველას ჩვენება"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "%s-დან გასვლა"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "აპლიკაციიდან გასვლა"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "დაბეჭდვის ოპერაციის ინიციალიზაციის შეცდომა"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "წერტილის ზომა"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "ფონტის სახის სახელი"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "სტილი"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "სიმძიმე"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "ოჯახი"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ButtonText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "GrayText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "მოუნიშნავის გაბუნდოვნება"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "მენიუ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "მინიშნება"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "TooltipText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "ფანჯარა"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "განსხვავებული"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "შავი"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "ბორდოსფერი"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "მუქი ლურჯი"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "იისფერი"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "მომწვანო ლურჯი"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "ნაცრისფერი"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "მწვანე"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "ზეთისხილისფერი"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "ყავისფერი"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "ლურჯი"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "ფუქსიისფერი"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "წითელი"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "ნარინჯისფერი"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "ვერცხლი"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "ლიმონის ფერი"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "წყლის ფერი"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "ყვითელი"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "თეთრი"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "ნაგულისხმები"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "ისარი"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "ისარი მარჯვნივ"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "სუფთა"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "სამიზნე"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "სიმბოლო"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "ჯვარი"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "ხელი"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "მარცხენა ღილაკი"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "გამადიდებელი"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "შუა ღილაკი"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "ჩანაწერის გარეშე"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "სახატავი ფუნჯი"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "ფანქარი"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "წერტილი მარცხნივ"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "წერტილი მარჯვნივ"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "კითხვა"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "მარჯვენა ღილაკი"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "ზომების შეცვლა NE-SW"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "ზომების შეცვლა N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "ზომების შეცვლა NW-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "ზომების შეცვლა W-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "ზომების შეცვლა"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "აეროზოლი"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "მოცდა"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "ყურება"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "მოცდის ნიშანი"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "აირჩიეთ:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "პარამეტრი"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "მნიშვნელობა"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "კატეგორიზირებული რეჟიმი"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "ანბანური რეჟიმი"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "მცდარი"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "ჭეშმარიტი"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "მიუთითებელი"
 
@@ -6873,48 +6879,48 @@ msgstr "თვისების შეცდომა"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "რესურსის შეცდომა: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "მნიშვნელობა %s ან მეტი უნდა იყოს."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "მნიშვნელობის დიაპაზონია %s-%s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "მნიშვნველობა %s ან ნაკლები უნდა იყოს."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "არა %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "აირჩიეთ საქაღალდე:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "ფაილის არჩევა"
 
@@ -7381,117 +7387,117 @@ msgstr "ჩასმა"
 msgid "Outset"
 msgstr "გარე ჩარჩო"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "სტილის შეცვლა"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "ობიექტის სტილის შეცვლა"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "თვისებების შეცვლა"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "სიის სტილის შეცვლა"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "სიის გადანომრვა"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "ტექსტის ჩასმა"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "გამოსახულების დამატება"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "ობიექტის ჩასმა"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "ველის ჩასმა"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "EndStyle -ის მეტისმეტად ბევრი გამოძახება!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "ფაილები"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "სტანდარტული/წრეწირი"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "სტანდარტული/წრეწირის-კონტური"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "სტანდარტული/ოთხკუთხედი"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "სტანდარტული/პრიზმა"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "სტანდარტული/სამკუთხედი"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "ველის თვისებები"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "ბევრი უჯრედის თვისება"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "უჯრედის თვისებები"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "უჯრედის სტილის დაყენება"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "მწკრივის წაშლა"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "სვეტის წაშლა"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "მწკრივის დამატება"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "წვეტის დამატება"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "ცხრილის თვისებები"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "სურათის თვისებები"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "გამოსახულება"
 
@@ -7699,24 +7705,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "გადათრევა"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "ტექსტის წაშლა"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "მარკერის მოცილება"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "ტექსტის შენახვა შეუძლებელია."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "ჩანაცვლება"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&ფონტი:"
 
@@ -8685,53 +8691,53 @@ msgstr "სიის სტილები"
 msgid "Box styles"
 msgstr "ველის სტილები"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "ფონტი, რომლიდანაც უნდა ავიღოთ სიმბოლო."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&ქვესეტი:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "უნიკოდის ქვესეტის ჩვენება."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&სიმბოლოს კოდი:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "სიმბოლოს კოდი."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&საიდან:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "უნიკოდი"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "საჩვენებელი დიაპაზონი."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "ჩასმა"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(ნორმალური ტექსტი)"
 
@@ -8915,7 +8921,7 @@ msgstr "Kqueue-დან მოვლენების მიღების �
 msgid "Media playback error: %s"
 msgstr "მედიის დაკვრის შეცდომა: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "%s -ის დასაკრავად მომზადების შეცდომა."
@@ -9015,77 +9021,77 @@ msgstr "ხმის მონაცემების მხარდაუჭ�
 msgid "Couldn't open audio: %s"
 msgstr "აუდიოს გახსნის პრობლემა: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "ნაკადების მგეგმავის პოლიტიკის მიღების შეცდომა."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "ნაკადის პრიორიტეტის პარამეტრი იგნორირებულია."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "ნაკადის (%d) პრიორიტეტის დაყენება შეუძლებელია."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "ნაკადის შეჩერების შეცდომა."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "%s-ის გაშვების შეცდომა\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "ფორკის შეცდომა"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "პროცესის პრიორიტეტის დაყენების შეცდომა"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "ქვეპროცესში შეტანის ან მიღების გადამისამართება გამოყენება ვერ მოხერხდა"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "ჰოსტის სახელის მიღების შეცდომა"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "ჰოსტის ოფიციალური სახელის მიღების შეცდომა"
 
@@ -9101,12 +9107,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "მითითებულ გეომეტრია არასწორია: %s"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets -მა ეკრანი ვერ გახსნა. გამოსვლა."
 
@@ -9120,27 +9126,52 @@ msgstr "ეკრანის დახურვის შეცდომა: %s
 msgid "Failed to open display \"%s\"."
 msgstr "ეკრანის გახსნის შეცდომა: %s."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML-ის დამუშვების შეცდომა: '%s' ხაზთან %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s'-დან რესურსების ჩატვირთვის შეცდომა."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "რესურსებს ფაილის გახსნის შეცდომა: %s."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "'%s'-დან რესურსების ჩატვირთვის შეცდომა."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "შექმნა %s \"%s\" შეცდომა."
+
+#~ msgid "Printing "
+#~ msgstr "დაბეჭდვა "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "კონტროლში ტექსტის ჩასმის პრობლემა."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "აირჩიეთ სწორი ფონტი."
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets -მა ვერ გახსნა ეკრანი '%s'-სთვის: გასვლა."
+
+#~ msgid "Filter"
+#~ msgstr "ფილტრი"
+
+#~ msgid "Directories"
+#~ msgstr "საქაღალდეები"
+
+#~ msgid "Files"
+#~ msgstr "ფაილები"
+
+#~ msgid "Selection"
+#~ msgstr "მონიშნული"

--- a/locale/ko_KR.po
+++ b/locale/ko_KR.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2009-04-23 18:29+0900\n"
 "Last-Translator: 정성기 <dragoneyes.org@gmail.com>\n"
 "Language-Team: Korean <Korean>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "X-Poedit-Country: KOREA, REPUBLIC OF\n"
 "Plural-Forms: nplurals=2; plural=n == 1 ? 0 : 1;\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "모든 파일 (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "모든 파일 (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "남은 시간:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "예"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "아니오"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "확인"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "취소"
@@ -104,7 +101,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Epoll 디스크립터 생성을 실패했습니다."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "인쇄"
@@ -149,7 +146,7 @@ msgstr "특성(&P)"
 msgid "Printing"
 msgstr "인쇄중"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "기호"
 
@@ -218,7 +215,7 @@ msgstr "이전(&P)"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "창(&W)"
 
@@ -778,11 +775,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr ""
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "이 도움말 계속 보기."
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "자세한 로그 메시지 생성"
 
@@ -804,84 +801,84 @@ msgstr "'%s' 테마는 지원하지 않습니다."
 msgid "Invalid display mode specification '%s'."
 msgstr "설정된 디스플레이 모드('%s')가 없습니다. "
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "%s 옵션을 찾을 수 없습니다."
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "%s 옵션을 찾을 수 없습니다."
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "'%s' 옵션에서 예기치 않은 문자가 있습니다."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "옵션에 '%s' 값이 필요합니다."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "옵션 '%s' 에 구분자가 없습니다."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "잘못된 숫자 '%s' 가 '%s' 에 입력 되었습니다."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "옵션 '%s': '%s' 를 날짜로 변환할 수 없습니다."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "'%s' 의 파라메타가 잘못되었습니다."
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (또는 %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' 옵션에 대한 값을 지정해야합니다."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "필수 매개 변수인 '%s' 가 지정되지 않았습니다."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "사용법: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr ""
 
@@ -899,7 +896,7 @@ msgid "Can't &Undo "
 msgstr "&실행취소 안됨"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "실행취소(&U)"
@@ -909,7 +906,7 @@ msgid "&Redo "
 msgstr "다시실행(&R)"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "다시실행(&R)"
@@ -936,12 +933,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' 에서  '..' 는 무시합니다."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -951,103 +948,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "밑줄"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "오늘"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "어제"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "내일"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "첫 번째"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "두 번째"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "세 번째"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "네 번째"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "다섯 번째"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "여섯 번째"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "일곱 번째"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "여덟 번째"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "아홉 번째"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "열 번째"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "열한 번째"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "열두 번째"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "열세 번째"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "열네 번째"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "열다섯 번째"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "열여섯 번째"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "열일곱 번째"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "열여덟 번째"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "열아홉 번째"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "스무 번째"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "정오"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "깊은 밤"
 
@@ -1114,44 +1111,81 @@ msgstr "Curl 을 실행할 수 없습니다. PATH 폴더에 설치해 주세요.
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "디버그 보고서 전송 실패 (오류 코드 %d)"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "다른 이름으로 저장"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "이름없음"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "%s 문서의 바뀐 내용을 저장하시겠습니까?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "저장(&S)"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "저장 하지 않음"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "%s 문서의 바뀐 내용을 저장하시겠습니까?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "텍스트를 저장할 수 없습니다."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "'%s' 파일을 쓰기 모드로 여는 데 실패했습니다."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "\"%s\" 비트맵 이미지 파을을 저장하는데 실패했습니다."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "'%s' 파일을 읽기 모드로 여는 데 실패했습니다."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1160,58 +1194,58 @@ msgstr ""
 "파일 '%s' 가 없습니다.\n"
 "최근 사용 파일 목록 에서 제거된거 같습니다."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "파이프 생성 실패"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "인쇄 미리보기"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Column 너비를 정의할수 없습니다."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "이름없음%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "파일 열기"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "파일 오류"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "파일을 열 수 없습니다."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "알수 없는 파일 형식 입니다."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "문서 템플릿을 선택합니다"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "템플릿"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "문서 뷰를 선택합니다"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "보기"
 
@@ -1245,41 +1279,41 @@ msgstr "'%s '파일을 읽는 데 오류가 발생했습니다."
 msgid "Write error on file '%s'"
 msgstr "'%s' 파일 쓰기 오류"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "파일 '%s'를 비우는데 실패 했습니다."
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "파일 '%s' 에서 찾기 실패(큰 파일형식을 지원하지 않습니다.)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' 파일에서 찾을 수 없습니다."
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "파일 '%s' 에서 현재 위치를 찾을 수 없습니다."
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "임시 파일의 접근 권한 설정을 실패 했습니다."
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "'%s' 파일을 지울 수 없습니다"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "'%s' 파일의 바뀐점을 저장할 수 없습니다."
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "'%s' 임시 파일을 지울 수 없습니다"
@@ -1304,27 +1338,27 @@ msgstr "파일 디스크립터 %d 에서 데이타를 읽어 올 수 없습니�
 msgid "can't write to file descriptor %d"
 msgstr "파일 디스크립터 %d 에서 데이타를 쓸 수 없습니다."
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "파일 디스크립터 %d 를 비울수 없습니다."
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "파일 디스크립터 %d 찾을 수 없습니다."
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "파일 디스크립터 %d 의 현재 위치를 얻을 수 없습니다"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "파일 디스크립터 %d 에서 파일의 길이를 얻어올 수 없습니다."
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1350,107 +1384,107 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "설정 읽기 오류."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "설정을 읽어오지 못했습니다."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "'%s' 파일: 잘못입력된 문자 데이터 %c (%d번째 줄)"
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "파일[%s], 행[%d]: 헤더 이후의 '%s' 는 무시합니다."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "'%s' 파일, %d번째 줄 : '=' 을 찾을 수 없습니다."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "파일[%s], 행[%d]: 변경 불가능한 키값 '%s'는 무시합니다."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "파일[%s], 행[%d], 키['%s'] : %d 행에서 처음으로 발견됨 "
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "설정파일에 문자열은 '%c' 로 시작할 수 없습니다."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "사용자 설정파일을 열수 없습니다."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "사용자 설정을 파일에 쓸 수 없습니다"
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "사용자 설정 정보 저장 실패."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "사용자 설정파일 '%s' 을 삭제할 수 없습니다."
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "항목 '%s' 가 구룹 '%s' 에 하나이상 있습니다."
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "변경 불가능한 설정의 변경을 시도했습니다. '%s' 무시합니다."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' 의 마지막 역슬러쉬는 무시됩니다."
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "%d 번째 줄('%s' 파일)에서 \" 문자가 잘못 입려되었습니다."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "파일 '%s' 를 '%s' 로 복사하는데 실패했습니다."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "'%s' 파일의 접근할 수 없습니다."
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "파일 '%s' 덮어쓰기 실패"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "파일 '%s' 를 '%s' 로 복사하는데 실패했습니다."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "'%s' 파일의 접근권한을 변경할 수 없습니다."
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1458,41 +1492,41 @@ msgid ""
 msgstr ""
 "파일이름을  '%s' 에서 '%s' 로 변경 실패, 동일한 파일이름이 이미 존재합니다."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' 디렉토리를 만들 수 없습니다."
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "'%s' 에 해당하는 파일을 찾을 수 없습니다"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "작업 디렉토리를 가져오는데 실패했습니다."
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "작업 디렉토리를 가져오는데 실패했습니다."
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "파일 (%s)"
@@ -1519,17 +1553,17 @@ msgstr "임시 파일을 생성을 실패했습니다"
 msgid "Failed to open temporary file."
 msgstr "임시 파일을 여는 데 실패했습니다."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "%s 번 파일을 수정하는 데 실패"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "'%s' 파일 만들기 실패"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s' 번 파일검색 실패 "
@@ -1538,22 +1572,22 @@ msgstr "'%s' 번 파일검색 실패 "
 msgid "Browse"
 msgstr "탐색창"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "모든 파일 (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s 파일 (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "%s 파일 불러오기"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "%s 파일 저장"
@@ -1926,107 +1960,107 @@ msgstr "기본값"
 msgid "unknown-%d"
 msgstr "알 수 없음-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "밑줄"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " 취소선"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " 가늘게"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " 가늘게"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " 굵게"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " 굵게"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " 굵게"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " 기울임"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 #, fuzzy
 msgid "strikethrough"
 msgstr "취소선(&S)"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "가늘게"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "가늘게"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "보통"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "굵게"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "굵게"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "굵게"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "기울임"
 
@@ -2105,7 +2139,7 @@ msgstr "FTP 접속 실패(Time-out), 패시브 모드로 시도해 보시오."
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP 전송모드를 %s 로 변경하지 못했습니다. "
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "아스키"
 
@@ -2126,7 +2160,7 @@ msgstr "FTP 서버가 패시브 모드를 지원하지 않습니다."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL 색상 할당을 실패 했습니다."
 
@@ -2144,7 +2178,7 @@ msgstr "사용자 지정 크기"
 msgid "&Customize..."
 msgstr "사용자 지정 크기"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "기본 탐색창에서 URL \"%s\" 여는데 실패했습니다."
@@ -2164,156 +2198,155 @@ msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 msgid "Failed to load icons from resource '%s'."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: 잘못된 이미지입니다. 저장할수 없음"
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage가 wxPalette를 가지고 있지 않습니다."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: 비트맵 해더를 작성할수 없습니다."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: 비트맵 해더정보를 작성할수 없습니다."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB 색상표(color map)를 사용한 쓰기 실패"
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: 데이타 쓰기 실패"
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: 메모리 할당 실패"
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB 헤더: 이미지 너비가 32767 픽셀 보다 큽니다."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB 헤더: 이미지 높이가  32767 픽셀 보다 큽니다."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB 헤더: 알수 없는 해상도."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB 헤더 : 알수없는 인코딩."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB 헤더: 인코딩이 해상도와 일치 하지 않습니다."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: 메모리 할당 실패"
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB 헤더: 이미지 너비가 32767 픽셀 보다 큽니다."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB 헤더: 이미지 높이가  32767 픽셀 보다 큽니다."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB 헤더: 알수 없는 해상도."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB 헤더 : 알수없는 인코딩."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB 헤더: 인코딩이 해상도와 일치 하지 않습니다."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "DIB 이미지 읽기 오류."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: DIB 마스크에서 읽기 오류가 발생했습니다."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: 아이콘 이미지가 너무큼(길이)"
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: 아이콘 이미지가 너무큼(너비)"
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: 이미지 파일 쓰기 오류!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ICON 인덱스가 잘못되었습니다."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "마스크의 사이즈 정보와 실제 이미지 사이즈가 동일하지 않습니다."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "이미지에서 사용되지 않는 색상을 감춥니다."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "%d 이미지('%s' 파일에서)를 읽어올 수 없습니다."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "이미지를 파일 '%s'에 저장할수 없음: 이미지 핸들러를 찾을 수 없습니다."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "이미지 핸들러가 없습니다."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "타입 %d 에대한 이미지 핸들러가 정의되지 않았습니다."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "%ld 타입은 이미지 파일이 아닙니다."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "데이터에 잘못된 형식이 있습니다."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: PCX 파일이 아닙니다."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "타입 %s 에대한 이미지 핸들러가 정의되지 않았습니다."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "%s 타입은 이미지 파일이 아닙니다."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "\"%s\" 비트맵 이미지 파을을 저장하는데 실패했습니다."
@@ -2415,52 +2448,52 @@ msgstr "PNM: 파일이 잘렸습니다."
 msgid " (in module \"%s\")"
 msgstr "tiff 모듈: %s"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: 이미지 읽어오기 오류."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "TIFF 이미지가 잘못되었습니다."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: 메모리를 할당할 수 없습니다."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: 이미지 읽기 오류."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "알 수 없는 TIFF 해상도 단위(%d)임, 무시합니다."
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: 이미지 저장 오류."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: 이미지 쓰기 오류"
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "명령행 인자 %d는 유니코드로 변경할수 없어 인자를 무시합니다."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "등록된 모듈들의 초기화를 실패했습니다."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "\"%s\" 에 대한 언어 로케일을 설정할 수 없습니다."
@@ -2559,7 +2592,7 @@ msgstr "압축 오류"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'%s' MIME 타입에서 '{' 의 짝이 맞지 않습니다."
@@ -2579,7 +2612,7 @@ msgstr "\"%s\" 에 종속적인 모듈 \"%s\" 이 존재하지 않습니다."
 msgid "Module \"%s\" initialization failed"
 msgstr "\"%s\" 모듈의 초기화 실패"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "알림 : %s"
@@ -3084,7 +3117,7 @@ msgstr "인쇄 오류"
 msgid "Print"
 msgstr "인쇄"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "페이지 설정"
 
@@ -3121,20 +3154,16 @@ msgstr "%d쪽 인쇄 중..."
 msgid " (copy %d of %d)"
 msgstr "페이지 %d/%d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "인쇄중"
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "다음 페이지"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "이전 페이지"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "다음 페이지"
 
@@ -3181,16 +3210,16 @@ msgstr "페이지 %d/%d"
 msgid "Page %d"
 msgstr "페이지 %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "알 수 없는 오류"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "올바르지 않은 정규식 '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "정규 표현식 %s 에 대한 검색 실패"
@@ -3200,21 +3229,21 @@ msgstr "정규 표현식 %s 에 대한 검색 실패"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Renderer \"%s\" 버전 %d.%d  는 호환되지 않습니다."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
@@ -3223,11 +3252,11 @@ msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 msgid "Failed to monitor I/O channels"
 msgstr "모니터의 I/O 채널 선택 실패"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "저장"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "저장 하지 않음"
 
@@ -3314,10 +3343,10 @@ msgid "Clear"
 msgstr "비우기(&C)"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "닫기"
 
@@ -3331,7 +3360,7 @@ msgstr "목차"
 msgid "Convert"
 msgstr "목차"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "복사(&D)"
@@ -3340,7 +3369,7 @@ msgstr "복사(&D)"
 msgid "Copy"
 msgstr "복사"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "잘라내기(&T)"
@@ -3349,13 +3378,13 @@ msgstr "잘라내기(&T)"
 msgid "Cut"
 msgstr "잘라내기"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "지우기(&D)"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "지우기"
@@ -3451,7 +3480,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "도움말(&H)"
 
@@ -3471,7 +3500,7 @@ msgstr "들여쓰기"
 msgid "&Index"
 msgstr "색인(&I)"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "차례"
 
@@ -3545,7 +3574,7 @@ msgstr "새로 만들기(&N)"
 msgid "New"
 msgstr "새로 만들기(&N)"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "아니오(&N)"
 
@@ -3563,12 +3592,12 @@ msgstr "열기...(&O)"
 msgid "Open..."
 msgstr "열기...(&O)"
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "붙여넣기(&P)"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "붙여 넣기"
@@ -3602,7 +3631,7 @@ msgid "Print..."
 msgstr "인쇄...(&P)"
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "특성(&P)"
 
@@ -3637,10 +3666,6 @@ msgstr "바꾸기"
 msgid "Revert to Saved"
 msgstr "저장된 상태로 되돌리기"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "저장(&S)"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "다른 이름으로 저장(&A)"
@@ -3650,7 +3675,7 @@ msgstr "다른 이름으로 저장(&A)"
 msgid "Save As..."
 msgstr "다른 이름으로 저장(&A)"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "모두 선택(&A)"
@@ -3768,7 +3793,7 @@ msgstr "위로(&U)"
 msgid "Up"
 msgstr "위로"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "예(&Y)"
 
@@ -3861,43 +3886,43 @@ msgstr "현재 문서를 저장합니다."
 msgid "Save current document with a different filename"
 msgstr "현재 문서를 다른 파일 이름으로 저장합니다."
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "문자 인코딩 '%s' 으로의 변환이 실패했습니다."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "알 수 없음"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "tar 헤더가 잘못되었습니다."
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "tar의 Checksum 실패"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "tar 확장 헤더가 잘못되었습니다."
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar 파일 열기 실패"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "파일이 갑작스럽게 끝났습니다"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s 발생 '%s' 파일의 tar 헤더 정보가 손상되었습니다"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tar 파일의 크기가 잘못되었습니다."
 
@@ -3906,7 +3931,7 @@ msgstr "tar 파일의 크기가 잘못되었습니다."
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' 는 이진 버퍼 입니다."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "파일을 읽어올 수 없습니다."
 
@@ -3920,49 +3945,49 @@ msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 msgid "can't write buffer '%s' to disk."
 msgstr "문자열 '%s' 를 디스크에 쓸 수 없습니다."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "로컬 시스템이 시간을 얻어올 수 없습니다."
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay 함수 실패"
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s'은 메시지 카탈로그가 아닙니다."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s'은 메시지 카탈로그가 아닙니다."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "복수형(Plural-Forms) 표현식을 해석할 수 없음: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' 카탈로그 사용 ('%s' 파일)"
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s'은 메시지 카탈로그가 아닙니다."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "스레드를 종료할 수없습니다."
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "HTML 기본 브라우저가 없습니다."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "기본 탐색창에서 URL \"%s\" 여는데 실패했습니다."
@@ -3995,7 +4020,7 @@ msgstr "문자열 '%s' 에는 알파벳 이외의 문자가 입력되었습니�
 msgid "Error: %s (%d)"
 msgstr "오류:"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4004,20 +4029,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Column 정보를 초기화 할 수 없습니다."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "데이타를 창으로 내보낼 수 없습니다."
 
@@ -4069,8 +4094,8 @@ msgstr "생성된 매개 변수 이름을 RTTI 에서 찾을 수 없습니다."
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "잘못된 클래스 객체입니다.(wxEvtHandler 상속한 클래스가 아님)"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "받드시 ConvertToLong 함수를 가져야 함니다."
 
@@ -4125,79 +4150,79 @@ msgstr "객체는 반드시 속성 ID를 가져야 합니다."
 msgid "Doubly used id : %d"
 msgstr "객체 ID가 이미 정의되어 있습니다: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "속성 %s 을 찾을 수 없습니다."
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "CollectionType 'element' 노드로 구성되어야 합니다."
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "잘못된 문자열 : '.' 문자가 없음"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib 출력 스트림을 재 초기화 할 수 없습니다"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib 입력 스트림을 재 초기화 할 수 없습니다"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "분활 압축으로 되어있습니다."
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "zip 파일이 잘못되었습니다"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "Zip 압축 스트립에서 Central-Directory 를 찾을 수 없습니다."
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "CENTRAL_MAGIC 을 읽을 수 없습니다."
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "Zip 파일 읽기 오류"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "Zip 파일 헤더가 잘못되었습니다."
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "Zip 헤더에 파일의 길이가 없습니다."
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "Zip 압축을 지원하지 않습니다."
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "ZIP 스트림 일기 (%s): 길이가 잘못됨"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "ZIP 스트림 일기 (%s): CRC 오류"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "Zip 오류('%s'): CRC 오류"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "Zip 오류('%s'): CRC 오류"
@@ -4283,33 +4308,33 @@ msgstr "그래픽"
 msgid "Translations by "
 msgstr "번역"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "버전 %s"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "%s 정보"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "사용권"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "개발자"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "문서 작성자"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artists"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "번역자"
 
@@ -4360,44 +4385,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "파일"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (또는 %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4408,8 +4432,7 @@ msgid "Left"
 msgstr "왼쪽"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4506,7 +4529,7 @@ msgid "Home directory"
 msgstr "홈 디렉토리"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "바탕 화면"
 
@@ -4519,8 +4542,7 @@ msgstr "잘못된 디렉토리 이름입니다."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "오류"
 
@@ -4704,16 +4726,16 @@ msgstr "자세히보기로 파일보기"
 msgid "Go to parent directory"
 msgstr "부모 디렉토리로 가기"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' 파일이 이미 있습니다.  이 파일을 덮어 쓰시겠습니까?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "확인"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "파일을 선택하십시오"
 
@@ -4807,7 +4829,7 @@ msgstr "글꼴 크기"
 msgid "Whether the font is underlined."
 msgstr "글꼴 밑줄이 있는지 여부입니다."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "미리보기:"
@@ -4825,48 +4847,47 @@ msgstr "선택한 글꼴을 취소하려면 여기를 누르십시오."
 msgid "Click to confirm the font selection."
 msgstr "선택한 글꼴을 적용하려면 여기를 누르십시오."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "글꼴 선택"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "도움말 디렉토리 \"%s\" 가 없습니다."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "도움말 파일 \"%s\" 이 없습니다."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "%lu 행(맵 파일 \"%s\" 에서) 에 문법이 잘못되었습니다."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "\"%s\" 로 검색된 파일이 없습니다."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "항목이 없습니다."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "도움말 인덱스"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "관련 항목:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "발견 항목"
 
@@ -4972,59 +4993,59 @@ msgstr "인쇄를 시작할 수 없습니다."
 msgid "Printing page %d..."
 msgstr "%d쪽 인쇄 중..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "인쇄 설정"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "파일로 인쇄"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "설정..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "프린터:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "상태:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "모두"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "페이지"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "인쇄 범위"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "송신:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "수신:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "인쇄 매수:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript 파일"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "인쇄 설정"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "프린터"
 
@@ -5032,25 +5053,25 @@ msgstr "프린터"
 msgid "Default printer"
 msgstr "프린터 기본값"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "용지 크기"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "세로 방향"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "가로 방향"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "방향"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "설정"
 
@@ -5062,52 +5083,52 @@ msgstr "인쇄 색상"
 msgid "Print spooling"
 msgstr "인쇄 스풀러"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "인쇄 명령:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "인쇄 설정:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "왼쪽 여백(mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "상단 여백(mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "오른쪽 여백(mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "버튼 여백(mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "프린터..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "건너뛰기(&S)"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "알수 없음"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "완료."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "찾기"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "tab ID를 찿을 수 없습니다."
 
@@ -5143,22 +5164,22 @@ msgstr "종료(&F)"
 msgid "< &Back"
 msgstr "< &뒤로"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "번역"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+ 초기화 할 수 없습니다. 디스플레이 설정이 바르게 되어 있습니까?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "디렉토리 \"%s\" 생성을 실패했습니다."
@@ -5184,12 +5205,12 @@ msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 msgid "Failed to register font configuration using private fonts."
 msgstr "사용자 설정 파일을 갱신하는데 실패했습니다."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "치명적인 오류"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5197,7 +5218,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5205,7 +5226,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI 자식"
 
@@ -5221,35 +5242,27 @@ msgstr "인쇄하는 도중 오류 발생:"
 msgid "Page Setup"
 msgstr "페이지 설정"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "컨트롤에 텍스트 삽입 실패."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "사용 가능한 글꼴을 선택하십시오."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5348,45 +5361,45 @@ msgstr "파일을 열 수 없습니다: %s"
 msgid "Cannot open index file: %s"
 msgstr "'%s' 차례 파일을 열 수 없습니다."
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "이름없음"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML 도움말을 열 수 없습니다: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "왼쪽에 도움말 탐색창을 표시합니다."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(책갈피)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "현재 페이지를 책갈피에 추가 합니다."
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "현재 페이지의 책갈피를 제거 합니다."
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "목차"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "찾기"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "모두 표시"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5394,166 +5407,166 @@ msgstr ""
 "문자열을 포함하는 모든 색인 항목을 표시합니다. 검색시 대소문자를 구분하지 않"
 "습니다"
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "색인의 모든 아이템 표시"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "대/소문자 구분"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "단어 단위로 검색"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "위에서 입력한 내용을 검색합니다.  "
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "탐색 도구모음 보이기/감추기"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "뒤로 가기"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "앞으로 가기"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "위로 이동"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "HTML 문서를 엽니다"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "이 페이지를 인쇄"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "보기 설정 창"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "표시할 페이지를 선택하시기 바랍니다 :"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "도움말 주제"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "찾는 중..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "일치하는 페이지를 찾을 수 없습니다."
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i 개의 항목 검색됨"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(도움말)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "모든 도움말 에서 찾기"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "도움말 설정"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "보통 글꼴:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "고정폭 글꼴:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "글꼴 크기:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "글꼴 크기"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "일반 모습<br>그리고 <u>밑줄</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>기울임 모습.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>굵게 모습.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>굵게 기울임 모습.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "고정 폭 모습.<br> <b>굵게</b> <i>기울임</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>굵게 기울임 <u>밑줄</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "인쇄 도움말"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "빈 페이지를 인쇄할 수 없습니다."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML 파일 (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "도움말 문서 (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML 도움말 프로젝트 (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "압축된 HTML 도움말 파일 (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i / %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i / %i"
@@ -5625,32 +5638,6 @@ msgid ""
 msgstr ""
 "페이지를 설정하는 동안 문제가 발생했습니다. 기본프린터를 설정해 주세요."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "%s 인코딩으로 HTML 문서 보기 실패"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets: 디스플레이 '%s' 의 열기 실패. 종료합니다."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "필터"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "디렉토리"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "파일"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "선택"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "클립보드를 여는 데 실패했습니다."
@@ -5692,58 +5679,58 @@ msgstr "색상 선택창에서 오류 발생 : %0lx"
 msgid "Failed to create cursor."
 msgstr "마우스 커서 생성을 실패했습니다."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "'%s' DDE 서버 등록 실패"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "등록된 '%s' DDE 서버를 제거하는데 실패했습니다. "
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "'%s' 서버의 '%s' 서비스로의 접속을 실패 했습니다."
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE 로 데이타 전송 실패"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE 서버의 어드바이스 루프로의 연결을 실패 했습니다."
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE 서버의 어드바이스를 종료할 수 없습니다."
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "DDE 어드바이서에서 통지 전송을 실패했습니다"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "DDE 문자열 생성을 실패 했습니다."
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "DDE 오류 없음."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "어브바이스 트랜잭션에 대한 동기화 요청이 제한 시간을 초과했습니다."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "DDE 오류: DMLERR_BUSY 상태"
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "데이터 트랜잭션에 대한  동기화 요청이 제한 시간을 초과했습니다."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5754,7 +5741,7 @@ msgstr ""
 "혹은 DDEML 함수에 전달된 인스턴스 ID가\n"
 "잘못되엇습니다."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5766,43 +5753,43 @@ msgstr ""
 "혹은 APPCMD_CLIENTONLY에서 초기화된 프로그램이\n"
 "서버 트랜잭션을 시도했습니다."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "트랜잭션을 실행에 대한 동기화 요청이 시간이 초과되었습니다."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML 오류: 잘못된 파라미터 전달"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "프로그램이 경쟁 상태에 빠졋습니다."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "메모리가 부족합니다."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "클라이언트의 연결시도가 실패했습니다."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "트랜잭션에 실패했습니다."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "포크 트랜잭션에 대한 동기화 요청이 제한 시간을 초과했습니다."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "내부 호출을 통한 PostMessage 함수 호출이 실패했습니다."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "재진입 문제 발생."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5812,15 +5799,15 @@ msgstr ""
 "트랜잭션이 종료되지 전에\n"
 "서버또는 클라이언트가 종료 되었습니다."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML: 시스템 오류 발생"
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "어브바이스 트랜잭션에 대한 종료 요청이 제한 시간을 초과했습니다."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5831,18 +5818,18 @@ msgstr ""
 "XTYP_XACT_COMPLETE 콜백함수에서 일단 프로그램으로 돌아옴,\n"
 "콜백을 위한 트랜잭션 ID(큐ID)가 더이상 유효하지 않습니다."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "%08x 의 DDE 오류 메세지를 찾을 수 없습니다."
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr "RAS가 설치되지 않아 전화 연결을 할수 없습니다. RAS 설치해 주십시오. "
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5851,64 +5838,64 @@ msgstr ""
 "RAS 버전이 오래되었습니다. 업데이트를 확인해 주세요(다음의 함수들을 지원하지 "
 "않습니다: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS 오류 메시지의 텍스트의 검색 실패"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "알 수 없는 오류 (오류 코드 %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "동작중인 전화 연결을 찾을수 없습니다: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "여러개의 활성화된 전화연결을 찾았습니다. 임의로 하나를 선택합니다."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "%s 에 dialup 연결을 실패했습니다."
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP 이름을 가져오기 실패: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "접속 실패: 전화 접속을 위한 ISP가 없음"
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "ISP에 전화 연결 "
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "연결할 ISP를 선택하십시오."
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "접속 실패: ID 또는 Password가 잘못되었습니다."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "주소록 파일에서 위치를 찾을 수 없습니다."
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "dialup 연결을 초기화 하는데 실패: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "접속을 끊을 수 없습니다 - 현재 활성화된 전화 연결이 없습니다."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "전화연결 종료 실패: %s"
@@ -5928,19 +5915,18 @@ msgstr "비트맵 데이타를  위한 메모리(%luKb) 할당이 실패했습�
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' 폴더에서 파일을 찾을 수 없습니다."
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "타이머를 생성할 수 없습니다."
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (오류 %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "이미지 목록에 이미지를 추가할 수 없습니다."
 
@@ -5954,7 +5940,7 @@ msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "표준 찾기/바꾸기 창 생성 실패(오류 코드 %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "색상 선택창에서 오류 발생 : %0lx"
@@ -5997,17 +5983,17 @@ msgstr "'%s' 파일 만들기 실패"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "타이머를 생성할 수 없습니다."
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL 초기화를 실패했습니다."
 
@@ -6015,7 +6001,7 @@ msgstr "OpenGL 초기화를 실패했습니다."
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6023,7 +6009,7 @@ msgstr ""
 "MS HTML Help SDK가 설치되어 있지 않아 MS HTML Help 함수를 사용할 수 없습니"
 "다. "
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML 도움말 초기화 실패."
 
@@ -6032,7 +6018,7 @@ msgstr "MS HTML 도움말 초기화 실패."
 msgid "Can't delete the INI file '%s'"
 msgstr "'%s' INI 파일을 삭제할 수 없습니다."
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "목록보기 에서  아이템 %d 의 정보를 가져올 수 없습니다.  "
@@ -6154,7 +6140,7 @@ msgstr "%s 형식을 클립보드에 등록할 수 없습니다."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "%d 포맷이 클립보드에 없습니다."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "건너뛰기"
 
@@ -6239,75 +6225,75 @@ msgstr ""
 "이 키를 지우시면 시스템이 불안전한 상태가 됩니다.:\n"
 "삭제를 취소 합니다."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "레지스터 키 '%s'  삭제 할 수 없습니다"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "레지스터 값 '%s' 을 지울수 없습니다(레지스터 키 '%s' 에서)"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "레지스터 키값 '%s' 를 읽을 수 없습니다."
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "레지스터 키 '%s' 의 값을 설정 할 수 없습니다."
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "레지스터 키값 '%s' 를 읽을 수 없습니다."
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "레지스터 키값 '%s' 를 찾을 수 없습니다."
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "레지스터 키 '%s' 의 하위 키들을 찾을 수 없습니다."
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "레지스터 키값 가져오기: 파일 \"%s\" 이미 존재합니다."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "지원되지 않는 %d 타입의 레지스트 값을 내보낼 수 없습니다."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "레지스터 값 \"%s\" 을 무시합니다.(레지스터 키 \"%s\" 에서)"
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6315,47 +6301,47 @@ msgstr ""
 "Rich Edit 컨트롤을 생성할 수 없어 Simple Text 컨트롤로 대체 하였습니다. "
 "riched32.dll 을 재설치 하십시오."
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "쓰레드 시작 실패: TLS 쓰기 오류."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "쓰레드 우선 순위를 설정할 수 없습니다."
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "쓰레드 생성 할 수 없습니다"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "스레드를 종료할 수없습니다."
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "쓰레드 종료 실패로 Thread를 강제로 종료합니다"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "쓰레드 %x 일시정지 할 수 없습니다"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "쓰레드 %x 를 다시시작 할 수 없습니다"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "현재 쓰레드 포인터를 얻지 못했습니다."
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "쓰레드 모듈 초기화 실패:TLS 인덱스 할당 실패"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6384,12 +6370,12 @@ msgstr "\"%s\" 파일에서 메타 파일을 읽어올 수 없습니다."
 msgid "Failed to lock resource \"%s\"."
 msgstr "'%s' 잠금 파일의 잠금 실패 "
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6401,47 +6387,47 @@ msgstr "익명 파이프 생성을 실패했습니다."
 msgid "Failed to redirect the child process IO"
 msgstr "자식 프로세스의 입출력 리다이렉트 실패"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' 명령 실행 실패"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll 을 읽어올 수 없습니다."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' 에서 장치이름을 읽어올 수 없습니다."
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' 아이콘을 읽어올 수 없습니다."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "쓰레드 우선 순위를 설정할 수 없습니다."
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "'%s' 실행을 실패했습니다.\n"
@@ -6475,7 +6461,7 @@ msgid "Check to make the font italic."
 msgstr "글꼴을 기울임"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "밑줄"
@@ -6543,17 +6529,32 @@ msgstr ""
 msgid "File type:"
 msgstr "파일 오류"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "창(&W)"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "도움말"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "최소화(&N)"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "확대(&I)"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6570,495 +6571,495 @@ msgstr "%s 파일이 없습니다."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "%s 정보"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "이 프로그램은(&A)"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "설정(&P)"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "도움말: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "선택"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "모두 표시"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "종료(&Q)"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "선택"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "사용중인 zlib 버전에서 Gzip을 지원하지 않습니다."
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Column 정보를 초기화 할 수 없습니다."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "크기(&P):"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "새 이름"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "모양새"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "두께(&W):"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "글꼴 패밀리(&F):"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "가늘게"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "텍스트 오른쪽 정렬"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Modern"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "메뉴"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "창(&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "창(&W)"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "창(&W)"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "사용자 지정 크기"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "탐색창"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "다시 실행"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "기본값"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "내일"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "오른쪽"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "글머리 모양새"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "문자 코드(&C):"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "크기(&P):"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "오른쪽 정렬"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "질문"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "오른쪽"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "오른쪽"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "선택한 부분을 붙여 넣기"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "특성(&P)"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 #, fuzzy
 msgid "False"
 msgstr "파일"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 #, fuzzy
 msgid "Unspecified"
 msgstr "정렬"
@@ -7073,49 +7074,49 @@ msgstr "인쇄 오류"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "%d 와 %d 사의의 페이지 번호를 입력 하십시오."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "%s 정보"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "디렉토리 생성"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "글꼴 선택"
@@ -7608,130 +7609,130 @@ msgstr "넣기"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "모양새 바꾸기"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 #, fuzzy
 msgid "Change Object Style"
 msgstr "목록 모양새 바꾸기"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "특성(&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "목록 모양새 바꾸기"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "목록 번호 다시 매기기"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "텍스트 넣기"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "그림 넣기"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "텍스트 넣기"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "텍스트 넣기"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "EndStyle 함수를 너무 많이 호출함"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "파일"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 #, fuzzy
 msgid "standard/circle"
 msgstr "표준"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 #, fuzzy
 msgid "standard/square"
 msgstr "표준"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "특성(&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "특성(&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "모양새 지우기"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "지우기"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "선택한 부분 지우기"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "특성(&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "특성(&P)"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "그림"
 
@@ -7939,25 +7940,25 @@ msgstr "~"
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "텍스트 삭제"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "지우기"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "텍스트를 저장할 수 없습니다."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "바꾸기"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "글꼴(&F):"
 
@@ -8994,53 +8995,53 @@ msgstr "목록 모양새"
 msgid "Box styles"
 msgstr "모든 모양새"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "기호의 글꼴."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "분류(&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Unicode 부분집합 표시"
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "문자 코드(&C):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "문자 코드."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "송신(&F):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "유니코드"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "범위 보기"
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "넣기"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(일반 텍스트)"
 
@@ -9231,7 +9232,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "'%s' 디스플레이를 여는 데 실패했습니다."
@@ -9331,80 +9332,80 @@ msgstr "소리 데이타가 알 수 없는 형식 입니다."
 msgid "Couldn't open audio: %s"
 msgstr "오디오 열기 실패: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "스레드 스케줄링 정책을 찾을 수 없습니다."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "스케줄링 정책 %d 에서 우선순위 범위를 얻을 수 없습니다."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "쓰레드 우선순위 설정을 무시합니다."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 "쓰레드 종료 실패, 잠재적인 메모리 누수 감지함. 프로그램을 다시 시작하십시오."
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "스레드를 종료를 실패했습니다."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "쓰레드 모듈 초기화 실패: 쓰레드 키 생성 실패"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "자식 프로세스의 입력 리다이렉트 실패"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "프로세스 %d 종료할 수 없습니다."
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' 실행을 실패했습니다.\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "포크 실패"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "스레드 우선순위(%d) 설정을 실패했습니다."
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "자식 프로세스의 입력 또는 출력의 리다이렉트 실패"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "hostname을 얻을 수 없습니다"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "공식 hostname을 얻을 수 없습니다"
 
@@ -9420,12 +9421,12 @@ msgstr "비동기 모드에서 파이프를 Wake-up 상태롤 변경하는데 �
 msgid "Failed to read from wake-up pipe"
 msgstr "Wake-up 파이프에서 읽는 데 실패했습니다."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "잘못된 Geometry 지정: '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets: 디스플레이 열기 실패. 종료합니다."
 
@@ -9439,30 +9440,59 @@ msgstr "디스플레이 \"%s\" 를 닫는 데 실패했습니다."
 msgid "Failed to open display \"%s\"."
 msgstr "'%s' 디스플레이를 여는 데 실패했습니다."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML 해석 오류: %s  (줄번호 %d)"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "'%s' 파일에서 리소스를 읽어올 수 없습니다."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
+
+#~ msgid "Printing "
+#~ msgstr "인쇄중"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "컨트롤에 텍스트 삽입 실패."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "사용 가능한 글꼴을 선택하십시오."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "%s 인코딩으로 HTML 문서 보기 실패"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets: 디스플레이 '%s' 의 열기 실패. 종료합니다."
+
+#~ msgid "Filter"
+#~ msgstr "필터"
+
+#~ msgid "Directories"
+#~ msgstr "디렉토리"
+
+#~ msgid "Files"
+#~ msgstr "파일"
+
+#~ msgid "Selection"
+#~ msgstr "선택"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "8비트 인코딩 변환 실패"
@@ -9628,8 +9658,8 @@ msgstr "'%s' 의 추출('%s' 에서) 실패 했습니다."
 #~ msgstr "데이타 Renderer가 데이타 타입 및 데이타를 처리할 수 없습니다."
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/lt.po
+++ b/locale/lt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2015-07-09 11:22+0200\n"
 "Last-Translator: Andrius <andrius.balsevicius@gmail.com>\n"
 "Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
@@ -12,11 +12,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n != 1;\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr ""
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr ""
 
@@ -33,24 +33,21 @@ msgid "Remaining time:"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Taip"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "GERAI"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Atsisakyti"
@@ -100,7 +97,7 @@ msgid "Unable to create I/O completion port"
 msgstr ""
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr ""
 
@@ -137,7 +134,7 @@ msgstr "Objektų savybs"
 msgid "Printing"
 msgstr ""
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simbolis"
 
@@ -206,7 +203,7 @@ msgstr "&Ankstesnis"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Langas"
 
@@ -735,11 +732,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr ""
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr ""
 
@@ -761,84 +758,84 @@ msgstr ""
 msgid "Invalid display mode specification '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (iš %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dvigubas"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -856,7 +853,7 @@ msgid "Can't &Undo "
 msgstr ""
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "Atša&ukti"
@@ -866,7 +863,7 @@ msgid "&Redo "
 msgstr "Paka&rtoti "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "Paka&rtoti"
@@ -893,12 +890,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -907,103 +904,103 @@ msgstr ""
 msgid "undetermined"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "pirmas"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "sekundė"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "penktas"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "aštuntas"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "vienuoliktas"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "keturioliktas"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "penkioliktas"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "aštuonioliktas"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr ""
 
@@ -1067,101 +1064,137 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Išsaugoti kaip"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr ""
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Ar norite išsaugoti %s pakeitimus?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Išsaugoti"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nesaugoti"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Ar norite išsaugoti %s pakeitimus?"
+
+#: ../src/common/docview.cpp:560
+msgid "The document must be closed."
+msgstr ""
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr ""
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr ""
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr ""
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr ""
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr ""
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr ""
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Spausdinimo peržiūra"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr ""
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr ""
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Atverti failą"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr ""
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr ""
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr ""
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr ""
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Šablonai"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr ""
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Vaizdai"
 
@@ -1195,41 +1228,41 @@ msgstr ""
 msgid "Write error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr ""
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr ""
@@ -1254,27 +1287,27 @@ msgstr ""
 msgid "can't write to file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1298,147 +1331,147 @@ msgstr ""
 msgid "Error reading config options."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Failas '%s' negali būti pervadintas į '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Failas '%s' negali būti pašalintas"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Nepavyko nustatyti aktyvaus darbo aplanko"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr ""
@@ -1465,17 +1498,17 @@ msgstr ""
 msgid "Failed to open temporary file."
 msgstr ""
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr ""
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr ""
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr ""
@@ -1484,22 +1517,22 @@ msgstr ""
 msgid "Browse"
 msgstr "Naršyti"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Išsaugoti %s failą"
@@ -1862,99 +1895,99 @@ msgstr "numatytasis"
 msgid "unknown-%d"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "pabrauktas"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " perbrauktas"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " lengvas"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " pastorintas"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kursyvas"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "perbrauktas"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "lengvas"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normalus"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "pastorintas"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kursyvas"
 
@@ -2024,7 +2057,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr ""
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2045,7 +2078,7 @@ msgstr ""
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr ""
 
@@ -2061,7 +2094,7 @@ msgstr ""
 msgid "&Customize..."
 msgstr "&Pritaikyti..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr ""
@@ -2081,155 +2114,154 @@ msgstr ""
 msgid "Failed to load icons from resource '%s'."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr ""
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr ""
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nepavyko įkelti taškinės grafikos \"%s\" iš resursų."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nepavyko įkelti piktogramos \"%s\" iš resursų."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr ""
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr ""
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr ""
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr ""
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr ""
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
@@ -2330,52 +2362,52 @@ msgstr ""
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr ""
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2474,7 +2506,7 @@ msgstr ""
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr ""
@@ -2494,7 +2526,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Pranešimas"
 
@@ -2996,7 +3028,7 @@ msgstr ""
 msgid "Print"
 msgstr "Spausdinti"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Puslapio sąranka"
 
@@ -3031,19 +3063,15 @@ msgstr "Spausdinamas puslapis %d iš %d"
 msgid " (copy %d of %d)"
 msgstr " kopija %d iš %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr ""
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Kitas puslapis"
 
@@ -3087,16 +3115,16 @@ msgstr ""
 msgid "Page %d"
 msgstr ""
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "nežinoma klaida"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr ""
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
@@ -3106,21 +3134,21 @@ msgstr ""
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr ""
@@ -3129,11 +3157,11 @@ msgstr ""
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Išsaugoti"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Nesaugoti"
 
@@ -3214,10 +3242,10 @@ msgid "Clear"
 msgstr "Išvalyti"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Užverti"
 
@@ -3229,7 +3257,7 @@ msgstr "&Paversti"
 msgid "Convert"
 msgstr "Konvertuoti"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopijuoti"
@@ -3238,7 +3266,7 @@ msgstr "&Kopijuoti"
 msgid "Copy"
 msgstr "Kopijuoti"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Iškirp&ti"
@@ -3247,13 +3275,13 @@ msgstr "Iškirp&ti"
 msgid "Cut"
 msgstr "Iškirpti"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Ištrinti"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Ištrinti"
@@ -3340,7 +3368,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Pagalba"
 
@@ -3360,7 +3388,7 @@ msgstr ""
 msgid "&Index"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeksas"
 
@@ -3429,7 +3457,7 @@ msgstr "&Naujas"
 msgid "New"
 msgstr "Naujas"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Ne"
 
@@ -3446,12 +3474,12 @@ msgstr "&Atverti..."
 msgid "Open..."
 msgstr "Atverti..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Įk&lijuoti"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Įklijuoti"
@@ -3481,7 +3509,7 @@ msgid "Print..."
 msgstr "Spausdinti..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Savybės"
 
@@ -3513,10 +3541,6 @@ msgstr ""
 msgid "Revert to Saved"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Išsaugoti"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Išs&augoti kaip..."
@@ -3525,7 +3549,7 @@ msgstr "Išs&augoti kaip..."
 msgid "Save As..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "P&ažymėti viską"
@@ -3632,7 +3656,7 @@ msgstr ""
 msgid "Up"
 msgstr "Aukštyn"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Taip"
 
@@ -3720,43 +3744,43 @@ msgstr "Išsaugoti aktyvų dokumentą"
 msgid "Save current document with a different filename"
 msgstr "Išsaugoti aktyvų dokumentą kitu pavadinimu"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "nežinomas"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3765,7 +3789,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr ""
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr ""
 
@@ -3779,47 +3803,47 @@ msgstr ""
 msgid "can't write buffer '%s' to disk."
 msgstr ""
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr ""
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr ""
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr ""
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr ""
@@ -3852,7 +3876,7 @@ msgstr ""
 msgid "Error: %s (%d)"
 msgstr ""
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3860,20 +3884,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr ""
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Platforma nepalaiko permatomo fono."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr ""
 
@@ -3925,8 +3949,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr ""
 
@@ -3976,79 +4000,79 @@ msgstr ""
 msgid "Doubly used id : %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4132,32 +4156,32 @@ msgstr ""
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versija "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Apie %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licencija"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr ""
 
@@ -4208,43 +4232,42 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4255,8 +4278,7 @@ msgid "Left"
 msgstr "Kairė"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4343,7 +4365,7 @@ msgid "Home directory"
 msgstr "Pagrindinis aplankas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Darbastalis"
 
@@ -4356,8 +4378,7 @@ msgstr ""
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Klaida"
 
@@ -4538,16 +4559,16 @@ msgstr ""
 msgid "Go to parent directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Patvirtinti"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr ""
 
@@ -4641,7 +4662,7 @@ msgstr ""
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Peržiūra:"
@@ -4659,48 +4680,47 @@ msgstr ""
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr ""
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr ""
 
@@ -4804,59 +4824,59 @@ msgstr ""
 msgid "Printing page %d..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Sąranka..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Spausdintuvas:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Būsena:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Viskas"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Nuo:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Spausdintuvas"
 
@@ -4864,25 +4884,25 @@ msgstr "Spausdintuvas"
 msgid "Default printer"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Popieriaus dydis"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Stačias"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Gulsčias"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientavimas"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Nuostatos"
 
@@ -4894,52 +4914,52 @@ msgstr ""
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Spausdintuvas..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Pralei&sti"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Nežinomas"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Baigta."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Ieškoti"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr ""
 
@@ -4975,22 +4995,22 @@ msgstr "&Baigti"
 msgid "< &Back"
 msgstr "< &Atgal"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr ""
@@ -5014,11 +5034,11 @@ msgstr ""
 msgid "Failed to register font configuration using private fonts."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5026,7 +5046,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5034,7 +5054,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
@@ -5050,15 +5070,11 @@ msgstr ""
 msgid "Page Setup"
 msgstr "Puslapio sąranka"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr ""
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5066,7 +5082,7 @@ msgstr ""
 "GTK+ įdiegtas šiame kompiuteryje yra per senas, kad palaikytų komponavimą "
 "ekrane, prašome instaliuoti GTK+ 2.12 arba naujesnį."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5074,17 +5090,13 @@ msgstr ""
 "Komponavimas nėra įgalintas šioje sistemoje, prašome įgalinti tai Windows "
 "tvarkyklėje."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Ši programa buvo sukompiliuota su sena GKT+ versija, prašome sukompiliuoti "
 "ją su GTK+ 2.12 arba naujesne versija."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr ""
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5183,209 +5195,209 @@ msgstr ""
 msgid "Cannot open index file: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Turinys"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Rasti"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Rodyti viską"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Eiti atgal"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "Pagalba"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d iš %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu iš %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Šrifto dydis:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "šrifto dydis"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i iš %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u iš %u"
@@ -5456,32 +5468,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr ""
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "FILTER"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Failai"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Parinktis"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr ""
@@ -5523,58 +5509,58 @@ msgstr ""
 msgid "Failed to create cursor."
 msgstr ""
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5582,7 +5568,7 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5590,140 +5576,140 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
 "old, please upgrade (the following required function is missing: %s)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr ""
@@ -5743,18 +5729,17 @@ msgstr ""
 msgid "Cannot enumerate files in directory '%s'"
 msgstr ""
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Nepavyko gauti aplanko pavadinimo"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr ""
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr ""
 
@@ -5768,7 +5753,7 @@ msgstr ""
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
@@ -5809,16 +5794,16 @@ msgstr ""
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr ""
 
@@ -5826,13 +5811,13 @@ msgstr ""
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr ""
 
@@ -5841,7 +5826,7 @@ msgstr ""
 msgid "Can't delete the INI file '%s'"
 msgstr ""
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -5961,7 +5946,7 @@ msgstr ""
 msgid "The clipboard format '%d' doesn't exist."
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Praleisti"
 
@@ -6043,121 +6028,121 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr ""
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr ""
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr ""
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr ""
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6186,12 +6171,12 @@ msgstr ""
 msgid "Failed to lock resource \"%s\"."
 msgstr ""
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bit laida"
 
@@ -6203,46 +6188,46 @@ msgstr ""
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr ""
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr ""
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr ""
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr ""
 
@@ -6275,7 +6260,7 @@ msgid "Check to make the font italic."
 msgstr ""
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr ""
@@ -6342,15 +6327,31 @@ msgstr ""
 msgid "File type:"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Langas"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pagalba"
+
+#: ../src/osx/cocoa/menu.mm:299
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
-msgstr ""
+msgstr "Didinti"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6367,472 +6368,472 @@ msgstr ""
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Apie %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Apie..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Tarnybos"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Slėpti %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Objektų parinktis"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Slėpti kitus"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Rodyti viską"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Išeiti %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Objektų parinktis"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr ""
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stilius"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Storis"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "Rėmelis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "&Aukštis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "Rėmelis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Meniu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Slinkties juosta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "&Langas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "&Langas"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "&Langas"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "&Pritaikyti"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Juoda"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Žalia"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Naršyti"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Mėlyna"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Raudonas"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Geltona"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Balta"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Numatytasis"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Rodyklė"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Dešinė"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Tuščia"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Kirsti"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "&Aukštis"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "&Aukštis"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Dešinė"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Dešinė"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Savybė"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Reikšmė"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Klaidingas"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Teisingas"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr ""
 
@@ -6845,48 +6846,48 @@ msgstr ""
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Parinkti failą"
 
@@ -7353,117 +7354,117 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "&Savybės"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Įterpti objektą"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Įterpti"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "failai"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Nustatyti langelio tipą"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Ištrinti"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Ištrinti stilių"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr ""
 
@@ -7671,24 +7672,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Vilkti"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Pašalinti ženklelį"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Pakeisti"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "Š&riftas:"
 
@@ -8657,53 +8658,53 @@ msgstr ""
 msgid "Box styles"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Nuo:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Įterpti"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr ""
 
@@ -8887,7 +8888,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr "Medijos grojimo klaida: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Nepavyko paruošti grojimui \"%s\"."
@@ -8987,77 +8988,77 @@ msgstr ""
 msgid "Couldn't open audio: %s"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Nepavyko nustatyti gijų sutapimo lygmens į %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr ""
 
@@ -9073,12 +9074,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr ""
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr ""
 
@@ -9092,27 +9093,36 @@ msgstr ""
 msgid "Failed to open display \"%s\"."
 msgstr ""
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr ""
+
+#~ msgid "Filter"
+#~ msgstr "FILTER"
+
+#~ msgid "Files"
+#~ msgstr "Failai"
+
+#~ msgid "Selection"
+#~ msgstr "Parinktis"

--- a/locale/lv.po
+++ b/locale/lv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2013-01-23 13:14+0300\n"
 "Last-Translator: Jānis Eisaks <jancs@dv.lv>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "X-Poedit-Country: LATVIA\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Visus failus (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Visus failus (*)|*"
 
@@ -41,24 +41,21 @@ msgid "Remaining time:"
 msgstr "Atlikušais laiks:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Jā"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nē"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Labi"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Atcelt"
@@ -108,7 +105,7 @@ msgid "Unable to create I/O completion port"
 msgstr ""
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Izdruka"
 
@@ -145,7 +142,7 @@ msgstr "Objekta īpašības"
 msgid "Printing"
 msgstr "Drukāšana"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simboli"
 
@@ -214,7 +211,7 @@ msgstr "Ie&priekšējais"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Logs"
 
@@ -776,11 +773,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "parādīt šo palīdzības paziņojumu"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "veidot izsmeļošus žurnāla ierakstus"
 
@@ -802,84 +799,84 @@ msgstr "Neatbalstīta tēma '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Nederīga ekrāna režīma specifikācija '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nezināma garā opcija '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nezināma opcija '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Negaidīti simboli aiz iestatījuma '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Iestatījumam '%s' ir nepieciešama vērtība."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Aiz iestatījuma '%s' ir jābūt atdalītājam."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' ir nekorekta skaitliska vērtība opcijai '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Iestatījums '%s': '%s' nav pārvēršams par datumu."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Negaidīts parametrs '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (vai %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Ir jānorāda iestatījuma '%s' vērtība."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Nav norādīts nepieciešamais parametrs '%s'."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Lietošana: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "Num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dubults"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "datums"
 
@@ -897,7 +894,7 @@ msgid "Can't &Undo "
 msgstr "Nevar &atcelt"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "Atsa&ukt"
@@ -907,7 +904,7 @@ msgid "&Redo "
 msgstr "Atat&saukt "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "Atat&saukt"
@@ -934,12 +931,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ir lieks '..', nav ņemts vērā."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -949,103 +946,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "pasvītrots"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "šodiena"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "varardiena"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "rītdiena"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "pirmais"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "otrais"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "trešā"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "ceturtais"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "piektais"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sestais"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "septītais"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "astotais"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "devītais"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "desmitais"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "vienpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "divpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "trīspadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "četrpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "piecpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "sešpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "septiņpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "astoņpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "deviņpadsmitais"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "divdesmitais"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "dienas vidus"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "pusnakts"
 
@@ -1112,44 +1109,81 @@ msgstr "Neizdevās izpildīt curl, lūdzu uzstādiet to sistēmas ceļā (PATH).
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Neizdevās augšupielādēt atkļūdošanas atskaiti (kļūda kods %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Saglabāt kā"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Atmest izmaiņas un atvērt pēdējo saglabāto versiju?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "nenosaukts"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vai vēlaties saglabāt izmaiņas %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Saglabāt"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nesaglabāt"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vai vēlaties saglabāt izmaiņas %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Tekstu nav iespējams saglabāt."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Fails \"%s\" nav atverams rakstīšanai."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Neizdevās saglabāt dokumentu failā \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Fails \"%s\" nav atverams lasīšanai."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1158,57 +1192,57 @@ msgstr ""
 "Fails '%s' nepastāv un nav atverams.\n"
 "Tas ir aizvākts no pēdējo izmantoto failu saraksta."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Neizdevās izveidot izdrukas priekšskatījumu."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Drukas priekšskatījums"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Nav iespējams noteikt faila '%s' formātu."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "nenosaukts%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Atvērt failu"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Faila kļūda"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Diemžēl, šis fails nav atverams."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Atvainojiet, šis faila formāts nav zinams."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Izvēlieties dokumenta sagatavi"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Sagataves"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Izvēlieties dokumenta skatu"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Skati"
 
@@ -1242,41 +1276,41 @@ msgstr "Lasīšanas kļūda failā '%s'"
 msgid "Write error on file '%s'"
 msgstr "Rakstīšanas kļūda failā '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nav iespējams atrast pašreizējo pozīciju failā '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Neizdevās uzstādīt pieejas tiesības pagaidu failam"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nevar nodzēst failu '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "failā '%s' nav iespējams saglabāt izmaiņas"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nevar nodzēst pagaidu failu '%s'"
@@ -1301,27 +1335,27 @@ msgstr ""
 msgid "can't write to file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1347,147 +1381,147 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Kļūda lasot konfigurācijas iestatījumus."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Neizdevās nolasīt konfigurācijas datus."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fails '%s': negaidīts simbols %c %d rindā."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "fails '%s', rinda %d: pēc grupas galvenes '%s' nav ņemts vērā."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fails '%s', rinda %d: nepieciešama '=' ."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "fails '%s', rinda %d: nemainīgās atslēgas vērtība '%s' nav ņemta vērā."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "fails '%s', rinda %d: atslēga '%s' pirmo reizi atrasta rindā %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurācijas ieraksta nosaukums nevar sākties ar  '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "nevar atvērt lietotāja konfigurācijas failu."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "nevar pierakstīt lietotāja konfigurācijas failu."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Kļūda saglabājot lietotāja konfigurācijas datus."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "nevar izdzēst lietotāja konfigurācijas failu '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "ieraksts '%s' grupā '%s' parādās vairākkārt"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "mēģinājums mainīt nemainīgu atslēgu '%s' nav ņemts vērā."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "nav ņemta vērā '%s' noslēdzošā reversā slīpsvītra"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "negaidīta \"  pozīcijā %d virknē  '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Neizdevās nokopēt failu '%s' uz '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nav iespējams iegūt pieejas tiesības failam  '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nav iespējams pārrakstīt failu '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Neizdevās nokopēt failu '%s' uz '%s'"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nav iespējams noteikt pieejas tiesības failam '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr "Neizdevās pārdēvēt failu '%s' par '%s' jo mērķa fails jau pastāv."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Fails '%s' nav pārdēvējams par '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Fails '%s' nav izdzēšams"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Mapi '%s' nevarēja izveidot"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Mapi '%s' nav iespējams izdzēst"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nav iespējams uzskaitīt failus '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Neizdevās noteikt darba mapi"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Neizdevās iestatīt pašreizējo darba mapi"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Faili (%s)"
@@ -1514,17 +1548,17 @@ msgstr "Neizdevās izveidot pagaidu faila nosaukumu"
 msgid "Failed to open temporary file."
 msgstr "Neizdevās uz atvērt pagaidu failu"
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Neizdevās izmainīt faila  '%s' laikus"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Neizdevās pieskarties (touch) failam '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Neizdevās iegūt faila '%s' laikus"
@@ -1533,22 +1567,22 @@ msgstr "Neizdevās iegūt faila '%s' laikus"
 msgid "Browse"
 msgstr "Pārlūkot"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Visus failus (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s failus (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Ielādēt %s failu"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Saglabāt %s failu "
@@ -1913,105 +1947,105 @@ msgstr "noklusētais"
 msgid "unknown-%d"
 msgstr "nezināms-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "pasvītrots"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " caursvītrots"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "gaišs"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr "gaišs"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "treknraksts"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr "treknraksts"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "treknraksts"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr "kursīvs"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "caursvītrots"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "viegls"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "viegls"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normāls"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "treknraksts"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "treknraksts"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "treknraksts"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "slīpraksts"
 
@@ -2090,7 +2124,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Neizdevās uzstādīt FTP datu pārraides režīmu %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2111,7 +2145,7 @@ msgstr "FTP serveris neatbalsta pasīvo režīmu."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Neizdevās piešķirt krāsu OpenGL"
 
@@ -2127,7 +2161,7 @@ msgstr "Pielāgot slejas"
 msgid "&Customize..."
 msgstr "&Pielāgot..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Noklusētajā pārlūkā neizdevās atvērt URL \"%s\"."
@@ -2147,155 +2181,154 @@ msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: nevar saglabāt kļūdainu attēlu."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nepastās individuāla wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: nav iespējams pierakstīt faila (Bitmap) galveni."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: nav iespējams pierakstīt faila  (BitmapInfo) galveni."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: nav iespējams pierakstīt RGB krāsu karti."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: nevar ierakstīt datus."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: nevar piešķirt atmiņu."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB galvene: attēla platums > 32767 pikseļiem."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB galvene: attēla augstums > 32767 pikseļiem."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB galvene: nezināms bitu dziļums."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB galvene: nezināms faila kodējums."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB galvene: kodējums neatbilst bitu dziļumam."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: nevar piešķirt atmiņu."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB galvene: attēla platums > 32767 pikseļiem."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB galvene: attēla augstums > 32767 pikseļiem."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB galvene: nezināms bitu dziļums."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB galvene: nezināms faila kodējums."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB galvene: kodējums neatbilst bitu dziļumam."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Kļūda nolasot attēla DIB"
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: kļūda lasot DIB masku."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: attēls ikonai ir pārāk augsts."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: attēls ikonai ir pārāk plats."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: kļūda rakstot attēla failu!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: nederīgs ikonas indekss."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Attēla un maskas izmēri nesakrīt."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Neizdevās ielādēt attēlu %d no straumējuma."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Neizdevās ielādēt attēlu no faila \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nav iespējams saglabāt attēlu failā '%s: nezināms paplašinājums."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Attēla faila tips nav %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Nezinām attēla datu formāts."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Šis nav %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Attēla tips nav %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Neizdevās pārbaudīt attēla \"%s\" faila formātu."
@@ -2396,41 +2429,41 @@ msgstr "PNM: fails šķiet aprauts."
 msgid " (in module \"%s\")"
 msgstr " (modulī \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: kļūda ielādējot attēlu."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Nederīgs TIFF attēla indekss."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: attēla izmērs ir nedabīgi liels."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: nevar piešķirt atmiņu."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: kļūda lasot attēlu."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Nav ņemta vērā nezināma TIFF izšķirtspējas vienība %d"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: kļūda saglabājot attēlu."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: kļūda pierakstot attēlu."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2439,11 +2472,11 @@ msgstr ""
 "Komandrindas parametru %d nav iespējams pārvērst uz Unikodu, tāpēc tas "
 "netiks ņemts vērā."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Neizdevās uzstādīt valodas \"%s\" lokāli."
@@ -2543,7 +2576,7 @@ msgstr "saspiešanas kļūda"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nenoslēgta '{' MIME tipa %s ierakstā."
@@ -2563,7 +2596,7 @@ msgstr "Bibliotēka \"%s\", kas nepieciešama moduļa \"%s\" darbībai, nepastā
 msgid "Module \"%s\" initialization failed"
 msgstr "Neizdevās inicializēt moduli \"%s\""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Vēstule"
 
@@ -3065,7 +3098,7 @@ msgstr "Drukāšanas Kļūda"
 msgid "Print"
 msgstr "Drukāt"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Lapas iestatījumi"
 
@@ -3102,19 +3135,15 @@ msgstr "Drukājas lapa %d..."
 msgid " (copy %d of %d)"
 msgstr "Lapa %d no %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Drukāšana"
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Pirmā lapa"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Iepriekšējā lapa"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Nākamā lapa"
 
@@ -3159,16 +3188,16 @@ msgstr "Lapa %d no %d"
 msgid "Page %d"
 msgstr "Lapa %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "nezināma kļūda"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Nederīga regulārā izteiksme '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Neizdevās atrast atbilstību regulārai izteiksmei: %s"
@@ -3178,21 +3207,21 @@ msgstr "Neizdevās atrast atbilstību regulārai izteiksmei: %s"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Neizdevās izveidot hronometru"
@@ -3201,11 +3230,11 @@ msgstr "Neizdevās izveidot hronometru"
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Saglabāt"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Nesaglabāt"
 
@@ -3289,10 +3318,10 @@ msgid "Clear"
 msgstr "Notīrīt"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Aizvērt"
 
@@ -3304,7 +3333,7 @@ msgstr "&Pārveidot"
 msgid "Convert"
 msgstr "Pārveidot"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopēt"
@@ -3313,7 +3342,7 @@ msgstr "&Kopēt"
 msgid "Copy"
 msgstr "Kopēt"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Izgriez&t"
@@ -3322,13 +3351,13 @@ msgstr "Izgriez&t"
 msgid "Cut"
 msgstr "Izgriezt"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Dzēst"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Dzēst"
@@ -3417,7 +3446,7 @@ msgstr "Cietais disks"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Palīdzība"
 
@@ -3437,7 +3466,7 @@ msgstr "Atkāpe"
 msgid "&Index"
 msgstr "&Indekss"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indekss"
 
@@ -3506,7 +3535,7 @@ msgstr "&Jauns"
 msgid "New"
 msgstr "Jauns"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nē"
 
@@ -3523,12 +3552,12 @@ msgstr "&Atvērt..."
 msgid "Open..."
 msgstr "Atvērt..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Ie&līmēt"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Ielīmēt"
@@ -3560,7 +3589,7 @@ msgid "Print..."
 msgstr "Drukāt..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Rekvizīti"
 
@@ -3594,10 +3623,6 @@ msgstr "Aizvietot"
 msgid "Revert to Saved"
 msgstr "Atgriezties pie saglabātā"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Saglabāt"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Saglabāt &kā..."
@@ -3607,7 +3632,7 @@ msgstr "Saglabāt &kā..."
 msgid "Save As..."
 msgstr "Saglabāt &kā..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Izvēlēties &visu"
@@ -3714,7 +3739,7 @@ msgstr "A&ugšup"
 msgid "Up"
 msgstr "Uz augšu"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Jā"
 
@@ -3805,43 +3830,43 @@ msgstr "Saglabāt aktīvo dokumentu"
 msgid "Save current document with a different filename"
 msgstr "Saglabāt pašreizējo dokumentu ar citu nosaukumu"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Pārvēršana uz kodējumu '%s' nedarbojas."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "nezināms"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "Nederīgi dati..."
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "negaidītas faila beigas"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3850,7 +3875,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s', iespējams, ir binārais buferis."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Failu nevar ielādēt."
 
@@ -3864,47 +3889,47 @@ msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "nevar ierakstīt bufera '%s' saturu diskā."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Neizdevās nolasīt lokālās sistēmas laiku"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay beidzās ar kļūdu."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ir nederīgs ziņojumu katalogs."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr ""
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "izmanto katalogu '%s' no '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Neizdevās uzskaitīt tulkojumus"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Noklusētā aplikācija HTML failu attēlošanai nav iestatīta."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Noklusētajā pārlūkā neizdevās atvērt URL \"%s\"."
@@ -3937,7 +3962,7 @@ msgstr "'%s' drīkst saturēt tikai alfabēta rakstzīmes."
 msgid "Error: %s (%d)"
 msgstr "Kļūda: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3946,21 +3971,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Nav iespējams inicializēt slejas aprakstu."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Virkņu pārvēršana nav atbalstīta"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Šī platforma neuztur fona caurspīdīgumu."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Neizdevās pārvietot datus uz logu"
 
@@ -4012,8 +4037,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr ""
 
@@ -4064,79 +4089,79 @@ msgstr "Objektiem ir jābūt id atribūtiem"
 msgid "Doubly used id : %d"
 msgstr "Divreiz izmantots id: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Nezināma īpašība %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "pieņemot, ka tas ir apvienots vairāku daļu zip"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "nederīgs zip fails"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "nav iespējams atrast galveno zip mapi"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "kļūda lasot zip galveno mapi"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "neatbalstīta Zip kompresijas metode"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4220,32 +4245,32 @@ msgstr "Grafiskais noformējums -"
 msgid "Translations by "
 msgstr "Tulkojumu autori -"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versija"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Par %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licence"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Izstrādātāji"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Dokumentācijas sastādītāji"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Izpildītāji"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Tulkotāji"
 
@@ -4297,44 +4322,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Aplams"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (vai %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4345,8 +4369,7 @@ msgid "Left"
 msgstr "Pa kreisi"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4441,7 +4464,7 @@ msgid "Home directory"
 msgstr "Mājas mape"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Darba virsma"
 
@@ -4454,8 +4477,7 @@ msgstr "Nederīgs mapes nosaukums."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Kļūda"
 
@@ -4640,16 +4662,16 @@ msgstr "Aplūkot failus detalizētajā skatā"
 msgid "Go to parent directory"
 msgstr "Iet uz vecāka direktoriju"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Fails '%s' jau eksistē, vai patiešām vēlaties to pārrakstīt?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Apstiprināt"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Lūdzu, izvēlieties esošu failu."
 
@@ -4743,7 +4765,7 @@ msgstr "Fonta izmērs punktos."
 msgid "Whether the font is underlined."
 msgstr "Vai fonts ir pasvītrots."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Priekšskatījums:"
@@ -4761,48 +4783,47 @@ msgstr "Nospiediet, lai atceltu fonta izvēli."
 msgid "Click to confirm the font selection."
 msgstr "Nospiediet, lai apstiprinātu fonta izvēli."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Izvēlieties fontu"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Palīdzības mape \"%s\" nav atrasta."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Palīdzības fails \"%s\" nav atrasts."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Nav atrasts neviens ieraksts."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Palīdzības saturs"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Saistītie ieraksti:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Ieraksti atrasti"
 
@@ -4908,59 +4929,59 @@ msgstr "Neizdevās sākt drukāšanu."
 msgid "Printing page %d..."
 msgstr "Drukājas lapa %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Printera iestatījumi"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Drukāt failā"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Iestatīt..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Drukas iekārta:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Statuss:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Visu"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Lapas"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Drukāt diapazonu"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Sūtītājs:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Saņēmējs:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopijas:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript fails"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Drukas iestatījumi"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Printeris"
 
@@ -4968,25 +4989,25 @@ msgstr "Printeris"
 msgid "Default printer"
 msgstr "Noklusētais printeris"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Papīra izmērs"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Portrets"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Ainava"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientācija"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Iestatījumi"
 
@@ -4998,52 +5019,52 @@ msgstr "Drukāt krāsainu"
 msgid "Print spooling"
 msgstr "Drukas spolēšana"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Printera komanda:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Printera iestatījumi:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Kreisā apmale (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Augšējā mala (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Labā apmale (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Apakšējā mala (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Printeris.."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Izlaist"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Nezināms"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Izdarīts."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Meklēt"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr ""
 
@@ -5079,23 +5100,23 @@ msgstr "&Pabeigt"
 msgid "< &Back"
 msgstr "< At&pakaļ"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "atzinība tulkotājiem"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "Nav iespējams inicializēt GTK+, vai DISPLAY parametrs ir iestatīts pareizi?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Neizdevās izveidot mapi \"%s\""
@@ -5121,12 +5142,12 @@ msgstr "Neizdevās ielasīt dokumentu no faila \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Neizdevās atsvaidzināt lietotāja konfigurācijas failu."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Fatāla kļūda"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5134,7 +5155,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5142,7 +5163,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
@@ -5158,37 +5179,29 @@ msgstr "Kļūda drukājot:"
 msgid "Page Setup"
 msgstr "Lapas iestatījumi"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Neizdevās ievietot tekstu vadīklā."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Šī programma ir kompilēta ar pārāk vecu GTK+ versiju, lūdzu, pārkompilējiet "
 "ar GTK+ 2.12 vai jaunāku."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Lūdzu, izvēlieties derīgu fontu."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5287,45 +5300,45 @@ msgstr "Nav iespējams atvērt satura failu: %s"
 msgid "Cannot open index file: %s"
 msgstr "Nav iespējams atvērt indeksu failu: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "bezvārda"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nav iespējams atvērt HTML palīdzības grāmatu: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Parāda palīdzību pārlūkojot grāmatu sarakstu kreisajā pusē."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(grāmatzīme)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Pievienot grāmatzīmēm pašreizējo lapu"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Izņemt pašreizējo lapu no grāmatazīmēm"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Saturs"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Meklēt"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Rādīt visas"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5333,165 +5346,165 @@ msgstr ""
 "Parādīt visus indeksa ierakstus, kas satur norādīto apakšvirkni. Meklēšana "
 "nav reģistrjūtīga."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Rādīt visus saraksta locekļus"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Reģistrjūtīgs"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Tikai veselus vārdus"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Meklēt palīdzības grāmatas(-u) saturā tekstu, ko ievadījāt augstāk"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Rādīt/slēpt navigācijas paneli"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Iet atpakaļ"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Iet uz priekšu"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Iet vienu līmeni augstāk dokumenta hierarhijā"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Atvērt HTML dokumentu"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Drukāt šo lapu"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Ekrāna iestatījumu dialogs"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Lūdzu, izvēlieties attēlojamo lapu:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Palīdzības temati"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Meklē..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Pagaidām netika atrasta atbilstoša lapa"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Atrastas %i atbilstības"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Palīdzība)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d no %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu no %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Meklēt visās grāmatās"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Palīdzības pārlūka iestatījumi"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normāls fonts:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fiksēts fonts:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Fonta izmērs:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "fonta izmērs"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normāls fonts<br>un  <u>pasvītrots</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursīvs.</i>"
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Treknraksts.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Treknraksts kursīvā.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Fiksēta izmēra.<br> <b>treknraksts</b> <i>kursīvs</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>treknraksts kursīvā <u>pasvītrots</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Palīdzība par drukāšanu"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Nav iespējams nodrukāt tukšu lapu."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML faili (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Palīdzības grāmatas (*.htb)|*.htb|Palīdzības grāmatas (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Saspiests HTML Help fails (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i no %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu no %lu"
@@ -5569,32 +5582,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "Kļūme lapas iestatījumos: iespējams, jānorāda noklusētais printeris."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Neizdevās parādīt  HTML dokumentu %s kodējumā"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets neizdevās atvērt ekrānu priekš '%s': beidz darbu."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtrs"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Mapes"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Faili"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Iezīmējums"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Neizdevās atvērt starpliktuvi."
@@ -5636,58 +5623,58 @@ msgstr "Krāsu izvēles dialogs pārtrauca darbību ar kļūdu  %0lx."
 msgid "Failed to create cursor."
 msgstr "Neizdevās izveidot kursoru."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Neizdevās reģistrēt DDE serveri '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Neizdevās dereģistrēt DDE serveri '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Neizdevās izveidot savienojumu ar serveri '%s'par tematu '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Neizdevās izveidot DDE virkni"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "nav DDE kļūdas."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5695,7 +5682,7 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5703,70 +5690,70 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML neapstiprināja parametru."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "atmiņas izdalīšanas kļūda."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "transakcija neizdevās."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "iekšējais funkcijas PostMessage izsaukums neizdevās."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML radās iekšēja kļuda."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Nezināma DDE kļūda %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5774,7 +5761,7 @@ msgstr ""
 "Iezvanpieejas funkcijas nav pieejamas, jo uz šī datora nav uzstādīts "
 "attālinātās pieejas serviss (RAS). Lūdzu, uzstādiet to."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5783,64 +5770,64 @@ msgstr ""
 "Uz šī datora uzstādītās attālinātās pieejas servisa (RAS) versija ir pārāk "
 "veca. Lūdzu, atsvaidziniet to (trūkst sekojoša nepieciešamā funkcija: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Neizdevās saņemt RAS ķļūdas paziņojuma tekstu."
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "nezināma kļūda (kļūdas kods %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Aktīva iezvanpieeja nav atrodama: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Atrastas vairākas aktīvas iezvanpieejas, tiek izvēlēja viena no tām."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Neizdevās izveidot iezvanpieejas savienojumu: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Neizdevās iegūt ISP nosaukumus: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Nav iespējams pieslēgties: nav ISP, kam zvanīt."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Izvēlieties ISP, kuram zvanīt"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Lūdzu izvēlieties ISP, kuram vēlaties pieslēgties"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Nav iespējams pieslēgties: nav norādīts lietotāja vārds.parole."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Nav iespējams noteikt adrešu grāmatas faila atrašanās vietu"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Neizdevās izveidot iezvanpieejas savienojumu: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nav iespējams nolikt klausuli - nav aktīva iezvanpieejas savienojuma"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Neizdevās pārtraukt iezvanpieejas savienojumu: %s"
@@ -5860,19 +5847,18 @@ msgstr "Neizdevās piešķirt %luKb atmiņas bitkartes datiem."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nav iespējams uzskaitīt failus mapē '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (kļūda %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Neizdevās pievienot attēlu sarakstam."
 
@@ -5886,7 +5872,7 @@ msgstr "Neizdevās ielādēt matafailu no faila \"%s\"."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Neizdevās atvērt standarta Meklēt/aizvietot dialogu (kļūdas kods %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Faila dialogs pārtrauca dabību ar kļūdu %0lx."
@@ -5927,17 +5913,17 @@ msgstr ""
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nav iespējams sekot izmaiņām neesoša mapē \"%s\"."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Neizdevās izveidot hronometru"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Neizdevās inicializēt OpenGL"
 
@@ -5945,7 +5931,7 @@ msgstr "Neizdevās inicializēt OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5953,7 +5939,7 @@ msgstr ""
 "MS HTML Help funkcijas nav pieejamas, jo MS HTML Help bibliotēka nav "
 "uzstādīta uz šīs mašīnas . Lūdzu, uzstādiet to."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Neizdevās inicializēt MS HTML Help."
 
@@ -5962,7 +5948,7 @@ msgstr "Neizdevās inicializēt MS HTML Help."
 msgid "Can't delete the INI file '%s'"
 msgstr "Nav iespējams izdzēst INI failu '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nav iespējams iegūt informāciju par saraksta vadīklas vienumu %d."
@@ -6082,7 +6068,7 @@ msgstr "Neizdevās reģistrēt starpliktuves formātu '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Starpliktuves formāts '%d' nepastāv."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Izlaist"
 
@@ -6167,116 +6153,116 @@ msgstr ""
 "tās dzēšana var novest sistēmu nelietojamā stāvoklī:\n"
 "darbība atcelta."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nav iespējams izdzēst atslēgu '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nav iespējams izdzēst vērtību '%s' no atslēgas '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nav iespējams nolasīt atslēgas '%s' vērtību"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nav iespējams iestatīt '%s' vērtību"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr " '%s' vērtība nav nolasāma"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nav iespējams uzskaitīt atslēgas '%s' vērtības"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nav iespējams uzskaitīt atslēgas '%s' apakšatslēgas"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Reģistra atslēgas eksports: fails \"%s\" jau pastāv un netiks pārrakstīts."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nav iespējams eksportēt neatbalstīta tipa %d vērtību."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorēta vērtība \"%s\" atslēgai \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nav iespējams palaist pavedienu: kļūda rakstot TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Nav iespējams uzstādīt pavediena prioritāti"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Nav iespējams izveidot pavedienu"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Nav iespējams pārtraukt pavedienu"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Nevar gaidīt uz pavediena apstāšanos"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nav iespējams apturēt pavedienu %x"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nav iespējams atsākt pavedienu %x"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Nevar iegūt pašreizējā pavediena rādītāju"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6284,7 +6270,7 @@ msgstr ""
 "Kļūda inicializējot pavediena moduli: nav iespējams piešķirt indeksu "
 "pavediena lokālajā glabātuvē"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6315,12 +6301,12 @@ msgstr "Neizdevās ielādēt resursu \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Neizdevās aizslēgt resursu: \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "versija %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64 bitu versija"
 
@@ -6332,47 +6318,47 @@ msgstr "Neizdevās izveidot anonīmu programmkanālu"
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Komandas '%s' izpilde neizdevās"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Nevar ielādēt mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nav iespējams nolasīt tipa nosaukumu no  '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr " Nav iespējams ielādēt ikonu no '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Nav iespējams uzstādīt pavediena prioritāti"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Neizdevās izpildīt '%s'\n"
@@ -6406,7 +6392,7 @@ msgid "Check to make the font italic."
 msgstr "Atzīmējiet, lai iegūtu fontu kursīvā."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Pasvītrots"
@@ -6474,17 +6460,32 @@ msgstr "<Jebkurš teletaipa>"
 msgid "File type:"
 msgstr "Teletaips"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Logs"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Palīdzība"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimizēt"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Tuvināt"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6501,487 +6502,487 @@ msgstr "Fails '%s' neeksistē."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Par %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "P&ar..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Iestatījumi.."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Slēpt %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Programma"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Slēpt citus"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Rādīt visas"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Iziet no %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Programma"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Šī zlib versija neuztur gzip"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Nav iespējams inicializēt slejas aprakstu."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Izmērs punktos"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Fonta nosaukums"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stils"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Svars"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Saime"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Mala"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "viegls"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Izlīdzināt tekstu pa labi."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Mala"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Izvēlne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Logs"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Logs"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Logs"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Pielāgots izmērs"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "Grieķu (MacGreek)"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "Pārlūkot"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "Atkārtot"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "noklusētais"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "rītdiena"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Pa labi"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Aizzīmju stils"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Rakstzī&mju kods:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Izmērs punktos"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Izlīdzināt gar labo"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Jautājums"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Pa labi"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Pa labi"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Veidot izvēli:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Īpašība"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Vērtība"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Šķirotais režīms"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alfabētiskais režīms"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Aplams"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Patiess"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Nenorādīts"
 
@@ -6995,12 +6996,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Jūs ievadījāt nederīgu vērtību. Nospiediet ESC, lai pārtauktu labošanu."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Kļūda resursā: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7009,36 +7010,36 @@ msgstr ""
 "Tipu operācijas \"%s\" kļūda: īpašības ar apzīmējumu \"%s\" tips ir \"%s\", "
 "NEVIS \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vērtībai jābūt vienādai ar %s vai lielākai."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Leņķim jābūt starp %s un %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vērtībai jābūt vienādai ar %s vai mazākai."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Nav %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Izvēlieties mapi:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Izvēlieties failu"
 
@@ -7519,120 +7520,120 @@ msgstr "Iespiests"
 msgid "Outset"
 msgstr "Izspiests"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Mainīt stilu"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Mainīt objekta stilu"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Mainīt īpašības"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Mainīt saraksta stilu"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Pārnumurēt sarakstu"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Ievietot tekstu"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Ievietot attēlu"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Ievietot objektu"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "Ievietot tekstu"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Par daudz EndStyle izsaukumu!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "failus"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standarta/rinķis"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standarta/riņķa aprises"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standarta/kvadrāts"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standarta/rombs"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standarta/trīsstūris"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Rāmja īpašības"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Vairāku šūnu īpašības"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Tabulas šūnas parametri"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Iestatīt šūnas stilu"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "Dzēst"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "Dzēst iezīmēto"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Tabulas īpašības"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Attēla īpašības"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "attēls"
 
@@ -7840,25 +7841,25 @@ msgstr "~"
 msgid "Drag"
 msgstr "Vilkt"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Dzēst tekstu"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Aizvākt"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Tekstu nav iespējams saglabāt."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Aizvietot"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Fonts:"
 
@@ -8844,53 +8845,53 @@ msgstr "Stilu saraksts"
 msgid "Box styles"
 msgstr "&Rāmju stili"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Fonts, no kura ņemt simbolu."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Apakškopa:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Rāda Unicode apakškopu."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "Rakstzī&mju kods:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Rakstzīmes kods."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&No:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unikods"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Rādāmais diapazons."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Parasts teksts)"
 
@@ -9077,7 +9078,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Neizdevās atvērt displeju \"%s\"."
@@ -9177,20 +9178,20 @@ msgstr "Skaņas dati ir neatbalstītā formātā."
 msgid "Couldn't open audio: %s"
 msgstr "Neizdevās atvērt audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Pavediena prioritātes iestatījums nav ņemts vērā."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9198,61 +9199,61 @@ msgstr ""
 "Kļūda pievienojoties pavedienam, atrasta iespējama atmiņas noplūde - lūdzu "
 "pārstartējiet programmu"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Neizdevās pārtraukt pavedienu."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Kļūda inicializējot pavediena moduli: nav iespējams izveidot pavediena "
 "atslēgu"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Neizdevās izpildīt '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Neizdevās uzstādīt pavediena prioritāti %d."
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Nevar atrast resursdatora vārdu"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Nevar atrast oficiālo resursdatora vārdu"
 
@@ -9268,12 +9269,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Nederīga ģeometrijas specifikācija '%s'."
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets neizdevās atvērt ekrānu. Beidz darbu."
 
@@ -9287,30 +9288,59 @@ msgstr "Neizdevās aizvērt ekrānu \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Neizdevās atvērt displeju \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nav iespējams ielādēt resursus no '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nav iespējams atvērt resursu failu  '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nav iespējams ielādēt resursus no faila '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Neizdevās izveidot hronometru"
+
+#~ msgid "Printing "
+#~ msgstr "Drukāšana"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Neizdevās ievietot tekstu vadīklā."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Lūdzu, izvēlieties derīgu fontu."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Neizdevās parādīt  HTML dokumentu %s kodējumā"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets neizdevās atvērt ekrānu priekš '%s': beidz darbu."
+
+#~ msgid "Filter"
+#~ msgstr "Filtrs"
+
+#~ msgid "Directories"
+#~ msgstr "Mapes"
+
+#~ msgid "Files"
+#~ msgstr "Faili"
+
+#~ msgid "Selection"
+#~ msgstr "Iezīmējums"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "neizdevās pārvērst 8 bitu kodējumā"
@@ -9451,8 +9481,8 @@ msgstr "Neizdevās izveidot hronometru"
 #~ msgstr "Datu objektam ir nederīgs datu formāts"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/ms.po
+++ b/locale/ms.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2006-11-06 10:48+0800\n"
 "Last-Translator: Mahrazi Mohd Kamal <mahrazi@gmail.com>\n"
 "Language-Team: ms_MY <ms@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Poedit-Language: Malay\n"
 "X-Poedit-Country: MALAYSIA\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Semua fail (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Semua fail (*)|*"
 
@@ -42,24 +42,21 @@ msgid "Remaining time:"
 msgstr "Masa yang tinggal :"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ya"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Tidak"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Batal"
@@ -111,7 +108,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Gagal cipta TextEncodingConverter"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "Cetak"
@@ -156,7 +153,7 @@ msgstr "&Ciri-ciri"
 msgid "Printing"
 msgstr "Mencetak "
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simbol"
 
@@ -225,7 +222,7 @@ msgstr "&Sebelum"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Tetingkap"
 
@@ -794,11 +791,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "tunjukkan mesej bantuan ini"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "menjana mesej log meleret"
 
@@ -820,84 +817,84 @@ msgstr "Tema tidak disokong '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Spesifikasi mod paparan '%s' tidak sah."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Pilihan panjang '%s' tidak diketahui"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Pilihan '%s' tidak diketahui"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Aksara mengikut pilihan '%s' tidak dijangka."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Pilihan '%s' perlukan nilai."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Pembahagi dijangka selepas pilihan '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' bukanlah nilai nombor yang betul untul pilihan '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Pilihan '%s': '%s' gagal ditukar kepada tarikh."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parameter tidak dijangka '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (or %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Nilai pilihan '%s' mesti ditentukan."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Parameter yang diperlukan '%s' tidak ditentukan."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Penggunaan: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "nom"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "tarikh"
 
@@ -915,7 +912,7 @@ msgid "Can't &Undo "
 msgstr "Tidak Nyahcara "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Nyahcara"
@@ -925,7 +922,7 @@ msgid "&Redo "
 msgstr "&Ulangcara "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ulangcara"
@@ -954,12 +951,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ada lebihan '..', diabaikan."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -969,103 +966,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "digaris bawahkan"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "hari ini"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "semalam"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "esok"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "pertama"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "kedua"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "ketiga"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "keempat"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "kelima"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "keenam"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "ketujuh"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "kelapan"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "kesembilan"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "kesepuluh"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "kesebelas"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "kedua belas"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "ketiga belas"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "keempat belas"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "kelima belas"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "keenam belas"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "ketujuh belas"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "kelapan belas"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "kesembilan belas"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "keduua puluh"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "tengahari"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "tengah malam"
 
@@ -1134,44 +1131,81 @@ msgstr "Gagal melaksanakan curl. sila pasangkannya dalam PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Gagal muatnaik laporan nyahpijat (kod ralat %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Simpan Sebagai"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "tanpanama"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Adakah anda ingin menyimpan perubahan kepada dokumen \"%s\"?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Simpan"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Jangan Simpan"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Adakah anda ingin menyimpan perubahan kepada dokumen \"%s\"?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Teks gagal disimpan."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Gagal buka '%s' untuk %s"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Gagal menyimpan peta bit kepada fail \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Gagal buka '%s' untuk %s"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Gagal memuat metafail dari fail \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1180,58 +1214,58 @@ msgstr ""
 "Fail '%s' tidak wujud dan Gagal dibuka.\n"
 "Ia telah dibuang dari senarai fail paling baru diguna."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Gagal mencipta paip"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Pralihat Cetak"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "tanpanama%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Buka Fail"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Ralat fail"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Maaf, Gagal membuka fail."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Maaf, format fail ini tidak diketahui."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Pilih templat dokumen"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Templat"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Pilih lihat dokumen"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Pandangan"
 
@@ -1265,41 +1299,41 @@ msgstr "Ralat baca pada fail '%s'"
 msgid "Write error on file '%s'"
 msgstr "Ralat tulis fail '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "gagal menyegarkan fail '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Mencari ralat pada fail '%s' (fail besar tidak disokong oleh stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Cari ralat pada fail '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Gagal mencari posisi semasa dalam fail '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "PGagal tetapkan keizinan fail sementara."
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "gagal membuang fail '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "Gagal lakukan perubahan kepada fail '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "gagal membuang fail sementara '%s'"
@@ -1324,27 +1358,27 @@ msgstr "gagal membaca dari penghurai fail %d"
 msgid "can't write to file descriptor %d"
 msgstr "gagal menulis kepada penghurai %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "gagal mengeluarkan penghurai fail %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "gagal menemui penghurai fail %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "Gagal menemui posisi pada fail penghurai %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "gagal menemui panjang fail pada penghurai fail %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "Gagal ditentukan jika EOF dicapai pada penghurai %d"
@@ -1368,108 +1402,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Ralat membaca pilihan konfig."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Ralat membaca pilihan konfig."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fail '%s': aksara %c tidak dijangka pada baris %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "fail '%s', baris %d: '%s' diabaikan selepas kepala kumpulan."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fail '%s', baris %d: '=' dijangka."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "fail '%s', baris %d: nilai untuk nilai tetap '%s' diabaikan."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "fail '%s', baris %d: kunci '%s' pertama kali sitemui pada baris %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Nama masukan konfig tidak boleh dimulakan dengan '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "gagal membuka fail konfigurasi pengguna."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "gagal menulis fail konfigurasi pengguna."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Gagal naiktaraf fail konfigurasi pengguna."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Ralat menulis fail konfigurasi pengguna."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "gagal memadam fail konfigurasi pengguna '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "masukan '%s' dipaparkan lebih dari sekali dalam kumpulan '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "Cubaan mengubah kunci tidak boleh disenyapkan '%s' diabaikan."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" tidak dijangka pada posisi %d dalam '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Gagal salin fail '%s' ke '%s'."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Mustahil mendapatkan keizinan untuk fail '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Mustahil untuk menindih fail '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Gagal salin fail '%s' ke '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Mustahil untuk menetapkan keizinan fail '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1478,41 +1512,41 @@ msgstr ""
 "Gagal menamakan semula fail '%s' kepada '%s' disebabkan fail destinasi telah "
 "wujud."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Direktori '%s' gagal dicipta"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Gagal menghitung fail '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Gagal mendapatkan direktori kerja"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Gagal mendapatkan direktori kerja"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Fail (%s)"
@@ -1539,17 +1573,17 @@ msgstr "Gagal mencipta nama fail sementara"
 msgid "Failed to open temporary file."
 msgstr "Gagal membuka fail sementara."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Gagal mengubahsuai masa fail untuk '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Gagal sentuh fail '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Gagal mendapatkan masa fail untuk '%s'"
@@ -1558,22 +1592,22 @@ msgstr "Gagal mendapatkan masa fail untuk '%s'"
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Semua fail (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "fail %s (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Memuatkan fail %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Simpan fail %s"
@@ -1948,106 +1982,106 @@ msgstr "lalai"
 msgid "unknown-%d"
 msgstr "tidak diketahui-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "digaris bawahkan"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "cerah"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr "cerah"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "tebal"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr "tebal"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "tebal"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr "italik"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "ringan"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "ringan"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "bold"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "bold"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "bold"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "italik"
 
@@ -2129,7 +2163,7 @@ msgstr "Masa tamat ketika menunggu sambuungan pelayan FTP, cuba mod pasif."
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Gagal menetapkan mod penhantaran FTP kepada %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2150,7 +2184,7 @@ msgstr "Pelayan FTP tidak menyokong mod pasif."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Gagal mencipta kursor."
@@ -2169,7 +2203,7 @@ msgstr "Saiz Fon"
 msgid "&Customize..."
 msgstr "Saiz Fon"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Gagal buka '%s' untuk %s"
@@ -2189,156 +2223,155 @@ msgstr "Gagal memuat imej %d dari fail '%s'."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Tidak sapat menyimpan imej yang tidak sah."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage tidak mempunyai wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Gagal menulis kepala fail (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Gagal menulis fail kepala (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Gagal menulis peta warna RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Gagal menulis data."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Gagal sediakan memori."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Kepala DIB: Lebar imej > 32767 piksel untuk fail."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Kepala DIB: Tinggi imej > 32767 piksel untuk fail."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Kepala DIB: kedalaman bit fail tidak diketahui."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Kepala DIB: mengenkod fail tidak diketahui."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Kepala DIB: pengenkod tidak sepadan kedalaman bit."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Gagal sediakan memori."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Kepala DIB: Lebar imej > 32767 piksel untuk fail."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Kepala DIB: Tinggi imej > 32767 piksel untuk fail."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Kepala DIB: kedalaman bit fail tidak diketahui."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Kepala DIB: mengenkod fail tidak diketahui."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Kepala DIB: pengenkod tidak sepadan kedalaman bit."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Ralat membaca DIB imej."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Ralat baca DIB topeng."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imej terlalu tinggi untuk ikon."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imej terlalu lebar untuk ikon."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "Ralat menulis fail imej!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Indeks ikon tidak sah."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Imej san topeng memiliki saiz berbeza."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Tiada warna yang tidak digunakan dalam imej ditopengkan."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Gagal memuat imej %d dari fail '%s'."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Gagal menyimpan fail imej '%s': sambungan tidak diketahui."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Tiada pengemudi ditemui untuk jenis imej."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Tiada pengemudi imej untuk jenis %d ditetapkan."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Fail imej bukan berjenis %ld."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "ralat dalam format data"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: ini bukahlah fail PCX."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Tiada pengemudi imej untuk jenis %s ditetapkan."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Fail imej bukan berjenis %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Gagal menyimpan peta bit kepada fail \"%s\"."
@@ -2440,52 +2473,52 @@ msgstr "PNM: Fail seperti dipotong."
 msgid " (in module \"%s\")"
 msgstr "modul tiff: %s"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Ralat memuat imej."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Indeks imej TIFF tidak sah."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Gagal menempatkan memori"
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Ralat membaca imej."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Ralat menyimpan imej."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Ralat menulis imej."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Permulaan gagal pada mula pos, gugurkan."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2583,7 +2616,7 @@ msgstr "ralat mampatan"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' tidak sepadan dalam masukan mime types %s."
@@ -2603,7 +2636,7 @@ msgstr "Kebergantungan modul \"%s\" daripada \"%s\" tidak wujud."
 msgid "Module \"%s\" initialization failed"
 msgstr "Modul \"%s\" gagal dimulakan"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "%s mesej"
@@ -3108,7 +3141,7 @@ msgstr "Ralat mencetak"
 msgid "Print"
 msgstr "Cetak"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Tetapan halaman"
 
@@ -3145,20 +3178,16 @@ msgstr "Mencetak laman %d..."
 msgid " (copy %d of %d)"
 msgstr "Laman %d of %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Mencetak "
-
 #: ../src/common/prntbase.cpp:1582
 #, fuzzy
 msgid "First page"
 msgstr "Laman berikut"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Laman sebelum:"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Laman berikut"
 
@@ -3205,16 +3234,16 @@ msgstr "Laman %d of %d"
 msgid "Page %d"
 msgstr "Laman %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "ralat tidak diketahui"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ungkapan nalar '%s' tidak sah: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Gagal menemui padanan ungkapan nalar: %s"
@@ -3226,21 +3255,21 @@ msgstr ""
 "Pelaku \"%s\" mempunyai versi %d.%d yang tidak serasi dan tidak akan "
 "dimuatkan."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
@@ -3249,11 +3278,11 @@ msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Simpan"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Jangan Simpan"
 
@@ -3340,10 +3369,10 @@ msgid "Clear"
 msgstr "Kosongkan"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Tutup"
 
@@ -3357,7 +3386,7 @@ msgstr "Kandungan"
 msgid "Convert"
 msgstr "Kandungan"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Salin"
@@ -3367,7 +3396,7 @@ msgstr "&Salin"
 msgid "Copy"
 msgstr "&Salin"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Potong"
@@ -3377,13 +3406,13 @@ msgstr "&Potong"
 msgid "Cut"
 msgstr "&Potong"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "Pa&dam"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Padam"
@@ -3479,7 +3508,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Bantuan"
 
@@ -3499,7 +3528,7 @@ msgstr "Jarak"
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3573,7 +3602,7 @@ msgstr "&Baru"
 msgid "New"
 msgstr "&Baru"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "T&idak"
 
@@ -3591,12 +3620,12 @@ msgstr "&Buka..."
 msgid "Open..."
 msgstr "&Buka..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Tepek"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Tampal"
@@ -3630,7 +3659,7 @@ msgid "Print..."
 msgstr "Ce&tak..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Ciri-ciri"
 
@@ -3666,10 +3695,6 @@ msgstr "Ganti"
 msgid "Revert to Saved"
 msgstr "Kembali untuk Disimpan"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Simpan"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Simp&an Sebagai..."
@@ -3679,7 +3704,7 @@ msgstr "Simp&an Sebagai..."
 msgid "Save As..."
 msgstr "Simp&an Sebagai..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Pilih &Semua"
@@ -3798,7 +3823,7 @@ msgstr "A&tas"
 msgid "Up"
 msgstr "Naik"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ya"
 
@@ -3891,43 +3916,43 @@ msgstr "Simpan dokumen semasa"
 msgid "Save current document with a different filename"
 msgstr "Simpan dokumen semasa dengan nama fail berbeza"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Penukaran kepada set aksara '%s' tidak berfungsi."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "tidak diketahui"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "blok kepala tidak lengkap dalam tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "uji-jumlah gagal membaca blok kepala tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "data tidak sah dalam kepala tar diperpanjang"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "masukan tar tidak dibuka"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "akhir fail tidak dijangka"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s tidak dapat muat kepala tar untuk masukan '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "saiz diberi tidak betul untuk masukan tar"
 
@@ -3936,7 +3961,7 @@ msgstr "saiz diberi tidak betul untuk masukan tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' kemungkinan adalah penimbal binari."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Fail gagal dimuatkan."
 
@@ -3950,49 +3975,49 @@ msgstr "Gagal memuat metafail dari fail \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "gagal menulis penimbal '%s' kepada cakera."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Gagal mendapatkan masa sistem lokal"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay gagal."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' bukanlah mesej katalog yang sah."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' bukanlah mesej katalog yang sah."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Gagal hurai Bentuk-Majmuk:'%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "guna katalog '%s' dari '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' bukanlah mesej katalog yang sah."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Gagal menamatkan benang"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Gagal buka '%s' untuk %s"
@@ -4025,7 +4050,7 @@ msgstr "'%s' sepatutnya mengandungi aksara abjab sahaja."
 msgid "Error: %s (%d)"
 msgstr "Ralat: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4034,21 +4059,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Fail gagal dimuatkan."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Penukaran rentetan tidak disokong"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Gagal hantar data ke tetingkap"
 
@@ -4101,8 +4126,8 @@ msgstr "Parameter Cipta tidak dijumpai dalam parameter RRTI yang dinyatakan"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Kelas Objek tidak sah (Non-wxEvtHandler) sebagai Sumber Kejadian"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Jenis mestilah pertukaran hitung - panjang"
 
@@ -4153,79 +4178,79 @@ msgstr "Objek perlu ada atribut id"
 msgid "Doubly used id : %d"
 msgstr "Dua ID diguna : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Milik Tidak Diketahui %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Pengumpulan bukan kosong mesti terdiri daripada nod 'elemen'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "rentetan pengemudi peristiwa salah, hilang titik"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Gagal memulakan semula strim zlib kempis"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Gagal memulakan semula strim zlib kembong"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "mengandaikan yang ini adalah cantuman banyak-bahagian zip"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "fail zip tidak sah"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "gagal menemui direktori pusat salam zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "ralat membaca direktori pusat zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "ralat membaca kepala lokal zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "offset fail zip kepada masukan rosak"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "panjang fail disimpan tidak dalam kepala Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "Mesej mampatan Zip tidak disokong"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "membaca strim zip (masukan %s): panjang buruk"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "membaca strim zip (masukan %s): crc buruk"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "gagal menulis masukan zip '%s': crc atau panjang rosak"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "gagal menulis masukan zip '%s': crc atau panjang rosak"
@@ -4311,35 +4336,35 @@ msgstr "Seni grafik oleh"
 msgid "Translations by "
 msgstr "Diterjemah oleh"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Versi"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "Perihal"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 #, fuzzy
 msgid "Developers"
 msgstr "Dibangunkan oleh"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 #, fuzzy
 msgid "Documentation writers"
 msgstr "Dokumentasi oleh"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 #, fuzzy
 msgid "Translators"
 msgstr "Diterjemah oleh"
@@ -4391,44 +4416,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Fail"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (or %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4439,8 +4463,7 @@ msgid "Left"
 msgstr "Kiri"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4539,7 +4562,7 @@ msgid "Home directory"
 msgstr "Direktori rumah"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -4552,8 +4575,7 @@ msgstr "Nama direktori tidak sah."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Ralat"
 
@@ -4737,16 +4759,16 @@ msgstr "Lihat fail sebagai lihat perincian"
 msgid "Go to parent directory"
 msgstr "Pergi ke direntori induk"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Fail '%s' sedia wujud, anda pasti untuk menindihnya?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Sah"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Sila pilih fail yang sedia ada."
 
@@ -4841,7 +4863,7 @@ msgstr "Saiz titik fon."
 msgid "Whether the font is underlined."
 msgstr "Sama ada fon bergaris-bawah."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Pralihat:"
@@ -4859,48 +4881,47 @@ msgstr "Klik untuk batal pemilihan fon."
 msgid "Click to confirm the font selection."
 msgstr "Klik untuk pasti pemilihan fon."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Pilih fon"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Direktori bantuan \"%s\" tidak ditemui."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Fail bantuan \"%s\" tidak ditemui."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Baris %lu fail peta \"%s\" terdapat sintaks tidak sah, dilangkau."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Tiada pemetaan sah ditemui dalam fail \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Tiada masukan ditemui."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indeks Bantuan"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Masukan berkaitan:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Masukan ditemui"
 
@@ -5008,59 +5029,59 @@ msgstr "Gagal mulakan mencetak."
 msgid "Printing page %d..."
 msgstr "Mencetak laman %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Pilihan pencetak"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Cetak ke Fail"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Tetapan..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Semua"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Laman"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Julat Cetak"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Dari:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Ke:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Salinan:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Fail PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Tetapan Cetak"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Pencetak"
 
@@ -5068,25 +5089,25 @@ msgstr "Pencetak"
 msgid "Default printer"
 msgstr "Pencetak default"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Saiz &kertas:"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Potret"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Lanskap"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientasi"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Pilihan"
 
@@ -5098,53 +5119,53 @@ msgstr "Cetak warna"
 msgid "Print spooling"
 msgstr "Gelendong cetak"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Arahan pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Pilihan pencetak:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Left margin (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Jidar bawah (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Jidar kanan (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Jidar bawah (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Pencetak..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 #, fuzzy
 msgid "&Skip"
 msgstr "Langkau"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Tidak Diketahui"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Selesai."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Cari"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Gagal menemui tab untuk id"
 
@@ -5180,22 +5201,22 @@ msgstr "&Tamat"
 msgid "< &Back"
 msgstr "< &Undur"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Mahrazi Mohd Kamal <mahrazi@gmail.com>, 2006."
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Gagal mencipta direktori \"%s\""
@@ -5221,12 +5242,12 @@ msgstr "Gagal memuat metafail dari fail \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Gagal naiktaraf fail konfigurasi pengguna."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Ralat maut"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5234,7 +5255,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5242,7 +5263,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Anak MDI"
 
@@ -5260,35 +5281,27 @@ msgstr "Ralat ketika menunggu semafor"
 msgid "Page Setup"
 msgstr "Tetapan Halaman"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Gagal menyelitkan teks dalam kawalan."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Sila pilih fon yang sah."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5387,45 +5400,45 @@ msgstr "Gagal buka kandungan fial: %s"
 msgid "Cannot open index file: %s"
 msgstr "Gagal buka fail indeks: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "tiada nama"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Gagal buka buku bantuan HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Papar bantuan sebaik sahaja anda melayari kiri buku."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(tanda laman)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Tambah laman semasa ke tanda laman"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Buang laman semasa dari tanda laman"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Kandungan"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Cari"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Papar Semua"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5433,19 +5446,19 @@ msgstr ""
 "Papar semua indeks item yang subrentetannya diberi. Carian adalah sensitif "
 "kes."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Tunjuk semua item indeks"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Sensitif kes"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Seluruh perkataan sahaja"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -5454,147 +5467,147 @@ msgstr ""
 "Mencari kandungan buku bantuan untuk semua kejadian yang anda taip teks "
 "diatasnya"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Tunjuk/sorok panel navigasi"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Kem&bali"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "&Maju"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Pergi satu aras ke atas dalam hirarki dokumen"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Buka dokumen HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Cetak laman ini"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Papar dialog pilihan"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Sila pilih laman yang ingin dipaparkan:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Topik Bantuan"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Mencari..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Tiada padanan laman ditemui"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i padanan ditemui"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Bantuan)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i of %i"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i of %i"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Carian dalam semua buku"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Pilihan Pelungsur Bantuan"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Fon normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fon tetap:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Saiz fon:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "Saiz Fon"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Rupa normal<br>dan <u>garis-bawah</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Rupa italik.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Rupa tebal.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Rupa tebal italik.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Rupa saiz tetap.<br><b>gelap</b><i>italik</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>tebal italik <u>garis bawah</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Mencetak Bantuan"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Gagal cipta laman kosong."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fail HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Buku Bantuan (*.htb)|*.htb|Buku Bantuan (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projek Bantuan HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fail Bantuan HTML Termampat (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i of %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i of %i"
@@ -5667,32 +5680,6 @@ msgstr ""
 "Terdapat masalah semasa pemasangan laman: anda mungkin perlukan memasang "
 "pencetak lalai."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Gagal papar dokumen HTML dalam pengkodan %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets Gagal membuka paparan '%s': keluar."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Tapis"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Direktori"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Fail"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Pemilihan"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Gagal membuka klipbod."
@@ -5734,58 +5721,58 @@ msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
 msgid "Failed to create cursor."
 msgstr "Gagal mencipta kursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Gagal daftar pelayan DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Gagal nyahdaftar pelayan DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Gagal cipta smabugan ke pelayan '%s' pada topik '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Permintaan poke DDE gagal"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Gagal dirikan gelung yang dipertimbangkan dengan pelayan DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Gagal menamatkan gelung yang dipertimbangkan dengan pelayan DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Gagal hantar pemberitahuan nasihat DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Gagal cipta rentetan DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "tiada ralat DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "permintaan untuk transaksi menyegerakkan nasihat telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "tindak balas kepada transaksi menyebabkan bit DDE_FBUSY ditetapkan."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "permintaan untuk transaksi menyegerakkan data telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5797,7 +5784,7 @@ msgstr ""
 "atau pengenal contoh tidak sah\n"
 "telah dilepaskan kepada fungsi DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5809,43 +5796,43 @@ msgstr ""
 "aplikasi dimulakan sebagai APPCMD_CLIENTONLY telah\n"
 "berusaha melakukan transaksi pelayan."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "permintaan untuk transaksi menyegerakkan laksana telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parameter gagal disahkan oleh DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "Aplikasi DDEML telah mencipta keadaan memanjangkan bangsa."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "memori gagal ditempatkan."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "klien mencuba untuk mendirikan perbualan tetapi gagal."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "transaksi gagal."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "permintaan untuk transaksi menyegerakkan penebuk telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "panggilan dalaman kepada fungsi PostMessage gagal."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "masalah kemassukan"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5855,15 +5842,15 @@ msgstr ""
 "yang telah ditamatkan oleh klien, atau pelayan\n"
 "ditamatkan sebelum menyudahkan transaksi."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "ralat dalaman telah berlaku dalam DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "permintaan untuk menamatkan transaksi nasihat telah tamat tempoh."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5873,12 +5860,12 @@ msgstr ""
 "Sekali aplikasi telah dipulangkan kepada panggil-balik XTYP_XACT_COMPLETE,\n"
 "pengenal transaksi untuk panggil-balik tidak lagi sah."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Ralat DDE %08x tidak diketahui"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5886,7 +5873,7 @@ msgstr ""
 "Fungsi mendial tiada disebabkan servis capaian jauh (RAS) tidak dipasang "
 "pada mesin ini. Sila pasangkan."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5895,64 +5882,64 @@ msgstr ""
 "Versi servis capaian jauh (RAS) dipasang pada mesin ini terlalu lama, sila "
 "naiktaraf (fungsi diperlukan berikut telah hilang: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Gagal mendapatkan teks mesej ralat RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "ralat tidak diketahui (kod ralat %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Gagal menemui sambungan mendial aktif: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Beberapa sambungan mendial aktif ditemui, pilih satu secara rawak."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Gagal mengukuhkan sambuungan mendial: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Gagal mendapatkan nama ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Gagal menyambung: tiada ISP untuk dail."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Pilih ISP untuk dail"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Sila pilih ISP yang mana anda ingin sambung kepadanya"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Sila menyambung: hilang nama pengguna/kata laluan."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Gagal menemui lokasi fail buku alamat"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Gagal menamatkan sambungan mendial: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Gagal menggantung - tiada sambungan mendial aktif."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Gagal menamatkan sambungan mendial: %s"
@@ -5972,19 +5959,18 @@ msgstr "Gagal menyediakan %luKb memori untuk data peta bit."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Gagal menghitung fail dalam direktori '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Gagal cipta pemasa"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (ralat %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Gagal tambah imej kepada senarai imej."
 
@@ -5998,7 +5984,7 @@ msgstr "Gagal memuat metafail dari fail \"%s\"."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Gagal mencipta dialog cari/ganti piawai (kod ralat %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Perlaksanaan arahan '%s' gagal dengan ralat: %ul"
@@ -6041,17 +6027,17 @@ msgstr "Gagal sentuh fail '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Gagal cipta pemasa"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Gagal memulakan OpenGL"
 
@@ -6059,7 +6045,7 @@ msgstr "Gagal memulakan OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6067,7 +6053,7 @@ msgstr ""
 "Fungsi Bantuan MS HTML tidak wujud kerana pustaka bantuan MS HTML tidak "
 "dipasang pasa mesin ini. SIla pasangkannya."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Gagal memulakan Bantuan MS HTML."
 
@@ -6076,7 +6062,7 @@ msgstr "Gagal memulakan Bantuan MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "Gagal memadam fail INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Gagal menyelamatkan maklumat perihal senarai item kawalan %d."
@@ -6198,7 +6184,7 @@ msgstr "Gagal daftar format klipbod '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format klipbod '%d' tidak wujud."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Langkau"
 
@@ -6283,76 +6269,76 @@ msgstr ""
 "memadamnya akan menjadikan sistem anda dalam keadaan tidak berguna:\n"
 "operasi digugurkan."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Gagal padam kunci '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Gagal memadam nilai '%s' daripada kunci '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Gagal baca nilai kunci '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Gagal tetapkan nilai '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Gagal baca nilai '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Gagal menghitung nilai untuk kunci '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Gagal menghitung subkunci untuk kunci '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Mengeksport kunci registri: fail \"%s\" sedia wujud dan tidak akan ditindih."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Gagal eksport nilai yang tidak menyokong jenis %d"
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Abaikan nilai \"%s\" kunci \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6360,41 +6346,41 @@ msgstr ""
 "Mustahil untuk mencipta kawalan edit rich, sebaliknya gunakan kawalan mudah "
 "teks. Sila pasang semula riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Gagal memulakan benang: ralat menulis TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Gagal tetapkan keutamaan benang."
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Gagal mencipta benang"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Gagal menamatkan benang"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Tidak dapat menunggu benang ditamatkan"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Gagal menggantung benang %x"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Gagal menyambung benang %x"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Gagal dapatkan penunjuk benang semasa"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6402,7 +6388,7 @@ msgstr ""
 "Gagal memulakan modul benang: mustahil untuk menyediakan indeks dalam "
 "penyimpan benang lokal"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6432,12 +6418,12 @@ msgstr "Gagal memuat metafail dari fail \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Gagal mengunci fail kunci '%s'"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (build %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6449,47 +6435,47 @@ msgstr "Gagal mencipta saliran tanpanama"
 msgid "Failed to redirect the child process IO"
 msgstr "Gagal mengalihkan IO proses anak"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Perlaksanaan arahan '%s' gagal"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Gagal memuat mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Gagal baca nama jenis dari '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Gagal memuat ikon dari '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Gagal tetapkan keutamaan benang."
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Gagal melaksanakan '%s'\n"
@@ -6523,7 +6509,7 @@ msgid "Check to make the font italic."
 msgstr "Tanda untuk buat fon italik."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Digaris bawahkan"
@@ -6591,17 +6577,32 @@ msgstr "<Sebarang Teletaip>"
 msgid "File type:"
 msgstr "Teletaip"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Tetingkap"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Bantuan"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimum"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zum Masuk"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6618,494 +6619,494 @@ msgstr "Fail %s tidak wujud."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Perihal"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Perih&al"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Keutamaan"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Bantuan: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Pemilihan"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Papar Semua"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "&Keluar"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Pemilihan"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip tidak disokong oleh versi zlib ini"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Gagal mulakan paparan."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "Saiz titik:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "NamaBaru"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Gaya"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "Berat:"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "Keluarga &fon:"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Moden"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "ringan"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Jajar-kanan teks."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Moden"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Tetingkap"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Tetingkap"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Tetingkap"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Saiz Fon"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "&Ulangcara"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "lalai"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "esok"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Kanan"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Gaya peluru"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Kod aksara:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Saiz titik:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Jajar Kanan"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Soalan"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Kanan"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Kanan"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Tampal pilihan"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "&Ciri-ciri"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 #, fuzzy
 msgid "False"
 msgstr "Fail"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 #, fuzzy
 msgid "Unspecified"
 msgstr "Ditentu"
@@ -7120,49 +7121,49 @@ msgstr "Ralat mencetak"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Masukkan nombor laman antara %d dan %d:"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "Perihal"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Cipta direktori"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "Pilih fon"
@@ -7655,130 +7656,130 @@ msgstr "Selit"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Ubah Gaya"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 #, fuzzy
 msgid "Change Object Style"
 msgstr "Ubah Gaya Senarai"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Ubah Gaya Senarai"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Menomborkan Semula Senarai"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Selit Teks"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Selit Imej"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "Selit Teks"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "Selit Teks"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Terlalu banyak panggilan EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "fail"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 #, fuzzy
 msgid "standard/circle"
 msgstr "Piawai"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 #, fuzzy
 msgid "standard/square"
 msgstr "Piawai"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Padam Gaya"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "Padam"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "Padam pilihan"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Ciri-ciri"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "imej"
 
@@ -7986,25 +7987,25 @@ msgstr "~"
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Padam Teks"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Buang"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Teks gagal disimpan."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Ganti"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Fon:"
 
@@ -9055,53 +9056,53 @@ msgstr "Gaya senarai"
 msgid "Box styles"
 msgstr "Semua gaya"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Fon yang akan mengambil simbol."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subset:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Tunjuk subset Unikod."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "Kod aksara:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Kod aksara."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "Dari: "
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unikod"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Julat untuk ditunjuk."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Selit"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Teks Normal)"
 
@@ -9296,7 +9297,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Gagal membuka papara \"%s\"."
@@ -9396,20 +9397,20 @@ msgstr "Data bunyi dalam format yang tidak disokong."
 msgid "Couldn't open audio: %s"
 msgstr "Gagal membuka audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Gagal mendapatkan benang penjadualan polisi."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Gagal mendapatkan keutamaan banjaran untuk penjadualan polisi %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Tetapan keutamaan benang diabaikan."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9417,60 +9418,60 @@ msgstr ""
 "Gagal mengikat benang, kemungkinan memori bocor dikesan - sila mulakan "
 "program"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Gagal tetapkan keutamaan benang %d."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Gagal tetapkan keutamaan benang %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Gagal menghentikan benang."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Modul benang gagal dimulakan: gagal cipta kunci benang"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Mustahil untuk mendapatkan input proses anak"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Gagal membunuh proses %d"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Gagal melaksanakan '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Cabang gagal"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Gagal tetapkan keutamaan benang %d."
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Gagal mengalihkan  input/output proses anak"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Gagal mendapatkan namahos"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Gagal mendapatkan namahos rasmi"
 
@@ -9488,12 +9489,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "Gagal membaca PID daripada fail kunci."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Spesifikasi geometri tidak sah '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets Gagal membuka paparan. Keluar."
 
@@ -9507,30 +9508,59 @@ msgstr "Gagal menutup paparan \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Gagal membuka papara \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Ralat menghurai XML: '%s' pada baris %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Gagal memuat sumber dari fail '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Gagal memuat sumber dari fail '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Gagal memuat sumber dari fail '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Pengekstrakan '%s' kepada '%s' gagal."
+
+#~ msgid "Printing "
+#~ msgstr "Mencetak "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Gagal menyelitkan teks dalam kawalan."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Sila pilih fon yang sah."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Gagal papar dokumen HTML dalam pengkodan %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets Gagal membuka paparan '%s': keluar."
+
+#~ msgid "Filter"
+#~ msgstr "Tapis"
+
+#~ msgid "Directories"
+#~ msgstr "Direktori"
+
+#~ msgid "Files"
+#~ msgstr "Fail"
+
+#~ msgid "Selection"
+#~ msgstr "Pemilihan"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "penukaran kepada pengenkod 8-bit gagal"
@@ -9677,15 +9707,15 @@ msgstr "Pengekstrakan '%s' kepada '%s' gagal."
 #~ msgstr "Gagal mulakan mencetak."
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"
 #~ "%s %1"
 #~ msgstr ""
-#~ "Anda ingin menindih arahan yang diguna untuk fail %s dengan sambungan \"%s"
-#~ "\"?\n"
+#~ "Anda ingin menindih arahan yang diguna untuk fail %s dengan sambungan "
+#~ "\"%s\"?\n"
 #~ "Nilai semasa adalah \n"
 #~ "%s, \n"
 #~ "Nilai baru adalah \n"

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2015-10-27 22:33+0100\n"
 "Last-Translator: Hans Fredrik Nordhaug <hans@nordhaug.priv.no>\n"
 "Language-Team: Norwegian Bokmål <i18n-nb@lister.ping.uio.no>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.7.5\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Alle filer (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Alle filer (*)|*"
 
@@ -41,24 +41,21 @@ msgid "Remaining time:"
 msgstr "Gjenstående tid :"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nei"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Avbryt"
@@ -110,7 +107,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Klarte ikke opprette peker."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 #, fuzzy
 msgid "Printout"
 msgstr "Utskrift"
@@ -154,7 +151,7 @@ msgstr "&Egenskaper"
 msgid "Printing"
 msgstr "Skriver ut"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symboler"
 
@@ -223,7 +220,7 @@ msgstr "&Forrige"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Vindu"
 
@@ -780,11 +777,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "ctrl"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "vis denne hjelpmeldingen"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "generer ordrike loggmeldinger"
 
@@ -806,84 +803,84 @@ msgstr "Ikke-støttet tema «%s»."
 msgid "Invalid display mode specification '%s'."
 msgstr "Ugyldig spesifikasjon «%s» for skjermmodus."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Ukjent lang opsjon «%s»"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Ukjent opsjon «%s»"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, fuzzy, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Uventet parameter «%s»"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opsjon «%s» må ha en verdi."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Seperator forventet etter opsjonen «%s»."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "«%s» er ikke en gyldig numerisk verdi for valg «%s»."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opsjon «%s»: «%s» kan ikke konverteres til en dato."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Uventet parameter «%s»"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (eller %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Verdien for opsjonen «%s» må oppgies."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Den nødvendige parameteren «%s» var ikke oppgitt."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Bruk: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "nummer"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dobbel"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "dato"
 
@@ -901,7 +898,7 @@ msgid "Can't &Undo "
 msgstr "Klarte ikke &angre"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Angre"
@@ -911,7 +908,7 @@ msgid "&Redo "
 msgstr "&Gjenta"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Gjenta"
@@ -939,12 +936,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "«%s» har ekstra «..», ignorert."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -954,103 +951,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "understreket"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "i dag"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "i går"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "i morgen"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "først"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "andre"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tredje"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "fjedre"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "femte"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sjette"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sjuende"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "åttende"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "niende"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "tiende"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "ellevte"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "tolvte"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "trettende"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "fjortende"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "femtende"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "sekstende"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "syttende"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "attende"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "nittende"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "tjuende"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "middag"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "midnatt"
 
@@ -1119,44 +1116,81 @@ msgstr "Klarte ikke kjøre curl, installere den i stien (PATH)."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Klarte ikke laste opp feilsøkingsrapporten (feilkode %d)"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Lagre Som"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Forkast endringene og last opp den forrige versjonen?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "uten navn"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vil du lagre endringer til document «%s»?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Lagre"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ikke lagre"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vil du lagre endringer til document «%s»?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Klarte ikke lagre teksten."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Klarte ikke lagre bitmap-bilde til filen «%s». "
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Klarte ikke laste metafil fra filen «%s»."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1165,58 +1199,58 @@ msgstr ""
 "Filen «%s» eksisterer ikke og kunne ikke åpnes.\n"
 "Den er fjernet fra listen over nylig brukte filer."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 #, fuzzy
 msgid "Print preview creation failed."
 msgstr "Røropprettelse feilet"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Forhåndsvisning av utskrift"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "uten navn %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Åpne Fil"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Filfeil"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Klarte ikke åpne denne filen."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Formatet for denne filen er ukjent."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Velg en dokumentmal"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Maler"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Velg en dokumentvisning"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Visninger"
 
@@ -1250,41 +1284,41 @@ msgstr "Lesefeil i fil «%s»"
 msgid "Write error on file '%s'"
 msgstr "Skrivefeil på fil «%s»"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "klarte ikke tømme filen «%s»"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Søker etter feil i fil «%s» (store filer ikke støttet av stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Søkefeil i filen «%s»"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Klarte ikke finne gjeldende posisjon i filen «%s»"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Klarte ikke sette rettigheter for midlertidige filer"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "klarte ikke slette fil «%s»"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "klarte ikke utføre endringene på filen «%s»"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "klarte ikke slette midlertidig fil «%s»"
@@ -1309,27 +1343,27 @@ msgstr "klarte ikke lese fra fildeskriptor %d"
 msgid "can't write to file descriptor %d"
 msgstr "klarte ikke skrive til deskriptor %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "klarte ikke tømme fildeskriptor %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "klarte ikke søke på fildeskriptor %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "klarte ikke finne søkeposisjon på fildeskriptor %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "klarte ikke finne lengde av filen med deskriptor %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "klarte ikke avgjøre om slutten på filen er nådd for deskriptor %d "
@@ -1348,115 +1382,115 @@ msgstr "klarte ikke åpne bruker konfigurasjonsfil «%s»."
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
-"Endringer vil ikke bli lagret for å unngå å overskrive eksisterende fil \"%s"
-"\""
+"Endringer vil ikke bli lagret for å unngå å overskrive eksisterende fil "
+"\"%s\""
 
 #: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Feil ved lesing av konfigurasjonsvalg."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Feil ved lesing av konfigurasjonsvalg."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fil «%s»: uventet tegn %c på linje %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "fil «%s», linje %d: «%s» ignorert etter gruppehode."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fil «%s», linje %d: «=» forventet."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "file «%s», linje %d: verdi for uforanderlig nøkkel «%s» ignorert."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "file «%s», linje %d: nøkkel «%s» ble først funnet på linje %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurasjonsoppføring kan ikke starte med «%c»."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "klarte ikke åpne bruker konfigurasjonsfil."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "klarte ikke skrive til bruker konfigurasjonsfil."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Feil ved lagring av brukerkonfigurasjonsdata."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "klarte ikke slette file «%s» for brukerkonfigurasjon"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "oppføring «%s» forekommer mer enn en gang i gruppen «%s»"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "forsøk på å endre uforanderlig nøkkel «%s» ignorert."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "uventet \" i posisjon %d i «%s»."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Klarte ikke kopiere file «%s» til «%s»."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Klarte ikke få tak i rettigheter for filen «%s»"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Klarte ikke overskrive filen «%s»"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Klarte ikke kopiere file «%s» til «%s»."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Klarte ikke sette rettigheter for filen «%s»"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1464,41 +1498,41 @@ msgid ""
 msgstr ""
 "Klarte ikke å døpe om fil '%s' til '%s' fordi navnet allerede er i bruk."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Mappe «%s» kunne ikke opprettes"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Klarte ikke telle opp filer «%s»"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Klarte ikke finne gjeldende mappe"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Klarte ikke finne gjeldende mappe"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Filer (%s)"
@@ -1525,17 +1559,17 @@ msgstr "Klarte ikke opprette et midlertidig filnavn"
 msgid "Failed to open temporary file."
 msgstr "Klarte ikke åpne midlertidig fil."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Klarte ikke endre filtid for «%s»"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Klarte ikke rør filen «%s»"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Klart ikke hente filtid for «%s»"
@@ -1544,22 +1578,22 @@ msgstr "Klart ikke hente filtid for «%s»"
 msgid "Browse"
 msgstr "Bla gjennom"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle filer (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s filer (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Laster %s fil"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Lagre %s fil"
@@ -1930,109 +1964,109 @@ msgstr "standard"
 msgid "unknown-%d"
 msgstr "ukjent-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "understreket"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr "streke over"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "lett"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 #, fuzzy
 msgid " light"
 msgstr "lett"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 #, fuzzy
 msgid " bold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 #, fuzzy
 msgid " italic"
 msgstr "kursiv"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "overstrek"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "lett"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "lett"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kursiv"
 
@@ -2110,7 +2144,7 @@ msgstr "Tidsavbrudd under venting på FTP-tilkobling, prøv passiv modus."
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Klarte ikke sette FTP-overføringsmodus til %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2131,7 +2165,7 @@ msgstr "FTP-tjeneren støtter ikke passiv modus."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Klarte ikke opprette peker."
@@ -2149,7 +2183,7 @@ msgstr "Selvvalgte kolonner"
 msgid "&Customize..."
 msgstr "skriftstørrelse"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Klarte ikke åpne «%s» for «%s»"
@@ -2169,156 +2203,155 @@ msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Klarte ikke lagre ugyldig bilde."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage har ikke egen wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Klarte ikke skrive filhodet (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Klarte ikke skrive filehodet (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Klarte ikke skrive RGB-fargekart."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Klarte ikke skrive data."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Klarte ikke reservere minne."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB-hode: Bildebredde > 32767 piksler for filen."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB-hode: Bildehøyde > 32767 piksler for filen."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB-hode: Ukjent bitdybde i filen."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB-hode: Ukjent koding i filen."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB-hode: Koding stemmer ikke med bitdybde."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Klarte ikke reservere minne."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB-hode: Bildebredde > 32767 piksler for filen."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB-hode: Bildehøyde > 32767 piksler for filen."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB-hode: Ukjent bitdybde i filen."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB-hode: Ukjent koding i filen."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB-hode: Koding stemmer ikke med bitdybde."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 #, fuzzy
 msgid "Error in reading image DIB."
 msgstr "Feil ved lesing av bilde DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Feil ved maskelesing DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Bilde er for høyt for et ikon."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Bilde er for bredt for et ikon."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Feil ved skriving av bildefil!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ugyldig ikonindeks"
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Bilde og maske har forskjellig størrelse."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Ingen ubrukte farger i bilde blir masket."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Klarte ikke laste bilde %d fra filen «%s»."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Klarte ikke lagre bilde til filen «%s»: Ukjent filtype"
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Ingen behandler funnet for bildetype."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Ingen bildebehandler for type %d definert."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "Bildefil er ikke av type %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Kan ikke automatisk bestemme bildeformatet."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Ukjent bildeformat"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: Dette er ikke en PCX-fil"
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Ingen bildebehandler for type %s definert."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "Bildefil er ikke av type %d."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Klarte ikke lagre bitmap-bilde til filen «%s». "
@@ -2421,52 +2454,52 @@ msgstr "PNM: Filen ser ut til å være trunkert."
 msgid " (in module \"%s\")"
 msgstr "TIFF-modul: %s"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Feil ved bildelasting."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Ugyldig TIFF bildeindeks."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Bildet er unormalt stort."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Klarte ikke reservere minne."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Feil ved bildelesing."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Ukjent enhet %d for oppløsning i TIFF ble ignorert"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Feil ved lagring av bilde."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Feil ved skriving av bilde."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan ikke sette språket til \"%s\"."
@@ -2564,7 +2597,7 @@ msgstr "kompresjonsfeil"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Ubalansert «{» i en oppføring for mime-type %s."
@@ -2584,7 +2617,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Melding"
 
@@ -3132,7 +3165,7 @@ msgstr "Feil ved utskrift"
 msgid "Print"
 msgstr "Utskrift"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Sideoppsett"
 
@@ -3168,19 +3201,15 @@ msgstr "Skriver ut side %d..."
 msgid " (copy %d of %d)"
 msgstr "Side %d av %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Skriver ut"
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Første side"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Forrige side"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Neste side"
 
@@ -3226,16 +3255,16 @@ msgstr "Side %d av %d"
 msgid "Page %d"
 msgstr "Side %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "ukjent feil "
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ugyldig regulært uttrykk «%s»: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, fuzzy, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Fant ingen treff for «%s» i regulært uttrykk: %s"
@@ -3245,21 +3274,21 @@ msgstr "Fant ingen treff for «%s» i regulært uttrykk: %s"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Utfører «%s» har ikke-kompatibel versjon %d.%d og ble ikke lastet."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Utpakking av «%s» inni «%s» feilet."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Utpakking av «%s» inni «%s» feilet."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Utpakking av «%s» inni «%s» feilet."
@@ -3268,11 +3297,11 @@ msgstr "Utpakking av «%s» inni «%s» feilet."
 msgid "Failed to monitor I/O channels"
 msgstr "Klarte ikke å overvåke I/O-kanalene"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "&Lagre"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Ikke lagre"
 
@@ -3359,10 +3388,10 @@ msgid "Clear"
 msgstr "&Fjern"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Lukk"
 
@@ -3376,7 +3405,7 @@ msgstr "Innhold"
 msgid "Convert"
 msgstr "Innhold"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopier"
@@ -3386,7 +3415,7 @@ msgstr "&Kopier"
 msgid "Copy"
 msgstr "&Kopier"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Klipp u&t"
@@ -3395,13 +3424,13 @@ msgstr "Klipp u&t"
 msgid "Cut"
 msgstr "Klipp u&t"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Slett"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 #, fuzzy
 msgid "Delete"
@@ -3497,7 +3526,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Hjelp"
 
@@ -3517,7 +3546,7 @@ msgstr "Innrykk"
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3590,7 +3619,7 @@ msgstr "&Ny"
 msgid "New"
 msgstr "&Ny"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nei"
 
@@ -3608,12 +3637,12 @@ msgstr "&Åpne..."
 msgid "Open..."
 msgstr "&Åpne..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Lim inn"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 #, fuzzy
 msgid "Paste"
@@ -3648,7 +3677,7 @@ msgid "Print..."
 msgstr "&Skriv ut..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Egenskaper"
 
@@ -3684,10 +3713,6 @@ msgstr "&Erstatt"
 msgid "Revert to Saved"
 msgstr "Gå tilbake til lagret versjon"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Lagre"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Lagre &som..."
@@ -3697,7 +3722,7 @@ msgstr "Lagre &som..."
 msgid "Save As..."
 msgstr "Lagre &som..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Velg &alle"
@@ -3815,7 +3840,7 @@ msgstr "&Opp"
 msgid "Up"
 msgstr "Opp"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ja"
 
@@ -3913,44 +3938,44 @@ msgstr "Velg en dokumentvisning"
 msgid "Save current document with a different filename"
 msgstr "Lagre dette dokumentet med et annet filnavn"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Klarte ikke konvertere til tegnsett «%s»."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "ukjent"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "ukomplett hodeblokk i tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "kontrollsumfeil ved lesing av hodeblokk fra tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "ugyldig data i utvidet tar-hode"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar-innslag er ikke åpent"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 #, fuzzy
 msgid "unexpected end of file"
 msgstr "Uventet slutt på filen under tolking av ressurs."
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s passet ikke med tar- hodet for innslag '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "ugyldig størrelse for tar-innslag"
 
@@ -3959,7 +3984,7 @@ msgstr "ugyldig størrelse for tar-innslag"
 msgid "'%s' is probably a binary buffer."
 msgstr "«%s» er sannsynligvis en binær buffer."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Klarte ikke laste filen."
 
@@ -3973,49 +3998,49 @@ msgstr "Klarte ikke laste metafil fra filen «%s»."
 msgid "can't write buffer '%s' to disk."
 msgstr "klarte ikke skriver buffer «%s» til disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Klarte ikke finne lokal systemtid"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay feilet."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "«%s» er ikke en gyldig meldingskatalog."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "«%s» er ikke en gyldig meldingskatalog."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Klarte ikke tolke flertallsformer: «%s»"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "bruker katalog «%s» fra «%s»."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "«%s» er ikke en gyldig meldingskatalog."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Klarte ikke avslutte tråden."
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Ingen applikasjon satt opp for HTML-filer."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Klarte ikke åpne «%s» for «%s»"
@@ -4048,7 +4073,7 @@ msgstr "«%s» må kun inneholde bokstaver."
 msgid "Error: %s (%d)"
 msgstr "Feil:"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4057,21 +4082,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Kolonnebeskrivele kunne ikke initialiseres."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "String conversions ikke støttet"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Denne plattformen støtter ikke transparente bakgrunner."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Klarte ikke overføre data til vindu"
 
@@ -4123,8 +4148,8 @@ msgstr "Create Parameter ble ikke funnet blant deklarerte RTTI parametere"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Ulovlig objektklasse (Ikke-wxEvtHandler) som hendelseskilde"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Type må ha enum - long conversion"
 
@@ -4175,79 +4200,79 @@ msgstr "Objekter må ha en ID attributt"
 msgid "Doubly used id : %d"
 msgstr "Dobbel bruker-ID: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Ukjent egenskap %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "En ikke-tom mengde må bestå av «element»-noder"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "ugyldig hendelsebehandlerstreng, mangler punktum"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Klarte ikke klargjøre zlib-strøm for nedpakking."
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Klarte ikke klargjøre zlib-strøm for utpakking."
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "antar dette er en mangedelt zip-fil slått sammen"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "ugyldig zipfil"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "Klarte ikke finne zip-sentralmappe"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "Feil ved lesing av zip-sentralmappe"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "feil ved lesing av lokalt zip-hode "
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "ugylidg zipfil forskyvning til oppføring"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "lagret fillengde ikke funnet i Zip-hode"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "ikke-støttet Zip-komprimeringsmetode"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "leser zip-strøm (oppføring %s): feil lengde"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "leser zip-strøm (oppføring %s): feil crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "feil ved skriving av zip-oppføring «%s»: feil crc eller lengde"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "feil ved skriving av zip-oppføring «%s»: feil crc eller lengde"
@@ -4333,33 +4358,33 @@ msgstr ""
 msgid "Translations by "
 msgstr "Oversatt av"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr "Rettigheter"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, fuzzy, c-format
 msgid "About %s"
 msgstr "%Om"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Lisens"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Utviklere"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Dokumentforfattere"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artister"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Oversettere"
 
@@ -4414,43 +4439,42 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (eller %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Legg til Kolonne"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4461,8 +4485,7 @@ msgid "Left"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4561,7 +4584,7 @@ msgid "Home directory"
 msgstr "Hjemmemappe"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Skrivebord"
 
@@ -4574,8 +4597,7 @@ msgstr "Ugyldig mappenavn."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Feil"
 
@@ -4761,16 +4783,16 @@ msgstr "Vis filer i detaljert visning"
 msgid "Go to parent directory"
 msgstr "Gå til foreldremappe"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Filen «%s» eksisterer allerede. Vil du virkelig overskrive filen?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Bekreft"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Velg en eksisterende fil."
 
@@ -4865,7 +4887,7 @@ msgstr "Skriftpunktstørrelse"
 msgid "Whether the font is underlined."
 msgstr "Om skriften er understreket."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Forhåndsvisning:"
@@ -4883,48 +4905,47 @@ msgstr "Klikk for å avbrytevalg av font."
 msgid "Click to confirm the font selection."
 msgstr "Klikk for å bekrefte skriftvalg"
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Velg skrift"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Hjelpemappe \"%s\" ble ikke funet."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, fuzzy, c-format
 msgid "Help file \"%s\" not found."
 msgstr "katalogfil for domene «%s» ikke funnet."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Ingen oppføringer funnet."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indeks for hjelp"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevante oppføringer:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Oppføringer funnet"
 
@@ -5032,59 +5053,59 @@ msgstr "Klarte ikke starte utskrift."
 msgid "Printing page %d..."
 msgstr "Skriver ut side %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Skriveropsjoner"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Skriv til fil"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Sett opp..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Skriver:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status: "
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Alle"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Sider"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Utskriftsområde"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Fra:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Til:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopier;"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript-fil"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Oppsett av utskrift"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Skriver"
 
@@ -5092,25 +5113,25 @@ msgstr "Skriver"
 msgid "Default printer"
 msgstr "Standard skriver"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Papirstørrelse"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Portrett"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Liggende"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientering"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opsjoner"
 
@@ -5122,54 +5143,54 @@ msgstr "Utskrift med farger"
 msgid "Print spooling"
 msgstr "Utskriftskø"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Skriverkommando:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Skriveropsjoner:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Venstremarg (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Toppmarg (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Høyremarg (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Marg nede (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Skriver..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 #, fuzzy
 msgid "&Skip"
 msgstr "Hopp over"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 #, fuzzy
 msgid "Unknown"
 msgstr "ukjent"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "ferdig."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Søk"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Klarte ikke finne tab for id"
 
@@ -5205,22 +5226,22 @@ msgstr "&Fullfør"
 msgid "< &Back"
 msgstr "< &Tilbake"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Klarte ikke opprette mappe «%s»"
@@ -5246,12 +5267,12 @@ msgstr "Klarte ikke laste metafil fra filen «%s»."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Klarte ikke oppdatere bruker konfigurasjonsfil."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Kritisk feil"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5259,7 +5280,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5267,7 +5288,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI-barn"
 
@@ -5284,36 +5305,27 @@ msgstr "Feil under venting på semafor"
 msgid "Page Setup"
 msgstr "Sideoppsett"
 
-#: ../src/gtk/textctrl.cpp:1273
-#, fuzzy
-msgid "Failed to insert text in the control."
-msgstr "Klarte ikke finne gjeldende mappe"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Velg en gyldig skrift."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5412,45 +5424,45 @@ msgstr "Klarte ikke åpne innholdsfil: %s"
 msgid "Cannot open index file: %s"
 msgstr "Klarte ikke åpne indeksfile: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "ikke navn"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Klarte ikke åpne HTML-hjelpebok: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Viser hjelp mens du blar gjennom bøkene til venstre."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(bokmerker)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Legg til gjeldende side til bokmerkene"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Slett gjeldende side fra bokmerker"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Innhold"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Finn"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Vis alle"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5458,166 +5470,166 @@ msgstr ""
 "Vis alle indekselementer som inneholder den oppgitte delstrengen. Søket er "
 "uavhengig av liten eller stor bokstav."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Vis alle elementer i indeksen"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Skill mellom små og store bokstaver"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Bare hele ord"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Søk innholdet av alle hjelpebøker etter teksten du skrev ovenfor"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Vis/skjul navigasjonspanel"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Gå tilbake"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Gå frem"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Gå et nivå opp i dokumenthierarkiet"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Åpne HTML-dokument"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Skriv ut denne siden"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Vis innstillingsvindu"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Velg siden som skal vises:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Emner for hjelp"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Søker..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Ingen sider med treff funnet enda"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Fant %i treff"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Hjelp)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, fuzzy, c-format
 msgid "%d of %lu"
 msgstr "%i av %i"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, fuzzy, c-format
 msgid "%lu of %lu"
 msgstr "%i av %i"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Søk i alle bøker"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Innstillinger for hjelpleser"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normal skrift:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fast skrift:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Skriftstørrelse:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "skriftstørrelse"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal skrift<br>og <u>understreket</u>."
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursiv skrift.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Fet skrift.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Fet kursiv skrift.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Fast størrelse skrift.<br> <b>fet</b> <i>kursiv</i>"
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>fet kursiv <u>understreket</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Skriv ut hjelp"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Klarte ikke skrive ut tom side."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-filer  (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hjelpebøker (*.htb)|*.htb|Hjelpebøker (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML hjelpprosjekt (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimert HTML-hjelpfil (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i av %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%i av %i"
@@ -5696,32 +5708,6 @@ msgstr ""
 "Det oppstod et problem med sideoppsettet - kanskje du må installere en "
 "skriver."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Klarte ikke vise HTML-dokument med %s koding"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets klarte ikke åpne skjerm for '%s': avslutter."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filter"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Mapper"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Filer"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Valg"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Klarte ikke åpne utklippstavle."
@@ -5763,58 +5749,58 @@ msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
 msgid "Failed to create cursor."
 msgstr "Klarte ikke opprette peker."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Klarte ikke registrere DDE-tjener «%s»"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Klarte ikke avregistrere DDE-tjener «%s»"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Klarte ikke opprette forbindelse til tjener «%s» med budskap «%s»"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE-«snuse» forespørsel feilet"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Klarte ikke opprette en rådgivningsløkke med DDE-tjeneren"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Klarte ikke avslutte rådgivningsløkka med DDE-tjeneren"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Klarte ikke send DDE-rådgivningsmelding"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Klarte ikke opprette DDE-streng"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "ingen DDE-feil"
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "tidsavbrudd i en forespørsel etter synkron rådtransaksjon"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "svaret på transaksjonen gjorde at DDE_FBUSY-biten ble satt."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "tidsavbrudd i en forespørsel etter synkron datatransaksjon"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5825,7 +5811,7 @@ msgstr ""
 "eller en ugyldig instanseindentifikator\n"
 "ble sendt til en DDEML-funksjon."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5837,43 +5823,43 @@ msgstr ""
 "eller et program initialisert som APPCMD_CLIENTONLY har\n"
 "prøvd å utføre tjenertransaksjoner."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "en forespørsel om en synkron utførselstransaksjon har gått ut på tid."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "en parameter ble ikke validert av DDEML-en."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "et DDEML-program har skapt en prolongert kappløpsbetingelse."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "en minnereservasjon feilet."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "en klients forsøk på å etablere en konversasjon feilet."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "en transaksjon feilet."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "en forespørsel om en asynkron «snuse»-transaksjon har gått ut på tid."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "Et internt kall til PostMessage-funksjonen feilet."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "gjeninngangsproblem."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5883,16 +5869,16 @@ msgstr ""
 "som ble avsluttet av klienten, eller tjeneren ble\n"
 "slått av før transaksjonen ble fullført."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "En intern feil har oppstått i DDEML-en."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "en forespørsel om å avslutte en rådgivningstransaksjon har gått ut på tid."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5903,12 +5889,12 @@ msgstr ""
 "så vil ikke transaksjonsidentifikatoren for det tilbakekallet lenger være "
 "gyldig."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Ukjent DDE-feil %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5916,7 +5902,7 @@ msgstr ""
 "Oppringingsfunskjonene er utilgjengelig fordi Remote Access Service (RAS) "
 "ikke er installert på denne maskinene."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5925,64 +5911,64 @@ msgstr ""
 "Versjonen av Remote Access Service (RAS) installert på denne maskinen er for "
 "gammel. Du må oppgradere - følgende påkrevd funksjon mangler: %s"
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Klarte ikke hente tekst fra RAS feilmelding"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "ukjent feil (feilkode %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Klarte ikke finne aktiv oppringingsforbindelse: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Flere aktive oppringingsforbindelser funnet, velger en tilfeldig."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Klarte ikke opprette oppringingsforbindelse: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Klarte ikke få ISP navn: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Klarte ikke opprette forbindelse: ingen ISP å ringe til."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Velg ISP for oppringing"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Velg hvilken ISP du vil koble til"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Klarte ikke opprette forbindelse: manglende brukernavn/passord."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Klarte ikke plasseringen til adressebokfilen"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Klarte ikke avslutte oppringingskoblingen: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Klarte ikke legge på - ingen aktiv oppringingsforbindelse."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Klarte ikke avslutte oppringingskoblingen: %s"
@@ -6002,19 +5988,18 @@ msgstr "Klarte ikke reservere %lu Kb minne for bitmap data."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Klarte ikke telle opp filer i mappen «%s»"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Klarte ikke opprette en timer"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr "(feil %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Klarte ikke legge til et bilde i bildelisten."
 
@@ -6028,7 +6013,7 @@ msgstr "Klarte ikke laste metafil fra filen «%s»."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Klarte ikke opprette standard finn/erstattvindu (feilkode %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Utførelse av kommandoen «%s» feilet med feil: %ul"
@@ -6071,17 +6056,17 @@ msgstr "Klarte ikke rør filen «%s»"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan ikke overvåke ikkeeksisterende katalog \"%s\" for endringer"
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Klarte ikke opprette en timer"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Klarte ikke initialisere OpenGL"
 
@@ -6089,7 +6074,7 @@ msgstr "Klarte ikke initialisere OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6097,7 +6082,7 @@ msgstr ""
 "MS HTML hjelpefunksjoner er utilgjengelig fordi MS HTML hjelpebiblioteket "
 "ikke er installert på denne maskinen."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Klarte ikke initialisere MS HTML hjelp."
 
@@ -6106,7 +6091,7 @@ msgstr "Klarte ikke initialisere MS HTML hjelp."
 msgid "Can't delete the INI file '%s'"
 msgstr "Klarte ikke slette INI-filen «%s»"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Klarte ikke hente informasjon om listekontrolelement %d."
@@ -6228,7 +6213,7 @@ msgstr "Klarte ikke registrere utklippstavleformat «%s»."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Utklippstavleformatet «%d» finnes ikke."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Hopp over"
 
@@ -6313,59 +6298,59 @@ msgstr ""
 "sletting vil etterlate system i en ubrukbar tilstand:\n"
 "operasjon avbrutt."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Klarte ikke slette nøkkel «%s»"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Klarte ikke slette verdien «%s» fra nøkkelen «%s»"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Klarte ikke lese verdien av nøkkel «%s»"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Klarte ikke sette verdien for «%s»"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Klarte ikke lese verdien til «%s»"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Klarte ikke telle opp verdier for nøkkel «%s»"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Klarte ikke telle opp undernøkler av nøkkel «%s»"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6373,17 +6358,17 @@ msgstr ""
 "Eksporterer registernøkkel: file «%s» eksisterer allerede og kan ikke "
 "overskrives"
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Klarte ikke eksportere verdi av ikke-støttet type %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorerer verdi «%s» for nøkkel «%s»"
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6391,41 +6376,41 @@ msgstr ""
 "Klarte ikke opprette rik redigeringskontroll, bruker enkel tekstkontroll i "
 "steden. Gjeninstaller riched32.dll."
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Klarte ikke starte tråden: feil ved skriving til TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Klarte ikke sette trådprioritet"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Klarte ikke opprette tråd"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Klarte ikke avslutte tråden."
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Klarte ikke vente på trådens avslutning"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Klarte ikke innstille tråden %x"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Klarte ikke gjenoppta tråden %x"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Klarte ikke finne gjeldende trådpeker"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6433,7 +6418,7 @@ msgstr ""
 "Initialisering av trådmodul feilet: umulig å reservere indeks i det lokale "
 "trådlager"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6464,12 +6449,12 @@ msgstr "Klarte ikke laste metafil fra filen «%s»."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Klarte ikke låse låsefilen «%s»"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (build %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6481,47 +6466,47 @@ msgstr "Klarte ikke opprette et anonym rør"
 msgid "Failed to redirect the child process IO"
 msgstr "Klarte ikke videresende underporsess IO"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Utførelse av kommandoen «%s» feilet"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Klarte ikke laste mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Klarte ikke lese typenavn fra «%s»!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Klarte ikke laste ikon fra «%s»."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Klarte ikke sette trådprioritet"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Klarte ikke utføre «%s»\n"
@@ -6559,7 +6544,7 @@ msgid "Check to make the font italic."
 msgstr "Klikk for å lage kursiv skrift."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 #, fuzzy
 msgid "Underlined"
@@ -6637,17 +6622,32 @@ msgstr "Teletype"
 msgid "File type:"
 msgstr "Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Vindu"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hjelp"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimer"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Vis &større"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6664,497 +6664,497 @@ msgstr "Filen «%s» eksisterer ikke."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "%Om"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "%Om"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "&Innstillinger"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Tjenester"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Hjelp: %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Seksjoner"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Skjul andre"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Vis alle"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "&Slutt"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Seksjoner"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip er ikke støttet av denne versjonen av zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Kolonnebeskrivele kunne ikke initialiseres."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "&Punktstørrelse"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "NyttNavn"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 #, fuzzy
 msgid "Style"
 msgstr "&Stil:"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "&Vekt:"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 #, fuzzy
 msgid "Family"
 msgstr "&Skriftfamilie:"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Moderne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Moderne"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Meny"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Vindu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Vindu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Vindu"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Svart"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Rødbrun"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Purpur"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Grå"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Grønn"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Oliven"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Brun"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Blå"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "&Gjenta"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Oransje"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Sølv"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Gul"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Hvit"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "standard"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "i morgen"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Høyrepil"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Punktlistestil"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Bokstavstiler"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Høyreknapp"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Forstørrelsesglass"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Høyreknapp"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Malepensel"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Blyant"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "&Punktstørrelse"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Høyrejustering"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Spørsmål"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Høyreknapp"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Sprayboks"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Vent"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Høyrepil"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "SeksjonerGjør et valg:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "&Egenskaper"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Verdi"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategorisert Modus"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alfabetisk Modus"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Uspesifisert"
 
@@ -7168,49 +7168,49 @@ msgstr "Feil ved utskrift"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Du har lagt inn en ugyldig verdi. Trykk ESC for å avbryte redigering."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Verdien må være %s eller høyere."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Oppgi et sidetall mellom %d og %d:"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Verdien må være %s eller mindre."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "%Om"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Opprett mappe"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 #, fuzzy
 msgid "Choose a file"
 msgstr "Velg skrift"
@@ -7692,125 +7692,125 @@ msgstr "Innrykk"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Endre stil"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Endre objektstilen"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Egenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Endre liststilen"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renummerer liste"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Sett inn Tekst"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Sett inn Bilde"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Sett inn Objekt"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "Innrykk"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "For mange kall til EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "Filer"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standard/sirkel"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standard/sirkel-omriss"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standard/firkant"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standard/triangel"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Egenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 #, fuzzy
 msgid "Cell Properties"
 msgstr "&Egenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Sett cellestil"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "&Slett"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "Seksjoner"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Legg til Rad"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Legg til Kolonne"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Egenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Egenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "bilde"
 
@@ -8022,27 +8022,27 @@ msgstr ""
 msgid "Drag"
 msgstr "Dra"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 #, fuzzy
 msgid "Delete Text"
 msgstr "Slett element"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Slett"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Klarte ikke lagre teksten."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 #, fuzzy
 msgid "Replace"
 msgstr "&Erstatt"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 #, fuzzy
 msgid "&Font:"
 msgstr "&Skriftfamilie:"
@@ -9063,56 +9063,56 @@ msgstr "List opp stiler"
 msgid "Box styles"
 msgstr "&Neste >"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Fonten som symbolet hentes fra."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Undergruppe:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Viser en undergruppe av Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Tegnkode:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Tegnkoden."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 #, fuzzy
 msgid "&From:"
 msgstr "Fra:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 #, fuzzy
 msgid "Unicode"
 msgstr "&Fjern innrykk"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Område som skal vises."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 #, fuzzy
 msgid "Insert"
 msgstr "Innrykk"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 #, fuzzy
 msgid "(Normal text)"
 msgstr "Normal skrift:"
@@ -9308,7 +9308,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr "Avspillingsfeil: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Klarte ikke åpne «%s» for «%s»"
@@ -9408,20 +9408,20 @@ msgstr "Format for lyddata er ikke støttet."
 msgid "Couldn't open audio: %s"
 msgstr "Klarte ikke åpne lyd: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Klarte ikke hente trådplanleggingspolitikk."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Klarte ikke finne prioritetsområde for planleggingspolitikk %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Trådprioritetinnstilling ignorert."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9429,61 +9429,61 @@ msgstr ""
 "Klarte ikke bli med en tråd, potensiell minnelekkasje oppdaget - start "
 "programmet på nytt"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Klarte ikke sette trådprioritet %d"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Klarte ikke sette trådprioritet %d"
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Klarte ikke avslutte en tråd."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Initialisering av trådmodul feilet: klarte ikke opprette trådnøkkel"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Klarte ikke få tak i inndata for underprosess"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Klarte ikke drepe prosess %d"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Klarte ikke utføre «%s»\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Forgrening feilet"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Klarte ikke sette trådprioritet %d"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Klarte ikke videresende underprosessen inndata/utdata"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Klarte ikke å sette opp ikke-blokkerende 'pipe', programmet kan bli hengende."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Klarte ikke finne tjenernavn"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Klarte ikke finne det offisielle tjenernavnet"
 
@@ -9501,12 +9501,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "Klarte ikke lses PID fra låsefil."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Ugyldig geometrispesifikasjon «%s»."
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets klarte ikke åpne skjerm. Avslutter."
 
@@ -9520,30 +9520,60 @@ msgstr "Klarte ikke lukke utklippstavlen."
 msgid "Failed to open display \"%s\"."
 msgstr "Klarte ikke åpne «%s» for «%s»"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML tolkefeil: «%s» på linje %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Klarte ikke laste ressurs fra filen «%s»."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Klarte ikke laste ressurs fra filen «%s»."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Klarte ikke laste ressurs fra filen «%s»."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Utpakking av «%s» inni «%s» feilet."
+
+#~ msgid "Printing "
+#~ msgstr "Skriver ut"
+
+#, fuzzy
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Klarte ikke finne gjeldende mappe"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Velg en gyldig skrift."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Klarte ikke vise HTML-dokument med %s koding"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets klarte ikke åpne skjerm for '%s': avslutter."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Mapper"
+
+#~ msgid "Files"
+#~ msgstr "Filer"
+
+#~ msgid "Selection"
+#~ msgstr "Valg"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "konvertering til 8-bit koding feilet"
@@ -9692,8 +9722,8 @@ msgstr "Utpakking av «%s» inni «%s» feilet."
 #~ msgstr "Klarte ikke å sette egenskapsflagg."
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/ne.po
+++ b/locale/ne.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2015-05-09 20:03+0545\n"
 "Last-Translator: drishtibachak@gmail.com\n"
 "Language-Team: Him Prasad Gautam <himjee@yahoo.com>\n"
@@ -15,11 +15,11 @@ msgstr ""
 "X-Generator: Poedit 1.7.5\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "सबै फाइलहरू(*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "सबै फाइलहरू(*)|*"
 
@@ -36,24 +36,21 @@ msgid "Remaining time:"
 msgstr "बांकि समय:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "हो"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "होइन"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "ठीक"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "रद्द गर"
@@ -103,7 +100,7 @@ msgid "Unable to create I/O completion port"
 msgstr "I/O completion port लाई सिर्जना गर्न सकिएन ।"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "छापिएका पानाहरू"
 
@@ -140,7 +137,7 @@ msgstr "वस्तु गुणहरू"
 msgid "Printing"
 msgstr "छाप्ने काम हुँदैछ ।"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "चिन्ह"
 
@@ -209,7 +206,7 @@ msgstr "&पछिल्लो"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&विन्डो"
 
@@ -739,11 +736,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "यो सहयोग सन्देश देखाउ "
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "लामो सन्देशहरू उत्पादन गर्छ ।"
 
@@ -765,84 +762,84 @@ msgstr "असमर्थित theme '%s'"
 msgid "Invalid display mode specification '%s'."
 msgstr "नमिल्दो दृश्य मुद्रा मानक '%s'"
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "विकल्प '%s' नकारात्मक हुन सक्दैन ।"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "अज्ञात लामो विकल्प '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "अज्ञात विकल्प '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "विकल्पहरू '%s' मा नसोचेका वर्णहरू "
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "विकल्प '%s' को एउटा मान हुनै पर्दछ"
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "विकल्प '%s' पछि विभाजक अपेक्षा गरिन्छ ।"
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' सहि सङ्ख्यात्मक मान विकल्प '%s' को लागि हदैन"
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "विकल्प '%s': '%s' मितिमा बदल्न सकिँदैन ।"
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "नसोचेका parameter '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (अथवा %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "विकल्प '%s' को मान तोक्न पर्छ ।"
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "आवश्यक parameter '%s' तोकिएको थिएन ।"
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "प्रयोग: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "दोबर"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "मिति"
 
@@ -860,7 +857,7 @@ msgid "Can't &Undo "
 msgstr "&उल्टाउन सकिँदैन । "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&उल्टाउ"
@@ -870,7 +867,7 @@ msgid "&Redo "
 msgstr "&फेरि गर "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&फेरि गर"
@@ -897,12 +894,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' मा अतिरिक्त '..' रहेछ, बेवास्ता गर्नु होस् ।"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -912,103 +909,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "अधोरेखाङ्कित"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "आज"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "हिजो"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "भोलि"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "प्रथम"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "दोस्रो"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "तेस्रो"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "चौथो"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "पाछौं"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "छैठौँ"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "सातौं"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "आठौं"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "नवौं"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "दसौं"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "एघारौं"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "बाह्रौं"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "तेह्रौं"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "चौधौं "
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "पन्ध्रौं"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "सोह्रौं"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "सत्रौं"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "अठारौं"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "उन्नाइसौं"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "बीसौं"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "मध्यान्न"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "मध्य रात"
 
@@ -1074,44 +1071,81 @@ msgstr "curl कार्यान्वयन गर्न सकिएन, क
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "खानतलासी प्रतिवेदन (गल्ती कोड %d) अपलोड गर्न सकिएन ।"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "यसरी बचत गर "
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "के परिवर्तन लाई त्यागेर अन्तिम बचत संस्करणलाई वहन गर्ने हो?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "नाम नपाएको"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "के तपाइ %s मा परिवर्तन लाई बचत गर्न चाहनु हुन्छ?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&बचत गर"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "बचत नगर"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "के तपाइ %s मा परिवर्तन लाई बचत गर्न चाहनु हुन्छ?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "पाठलाई बचत गर्न सकेन"
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "फाइल \"%s\" लेख्नका लागि खोल्न सकिएन ।"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "फाइल \"%s\" मा कागजातहरू बचत गर्न सकिएन ।"
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "फाइल \"%s\" पढ्नको लागि खोल्न सकिएन ।"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "फाइल \"%s\". बाट कागजात पढ्न सकिएन ।"
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1120,57 +1154,57 @@ msgstr ""
 "फाइल '%s' नभेटिएकोले खोल्न सकिएन ।\n"
 "यसलाई हालै प्रयोग गरेका फाइलहरूको सूचीबाट हटाइयो ।"
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "छापिने चेहराको सिर्जना असफल भयो ।"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "छापिने चेहरा"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "फाइल '%s' को बनोट पता लगाउन सकिएन ।"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "नाम नभएको %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "फाइल पल्टाउ "
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "फाइलको गल्ती"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "माफ गर्नु होस्, यो फाइल खोल्न सकिएन ।"
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "माफ गर्नु होस्, यो फाइलको बनोट थाहा भएन ।"
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "एउटा कागजात  लेखोट चयन गर ।"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "लेखोट"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "एउटा कागजातको दृश्य चयन गर"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "दृश्यहरू"
 
@@ -1204,41 +1238,41 @@ msgstr "फाइल '%s' मा पढ्न गल्ती भयो ।"
 msgid "Write error on file '%s'"
 msgstr "फाइल '%s' को लेखाइमा गल्ती"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "फाइल '%s' लाइ चिल्लो पार्न असफल भयो ।"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "फाइल '%s' (stdio ले ठूलो फाइललाई समर्थन गर्दै न ) मा खोजिको गल्ती । "
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "फाइल '%s' मा खोजीको गल्ती ।"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "फाइल '%s' मा चालू स्थान पता लगाउन सकिँदैन ।"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "अस्ताई फाइल अनुमित राख्न सकिएन ।"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "फाइल '%s' लाइ हटाउन सकिँदैन ।"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "फाइल '%s' लाई वाचा गर्न सकिँदैन ।"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "अस्ताइ फाइल '%s' लाई हटाउन सकिँदैन ।"
@@ -1263,27 +1297,27 @@ msgstr "फाइल ब्याख्याकार %d बाट पढ्न
 msgid "can't write to file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d लाई लेख्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d लाई माझ्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d मा खोज्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d मा खोजी को स्थान पाउन सकिँदैन ।"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "फाइल ब्याख्याकार %d मा फाइल को लम्बाइ फेला पार्न सकिँदैन ।"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "यदि फाइलको अन्त ब्याख्याकार %d मा पुगेको छ भने यसलाई पता लगाउन सकिँदैन ।"
@@ -1308,147 +1342,147 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "config विकल्प पढ्न गल्ती भयो ।"
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "अभियोजन विकल्प पढ्न सकिएन ।"
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "फाइल '%s': वर्ण %c (%d लाइनमा ) अनपेक्षित छ ।"
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "फाइल '%s', लाइन %d: '%s' लाइ समूह header पछि बेवास्ता गरियो ।"
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "फाइल '%s', लाइन %d: '=' को अपेक्षा गरियो ।"
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "फाइल '%s', लाइन %d: अपरिवर्तित कुञ्जी '%s' को मान बेवास्ता गरियो ।"
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "फाइल '%s', लाइन %d: कुञ्जी '%s' पहिलो पटक लाइन %d मा पाइएको थियो ।"
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Config प्रविष्टि नाम '%c' सित सुरु हुँदैन"
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "उपभोक्ताको अभियोजन फाइललाई खोल्न सकिएन ।"
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "उपभोक्ताको अभियोजन फाइल लेख्न सकिँदैन "
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "उपभोक्ताको अभियोजन तथ्याङ्क बचतमा गल्ती भयो ।"
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "उपभोक्ताको अभियोजन फाइल '%s' मेटाउन सकिँदैन ।"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "प्रविष्टि '%s' समूह '%s' मा एक पल्ट भन्दा बढि देखिन्छ "
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "परिवर्तित नहुने कुञ्जी '%s' को परिवर्तन प्रयासलाई बेवास्ता गरियो ।"
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' मा पछाडिको backslash बेवास्ता गरियो ।"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" अनपेक्षित छ, (स्थान %d '; %s' को ) ।"
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "फाइल '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "फाइल '%s' को स्वीकृति पाउन सम्भव छैन ।"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "फाइल '%s' मेटाएर अर्को फाइल बनाउन सम्भव छैन ।"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "फाइल '%s' को नक्कल '%s' मा उतार्न सकिएन ।"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "फाइल '%s' को स्वीकृति तय गर्न सम्भव छैन ।"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr "यही नामको अर्को फाइल भएकोले '%s' फाइलको नाम '%s' मा फेर्न सकिएन ।"
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "फाइल '%s' को नामा करण '%s' राख्न सकिएन ।"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "फाइल '%s' लाई हटाउन सकिएन ।"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' घर्रा सिर्जना गर्न सकिएन ।"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' घर्रा मेटाउन सकिएन ।"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "गल्ती '%s' गणना गर्न सकिँदैन ।"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "कार्य गर्दै गरेको घर्रा पाउन सकिएन ।"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "चालू अवस्थामा रहेको घर्रा तय गर्न सकिएन"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "फाइलहरू (%s)"
@@ -1475,17 +1509,17 @@ msgstr "अस्ताई फाइलको नाम सिर्जना �
 msgid "Failed to open temporary file."
 msgstr "अस्ताई फाइल खोल्न सकिएन ।"
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "'%s' फाइलको समय फेर बदल गर्न सकिएन ।"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "फाइल '%s' लाइ छु सकिएन ।"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "फाइल '%s' को समय लिन सकिएन ।"
@@ -1494,22 +1528,22 @@ msgstr "फाइल '%s' को समय लिन सकिएन ।"
 msgid "Browse"
 msgstr "खोतल्ने"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "सबै फाइलहरू (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s फाइल (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "%s फाइल वहन गर "
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "%s फाइललाई बचत गर "
@@ -1872,106 +1906,106 @@ msgstr "निर्धारित"
 msgid "unknown-%d"
 msgstr "अज्ञात -%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "अधोरेखाङ्कित"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 #, fuzzy
 msgid " strikethrough"
 msgstr "strikethrough"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "हलुको"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr "हलुको"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "मोटो"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr "मोटो"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "मोटो"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr "डल्केको"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "strikethrough"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "हलुको"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "हलुको"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "सामान्य"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "मोटो"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "मोटो"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "मोटो"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "डल्केको"
 
@@ -2050,7 +2084,7 @@ msgstr "FTP सर्बरको जडानलाई पर्ख दा स�
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP सरुवा मुद्रालाई %s मा तय गर्न सकिएन ।"
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2071,7 +2105,7 @@ msgstr "FTP सर्बरले निष्क्रिय मुद्रा
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "अशुद्ध GIF फ्रेम आकार (%u, %d) (फ्रेम #%u का लागि ) "
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL को लागि रङ्ग उपलब्ध गराउन सकिएन ।"
 
@@ -2087,7 +2121,7 @@ msgstr "आफ्नो अनुकूलको महल बनाउ "
 msgid "&Customize..."
 msgstr "&आफू अनुकूल बनाउ.."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "निर्धारित Browser मा \"%s\" खोल्न सकिएन ।"
@@ -2107,155 +2141,154 @@ msgstr "stream बाट %d तस्विर वहन गर्न सकि�
 msgid "Failed to load icons from resource '%s'."
 msgstr "श्रोतबाट %s प्रतिमा वहन गर्न सकिएन "
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: चित्र गल्ती भएकोले बचत भएन ।"
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage को आफ्नै wxPalette छैन ।"
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: फाइल (Bitmap) को शीर्षक लेख्न सकिएन ।"
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: फाइल (Bitmap जानकारी) शीर्षक लेख्न सकिएन ।"
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB रङ्गिन नक्सा लेख्न सकेन"
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: तथ्याङ्क लेख्न सकिएन ।"
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: भण्डार उपलब्ध गराउन सकेन ।"
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB शीर्षक: फाइलको लागि तस्विर छोडाइ >32767 pixels"
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB शीर्षक: फाइलको लागि तस्विरको उचाइ > 32767 pixels "
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB शीर्षक: फाइलमा अज्ञात bitdepth "
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB शीर्षक: फाइलमा अज्ञात अनुसंहिता"
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB शीर्षक: अनुसंहिता bitdepth सित मिल्दैन "
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: भण्डार उपलब्ध गराउन सकेन ।"
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB शीर्षक: फाइलको लागि तस्विर छोडाइ >32767 pixels"
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB शीर्षक: फाइलको लागि तस्विरको उचाइ > 32767 pixels "
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB शीर्षक: फाइलमा अज्ञात bitdepth "
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB शीर्षक: फाइलमा अज्ञात अनुसंहिता"
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB शीर्षक: अनुसंहिता bitdepth सित मिल्दैन "
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "तस्विरको डिपो ट पढ्न गल्ती भयो ।"
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: मखुन्डो खण्ड पढाइमा गल्ती "
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: प्रतिमाको लागि तस्विर धेरै अग्लो भयो"
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: प्रतिमाको लागि तस्विर धेरै चौडा भयो"
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: तस्विर फाइल लेखाइमा गल्ती !"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: प्रतिमा अनुक्रमणिका मिलेन"
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "तस्विर र मखुन्डो फरक फरक आकारका छन् ।"
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "तस्विरमा प्रयोग नगरिएको रङ्ग मकुन्डोमा चलाएन ।"
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "श्रोतबाट %s BitMap वहन गर्न सकिएन "
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "श्रोतबाट %s प्रतिमा वहन गर्न सकिएन "
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "फाइल \"%s\" बाट तस्विर वहन गर्न सकिएन "
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "अज्ञात Extension भएको फाइल '%s' मा चित्र बचत गर्न सकिँदैन ।"
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "तस्विर किसिमको लागि कुनै चालक पाइ एन ।"
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "तोकिएको %d किसिमका लागि तस्विर चालक छैन ।"
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "तस्विर फाइल %d किसिमको छैन ।"
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "खोज्न नसकिने Input चित्रको बनोट आफै पता लगाउन सकिँदैन ।"
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "अज्ञात तस्विर तथ्याङ्क बनोट"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "यो %s होइन ।"
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "तोकिएको %s किसिमका लागि तस्विर चालक छैन ।"
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "तस्विर %s किसिमको छैन ।"
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "तस्विर फाइल \"%s\" को स्वरूप जाँच्न सकिएन ।"
@@ -2356,52 +2389,52 @@ msgstr "PNM: फाइल काटकुट भए जस्तो छ ।"
 msgid " (in module \"%s\")"
 msgstr "(Module \"%s\"मा)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: तस्विर वहनमा गल्ती"
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "नमिल्दो TIFF तस्विर अनुक्रमणिका"
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: तस्विरको आकार असाधारण ठूलो छ ।"
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: भण्डार उपलब्ध गराउन सकिएन ।"
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: तस्विर पढ्नमा गल्ती "
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "अज्ञात TIFF resolution एकाइ %d लाई बेवास्ता गरियो "
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: तस्विर बचतमा गल्ती "
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: तस्विर लेखाइमा गल्ती "
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "आदेश लाइन argument %d लाई युनिकोडमा फेर्न नसकि एकोले बेवास्ता गरियो ।"
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "post init मा सुरुवात असफल भयो, त्यसैले तुहिधै छ"
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "भाषा \"%s\" लाइ स्थानीयतामा सेट गर्न सकिँदैन ।"
@@ -2499,7 +2532,7 @@ msgstr "दबाब गल्ती"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Mime किसिम %s को entry मा '{' मल्दैन ।"
@@ -2519,7 +2552,7 @@ msgstr "आश्रय \"%s\" मोड्युल \"%s\" मा छदै छ
 msgid "Module \"%s\" initialization failed"
 msgstr "Module \"%s\" को सुरुवात असफल भयो ।failed"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "सन्देश"
 
@@ -3021,7 +3054,7 @@ msgstr "छपाइमा गल्ती"
 msgid "Print"
 msgstr "छाप्ने काम गर"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "पृष्ट मिलाउ"
 
@@ -3056,19 +3089,15 @@ msgstr "पृष्ट %d बट्टा %d छापिँदै छ ।"
 msgid " (copy %d of %d)"
 msgstr "%d बट्टा %d को नक्कल"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "छाप्ने काम हुँदैछ ।"
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "प्रथम पृष्ट"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "पछिल्लो पृष्ट"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "अघिल्लो पृष्ट"
 
@@ -3112,16 +3141,16 @@ msgstr "पृष्ट %d बट्टा %d"
 msgid "Page %d"
 msgstr "पृष्ट %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "अज्ञात गल्ती"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "नमिल्दो नियमित अभिव्यक्ति %s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "नियमित अभिव्यक्ति%s सित मिल्ने शब्द पाइ एन ।"
@@ -3131,21 +3160,21 @@ msgstr "नियमित अभिव्यक्ति%s सित मिल�
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Renderer \"%s\" सित मिलान गर्न नसकिने संस्करण %d.%d भएकोले वहन गर्न सकिएन ।"
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
@@ -3154,11 +3183,11 @@ msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भ
 msgid "Failed to monitor I/O channels"
 msgstr "लगानी/प्रतिफल मार्ग अनुगमन गर्न सकिएन ।"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "बचत गर"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "बचत नगर"
 
@@ -3242,10 +3271,10 @@ msgid "Clear"
 msgstr "मेटाउ"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "बन्द गर"
 
@@ -3257,7 +3286,7 @@ msgstr "&रूपान्तरण गर"
 msgid "Convert"
 msgstr "बदलि देउ"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&नक्कल उतार"
@@ -3266,7 +3295,7 @@ msgstr "&नक्कल उतार"
 msgid "Copy"
 msgstr "नक्कल उतार"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&काट्नु होस्"
@@ -3275,13 +3304,13 @@ msgstr "&काट्नु होस्"
 msgid "Cut"
 msgstr "काट"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&मेटाइ देउ"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "मेटाइ देउ"
@@ -3370,7 +3399,7 @@ msgstr "Harddisk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&सहयोग"
 
@@ -3390,7 +3419,7 @@ msgstr "Indent"
 msgid "&Index"
 msgstr "&अनुक्रमणिका"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "अनुक्रमणिका"
 
@@ -3459,7 +3488,7 @@ msgstr "&नया"
 msgid "New"
 msgstr "नया"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&होइन"
 
@@ -3476,12 +3505,12 @@ msgstr "&खोली देउ"
 msgid "Open..."
 msgstr "पल्टाउ.."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&टाँसि देउ"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "टाँसि देउ"
@@ -3511,7 +3540,7 @@ msgid "Print..."
 msgstr "छापी देउ.."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&गुणहरू"
 
@@ -3545,10 +3574,6 @@ msgstr "प्रतिस्थापन गर"
 msgid "Revert to Saved"
 msgstr "बचत उल्टियो "
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&बचत गर"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&यसरी बचत गर"
@@ -3558,7 +3583,7 @@ msgstr "&यसरी बचत गर"
 msgid "Save As..."
 msgstr "&यसरी बचत गर"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&सबैलाई चयन गर"
@@ -3665,7 +3690,7 @@ msgstr "&माथि"
 msgid "Up"
 msgstr "माथि"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&हो"
 
@@ -3756,43 +3781,43 @@ msgstr "चालू कागजातलाई बचत गर "
 msgid "Save current document with a different filename"
 msgstr "चालू कागजातलाई अर्कै फाइल नाम दिएर बचत गर "
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "वर्ण समूह '%s' मा परिवर्तन हुन सक्दैन"
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "अज्ञात"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "tar मा अपूरो header हिस्सा"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "tar header हिस्सा असफलता जाँच सुची "
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "विस्तारित tar header मा अवैध तथ्याङ्क छ ।"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar प्रविष्टि नपल्टाउ"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "फाइलको अनपेक्षित अन्त"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s tar header '%s' प्रविष्टिको लागि मिलेन ।"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tar प्रविष्टिका लागि दिइएको आकार असुद्धी छ ।"
 
@@ -3801,7 +3826,7 @@ msgstr "tar प्रविष्टिका लागि दिइएको �
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' सम्भवता binary buffer हो ।"
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "फाइल वहन गर्न सकिएन ।"
 
@@ -3815,47 +3840,47 @@ msgstr "फाइल \"%s\". बाट कागजात पढ्न सकि
 msgid "can't write buffer '%s' to disk."
 msgstr "buffer '%s' लाई disk मा लेख्न सकिँदैन ।"
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "कम्प्युटर प्रणालीमा स्थानीय समय भेटिएन ।"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay असफल भयो ।"
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' सहि सन्देश सूची होइन"
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "नमिल्दो सन्देश सूची"
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "बहुवचन स्वरूप '%s' पठाउन सकिएन ।"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' सूचि प्रयोग हुदैछ (%s' वाट ) ।"
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "श्रोत '%s' वैध सन्देश सूचि होइन ।"
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "अनुवाद को लेखाजोखा गर्न सकिएन"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "HTML फाइलहरूका लागि निर्धारित अनुप्रयोग अनियोजित छैन ।"
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "निर्धारित Browser मा \"%s\" खोल्न सकिएन ।"
@@ -3888,7 +3913,7 @@ msgstr "'%s' मा अवैध वर्णहरू छन् ।"
 msgid "Error: %s (%d)"
 msgstr "गल्ती: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3897,20 +3922,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "महलको बयान सुरु भएन"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "यो platform ले पृष्ठभूमि पारदर्शितालाई समर्थन गर्दैन ।"
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "विन्डोमा तथ्याङ्क सार्न सकिएन"
 
@@ -3962,8 +3987,8 @@ msgstr "%s मापकहरूको सिर्जना घोषित RTT
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "घटना श्रोतको रूपमा अवैध वस्तु वर्ग (Non-wxEvtHandler) "
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Type must have enum - long conversion"
 
@@ -4013,79 +4038,79 @@ msgstr "वस्तुको id attribute हुनै पर्दछ "
 msgid "Doubly used id : %d"
 msgstr "दोहोरिएर प्रयोग भएको id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "अज्ञात गुण %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "खालि नभएको सङ्ग्रहमा 'Element' टिप्पणी हुनै पर्दछ ।"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "अशुद्ध घटना सञ्चालक , थोप्लो छुटेको छ ।"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib deflate stream लाई पुनः सुरुवात गर्न सकिँदैन ।"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib inflate stream लाई पुनः सुरुवात गर्न सकिँदैन ।"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "यो बहू-टुक्रा जोडजाड गरेर बनाइएको zip मानियो । "
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "अवैध zip फाइल"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "zip मा केन्द्रीय घर्रा फेला पार्न सकिँदैन ।"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "केन्द्रीय घर्रा पढ्दा गल्ती "
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "स्थानीय header पढ्दा गल्ती "
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "प्रविष्टिका लागि गलत zip फाइलको हातो"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "फाइलको लम्बाइ Zip header भन्दा अन्तै भण्डार गर"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "असमर्थित Zip दबाब विधि "
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zip stream (प्रविष्टि %s) पढिँदै: गलत लम्बाइ"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zip stream (प्रविष्टि %s) पढिँदै: गलत crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "zip प्रविष्टि '%s' लेखाइमा गल्ती: गलत crc अथवा लम्बाइ"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "zip प्रविष्टि '%s' लेखाइमा गल्ती: गलत crc अथवा लम्बाइ"
@@ -4169,32 +4194,32 @@ msgstr "चित्रकाव्यकन कलाकार"
 msgid "Translations by "
 msgstr "अनुवादन कर्ता "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "संस्करण"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "%s को बारेमा"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "इजाजत"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "विकास कर्मी"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "कागजातहरूका लेखकहरू"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "कलाकारहरू"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "अनुवादकहरू"
 
@@ -4247,44 +4272,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "असत्य"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (अथवा %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "महल थप"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4295,8 +4319,7 @@ msgid "Left"
 msgstr "देब्रे"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4391,7 +4414,7 @@ msgid "Home directory"
 msgstr "गृह घर्रा"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "डेस्कटप"
 
@@ -4404,8 +4427,7 @@ msgstr "अवैध घर्राको नाम"
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "गल्ती"
 
@@ -4589,17 +4611,17 @@ msgstr "विस्तृत दृश्यको रूपमा फाइल
 msgid "Go to parent directory"
 msgstr "उपल्लो गर्रामा जाउ"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 "फाइल '%s' पहिले देखि नै छ, के तपाइ वास्तवमा नै यसलाई मेटाएर नया राख्न चाहनु हुन्छ?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "यकिन गर्नु होस्"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "भण्डारमा भएको फाइल छान्नु होस् ।"
 
@@ -4693,7 +4715,7 @@ msgstr "वरणाकृतिको आकार (थोप्लोमा)"
 msgid "Whether the font is underlined."
 msgstr "वरणाकृति अधोरेखाङ्कित छ वा चैन ।"
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "चेहरा:"
@@ -4711,48 +4733,47 @@ msgstr "वरणाकृतिको चयन रद्द गर्न क�
 msgid "Click to confirm the font selection."
 msgstr "वरणाकृतिको चयन यकिन गर्न किटिक्क पार्नु होस्"
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "वरणाकृति छान्नु होस्"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "सहयोग घर्रा \"%s\" पाइ एन ।"
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "सहयोग फाइल \"%s\" पाइ एन ।"
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "लाइन %lu मा (नक्सा फाइल \"%s\" ) नमिल्दो लेखाइ छ, फड्को मारेर जाउ"
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "फाइल \"%s\" मा वैध रङ्गिन नक्सा पाइ एन ।"
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "कुनै प्रविष्टि पाइ एन"
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "सहयोग अनुक्रमणिका"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "सन्दर्भित प्रविष्टि:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "प्रविष्टि पाइयो"
 
@@ -4856,59 +4877,59 @@ msgstr "प्रिन्टिङ सुरु गर्न सकिएन"
 msgid "Printing page %d..."
 msgstr "पृष्ट %d.. छापिँदै छ ।"
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "प्रिन्टर विकल्पहरू"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "फाइलमा लेख ।"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "स्थापक"
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "प्रिन्टर:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "स्थिति:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "सबै"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "पानाहरू "
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "कति छाप्ने हो"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "बाट:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "लाई:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "प्रतिहरू:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript फाइल"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "छाप्ने रूप"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "प्रिन्टर"
 
@@ -4916,25 +4937,25 @@ msgstr "प्रिन्टर"
 msgid "Default printer"
 msgstr "निर्धारित प्रिन्टर"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "कागजको आकार"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "ठाडो"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "तेर्सो"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "झुकाव"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "विकल्पहरू"
 
@@ -4946,52 +4967,52 @@ msgstr "रङ्गिन छाप्ने काम"
 msgid "Print spooling"
 msgstr "छापिने काम बिग्रयो ।"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "प्रिन्टर आदेश:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "प्रिन्टर विकल्पहरू:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "देब्रे सिमान्त(मिमी):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "सिरान किनार (मिमि):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "दाहिने सिमान्त (मिमि):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "तलको सिमान्त (मिमि):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "प्रिन्टर.."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&उफ्र"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "अज्ञात"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "सकियो"
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "खोजतलास"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "ID का लागि tab फेला परेन"
 
@@ -5027,22 +5048,22 @@ msgstr "&समाप्त"
 msgid "< &Back"
 msgstr "< &पछाडि"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "अणुवादकन-श्रेय"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+ लाई सुरुवात गर्न सकिएन, के दृश्यक त राम्ररी मिलाएको छ ?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "घर्रा \"%s\" सिर्जना गर्न सकिएन ।"
@@ -5068,12 +5089,12 @@ msgstr "फाइल \"%s\". बाट कागजात पढ्न सकि
 msgid "Failed to register font configuration using private fonts."
 msgstr "उपभोक्ता अभियोजन फाइल अद्यावधि करण गर्न सकिएन ।"
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "फाइलको गल्ती"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5081,7 +5102,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5089,7 +5110,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI शिशु"
 
@@ -5105,15 +5126,11 @@ msgstr "प्रिन्टिङ गर्दा गल्ती भयो : 
 msgid "Page Setup"
 msgstr "पृष्ट मिलाउ"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "नियन्त्रणमा पाठ लेख्न सकिएन ।"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5121,7 +5138,7 @@ msgstr ""
 "यो कम्प्युटरमा स्थापित GTK+ धेरै पुरानो रहेछ पर्दाको पूर्तिको लागि GTK+ 2.12 अथवा यो "
 "भन्दा नयाँ संस्करण स्थापित गर्नु होला ।"
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5129,17 +5146,13 @@ msgstr ""
 "यो प्रणालीले क्षतिपूर्ति लाइ समर्थन गर्दैन । कृपया तपाइको विन्डो व्यवस्थापकमा यसलाई सक्षम "
 "बनाउनु होस् "
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "यो कार्यक्रम निकै पुरानो GTK+ संस्करणमा प्रशोधन गरियो । कृपया GTK+ 2.12 अथवा यो भन्दा "
 "नया संस्करण राख्नु होला ।"
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "कृपया वैध वरणाकृति छान्नु होस् ।"
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5238,45 +5251,45 @@ msgstr "विषय सुची फाइल: %s लाइ खोल्न स
 msgid "Cannot open index file: %s"
 msgstr "अनुक्रमणिका फाइल: %s खोल्न सकिँदैन ।"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "बैनामै "
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML सहयोग किताब: %s लाइ खोल्न सकिँदैन ।"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "किताब पल्टाउँदा देब्रे पट्टि सहयोग देखाउँछ "
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(बुकमार्क)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "चालू पृष्टलाई बुकमार्कमा थप गर"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "पृष्ट लाई बुकमार्कबाट हटाउ"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "सामाग्रीहरू"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "फेला पार"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr " सबै देखाउ "
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5284,165 +5297,165 @@ msgstr ""
 "प्रदान गरिएको शब्द भएका सबै अनुसूची लाई देखाउ । खोज तलासले ठूलो वा सानो वर्णको वास्ता "
 "गर्दैन । "
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "सबै सामाग्रीलाई अनुक्रमणिकामा देखाउ "
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Case सम्बेदनसिल "
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "पुरै शब्दहरू मात्र"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "सहयोग किताब (s) का सबै सामाग्रीमा यस अघि टङ्कण गरेको पाठहरू लाई खोज ।"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "आवागमन कक्ष देखाउ/लुकाउ "
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "फर्केर जाउ"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "अगाडी जाउ"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "कागजातको मर्यादामा एक तह माथि जाउ"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "HTML कागजात पल्टाउ "
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "यो पृष्ट छापी देउ"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "विकल्प पातो देखाउ"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "कृपया देखाइने पृष्ट छान्नु होस् ।"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "सहयोग शीर्षक"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "खोजतलास हुँदैछ "
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "मिल्दो पृष्ट अझसम्म पाइ एन ।"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i मिल्दो झुल्दो पाइयो ।"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(सहयोग)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d को %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu को %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "सबै किताबहरूमा खोज ।"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "सहयोगी Browser विकल्पहरू"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "साधारण वरणाकृति:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "निश्चित वरणाकृति:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "वरणाकृतिको आकार:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "वरणाकृतिको आकार"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "साधारण अनुहार<br>and <u> अधोरेखाङ्कित </u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>डल्केको .</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>मोटो .</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>मोटो डल्केको </i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "निश्चित आकार face.<br> <b>मोटो</b> <i>डल्केको</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i> मोटो डल्केको <u> अधोरेखाङ्कित </u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "सहयोग छापिँदै "
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "खाली पृष्ट छाप्न सकिँदैन ।"
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML फाइलहरू (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "सहयोग किताबहरू (*.htb)|*.htb|सहयोग किताबहरू (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML सहयोग योजना (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "खाँदिएको HTML सहयोग फाइल (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i - %u को"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u को %u"
@@ -5517,32 +5530,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "पृष्ट मिलाउँदा समस्या आयो: तपाइले निर्धारित प्रिन्टर नै रोज्नु राम्रो होला ।"
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "%s अनुसंहितामा html कागजात सिर्जना गर्न सकिएन ।"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets ले दृश्यक '%s' लाइ खोल्न सकेन: बहिर्गमन गरिदैं छ ।"
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "फिल्टर"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "घर्रा"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "फाइलहरू"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "चयन"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "क्लिप पाटी खोल्न सकिएन ।"
@@ -5584,58 +5571,58 @@ msgstr "रङ्ग चयन पातो %0lx गल्तीले गर्
 msgid "Failed to create cursor."
 msgstr "कर्सर सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "DDE सर्भर '%s' दर्ता गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "DDE सर्भर '%s' को दर्ता खारेज गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "सर्बर '%s' मा शीर्षक '%s' सित सम्बन्ध गाँस्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE poke अनुरोध असफल भयो"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE सर्भर सित advise loop सम्बन्ध राख्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "advise loop with DDE server बन्द गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "DDE सूचना सल्लाह पठाउन सकिएन ।"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "DDE string को सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "DDE गल्ती छैन"
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "व्यवस्थित सल्लाह कारोबारका लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "कारोबारको प्रतिक्रियाले DDE_FBUSY bit लाइ तय गर्नु पर्ने बनायो ।"
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "व्यवस्थित तथ्याङ्क कारोबारका लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5647,7 +5634,7 @@ msgstr ""
 "अथवा \n"
 "अवैध परिचायक लाई DDEML function मा पटाइयो ।"
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5658,45 +5645,45 @@ msgstr ""
 "अथवा \n"
 " अनुप्रयोगले APPCMD_CLIENTONLY को रूपमा सर्बर कारोबार को प्रयास आरम्भ गरायो।"
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "व्यवस्थित कार्यकारी कारोबारका लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "एउटा parameter DDEML वाट वैधता पाउन असफल भयो ।"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML अनुप्रयोगले लम्बिएको दौडको सिर्जना गरेको छ ।"
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "भण्डार उपलब्ध गराउने प्रयास असफल भयो ।"
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "वार्तालापको लागि ग्राहकको जडान प्रयास असफल भयो ।"
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "कारोबार असफल भयो ।"
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "व्यवस्थित poke कारोबारका लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 "PostMessage function को आन्तरिक बोलावट असफल भयो । an internal call to the has "
 "failed. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "पुनः प्रविष्टिको समस्या"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5706,15 +5693,15 @@ msgstr ""
 " अथवा \n"
 "सर्बरले नै कारोबार समाप्त हुनु अगावै काटि दियो ।"
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "आन्तरिक रूपमा DDEML मा गल्ती भयो ।"
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "व्यवस्थित सल्लाह कारोबार समाप्तिको लागि अनुरोध समय सकियो ।"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5725,12 +5712,12 @@ msgstr ""
 " फिर्ता पठाइ सके पछि, \n"
 " कारोबार परिचायक लाई फिर्ता बोलाउने कार्य मान्य हुने छैन । "
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "अज्ञात DDE गल्ती %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5738,7 +5725,7 @@ msgstr ""
 "यो कम्प्युटरमा दूर पहुँच सेवा (RAS) स्थापना नघरैकोले डायल सेवा उपलब्ध हुन सकेन । कृपया "
 "यसलाई स्थापना गर्नु होला ।"
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5747,64 +5734,64 @@ msgstr ""
 "यो कम्प्युटरमा स्थापित दूर पहुँच सेवा (RAS) निकै पुरानो संस्करण रहेछ, कृपया स्तर वृद्धि गर्नु "
 "होला (आवश्यक पर्ने Function %s यसमा छैन: )"
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS गल्ती सन् देसको पाठहरू लिन सकिएन ।"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "अज्ञात गल्ती (गल्ती कोड %08x)"
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "सक्रिय डायलअप जडान फेला पार्न सकिँदैन ।: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "धेरै वटा सक्रिय डायल अप जडान भएको पाइयो । कुनै एउटालाई चयन गरिदैं छ ।"
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "डायलअप जडान %s स्थापित गर्न सकिएन ।"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISP नामहरू %s पाउन सकिएन ।"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "जोड्न सकिएन: डायल गर्न ISP छैन"
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "डायल गर्न ISP छान्नु होस्"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "कृपया जुन ISP मा जोड्ने हो उही छान्नु होस् "
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "जोड्न सकिएन: ग्राहकको नाम/पाल्सीशब्द छैन ।"
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "ठेगाना किताब फाइलको स्थान फेला पार्न सकिँदैन ।"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "%s डायलअप जडान गराउन सकिएन ।"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "सक्रिय डायल जडान पाउन सकिँदैन ।"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "डायलअप जडान %s बन्द गर्न सकिएन ।"
@@ -5824,18 +5811,17 @@ msgstr "bitmap तथ्याङ्कको लागि %luKb को भण�
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' घर्रामा भएको गल्ती गणना गर्न सकिँदैन ।"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "थैलीको नाम पाउनसकिएन"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (गल्ती %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "तस्विर सुचीमा तस्विर थप्न सकिएन"
 
@@ -5849,7 +5835,7 @@ msgstr "फाइल \"%s\" बाट metafile तस्विर वहन ग�
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "स्तरीय फेला पार्ने/प्रतिस्थापित गर्ने पातो (गल्ती संहिता %d) सिर्जना गर्न सकिएन ।"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "फाइल पाटी गल्ती कोड %0lx ले असफल भयो ।"
@@ -5890,18 +5876,18 @@ msgstr "घडी '%s' लाई कायम गर्न सकिएन ।"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "परिवर्तनको लागी भनेर हुँदै नभएको घर्रा \"%s\" लाइ अनुगमन गर्न सकिँदैन ।"
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 #, fuzzy
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "भित्रि OpenGL पार्श्वचित्रलाई OpenGL driver ले समर्थन गर्दैन."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "टाइम र सिर्जना गर्न सकिएन"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL सुरु गर्न सकिएन ।"
 
@@ -5909,7 +5895,7 @@ msgstr "OpenGL सुरु गर्न सकिएन ।"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5917,7 +5903,7 @@ msgstr ""
 "यो कम्प्युटरमा MS HTML सहयोग पुस्तकालय स्थापित नभएकोले MS HTML सहयोग उपलब्ध भएन । "
 "कृपया यसलाई स्थापना गर्नु होला ।"
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML सहयोग सुरु गर्न सकिएन ।"
 
@@ -5926,7 +5912,7 @@ msgstr "MS HTML सहयोग सुरु गर्न सकिएन ।"
 msgid "Can't delete the INI file '%s'"
 msgstr "INI फाइल '%s' लाई मेटाउन सकिँदैन ।"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "सूचि नियन्त्रण सामाग्री %d को बारेमा सूचना पाउन सकिएन "
@@ -6046,7 +6032,7 @@ msgstr "क्लिप पाटीको स्वरूप '%s' दर्त�
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "क्लिप पाटी बनोट '%d' अस्तित्वमा छैन ।"
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "उफ्र"
 
@@ -6130,75 +6116,75 @@ msgstr ""
 "सामान्य रूपमा यस प्रणालीलेकाम गर्नका लागि Registry कुञ्जी '%s' चाहिन्छ ।\n"
 "यसलाई मेट्नु भयो भने यो प्रणाली निकम्मा हुने छ ।सञ्चालन त तुहियो!"
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "'%s' कुञ्जीलाई मेटाउन सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "मान '%s' लाई कुञ्जी '%s' बाट मेटाउन सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "कुञ्जी '%s' को मान पढ्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s' को मान सेट गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s' को मान पड्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "%s' कुञ्जीको मान लेखाजोखा गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "%s' कुञ्जीको उप कुञ्जी लेखाजोखा गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "registry कुञ्जी निर्यात हुँदैछ: फाइल\"%s\" छदै च त्यसैले फेरी लेखिने काम हुँदैन ।"
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "%d किसिमको असमर्थित मान निर्यात गर्न सकिँदैन ।"
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "मान \"%s\" लाई (कुञ्जी \"%s\" ko ) बेवास्ता गरिदै छ ।"
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6206,47 +6192,47 @@ msgstr ""
 "सामान्य पाठ नियन्त्रकको प्रयोग गरी rich edit control सिर्जना गर्न सम्भव छैन, कृपया "
 "riched32.dll लाई फेरी स्थापित गर्नु होला ।"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "thread सुरु गर्न सकिँदैन: TLS लेखाइमा गल्ती भयो ।"
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "thread प्राथमिकता सेट गर्न सकिँदैन ।"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "thread सिर्जना गर्न सकिँदैन ।"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "thread बन्द गर्न सकिएन"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "thread को समाप्ति पर्खन सकिँदैन ।"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "%lx धागो निलम्बन गर्न सकिएन ।"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "%lx धागो सुभारम्भ गर्न सकिएन।"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "चालू thread Adder पाउन सकिएन"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "Thread module सुरु हुन सकेन: स्थानीय thread भण्डारमा सुची राख्न सम्भव छैन ।"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6275,12 +6261,12 @@ msgstr "श्रोत \"%s\" वहन गर्न सकिएन "
 msgid "Failed to lock resource \"%s\"."
 msgstr "श्रोत \"%s\" लाई चाबी लगाउन सकिएन ।"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "निर्माण %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bit संस्करण"
 
@@ -6292,47 +6278,47 @@ msgstr "anonymous pipe को सिर्जना गर्न सकिएन
 msgid "Failed to redirect the child process IO"
 msgstr "बाल प्रक्रिया लगानी/प्रतिफल फेरि पठाउन सकिएन ।"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "आदेश '%s' को कार्यान्वयन असफल भयो ।"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll वहन गर्न सकिएन "
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' बाट typename पढ्न सकिँदैन ।"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' बाट प्रतिमा वहन गर्न सकिँदैन ।"
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "thread प्राथमिकता सेट गर्न सकिँदैन ।"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "'%s' कार्यान्वयन गर्न सकिएन ।\n"
@@ -6366,7 +6352,7 @@ msgid "Check to make the font italic."
 msgstr "वरणाकृति डल्केको बनाउने हो भने टिक लगाउ"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "अधोरेखाङ्कित"
@@ -6434,17 +6420,32 @@ msgstr "<कुनै Teletype>"
 msgid "File type:"
 msgstr "Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "सन्झ्याल"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "सहयोग"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "&सूक्ष्म बनाउ"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "ठूलो पार"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6461,493 +6462,493 @@ msgstr ": फाइल छैन ।"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "%s को बारेमा"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "बारेमा"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "प्राथमिकताहरू.."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "सेवा"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "%s लुकाउ "
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "अनुप्रयोग"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "अरूलाई पनि लुकाउ "
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "सबै देखाउ "
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "%s लाई त्यागि देउ "
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "अनुप्रयोग"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "यो zlib को संस्करणले Gzip समर्थन गर्दैन ।"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "महलको बयान सुरु भएन"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "थोप्लोको आकार"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "अनुहारको नाम"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "शैली"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "भार"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "परिवार"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "एपकार्यस्थल"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "सक्रिय सिमाना"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "सक्रिय शिर्षक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "टाँकचेहरा"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "उज्यालोटाक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "विम्वटाँक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "टाँकपाठ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "शिर्षकपाठ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "अध्यारोनियन्त्रण"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "उज्यालोनियन्त्रण"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "खैरोपाठ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "प्रकासीकरण"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "प्रकासयुक्त पाठ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "निस्क्रिय सिमाना"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "निस्क्रियशिर्षक"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "निस्क्रियशिर्षकपाठ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "मेनु"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "घिसार्नेपट्टी"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "औजारपट्टी"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "औजारपट्टीपाठ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "सन्झ्याल"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "विन्डोफ्रेम"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "विन्डोपाठ"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "प्रचलित"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "कालो"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "गम्भिर"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "समुन्द्री नीलो"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "बैजनी"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "गाढा नीलो"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "खैरो"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "हरियो"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "जैतुन"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "खैरो"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "नीलो"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "अबिरे"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "रातो"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "सुन्तला"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "चाँदी"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "कागती"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "पानी रङ्ग"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "पहेँलो"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "सेतो"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "निर्धारित"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "वाण"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "दायाँ वाण"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "रित्तो"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Bullseye"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "वर्ण"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "क्रस"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "हात"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "i-बलो"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "वाञाँ टाँक"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "अभिबर्धक"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "मध्य टाँक"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "प्रविष्टि हिन "
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "पोत्ने बुरुस"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "पेन्सिल"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "थोप्लो वायाँ"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "थोप्लो दाया"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "जिज्ञासा वाण"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "दायाँ टाँक"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "पूउ-पद तर्फ आकारकरण"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "उ-द तर्फ आकारकरण"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "उप-दपू तर्फ आकारकरण"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "पूप तर्फ आकारकरण"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "आकारकरण"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Spraycan"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "प्रतिक्षा"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "घडी"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "प्रतिक्षा वाण"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "चयन गर"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "गुण"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "मान"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "निर्दिष्ट मुद्रा"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "वर्णीय मुद्रा"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "असत्य"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "True"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "नतोकिएको"
 
@@ -6960,12 +6961,12 @@ msgstr "गुणको गल्ती"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "तपाइले गल्ती मान राख्नु भयो । सम्पादनलाई रद्द गर्न ESC दबाउनु होस् ।"
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "श्रोतमा गल्ती: : %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6974,36 +6975,36 @@ msgstr ""
 "टङ्कण सञ्चालन \"%s\" असफल भयो: सम् पति तह \"%s\" \"%s\" खालको छ, \"%s\" किसिमको "
 "होइन"
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "मान %s अथवा यो भन्दा बढि हुनै पर्दछ ।"
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "मान %s र %s को बीचमा हुनै पर्दछ ।"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "मान %s अथवा यो भन्दा घटि हुनै पर्दछ ।"
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "%s होइन"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "एउटा घर्रा छान्नु होस्:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "एउटा फाइल छान्नु होस्"
 
@@ -7482,117 +7483,117 @@ msgstr "चित्र भित्रको चित्र"
 msgid "Outset"
 msgstr "बाहिरी चित्र"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "शैलीको परिवर्तन"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "वस्तुको शैली परिवर्तन"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "गुणहरूको परिवर्तन "
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "सूचिको शैली परिवर्तन "
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "फेरि सङ्ख्या राख"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "पाठ घुसाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "तस्विर घुसाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "वस्तु घुसाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "क्षेत्र घुसाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "धेरै अन्त शैली बोलावट!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "फाइलहरू"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "स्तरीय/वृत"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "स्तरीय/वृत-बाह्यरेखा"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "वर्ग/वर्ग"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "हिरा/हिरा"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "स्तरीय/त्रिभुज"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "बाकसका गुणहरू"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "बहु कोशिका गुणहरू"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "कोशिका गुणहरू"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "कोशिका शैली तय गर्नु होस् ।"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "हरफ हटाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "महल हटाउ"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "हरफ थप"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "महल थप"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "तालिका गुणहरू"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "तस्विरका गुणहरू"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "तस्विर"
 
@@ -7800,24 +7801,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "घिसार्नू"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "पाठ मेटाइ देउ "
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "गोली चिन्ह हटाउ"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "पाठलाई बचत गर्न सकेन"
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "प्रतिस्थापन गर"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&वरणाकृति:"
 
@@ -8786,53 +8787,53 @@ msgstr "शैलीहरूको सुची"
 msgid "Box styles"
 msgstr "बाकसका शैलीहरू"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "त्यो वरणाकृति जसबाट चिन्ह लिइन्छ ।"
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&उप समूह"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "युनिकोड subset देखाउ छ ।"
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&वर्ण संहिता"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "वर्ण कोड "
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&बाट:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "युनिकोड"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "देखाउने तह"
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "घुसाउ"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(सामान्य पाठ)"
 
@@ -9017,7 +9018,7 @@ msgstr "kqueue बाट घटना पाउन सकिएन ।"
 msgid "Media playback error: %s"
 msgstr "श्रव्य सामाग्री पृष्ठध्वनी त्रुटी: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "\"%s\" लाई बजाउने तयारी असफल भयो ।"
@@ -9117,77 +9118,77 @@ msgstr "ध्वनि तथ्याङ्क असमर्थित बन
 msgid "Couldn't open audio: %s"
 msgstr "श्रव्य हटाउन सकिएन: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "thread कार्य सुची नीति प्राप्त गर्न सकिँदैन ।"
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "प्राथमिकता तह for कार्यसूची नीति %d पाउन सकिँदैन ।"
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Thread प्राथमिकता कायम लाइ बेवास्ता गरियो"
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr "Thread जोड्न सकिएन, भण्डार चुहावट प्रबल छ- कृपया कार्यक्रम फेरी सुरु गर्नु होला"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "thread स्वीकृति तहलाई %lu मा तय गर्न सकिएन ।"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "thread प्राथमिकता %d कायम गर्न सकिएन ।"
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "thread लाई बन्द गर्न सकिएन ।"
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Thread module को सुरुवात असफल भयो : thread कुञ्जी सिर्जना गर्न असफल भयो ।"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "शिशु प्रक्रिया लगानी प्राप्त गर्न सम्भव छैन ।"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "सीसु प्रक्रिया s stdin मा लेख्न सकिँदैन ।"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' कार्यान्वयन गर्न सकिएन ।\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Fork असफल भयो ।"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "प्रक्रिया प्राथमिकता क्रम तोक्न सकिएन ।"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "बाल प्रक्रिया लगानी/प्रतिफल फेरि पठाउन सकिएन ।"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "न टालिएको पाइप जडान गर्न सकिएन, कार्यक्रम निष्क्रिय हुन सक्छ ।"
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "सत्कार कर्ताको नाम पाउन सकिँदैन ।"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "अतिरिक्त सत्कार कर्ताको नाम पाउन सकिँदैन ।"
 
@@ -9203,12 +9204,12 @@ msgstr "wake Up pipe लाई न टालिएको मुद्राम�
 msgid "Failed to read from wake-up pipe"
 msgstr "Wake-Up pipe बाट पढ्न सकिएन ।"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "नमिल्दो ज्यामिति मानक '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets ले दृश्यक खोल्न सकेन: बहिर्गमन गरिदैं छ ।"
 
@@ -9222,30 +9223,59 @@ msgstr "दृश्य \"%s\" बन्द गर्न सकिएन ।"
 msgid "Failed to open display \"%s\"."
 msgstr "दृश्य \"%s\" खोल्न सकिएन ।"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML पठाउन मा गल्ती: '%s' (%d लाइनमा)"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s' बाट श्रोत वहन गर्न सकिँदैन ।"
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "श्रोत फाइल '%s' खोल्न सकिँदैन ।"
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "फाइल '%s' बाट श्रोत वहन गर्न सकिँदैन ।"
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भयो ।"
+
+#~ msgid "Printing "
+#~ msgstr "छाप्ने काम हुँदैछ ।"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "नियन्त्रणमा पाठ लेख्न सकिएन ।"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "कृपया वैध वरणाकृति छान्नु होस् ।"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "%s अनुसंहितामा html कागजात सिर्जना गर्न सकिएन ।"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets ले दृश्यक '%s' लाइ खोल्न सकेन: बहिर्गमन गरिदैं छ ।"
+
+#~ msgid "Filter"
+#~ msgstr "फिल्टर"
+
+#~ msgid "Directories"
+#~ msgstr "घर्रा"
+
+#~ msgid "Files"
+#~ msgstr "फाइलहरू"
+
+#~ msgid "Selection"
+#~ msgstr "चयन"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "8-bit अनुसंहिता मा रूपान्तरण असफल भयो ।"
@@ -9408,8 +9438,8 @@ msgstr "'%s' लाई '%s' मा खिच्ने काम असफल भ
 #~ msgstr "मिति खोज्नाले मान पाइ एन ; मान को किसिम: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-02-28 20:39+0100\n"
 "Last-Translator: gvmelle <translations@gvmelle.com>\n"
 "Language-Team: Dutch (http://www.transifex.com/projects/p/"
@@ -20,11 +20,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Alle bestanden (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Alle bestanden (*)|*"
 
@@ -41,24 +41,21 @@ msgid "Remaining time:"
 msgstr "Resterende tijd:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nee"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Annuleer"
@@ -108,7 +105,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Niet mogelijk een I/O voltooiingspoort aan te maken"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Afdruk"
 
@@ -145,7 +142,7 @@ msgstr "Object eigenschappen"
 msgid "Printing"
 msgstr "Bezig met afdrukken"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symbolen"
 
@@ -214,7 +211,7 @@ msgstr "&Vorig"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Venster"
 
@@ -743,11 +740,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "dit helpbericht weergeven"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "genereer uitgebreide log meldingen"
 
@@ -769,84 +766,84 @@ msgstr "Niet ondersteund thema '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Ongeldige beeldscherm mode specificatie. '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Optie '%s' kon niet worden genegeerd"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Onbekende lange optie '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Onbekende optie '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Onverwachte lettertekens na de optie '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Optie '%s' vereist een waarde."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Scheidingsteken verwacht na de optie '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' is geen geldige numerieke waarde voor optie '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Optie '%s': '%s' kan niet naar een datum worden geconverteerd."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Onverwachte parameter '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (of %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "De waarde voor de optie '%s' moet worden opgegeven."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "De benodigde parameter '%s' was niet gespecificeerd."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Gebruik: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dubbel"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "datum"
 
@@ -864,7 +861,7 @@ msgid "Can't &Undo "
 msgstr "Kan niet &ongedaan maken: "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Ongedaan maken"
@@ -874,7 +871,7 @@ msgid "&Redo "
 msgstr "Opnie&uw "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "Opnie&uw"
@@ -904,12 +901,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' heeft extra '..', genegeerd."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "aangevinkt"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "niet aangevinkt"
 
@@ -918,103 +915,103 @@ msgstr "niet aangevinkt"
 msgid "undetermined"
 msgstr "onbepaald"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "vandaag"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "gisteren"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "morgen"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "eerste"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "tweede"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "derde"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "vierde"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "vijfde"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "zesde"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "zevende"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "achtste"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "negende"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "tiende"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "elfde"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "twaalfde"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "dertiende"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "veertiende"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "vijftiende"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "zestiende"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "zeventiende"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "achttiende"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "negentiende"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "twintigste"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "middag"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "middernacht"
 
@@ -1082,44 +1079,81 @@ msgstr "Uitvoeren van curl mislukt, installeer het alstublieft in PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Uploaden van het foutopsporingsrapport is mislukt (foutcode %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Opslaan Als"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Wijzigingen negeren en laatst opgeslagen versie herladen?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "naamloos"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Wilt u de veranderingen aan %s opslaan?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "Op&slaan"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Niet Opslaan"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Wilt u de veranderingen aan %s opslaan?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "De tekst kon niet worden opgeslagen."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Openen van bestand \"%s\" voor schrijven mislukt."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Opslaan van document naar het bestand \"%s\" mislukt."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Openen van bestand \"%s\"  voor lezen mislukt."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Lezen van document van het bestand \"%s\" mislukt."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1128,57 +1162,57 @@ msgstr ""
 "Het bestand '%s' bestaat niet en kon niet geopend worden.\n"
 "Het is verwijderd van de lijst 'recente bestanden'."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Maken afdrukvoorbeeld mislukt."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Afdrukvoorbeeld"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Het formaat van bestand '%s' kan niet worden bepaald."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "naamloos%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Open Bestand"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Bestandsfout"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Sorry, kon dit bestand niet openen."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Helaas, het formaat van dit bestand is onbekend."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Selecteer een documentsjabloon"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Sjablonen"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Selecteer een documentweergave"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Weergaven"
 
@@ -1212,43 +1246,43 @@ msgstr "Leesfout bij bestand '%s'"
 msgid "Write error on file '%s'"
 msgstr "Schrijffout bij bestand '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "legen van bestand '%s' mislukt"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Zoek fout in bestand '%s' (grote bestanden die niet worden ondersteund door "
 "stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Zoekfout bij bestand '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kan huidige positie in bestand '%s' niet vinden"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Instellen van machtigingen van tijdelijk bestand mislukt"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "kan bestand '%s' niet verwijderen"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "kan verandering niet doorvoeren in bestand '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "kan tijdelijk bestand '%s' niet verwijderen"
@@ -1273,27 +1307,27 @@ msgstr "kan niet lezen van bestandsbeschrijving %d"
 msgid "can't write to file descriptor %d"
 msgstr "kan niet schrijven naar bestandsbeschrijving %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "kan bestandsbeschrijving %d niet legen"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "kan niet zoeken bij bestandsbeschrijving %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "kan zoekpositie niet verkrijgen bij bestandsbeschrijving %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "kan bestandslengte niet vinden bij bestandsbeschrijving %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1320,109 +1354,109 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Fout bij lezen van configuratie opties."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Lezen van config opties mislukt."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "bestand '%s': onverwacht teken %c bij regel %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "bestand '%s', regel %zu: '%s' genegeerd na groepskoptekst."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "bestand '%s', regel %zu: '=' verwacht."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "bestand '%s', regel %zu: waarde voor onveranderlijke toets '%s' genegeerd."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "bestand '%s', regel %zu: key '%s' werd voor het eerst gevonden op regel %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Naam van configuratie-ingang kan niet beginnen met '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "kan gebruikers-configuratiebestand niet openen."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "kan gebruikers-configuratiebestand niet schrijven."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Updaten van gebruikersconfiguratie bestand is mislukt."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Fout van bij het opslaan van de instellingsgegevens."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "kan bestand met gebruikersinstellingen '%s' niet wissen"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "ingang '%s' komt meer dan één keer voor in groep '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "poging tot wijzigen van onveranderbare sleutel '%s' genegeerd."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "trailing backslash genegeerd in '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "onverwachte \" op positie %d in '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kopiëren van bestand '%s' naar '%s' mislukt"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Onmogelijk om machtigingen voor bestand '%s' te krijgen"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Overschrijven van bestand '%s' mislukt"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Fout bij het kopiëren van het bestand '%s' naar '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Onmogelijk om machtigingen voor het bestand '%s' in te stellen"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1431,40 +1465,40 @@ msgstr ""
 "Hernoemen van het bestand ‘%s’ naar ‘%s’ mislukt omdat het doelbestand al "
 "bestaat."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Bestand '%s' kon niet worden hernoemd naar '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Bestand '%s' kon niet worden verwijderd"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Map '%s' kon niet worden gemaakt"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Map '%s' kon niet worden verwijderd"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kan bestanden in map '%s' niet opsommen"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Verkrijgen van de werk map mislukt"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Instellen van huidige werk map mislukt"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Bestanden (%s)"
@@ -1491,17 +1525,17 @@ msgstr "Maken van een tijdelijke bestandsnaam mislukt"
 msgid "Failed to open temporary file."
 msgstr "Openen van tijdelijk bestand mislukt."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Veranderen van bestandstijden van '%s' mislukt"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Touchen van bestand '%s' mislukt"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Verkrijgen van bestandstijden voor '%s' mislukt"
@@ -1510,22 +1544,22 @@ msgstr "Verkrijgen van bestandstijden voor '%s' mislukt"
 msgid "Browse"
 msgstr "Bladeren"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alle bestanden (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s bestanden (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Laad %s-bestand"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Sla %s-bestand op"
@@ -1888,99 +1922,99 @@ msgstr "standaard"
 msgid "unknown-%d"
 msgstr "onbekend-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "onderstreept"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " doorhalen"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " dun"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " extra licht"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " licht"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " Gemiddeld"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " halfvet"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " vet"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " extravet"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " zwaar"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " extra zwaar"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " cursief"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "doorhalen"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "dun"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "extralicht"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "licht"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normaal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "medium"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "halfvet"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "vet"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "extravet"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "zwaar"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "extra zwaar"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "cursief"
 
@@ -2064,7 +2098,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Instellen van FTP transfer mode naar %s mislukt."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2085,7 +2119,7 @@ msgstr "De FTP server ondersteunt niet passieve mode."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Onjuiste GIF frame grootte (%u, %d) voor het frame #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Kon geen kleur allokeren voor OpenGL"
 
@@ -2101,7 +2135,7 @@ msgstr "Kolommen aanpassen"
 msgid "&Customize..."
 msgstr "&Aanpassen..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Openen van URL \"%s\" in standaard browser mislukt"
@@ -2121,156 +2155,155 @@ msgstr "Laden van afbeelding %d van stream mislukt."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Kan geen pictogrammen laden van resource '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: kon ongeldige afbeelding niet opslaan."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage heeft geen eigen wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Kon koptekst van bestand (Bitmap) niet schrijven."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: kon de bestandsheader niet schrijven."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Kon RGB kleur map niet schrijven."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: kon gegevens niet wegschrijven."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: kon geen geheugen reserveren."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB Header: Afbeeldingsbreedte > 32767 pixels in bestand."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB Header: Afbeeldingshoogte > 32767 pixels in bestand."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB Header: Onbekende bitdiepte in bestand."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB Header: Onbekende codering in bestand."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB Header: Codering komt niet overeen met bit-diepte."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: kon geen geheugen reserveren."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB Header: Afbeeldingsbreedte > 32767 pixels in bestand."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB Header: Afbeeldingshoogte > 32767 pixels in bestand."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB Header: Onbekende bitdiepte in bestand."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB Header: Onbekende codering in bestand."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB Header: Codering komt niet overeen met bit-diepte."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Fout bij lezen afbeelding DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Fout bij lezen masker DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Afbeelding is te hoog voor een pictogram."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Afbeelding is te breed voor een pictogram."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Fout bij het wegschrijven van de afbeelding!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ongeldige pictogram index."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Afbeelding en masker hebben verschillende afmetingen."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Geen ongebruikte kleur in afbeelding gemaskeerd."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Laden van bitmap \"%s\" van bronnen mislukt."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Laden van icoon \"%s\" van bronnen mislukt."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Laden van afbeelding van bestand \"'%s\" mislukt."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kan afbeelding niet opslaan naar bestand '%s': Onbekende extensie."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Geen handler gevonden voor afbeeldingstype."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Geen afbeeldingshandler voor het type %d gedefinieerd."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Afbeeldingsbestand is niet van type %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Kan niet automatisch het afbeeldingsformaat bepalen voor niet vindbare input."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Onbekende afbeelding gegevensformaat."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Dit is niet een %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Geen afbeeldingshandler voor het type %s gedefinieerd."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Afbeelding is niet van type %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Controleren van formaat afbeeldingsbestand \"%s\" mislukt."
@@ -2372,41 +2405,41 @@ msgstr "PNM: bestand lijkt afgekapt."
 msgid " (in module \"%s\")"
 msgstr " (in module \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: fout bij laden van afbeelding."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Ongeldige TIFF-afbeeldingsindex."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Afbeeldingsgrootte is abnormaal groot."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: kon geen geheugen reserveren."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: fout bij lezen van afbeelding."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Onbekende TIFF resolutie eenheid%d genegeerd"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: fout bij opslaan van afbeelding."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: fout bij schrijven van afbeelding."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2415,11 +2448,11 @@ msgstr ""
 "Commandoregel argument %d kon niet omgezet worden naar Unicode en zal worden "
 "genegeerd."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Initialisatie mislukt in post init: voortijdig beëindigd.."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan de lokale niet naar Taal \"%s\" omzetten."
@@ -2513,7 +2546,7 @@ msgstr "LZMA-compressiefout: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "LZMA compressiefout tijdens wurging van de output: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Niet afgesloten '{' in ingang voor mime-type %s."
@@ -2534,7 +2567,7 @@ msgstr "Afhankelijkheid \"%s\" van module \"%s\" bestaat niet."
 msgid "Module \"%s\" initialization failed"
 msgstr "Initialisatie Module \"%s\" mislukt"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Bericht"
 
@@ -3036,7 +3069,7 @@ msgstr "Afdrukfout"
 msgid "Print"
 msgstr "Afdrukken"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Pagina instellingen"
 
@@ -3071,19 +3104,15 @@ msgstr "Bezig met afdrukken van pagina %d van %d"
 msgid " (copy %d of %d)"
 msgstr " (%d van %d kopiëren)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Bezig met afdrukken "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Eerste pagina"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Vorige pagina"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Volgende pagina"
 
@@ -3127,16 +3156,16 @@ msgstr "Pagina %d van %d"
 msgid "Page %d"
 msgstr "Pagina %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "onbekende fout"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ongeldige reguliere expressie '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Vinden van overeenkomst voor reguliere expressie '%s' mislukt"
@@ -3147,21 +3176,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer \"%s\" heeft incompatibele versie %d.%d en kan niet worden geladen."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Niet beschikbaar op dit platform"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Het opslaan van wachtwoord voor “%s” is mislukt: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Het lezen van wachtwoord voor \"%s\" is mislukt: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Het verwijderen van het wachtwoord voor \"%s\" is mislukt: %s."
@@ -3170,11 +3199,11 @@ msgstr "Het verwijderen van het wachtwoord voor \"%s\" is mislukt: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Toezicht houden op I/O kanalen mislukt"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Bewaren"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Niet Opslaan"
 
@@ -3255,10 +3284,10 @@ msgid "Clear"
 msgstr "Wissen"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Sluiten"
 
@@ -3270,7 +3299,7 @@ msgstr "&Converteren"
 msgid "Convert"
 msgstr "Converteren"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiëren"
@@ -3279,7 +3308,7 @@ msgstr "&Kopiëren"
 msgid "Copy"
 msgstr "Kopi&#235;ren"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Kni&ppen"
@@ -3288,13 +3317,13 @@ msgstr "Kni&ppen"
 msgid "Cut"
 msgstr "Knippen"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Verwijderen"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Verwijderen"
@@ -3381,7 +3410,7 @@ msgstr "Hardeschijf"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Help"
 
@@ -3401,7 +3430,7 @@ msgstr "Inspringen"
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Index"
 
@@ -3470,7 +3499,7 @@ msgstr "&Nieuw"
 msgid "New"
 msgstr "Nieuw"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nee"
 
@@ -3487,12 +3516,12 @@ msgstr "&Openen..."
 msgid "Open..."
 msgstr "Openen..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Plakken"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Plakken"
@@ -3522,7 +3551,7 @@ msgid "Print..."
 msgstr "Afdrukken..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "Eigenscha&ppen"
 
@@ -3554,10 +3583,6 @@ msgstr "Vervangen…"
 msgid "Revert to Saved"
 msgstr "Terug naar Opgeslagen"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "Op&slaan"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Opslaan &Als..."
@@ -3566,7 +3591,7 @@ msgstr "Opslaan &Als..."
 msgid "Save As..."
 msgstr "Opslaan Als..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecteer alles"
@@ -3673,7 +3698,7 @@ msgstr "&Omhoog"
 msgid "Up"
 msgstr "Omhoog"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ja"
 
@@ -3761,43 +3786,43 @@ msgstr "Huidig document opslaan"
 msgid "Save current document with a different filename"
 msgstr "Het huidige bestand onder een nieuwe naam opslaan"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Conversie naar karakterset '%s' werkt niet."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "onbekend"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "onvolledige header blok in tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "checksum mislukt tijdens lezen tar header blok"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "ongeldige data in extended tar header"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar ingang niet open"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "onverwacht einde van bestand"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s paste niet bij de tar-header voor regel '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "onjuiste grootte aangegeven voor tar invoer"
 
@@ -3806,7 +3831,7 @@ msgstr "onjuiste grootte aangegeven voor tar invoer"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' is waarschijnlijk een binaire buffer."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Bestand kon niet worden geladen."
 
@@ -3820,47 +3845,47 @@ msgstr "Lezen van tekstbestand \"%s\" mislukt."
 msgid "can't write buffer '%s' to disk."
 msgstr "kan buffer '%s' niet naar schijf schrijven."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Verkrijgen van lokale systeemtijd mislukt"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay mislukt."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' is geen geldige berichtcatalogus."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Ongeldige berichtencatalogus."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Kan Plural-Forms:'%s' niet parseren"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "catalogus '%s' van '%s' wordt gebruikt."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Bronbestand '%s' is geen geldige berichtencatalogus."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Kon vertalingen niet opsommen"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Er is geen standaard toepassing geconfigureerd voor HTML bestanden."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Openen van URL \"%s\" in standaard browser mislukt."
@@ -3893,7 +3918,7 @@ msgstr "'%s' bevat ongeldig(e) teken(s)"
 msgid "Error: %s (%d)"
 msgstr "Fout: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Niet genoeg vrije schijfruimte voor downloaden."
 
@@ -3901,20 +3926,20 @@ msgstr "Niet genoeg vrije schijfruimte voor downloaden."
 msgid "libcurl could not be initialized"
 msgstr "libcurl kan niet worden geïnitialiseerd"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Fout bij het uitvoeren van JavaScript: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Dit platform ondersteunt  geen transparante achtergrond."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Kon gegevens niet naar venster overdragen"
 
@@ -3966,8 +3991,8 @@ msgstr "Create Parameter %s niet gevonden in gedeclareerde RTTI Parameters"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Illegale Object Class (Non-wxEvtHandler) als Event Source"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Type moet enum hebben - lange conversie"
 
@@ -4017,80 +4042,80 @@ msgstr "Objecten moeten een id attribuut hebben"
 msgid "Doubly used id : %d"
 msgstr "Dubbel gebruikt ID: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Onbekende Eigenschap %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Een niet lege verzameling moet bestaan uit 'element'-knopen"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "onjuiste gebeurtenishandlerreeks, ontbrekende stip"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "kan zlib deflate stream niet opnieuw starten"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "kan zlib inflate stream niet opnieuw starten"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr "Negeren van misvormde extra dataregel, ZIP-bestand kan corrupt zijn"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "aangenomen dat dit een multi-part zip concatenatie is"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "ongeldig zip-bestand"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "kan centrale map in zipbestand niet vinden"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "fout bij het lezen van zip centrale map"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "fout lezen zip lokale header"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "slechte zipfile offset naar binnenkomst"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "opgeslagen bestandslengte niet in Zip header"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "niet ondersteunde Zip-compressiemethode"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "inlezen van zip stream (regel %s): foute lengte"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "inlezen van zip stream (regel %s): foute crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "fout bij het wegschrijven van zip-invoer ‘%s’: bestand te groot zonder ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "fout schrijven zip invoer '%s': foute crc of lengte"
@@ -4177,32 +4202,32 @@ msgstr "Grafische kunst door "
 msgid "Translations by "
 msgstr "Vertalingen door "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versie "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Over %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licentie"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Ontwikkelaars"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Documentatie schrijvers"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Kunstenaars"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Vertalers"
 
@@ -4253,43 +4278,42 @@ msgid "Password:"
 msgstr "Wachtwoord:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "true"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "onwaar"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Rij %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Inklappen"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Uitvouwen"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s ( %d elementen)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Kolom %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4300,8 +4324,7 @@ msgid "Left"
 msgstr "Links"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4398,7 +4421,7 @@ msgid "Home directory"
 msgstr "Thuismap"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Bureaublad"
 
@@ -4411,8 +4434,7 @@ msgstr "Ongeldige mapnaam."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Fout"
 
@@ -4596,16 +4618,16 @@ msgstr "Toon bestanden in detail-weergave"
 msgid "Go to parent directory"
 msgstr "Ga naar bovenliggende map"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Bestand '%s' bestaat al, overschrijven?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Bevestig"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Kies a.u.b. een bestaand bestand."
 
@@ -4699,7 +4721,7 @@ msgstr "De lettertype puntgrootte."
 msgid "Whether the font is underlined."
 msgstr "Of het lettertype is onderstreept."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Afdrukvoorbeeld:"
@@ -4717,51 +4739,50 @@ msgstr "Klik voor het annuleren van lettertypekeuze."
 msgid "Click to confirm the font selection."
 msgstr "Klik voor bevestiging van lettertypeselectie."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Kies lettertype"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "Het kopiëren van meer dan één geselecteerd blok naar het klembord wordt niet "
 "ondersteund."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Helpmap \"%s\" niet gevonden."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Helpbestand \"%s\" niet gevonden."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "Line %lu van mappingbestand \"%s\" heeft een ongeldige syntax: overgeslagen."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Geen geldige mappingen gevonden in het bestand \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Geen ingangen gevonden."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Help Index"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevante ingangen:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Ingangen gevonden"
 
@@ -4865,59 +4886,59 @@ msgstr "Kon printen niet starten."
 msgid "Printing page %d..."
 msgstr "Bezig met afdrukken van pagina %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Printer-opties"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Naar bestand afdrukken"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Instellingen..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Printer:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Alles"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Pagina's"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Afdrukbereik"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Van:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Aan:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopieën:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript-bestand"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Afdrukinstellingen"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Printer"
 
@@ -4925,25 +4946,25 @@ msgstr "Printer"
 msgid "Default printer"
 msgstr "Standaardprinter"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Papierformaat"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Staand"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Liggend"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Oriëntatie"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Instellingen"
 
@@ -4955,52 +4976,52 @@ msgstr "In kleur afdrukken"
 msgid "Print spooling"
 msgstr "Afdruk-spoolen"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Printercommando:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Printer-opties:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Linkermarge (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Bovenmarge (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Rechtermarge (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Ondermarge (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Printer..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Over&slaan"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Unknown"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Klaar."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Zoeken"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Kon tabblad niet vinden voor id"
 
@@ -5036,11 +5057,11 @@ msgstr "&Voltooien"
 msgid "< &Back"
 msgstr "< &Terug"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "vertaling credits"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5050,11 +5071,11 @@ msgstr ""
 "kan leiden tot problemen met invoerverwerking en flikkering. Overweeg om "
 "GTK_IM_MODULE uit te schakelen of in te stellen op “ibus”."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Niet in staat GTK+ te initialiseren. Is DISPLAY juist ingesteld?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Het veranderen van de huidige directory naar \"%s\" is mislukt"
@@ -5080,11 +5101,11 @@ msgstr "Kan aangepast lettertype “%s” niet toevoegen."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Kan lettertypeconfiguratie niet registreren met privélettertypen."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Fatale fout"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5097,7 +5118,7 @@ msgstr ""
 "door instelling\n"
 "omgevingsvariabele GDK_BACKEND=x11 voordat u uw programma start."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5109,7 +5130,7 @@ msgstr ""
 "dit omzeilen door omgevingsvariabele GDK_BACKEND=x11 in te stellen voor\n"
 "het starten van uw programma."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI subvenster"
 
@@ -5125,16 +5146,12 @@ msgstr "Fout bij het printen: "
 msgid "Page Setup"
 msgstr "Pagina-instellingen"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Kan geen tekst aanbrengen in de control."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 "Het ophalen van JavaScript scriptuitvoer wordt niet ondersteund met WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5142,7 +5159,7 @@ msgstr ""
 "GTK+ geïnstalleerd op deze machine is te oud om schermsamenstellingen te "
 "ondersteunen. Installeer GTK+ 2.12 of nieuwer."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5150,17 +5167,13 @@ msgstr ""
 "Samenstellen niet ondersteund door dit systeem. U kunt dit inschakelen in uw "
 "Vensterbeheer."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Dit programma is gecompileerd met een te oude versie van GTK+. Herbouw het "
 "met GTK+ 2.12 of nieuwer."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Kies a.u.b. een geldig lettertype."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5259,45 +5272,45 @@ msgstr "Kon inhoudsopgave-bestand niet openen: %s"
 msgid "Cannot open index file: %s"
 msgstr "Kan index-bestand niet openen: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "naamloos"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Kan HTML-helpbestand '%s' niet openen"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Toont hulptekst terwijl u de boeken aan de linkerzijde doorbladert."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(favorieten)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Voeg huidige pagina toe aan favorieten"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Verwijder huidige pagina uit favorieten"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Inhoud"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Zoeken"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Toon alles"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5305,19 +5318,19 @@ msgstr ""
 "Toon alle index elementen die de gegeven subtekenreeks bevatten. Niet "
 "hoofdlettergevoelig."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Toon alle elementen in de index"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Hoofdlettergevoelig"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Alleen hele woorden"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5325,147 +5338,147 @@ msgstr ""
 "Zoek in inhoudsopgave van helpbestand(en) naar alle plaatsen waar de tekst "
 "die u boven heeft getypt voorkomt"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Toon/verberg navigatie-paneel"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Ga terug"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Ga vooruit"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Ga niveau hoger in document-hiërarchie"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "HTML-document openen"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Deze pagina afdrukken"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Toon optie-dialoog"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Selecteer een pagina om te tonen:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Hulp-onderwerpen"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Bezig met zoeken..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Nog geen overeenkomende pagina gevonden"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i Overeenkomsten gevonden"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Help)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d of %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu van %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Zoek in alle boeken"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Help Browser Instellingen"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normaal lettertype:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Niet proportioneel lettertype:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Lettertype-grootte:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "lettertype grootte"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normale letter<br>en <u>onderstreept</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursief lettertype.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Vet lettertype.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Vet cursief lettertype.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Lettertype met vaste breedte.<br> <b>vet</b> <i>cursief</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>vet cursief <u>onderstreept</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Help Afdrukken"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Kan geen lege pagina afdrukken."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML bestanden (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Helpboeken (*.htb)|*.htb|Helpboeken (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Gecomprimeerd HTML-hulpbestand (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i van %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u van %u"
@@ -5546,32 +5559,6 @@ msgstr ""
 "Er was een probleem tijdens pagina-instellingen: u moet mogelijk een "
 "standaard printer instellen."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Weergeven van HTML-document in %s-codering mislukt"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets kon beeldscherm niet openen voor '%s': afbreken."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filter"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Mappen"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Bestanden"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selectie"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Openen van klembord mislukt."
@@ -5613,60 +5600,60 @@ msgstr "Kleurenselectie dialoog mislukt met fout %0lx."
 msgid "Failed to create cursor."
 msgstr "Cursor aanmaken mislukt."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Registratie van DDE-server '%s' mislukt"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Deregistreren van DDE-server %s mislukt"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Maken van verbinding met server '%s' voor onderwerp '%s' mislukt"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE poke verzoek mislukt"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Opzetten van advies-lus met de DDE-server mislukt"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Beëindigen van advies-lus met de DDE-server mislukt"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Versturen van DDE-adviesnotificatie mislukt"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Maken van DDE-string mislukt"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "geen DDE-fout."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "aanvraag voor synchrone adviestransactie heeft een time-out veroorzaakt."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "het antwoord op de transactie heeft de DDE_FBUSY-bit op 1 gezet."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "aanvraag voor synchrone gegevenstransactie heeft een time-out veroorzaakt."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5677,7 +5664,7 @@ msgstr ""
 "te roepen\n"
 "of een ongeldige applicatie-pid was doorgegeven aan een DDEML-functie."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5689,47 +5676,47 @@ msgstr ""
 "is\n"
 "gestart heeft geprobeerd een server-transactie uit te voeren."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "aanvraag voor synchrone uitvoeringstransactie heeft een time-out veroorzaakt."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "een parameter kon niet door de DDEML gevalideerd worden."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 "een DDEML-applicatie heeft door een 'race'-conditie geheugengebrek "
 "veroorzaakt."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "een geheugenreservering is mislukt."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "een poging van een cliënt om een conversatie op te zetten is mislukt."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "een transactie is mislukt."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "aanvraag voor synchrone 'poke' transactie heeft een time-out veroorzaakt."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "een interne oproep van de PostMessage-functie is mislukt "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "probleem met 'reentrancy'."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5739,17 +5726,17 @@ msgstr ""
 "die door de cliënt was beëindigd of de server heeft afgebroken\n"
 "voordat de transactie was afgerond."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "een interne fout is opgetreden in de DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "aanvraag voor beëindigen  van adviestransactie heeft een time-out "
 "veroorzaakt."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5759,12 +5746,12 @@ msgstr ""
 "Als de applicatie verdergaat na een XTYP_XACT_COMPLETE-callback dan is\n"
 "de transactie-id voor die callback niet meer geldig."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Onbekende DDE-fout %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5772,7 +5759,7 @@ msgstr ""
 "Inbelfuncties zijn niet beschikbaar omdat de inbelverbindingsoftware (RAS) "
 "niet op deze machine is geïnstalleerd. Installeer het a.u.b."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5782,65 +5769,65 @@ msgstr ""
 "Bijwerken naar nieuwere versie is aanbevolen (de volgende benodigde functie "
 "ontbreekt: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Verkrijgen van tekst van inbel-foutmelding mislukt"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "onbekende fout (foutnummer %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kan geen actieve inbelverbinding vinden: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Meerdere actieve inbelverbindingen gevonden, willekeurige keuze gemaakt."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Maken van inbelverbinding mislukt: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Verkrijgen van namen van internetaanbieders mislukt: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Verbinding mislukt: geen internetaanbieder om te bellen."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Kies internetaanbieder om te bellen"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Kies a.u.b. een internetaanbieder waarmee u verbinding wilt maken"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Verbinding mislukt: gebruikersnaam/wachtwoord ontbreekt."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Kan locatie van adresboek niet vinden"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Maken van inbelverbinding mislukt: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kan niet ophangen - geen actieve inbelverbinding."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Ophangen van inbelverbinding mislukt: %s"
@@ -5860,18 +5847,17 @@ msgstr "Allokeren van %luKb geheugen voor bitmap-data is mislukt."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kan bestanden in map '%s' niet opsommen"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Kon de mapnaam niet verkrijgen"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(Fout %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Kon geen afbeelding aan de lijst toevoegen."
 
@@ -5885,7 +5871,7 @@ msgstr "Laden van metabestand uit bestand \"%s\" mislukt."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Maken van het standaard zoek/vervang dialoog mislukt (foutcode %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Bestandsdialoog mislukt met foutcode %0lx."
@@ -5928,16 +5914,16 @@ msgstr "Kan controle op '%s' niet instellen"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan niet bestaande map \"%s\" niet controleren op veranderingen."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 of hoger wordt niet ondersteund door de OpenGL driver."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Kan geen OpenGL-context maken"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Initialiseren van OpenGL mislukt"
 
@@ -5945,7 +5931,7 @@ msgstr "Initialiseren van OpenGL mislukt"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "Kan aangepaste DirectWrite-lettertypelader niet registreren."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5953,7 +5939,7 @@ msgstr ""
 "MS HTML Help functies zijn niet beschikbaar omdat de MS HTML Help "
 "bibliotheek niet op deze machine is geïnstalleerd. Installeer het a.u.b."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Initialiseren van MS HTML Help mislukt."
 
@@ -5962,7 +5948,7 @@ msgstr "Initialiseren van MS HTML Help mislukt."
 msgid "Can't delete the INI file '%s'"
 msgstr "Kan INI-bestand '%s' niet verwijderen"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kon geen informatie verkrijgen over lijst-control element %d."
@@ -6082,7 +6068,7 @@ msgstr "Kon klembord-formaat '%s' niet registreren."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Het klembord-formaat '%d' bestaat niet."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Overslaan"
 
@@ -6167,59 +6153,59 @@ msgstr ""
 "wissen maakt uw systeem onbruikbaar:\n"
 "bewerking afgebroken."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kan sleutel '%s' niet verwijderen"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kan waarde '%s' niet verwijderen uit sleutel '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kan waarde van sleutel '%s' niet lezen"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kan waarde van '%s' niet instellen"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Registerwaarde “%s” is niet numeriek (maar van het type %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Registerwaarde “%s” is niet binair (maar van het type %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Registerwaarde “%s” is geen tekst (maar van het type %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kan waarde van '%s' niet lezen"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kan waarden van sleutel '%s' niet opsommen"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kan subsleutels van sleutel '%s' niet opsommen"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6227,17 +6213,17 @@ msgstr ""
 "Exporteren registersleutel: bestand \"%s\" bestaat al en wordt niet "
 "overschreven."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kan geen waarde van niet-ondersteund type %d exporteren."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Negeren van waarde \"%s\" van de sleutel \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6245,41 +6231,41 @@ msgstr ""
 "Niet mogelijk om Rich Edit control te maken, gewone tekst wordt gebruikt. "
 "Installeer riched32.dll a.u.b. opnieuw"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kan thread niet starten: fout bij schrijven TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Kan thread-prioriteit niet instellen"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Kan thread niet maken"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Kon thread niet beëindigen"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Kan niet wachten op thread-beëindiging"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kan thread %lx niet tijdelijk buiten dienst stellen"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kan thread %lx niet voortzetten"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Kon pointer naar huidige thread niet verkrijgen"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6287,7 +6273,7 @@ msgstr ""
 "Threadmodule-initialisatie mislukt: niet mogelijk een index te reserveren in "
 "lokale thread-geheugenruimte"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6318,12 +6304,12 @@ msgstr "Laden van bronbestand \"%s\" mislukt."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Vergrendelen van bronbestand \"%s\" mislukt."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bit editie"
 
@@ -6335,46 +6321,46 @@ msgstr "Maken van een anonieme pipe mislukt"
 msgid "Failed to redirect the child process IO"
 msgstr "Omleiden van I/O van child proces mislukt"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Uitvoering van opdracht '%s' mislukt"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Laden van mpr.dll mislukt."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kan typenaam van '%s' niet lezen!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kan pictogram niet laden van '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "Kan emulatieniveau voor webweergave niet vinden in het register"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Kan webweergave niet instellen op modern emulatieniveau"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "Kan webweergave niet resetten naar standaard emulatieniveau"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Kan geen JavaScript-script uitvoeren zonder een geldig HTML-document"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Kan het JavaScript-object niet ophalen"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "evalueren mislukt"
 
@@ -6407,7 +6393,7 @@ msgid "Check to make the font italic."
 msgstr "Aanvinken voor Cursief Lettertype."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Onderstreept"
@@ -6474,15 +6460,33 @@ msgstr "<Elke Teletype>"
 msgid "File type:"
 msgstr "Bestandstype:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Venster"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Help"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimaliseren"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Inzoomen"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Breng alles naar voren"
 
@@ -6499,493 +6503,493 @@ msgstr "Lettertypebestand “%s” bestaat niet."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Lettertypebestand “%s” kan niet worden gebruikt omdat het zich niet in de "
 "lettertypemap “%s” bevindt."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Over %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Over..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Voorkeuren..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Diensten"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Verberg %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Applicatie"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Verberg anderen"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Toon alles"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Stop %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Applicatie"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Afdrukken wordt niet ondersteund door de webbesturing van het systeem"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Afdrukbewerking kon niet worden geïnitialiseerd"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Puntgrootte"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Letterbeeld Naam"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stijl"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Gewicht"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ButtonText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "GrayText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Markeer"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Gemarkeerde tekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Tooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "TooltipText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Venster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Aangepast"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Zwart"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Kastanjebruin"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Marineblauw"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Paars"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Blauwgroen"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Grijs"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Groen"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Olijfgroen"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Bruin"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Blauw"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuchsiapaars"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Rood"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Oranje"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Zilver"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Citroengeel"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Agua"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Geel"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Wit"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Standaard"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Pijl"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Right Arrow"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Blanco"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Roos"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Letterteken"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Kruis"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Hand"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Linker knop"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Vergrootglas"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Middelste knop"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Geen toegang"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Penseel"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Potlood"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Wijs links"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Wijs rechts"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Vraagteken pijl"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Rechter knop"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Dimensionering NO-ZW"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Dimensionering N-Z"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Dimensionering NW-ZO"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Dimensionering W-O"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Dimensionering"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Spuitbus"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Wacht"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Bekijk"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Wacht pijl"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Maak een selectie:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Eigenschap"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Waarde"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Gecatogoriseerde modus"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alfabetische modus"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Onwaar"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Waar"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Ongespecifieerd"
 
@@ -7000,50 +7004,50 @@ msgstr ""
 "U heeft een ongeldige waarde ingevoerd. Druk op Esc om de bewerking te "
 "annuleren."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Fout in bron: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
-"Type handeling \"%s\" mislukt: Eigenschap met label \"%s\" is van type \"%s"
-"\", NIET \"%s\"."
+"Type handeling \"%s\" mislukt: Eigenschap met label \"%s\" is van type "
+"\"%s\", NIET \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Onbekende basis %d. Basis 10 zal worden gebruikt."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Waarde moet %s zijn of meer."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Waarde moet tussen %s en %s liggen."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Waarde moet %s zijn of minder."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Niet %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Kies een map:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Kies een bestand"
 
@@ -7510,117 +7514,117 @@ msgstr "Invoeging"
 msgid "Outset"
 msgstr "Aanvang"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Verander Stijl"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Verander lijst Stijl"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Wijzig Eigenschappen"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Verander lijst Stijl"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Hernummer lijst"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Tekst invoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Afbeelding Invoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Object invoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Veld invoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Te veel EindStijl aanroepen!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "bestanden"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standaard/circel"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standaard/circel-buitenrand"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standaard/vierkant"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standaard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standaard/driehoek"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Vak Eigenschappen"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Mutiple Cel eigenschappen"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Cel Eigenschappen"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Cel stijl instellen"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Rij verwijderen"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Kolom verwijderen"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Rij toevoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Kolom toevoegen"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Tabel eigenschappen"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Afbeelding Eigenschappen"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "afbeelding"
 
@@ -7828,24 +7832,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Slepen"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Tekst verwijderen"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Bolletje weghalen"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "De tekst kon niet worden opgeslagen."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Vervangen"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Lettertype:"
 
@@ -8814,53 +8818,53 @@ msgstr "Lijst stijlen"
 msgid "Box styles"
 msgstr "Vak stijlen"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Het lettertype waar het symbool van wordt genomen."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subset:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Toont een Unicode subset."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Lettertekencode:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "De Letterteken code."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Van:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "De te tonen range."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Invoegen"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normale tekst)"
 
@@ -9046,7 +9050,7 @@ msgstr "Kan gebeurtenissen niet uit kqueue halen"
 msgid "Media playback error: %s"
 msgstr "Media-afspeelfout: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Voorbereiden om \"%s\" af te spelen mislukt."
@@ -9146,20 +9150,20 @@ msgstr "De geluidsdata zijn in een niet ondersteund formaat."
 msgid "Couldn't open audio: %s"
 msgstr "Kon audio: %s niet openen"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kan thread-planningstrategie niet verkrijgen."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Kan prioriteitbereik niet verkrijgen voor planningstrategie %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Thread-prioriteitsinstelling is genegeerd."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9167,58 +9171,58 @@ msgstr ""
 "Aansluiten bij een draadje mislukt, mogelijk geheugenlek aangetroffen - "
 "herstart het programma a.u.b"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Instellen van concurrency-niveau van thread op %lu mislukt"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Instellen van prioriteit van thread %d mislukt."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Beëindigen van thread mislukt."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Threadmodule-initialisatie mislukt: maken van thread-sleutel mislukt"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Onmogelijk om child proces input te verkrijgen"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Kan niet schrijven naar child proces's stdin"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Uitvoeren van '%s' mislukt\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Vork mislukt"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Instellen van prioriteit van proces mislukt"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Omleiden van I/O van child proces mislukt"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Niet-blokkerende pipe instellen mislukt. Het programma kan hangen."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Kan hostnaam niet verkrijgen"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Kan officiële hostnaam niet verkrijgen"
 
@@ -9234,12 +9238,12 @@ msgstr "Kan de wake-up-pipe niet overschakelen naar de niet-blokkerende modus"
 msgid "Failed to read from wake-up pipe"
 msgstr "Lezen van wake-up pipe mislukt"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Ongeldige geometrie specificatie '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets kon beeldscherm niet openen. Afbreken."
 
@@ -9253,30 +9257,59 @@ msgstr "Kon de display \"%s\" niet sluiten"
 msgid "Failed to open display \"%s\"."
 msgstr "Openen van display \"%s\" mislukt."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML ontleed fout: '%s' in lijn %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kan bronnen niet laden uit '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kan bronbestand '%s' niet openen."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kan bronnen niet laden uit bestand '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Aanmaken van '%s' in '%s' mislukte."
+
+#~ msgid "Printing "
+#~ msgstr "Bezig met afdrukken "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Kan geen tekst aanbrengen in de control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Kies a.u.b. een geldig lettertype."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Weergeven van HTML-document in %s-codering mislukt"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets kon beeldscherm niet openen voor '%s': afbreken."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Mappen"
+
+#~ msgid "Files"
+#~ msgstr "Bestanden"
+
+#~ msgid "Selection"
+#~ msgstr "Selectie"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "conversie naar 8-bit versleuteling mislukt"

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2014-06-04 16:19+1200\n"
 "Last-Translator: Mariusz Drozdowski <schemedit@wp.pl>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Poedit 1.6.5\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Wszystkie pliki (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Wszystkie pliki (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "Pozostały czas:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Tak"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nie"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Zrezygnuj"
@@ -104,7 +101,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Nie można utworzyć portu zakończenia I/O."
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Wydruk"
 
@@ -141,7 +138,7 @@ msgstr "&Właściwości obiektu"
 msgid "Printing"
 msgstr "Drukowanie"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symbole"
 
@@ -214,7 +211,7 @@ msgstr "&Poprzednie"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Okno"
 
@@ -776,12 +773,12 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "wyświetla ten komunikat"
 
 # inaczej
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "generuje listę komunikatów"
 
@@ -803,85 +800,85 @@ msgstr "Nieobsługiwana kompozycja '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Błędna specyfikacja trybu wyświetlania '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Opcja '%s' nie może zostać zanegowana"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nieznana długa opcja '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nieznana opcja '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Nieoczekiwane znaki następujących opcji '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opcja '%s' wymaga podania wartości."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Oczekiwano separatora po opcji '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' nie jest poprawną wartością numeryczną opcji '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opcja '%s': nie można przekształcić '%s' na datę."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Nieoczekiwany parametr '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (lub %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Wartość opcji '%s' musi zostać podana."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Wymagany parametr '%s' nie został podany."
 
 # hm
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Użycie: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "tekst"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "liczba"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "podwójnie"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -899,7 +896,7 @@ msgid "Can't &Undo "
 msgstr "Nie można &cofnąć "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Cofnij"
@@ -909,7 +906,7 @@ msgid "&Redo "
 msgstr "&Ponów "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ponów"
@@ -940,12 +937,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ma nadmiarowe '..', zignorowane."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -955,103 +952,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "podkreślony"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "dziś"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "wczoraj"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "jutro"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "pierwszy"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "drugi"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "trzeci"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "czwarty"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "piąty"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "szósty"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "siódmy"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "ósmy"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "dziewiąty"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "dziesiąty"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "jedenasty"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dwunasty"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "trzynasty"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "czternasty"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "piętnasty"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "szesnasty"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "siedemnasty"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "osiemnasty"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "dziewiętnasty"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "dwudziesty"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "południe"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "północ"
 
@@ -1121,44 +1118,81 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Nie udało się przesłanie raportu błędów (kod błędu %d)"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Zapisz Jako"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Odrzucić zmiany i wczytać ponownie ostatnio zapisaną wersję?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "beznazwy"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Chcesz zapisać zmiany w dokumencie %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "Zapi&sz"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nie Zapisuj"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Chcesz zapisać zmiany w dokumencie %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Tekst nie może być zapisany.."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Nie udało się otworzyć pliku '%s' do zapisu"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Nie udało się zapisać dokumentu do pliku \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Nie udało się otworzyć pliku '%s' do odczytu"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1167,58 +1201,58 @@ msgstr ""
 "Plik '%s' nie istnieje i nie można go otworzyć.\n"
 "Informacja o nim została usunięta z listy ostatnio używanych plików."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Nie udało się utworzyć podglądu wydruku."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Podgląd wydruku"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Nie można wykryć formatu pliku '%s' ."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "beznazwy%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Otwieranie Pliku"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Błąd plikowy"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Niestety nie można otworzyć tego pliku."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Niestety, nieznany format pliku."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Wybierz szablon dokumentu"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Szablony"
 
 # perspektywę?
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Wybierz widok dokumentu"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Widoki"
 
@@ -1254,41 +1288,41 @@ msgid "Write error on file '%s'"
 msgstr "Błąd zapisu do pliku '%s'"
 
 # nie do końca...
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "nie udało się opróżnić (flush) pliku '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Błąd wyszukiwania w pliku '%s' (stdio nie wspiera olbrzymich plików)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Błąd pozycjonowania w pliku '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nie można znaleźć bieżącej pozycji w pliku '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Nie udało się nadać praw dostępu pliku tymczasowemu"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nie można usunąć pliku '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nie można zatwierdzić zmian w pliku '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nie można usunąć tymczasowego pliku '%s'"
@@ -1313,27 +1347,27 @@ msgstr "nie można czytać z deskryptora pliku %d"
 msgid "can't write to file descriptor %d"
 msgstr "nie można zapisać do deskryptora pliku %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nie można opróżnić deskryptora pliku %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nie można ustawić pozycji w deskryptorze pliku %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nie można odczytać bieżącej pozycji w deskryptorze pliku %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "nie można znaleźć rozmiaru pliku w deskryptorze pliku %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "nie można określić czy osiągnięto koniec pliku w deskryptorze %d"
@@ -1359,108 +1393,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Błąd odczytu opcji konfiguracji."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Nie udało się odczytać opcji konfiguracji."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "plik '%s': nieoczekiwany znak %c w lini %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "plik '%s', linia %d: zignorowano '%s' po nagłówku grupy."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "plik '%s', linia %d: oczekiwano '='."
 
 # niezmiennego?
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "plik '%s', linia %d: zignorowano wartość dla niezmiennego klucza '%s'."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "plik '%s', linia %d: klucz '%s' wystąpił po raz pierwszy w lini %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Nazwa pozycji konfiguracji nie może zaczynać się od '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "nie można otworzyć pliku konfiguracyjnego użytkownika."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "nie można zapisać pliku konfiguracyjnego użytkownika."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Błąd zapisu konfiguracji użytkownika."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "nie można usunąć pliku konfiguracyjnego użytkownika '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "pozycja '%s' występuje w grupie '%s' więcej niż jeden raz"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "zignorowano próbę zmiany niezmiennego klucza '%s'."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "końcowy ukośnik odwrotny zignorowany w '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "nieoczekiwany \" na pozycji %d w '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Nie udało się skopiować pliku '%s' do '%s'."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Uzyskanie praw dostępu do pliku '%s' jest niemożliwe"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Zastąpienie pliku '%s' jest niemożliwe"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Nie udało się skopiować pliku '%s' do '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nie jest możliwe nadanie praw dostępu plikowi '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1469,40 +1503,40 @@ msgstr ""
 "Nie udało się zmienić nazwy pliku '%s' na '%s', ponieważ plik docelowy już "
 "istnieje."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Nazwa pliku '%s' nie mogła zostać zmieniona '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Plik '%s' nie mógł zostać usunięty"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nie można utworzyć katalogu '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nie można usunąć katalogu '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nie można wyliczyć plików '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Nie udało się uzyskać katalogu roboczego"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Nie udało się ustawić katalogu roboczego"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Pliki (%s)"
@@ -1531,17 +1565,17 @@ msgid "Failed to open temporary file."
 msgstr "Nie udało się otworzyć pliku tymczasowego."
 
 # nieładne
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Nie udało się zmodyfikować czasów pliku '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Nie udało się zmienić czasów pliku '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Nie udało się odczytać czasów pliku '%s'"
@@ -1550,22 +1584,22 @@ msgstr "Nie udało się odczytać czasów pliku '%s'"
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Wszystkie pliki (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s pliki (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Wczytaj plik %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Zapisz plik %s"
@@ -1928,105 +1962,105 @@ msgstr "domyślny"
 msgid "unknown-%d"
 msgstr "nieznany-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "podkreślony"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " przekreślenie"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr "lekki"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr "lekki"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr "pogrubiony"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr "pogrubiony"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr "pogrubiony"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr "kursywa"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "Przekreślenie"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "lekki"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "lekki"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "Normalny"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "pogrubiony"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "pogrubiony"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "pogrubiony"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kursywa"
 
@@ -2106,7 +2140,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP: Nie udało się ustawić trybu transmisji na '%s'."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2127,7 +2161,7 @@ msgstr "Serwer FTP nie obsługuje trybu pasywnego."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nieprawidłowy rozmiar ramki GIF (%u, %d) dla ramki #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Nie udało się przydzielić koloru dla OpenGL"
 
@@ -2143,7 +2177,7 @@ msgstr "Dostosuj kolumny"
 msgid "&Customize..."
 msgstr "&Dostosuj..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Nie udało się otworzyć URL \"%s\" w domyślnej przeglądarce."
@@ -2163,160 +2197,159 @@ msgstr "Nie udało się wczytanie obrazu %d ze strumienia."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Nie udało się wczytanie ikony \"%s\" z zasobów."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nie można zapisać nieprawidłowego obrazu.."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nie ma własnej wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nie można zapisać nagłówka pliku (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nie można zapisać nagłówka pliku (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nie można zapisać mapy kolorów RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nie można zapisać danych."
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Nie można przydzielić pamięci."
 
 # dla pliku? moim zdaniem zbędne
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr "Nagłówek DIB: Szerokość obrazu > 32767 pikseli."
 
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr "DIB nagłówek: Wysokość obrazu > 32767 pikseli."
 
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "Nagłówek DIB: Plik z nieznaną rozdzielczością."
 
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Nagłówek DIB: Plik z nieznanym kodowaniem."
 
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Nagłówek DIB: kodowanie nie odpowiada rozdzielczości."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Błąd odczytu obrazu DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Błąd odczytu maski DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Obraz jest zbyt wysoki jak na ikonę."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Obraz jest zbyt szeroki jak na ikonę."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Błąd przy zapisie do pliku."
 
 # ...indeks w grafice (?)
 # ideks - katalog, wskanik?
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Brak ikony o podanym indeksie.."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Obraz i maska mają różne rozmiary."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Brak nieużywanych kolorów w maskowanym obrazie."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nie udało się wczytanie obrazu \"%s\" z zasobów."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nie udało się wczytanie ikony \"%s\" z zasobów."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Nie udało się wczytanie obrazu z pliku \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nie można zapisać obrazu do pliku '%s': nieznane rozszerzenie."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Brak procedury obsługi grafiki."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Brak procedury obsługi obrazów typu %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Nie jest to obraz typu %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Nie można automatycznie określić formatu obrazu dla nieprzeszukiwalnego "
 "wejścia."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Nieznany format graficzny"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "To nie jest %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Brak procedury obsługi obrazów typu %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Nie jest to obraz typu %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Nie sprawdzić format obrazu z pliku \"%s\"."
@@ -2418,43 +2451,43 @@ msgstr "PNM: Plik wygląda na obcięty."
 msgid " (in module \"%s\")"
 msgstr " (w module \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Błąd przy wczytywaniu obrazu."
 
 # ...indeks w grafice (?)
 # ideks - katalog, wska?nik?
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "TIFF: Brak obrazu o podanym indeksie."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Rozmiar obrazu jest wyjątkowo duży."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nie można przydzielić pamięci."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Błąd odczytu."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Zignorowana nieznana jednostka %d rozdzielczości TIFF"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Wystąpił błąd przy zapisie."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Błąd zapisu."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2463,11 +2496,11 @@ msgstr ""
 "Argument wiersza polecenia %d nie może zostać zamieniony na Unicode i "
 "zostanie zignorowany."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicjalizacja nie powiodła się powodując wyjście."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nie można ustawić lokalizacji na język \"%s\"."
@@ -2568,7 +2601,7 @@ msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
 # inaczej
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nieodpowiedni '{' w pozycji dla typu mime %s."
@@ -2588,7 +2621,7 @@ msgstr "Zależność \"%s\" z modułu \"%s\" nie istnieje."
 msgid "Module \"%s\" initialization failed"
 msgstr "Inicjalizacja modułu \"%s\" nie powiodła się"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Komunikat"
 
@@ -3090,7 +3123,7 @@ msgstr "Błąd wydruku"
 msgid "Print"
 msgstr "Drukuj"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Ustawienia strony"
 
@@ -3125,19 +3158,15 @@ msgstr "Drukowanie strony %d z %d"
 msgid " (copy %d of %d)"
 msgstr " (kopia %d z %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Drukowanie "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Pierwsza strona"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Poprzednia strona"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Następna strona"
 
@@ -3181,16 +3210,16 @@ msgstr "Strona %d z %d"
 msgid "Page %d"
 msgstr "Strona %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "nieznany błąd"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Nieprawidłowe wyrażenie regularne '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Nie udało się znaleźć połączenia dla regularnego wyrażenia: %s"
@@ -3201,21 +3230,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Wizualizator \"%s\" ma niezgodną wersję %d.%d i nie może być załadowany."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
@@ -3224,11 +3253,11 @@ msgstr "Pobranie '%s' do '%s' nie powiodło się."
 msgid "Failed to monitor I/O channels"
 msgstr "Nie udało się monitorować kanałów wejściowych/wyjściowych"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Nie Zapisuj"
 
@@ -3312,10 +3341,10 @@ msgid "Clear"
 msgstr "Wyczyść"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Zamknij"
 
@@ -3327,7 +3356,7 @@ msgstr "&Konwertuj"
 msgid "Convert"
 msgstr "KonwertujZawartość"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiuj"
@@ -3336,7 +3365,7 @@ msgstr "&Kopiuj"
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Wytnij"
@@ -3345,13 +3374,13 @@ msgstr "&Wytnij"
 msgid "Cut"
 msgstr "Wytnij"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Usuń"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Usuń"
@@ -3440,7 +3469,7 @@ msgstr "Dysk twardy"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Pomoc"
 
@@ -3460,7 +3489,7 @@ msgstr "Wcięcie"
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3529,7 +3558,7 @@ msgstr "&Nowy"
 msgid "New"
 msgstr "Nowy"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nie"
 
@@ -3546,12 +3575,12 @@ msgstr "&Otwórz..."
 msgid "Open..."
 msgstr "Otwórz..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Wkl&ej"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Wklej"
@@ -3581,7 +3610,7 @@ msgid "Print..."
 msgstr "Drukuj..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Właściwości"
 
@@ -3615,10 +3644,6 @@ msgstr "Zastąp"
 msgid "Revert to Saved"
 msgstr "Przywróć zapisany"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "Zapi&sz"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Zapisz J&ako..."
@@ -3628,7 +3653,7 @@ msgstr "Zapisz J&ako..."
 msgid "Save As..."
 msgstr "Zapisz J&ako..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Zaznacz wszystko"
@@ -3735,7 +3760,7 @@ msgstr "&W górę"
 msgid "Up"
 msgstr "W górę"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Tak"
 
@@ -3827,43 +3852,43 @@ msgstr "Zapisz bieżący dokument"
 msgid "Save current document with a different filename"
 msgstr "Zapisz bieżący dokument pod inną nazwą pliku"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Nie działa konwersja do zestawu znaków '%s'."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "nieznany"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "niekompletny blok nagłówka w tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "Niepowodzenie sumy kontrolnej czytania nagłówka bloku tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "nieprawidłowe dane w rozszerzonym nagłówku tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "wpis tar nie otwarty"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "nieoczekiwany koniec pliku"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s nie pasuje nagłówek tar do wpisu '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "nieprawidłowy rozmiar podany w wpisie tar"
 
@@ -3872,7 +3897,7 @@ msgstr "nieprawidłowy rozmiar podany w wpisie tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' jest prawdopodobnie buforem binarnym."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Plik nie może być wczytany."
 
@@ -3886,47 +3911,47 @@ msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "nie można zapisać bufora '%s' na dysk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Nie udało się pobrać lokalnego czasu systemowego"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay zwróciło błąd."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' nie jest prawidłowym katalogiem komunikatów."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Nieprawidłowy katalog komunikatów."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Nie można przetworzyć formy liczby mnogiej: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "użycie katalogu '%s' z '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Zasób '%s' nie jest prawidłowym katalogiem komunikatów."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Nie można policzyć tłumaczeń"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Nie ma ustawionej domyślnej aplikacji dla plików HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Nie udało się otworzyć URL \"%s\" w domyślnej przeglądarce."
@@ -3959,7 +3984,7 @@ msgstr "'%s' powinien zawierać tylko wartości znakowe."
 msgid "Error: %s (%d)"
 msgstr "Błąd: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3968,22 +3993,22 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Opis kolumny nie może być zainicjowany."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Konwersja tekstu nie jest wspierana"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Ta platforma nie obsługuje przezroczystości tła."
 
 # przenieść?
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Nie można przenieść danych do okna"
 
@@ -4035,8 +4060,8 @@ msgstr "NIe odnaleziono parametru %s w zadeklarowanych parametrach RTTI"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Błędna Klasa Obiekty (nie typu wxEvtHandler) jako Źródło Zdarzenia"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Typ musi umożliwiać konswersję enum - long"
 
@@ -4091,79 +4116,79 @@ msgstr "Obiekty muszą posiadać właściwość typu 'id'"
 msgid "Doubly used id : %d"
 msgstr "Dwukrotnie użyty identyfikator : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Nieznana właściwość %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Nie pusta kolekcja musi składać się z węzłów typu 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "nieprawidłowy uchwyt zdarzenia, brak kropki w nazwie"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nie można ponownie zainicjować strumienia kompresji biblioteki zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nie można ponownie zainicjować strumienia dekompresji biblioteki zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "założenie że jest to połączony wieloczęściowy zip"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "nieprawidłowy plik zip"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "nie można znaleźć centralnego katalogu zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "błąd przy odczycie centralnego katalogu zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "błąd odczytu lokalnego nagłówka zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "błędne przemieszczenie w pliku zip"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "długość pliku nie w nagłówku Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "niewspierana metoda kompresji Zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "odczyt strumienia zip (%s): niepoprawna długość"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "odczyt strumienia zip (%s): niepoprawna sygnatura crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "błąd zapisu zip '%s': niepoprawna sygnatura crc lub długość"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "błąd zapisu zip '%s': niepoprawna sygnatura crc lub długość"
@@ -4250,32 +4275,32 @@ msgid "Translations by "
 msgstr "Tłumaczenia autorstwa"
 
 # prawa?
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Wersja"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "O %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licencja"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Programiści"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autorzy dokumentacji"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artyści"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Tłumacze"
 
@@ -4327,44 +4352,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Fałsz"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (lub %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Dodaj kolumnę"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4375,8 +4399,7 @@ msgid "Left"
 msgstr "Lewo"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4472,7 +4495,7 @@ msgid "Home directory"
 msgstr "Katalog początkowy"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Pulpit"
 
@@ -4485,8 +4508,7 @@ msgstr "Niedozwolona nazwa katalogu."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Błąd"
 
@@ -4673,16 +4695,16 @@ msgstr "Przeglądaj pliki w formie szczegółowej listy"
 msgid "Go to parent directory"
 msgstr "Idź do katalogu nadrzędnego"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Plik '%s' już istnieje, naprawdę chcesz go zastąpić?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Potwierdź"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Proszę wybrać istniejący plik."
 
@@ -4776,7 +4798,7 @@ msgstr "Rozmiar czcionki."
 msgid "Whether the font is underlined."
 msgstr "Określenie podkreślenia."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Podgląd:"
@@ -4794,51 +4816,50 @@ msgstr "Anulowanie wyboru czcionki"
 msgid "Click to confirm the font selection."
 msgstr "Potwierdzenie wyboru czcionki"
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Wybierz czcionkę"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Nie znaleziono katalogu pomocy \"%s\"."
 
 # catalog file --> ?
 # domain --> ?
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Nie znaleziono pliku pomocy \"%s\"."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "Linijka %lu pliku mapy \"%s\" posiada nieprawidłową składnię, pominięta."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Znaleziono nie ważne mapowania w pliku \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Nie znaleziono pozycji."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Spis treści"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Pozycje związane:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Znalezione pozycje"
 
@@ -4942,59 +4963,59 @@ msgstr "Nie można rozpocząć drukowania."
 msgid "Printing page %d..."
 msgstr "Drukowanie strony %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opcje drukarki"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Drukuj do pliku"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Ustawienia..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Drukarka:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Wszystko"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Strony"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Zakres wydruku"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopie:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "plik PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Ustawienia wydruku"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Drukarka"
 
@@ -5002,25 +5023,25 @@ msgstr "Drukarka"
 msgid "Default printer"
 msgstr "Domyślna drukarka"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Rozmiar papieru"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Portret"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Pejzaż"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientacja"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcje"
 
@@ -5032,52 +5053,52 @@ msgstr "Wydruk w kolorze"
 msgid "Print spooling"
 msgstr "Kolejkowanie wydruków"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Polecenie drukarki:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opcje drukarki:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Lewy margines (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Górny margines (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Prawy margines (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Dolny margines (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Drukarka..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Pomiń"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Zrobione."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Szukaj"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Nie można znaleźć (tab) dla (id)"
 
@@ -5113,22 +5134,22 @@ msgstr "Za&kończ"
 msgid "< &Back"
 msgstr "< &Wstecz"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Michał Trzebiatowski"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nie można ustawić GTK+, czy jest prawidłowo ustawiony EKRAN?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Nie udało się utworzenie katalogu \"%s\""
@@ -5154,12 +5175,12 @@ msgstr "Nie udało się wczytanie dokumentu z pliku \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Nie udała się aktualizacja pliku konfiguracyjnego użytkownika."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Błąd krytyczny "
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5167,7 +5188,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5175,7 +5196,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "potomek MDI"
 
@@ -5191,15 +5212,11 @@ msgstr "Błąd podczas drukowania:"
 msgid "Page Setup"
 msgstr "Ustawienia strony"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Nie udało się  wstawić tekstu w kontroli."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5207,24 +5224,20 @@ msgstr ""
 "GTK+ zainstalowana na tej maszynie jest zbyt stara i nie wspiera kompozycji "
 "ekranu, proszę zainstalować GTK+ 2.12 lub nowszą."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "Kompozycje nie są wspierane w tym systemie, proszę je włączyć w managerze."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Ten program został skompilowany przy użyciu zbyt starej wersji GTK+, proszę "
 "skompilować ponownie z użyciem GTK+ 2.12 or nowszej."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Proszę wybrać poprawną czcionkę."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5323,45 +5336,45 @@ msgstr "Nie można otworzyć pliku spisu treści: %s"
 msgid "Cannot open index file: %s"
 msgstr "Nie można otworzyć pliku indeksowego: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "beznazwy"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nie można otworzyć książki pomocy HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Wyświetla pomoc podczas przeglądania książek po lewej."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(zakładki)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Dodaj bieżącą stronę do listy zakładek"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Usuń bieżącą stronę z listy zakładek"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Zawartość"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Znajdź"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Pokaż wszystko"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5369,19 +5382,19 @@ msgstr ""
 "Wyświetla wszystkie elementy indeksu zawierające podany łańcuch. Szuka bez "
 "uwzględniania wielkości liter."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Pokaż wszystkie elementy indeksu"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Uwzględniaj wielkość liter"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Tylko całe słowa"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5389,149 +5402,149 @@ msgstr ""
 "Przeszukuje zawartość pliku(ów) pomocy dla wszystkich wystąpień "
 "wprowadzonego powyżej tekstu"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Pokaż/ukryj panel sterowania"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Idź wstecz"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Idź dalej"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Idź poziom wyżej w hierarchi dokumentu"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Otwórz dokument HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Drukuj stronę"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Wyświetl okno dialogowe opcji"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Wybierz stronę do wyświetlenia:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Tematy Pomocy"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Wyszukiwanie..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Jeszcze nie znaleziono pasującej strony"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Znaleziono %i odpowiednik(i/ów)"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Pomoc)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d z %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu z %lu"
 
 # spisach?
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Szukaj we wszystkich plikach pomocy"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opcje przeglądarki pomocy"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normalna czcionka:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Czcionka o stałej szerokości:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Rozmiar czcionki:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "rozmiar czcionki"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Zwykły tekst<br>i <u>podkreślony</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursywa.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Pogrubienie.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Pogrubiona kursywa.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Ustalony rozmiar tekstu.<br> <b>pogrubienie</b> <i>kursywa</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>pogrubiona kursywa <u>z podkreśleniem</u></i></b><br>"
 
 # pomoc do drukowania?
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Drukowanie pomocy"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Nie można wydrukować pustej strony."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Pliki HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Pakiety pomocy (*.htb)|*.htb|Pakiety pomocy (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Plik projektu pomocy HTML Help (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Skompresowane pliki pomocy HTML Help (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i z %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu z %lu"
@@ -5612,32 +5625,6 @@ msgstr ""
 "Wystąpił błąd podczas konfigurowania strony: powinieneś określić domyślną "
 "drukarkę."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Nie udało się wyświelić dokumentu HTML w kodowaniu %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "Nie można zainicjować wyświetlania dla '%s': program kończy pracę."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtr"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Katalogi"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Pliki"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Wybór"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Nie udało się otworzyć schowka."
@@ -5679,65 +5666,65 @@ msgstr "Okno wyboru koloru nie powiodło się z błędem %0lx."
 msgid "Failed to create cursor."
 msgstr "Nie udało się utworzyć kursora."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Nie udało się zarejestrować serwera DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Nie udało się wyrejestrować serwera DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Nie udało się utworzyć połączenia do serwera '%s' na temat '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "żądanie danych z serwera DDE nie powiodło się"
 
 # to moja swobodna interpretacja
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 "Nie udało się rozpocząć transakcji doradzającej (advise) z serwerem DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 "Nie udało się zakończyć transakcji doradzającej (advise) z serwerem DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Nie udało się wysłać powiadomienia DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Nie udało się utworzyć łańcucha DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "bez błędu DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji advise."
 
 # niezręczne
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odpowiedź na transakcję spowodowała ustawienie bitu DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji data."
 
 # instance -->
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5750,7 +5737,7 @@ msgstr ""
 "nieprawidłowy identyfikator instancji."
 
 # transakcję normalnie wykonywaną przez serwer, inaczej
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5762,45 +5749,45 @@ msgstr ""
 "lub aplikacja zainicjowana jako APPCMD_CLIENTONLY\n"
 "usiłowała wykonać transakcję serwera."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji execute."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parametr nie przeszedł kontroli poprawności DDEML"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "Aplikacja DDEML utworzyła przedłużony wyścig (race condition)."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "przydzielenie pamięci nie powiodło się."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "próba nawiązania konwersacji przez klienta nie powiodła się."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "transakcja nie powiodła się."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "upłynął czas oczekiwania na rozpoczęcie synchronicznej transakcji poke."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "wewnętrzne wywołanie funkcji PostMessage zakończyło się niepowodzeniem"
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problem współbieżności"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5810,15 +5797,15 @@ msgstr ""
 "zakończoną przez klienta, lub serwer\n"
 "zakończył pracę przez zakończeniem transakcji."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "wystąpił wewnętrzny błąd w DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "upłynął czas oczekiwania na zakończenie trancakcji advise."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5828,12 +5815,12 @@ msgstr ""
 "Kiedy aplikacja kończy połączenie zwrotne XTYP_XACT_COMPLETE,\n"
 "identyfikator transakcji dla tego połączenia nie jest dłużej ważny."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Nieznany błąd DDE %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5841,7 +5828,7 @@ msgstr ""
 "Funkcje Dial up nie są dostępne, ponieważ serwis zdalnego dostępu (RAS) nie "
 "jest zainstalowany na tej maszynie. Zainstaluj go."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5850,64 +5837,64 @@ msgstr ""
 "Zainstalowana wersja serwisu zdalnego dostępu (RAS) jest zbyt stara, "
 "zainstaluj nowszą (brakująca funkcja to: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Nie udało się uzyskać tekstu komunikatu błędu RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "nieznany błąd (kod błędu %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nie można znaleźć aktywnego połączenia dialup: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Znalezione kilka dostępnych połączeń dialup, zostanie użyte pierwsze."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Nie udało się nawiązać połączenia dialup: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Nie udało się usyskać listy ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Nie udało się połączyć: brak ISP."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Wybierz ISP do połączenia"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Wybierz ISP, z którym chcesz się połączyć"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Nie udało się połączyć: brakuje użytkownika/hasła."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Nie można znaleźć lokalizacji pliku książki adresowej"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Nie udało się rozpocząć połączenia dialup: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nie można rozłączyć - brak aktywnego połączenia dialup."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Nie udało się zakończyć połączenia dialup: %s"
@@ -5927,18 +5914,17 @@ msgstr "Nie udała się rezerwacja %luKb pamięci na dane obrazu."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nie można wyliczyć plików w katalogu '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Nie można pobrać nazwy folderu"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (błąd %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Nie można dodać obrazu do listy obrazów."
 
@@ -5954,7 +5940,7 @@ msgstr ""
 "Nie udało się utworzyć standardowego okna dialogowego wyszukaj/zastąp (kod "
 "błędu %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialog zawiódł zwracając kod błędu %0lx."
@@ -5996,17 +5982,17 @@ msgstr "Nie można zacząć obserwować '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nie można monitorować zmian w nieistniejącym folderze \"%s\"."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Nie można utworzyć stopera"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Nie udało się zainicjować OpenGL"
 
@@ -6014,7 +6000,7 @@ msgstr "Nie udało się zainicjować OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6022,7 +6008,7 @@ msgstr ""
 "Funkcje pomocy dla MS HTML Help nie są dostępne, ponieważ biblioteka MS HTML "
 "Help nie jest zainstalowana na tej maszynie. Zainstaluj ją."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Nie udało się zainicjować pomocy MS HTML."
 
@@ -6031,7 +6017,7 @@ msgstr "Nie udało się zainicjować pomocy MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "Nie można usunąć pliku INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nie można pobrać informacji o elemencie listy kontroli %d."
@@ -6153,7 +6139,7 @@ msgstr "Nie można zarejestrować formatu schowka '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format schowka '%d' nie istnieje."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Pomiń"
 
@@ -6238,59 +6224,59 @@ msgstr ""
 "usunięcie go zdestabilizowałoby system:\n"
 "operacja została przerwana."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nie można usunąć klucza '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nie można usunąć wartości '%s' z klucza '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nie można odczytać wartości klucza '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nie można nadać wartości '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nie można odczytać wartości '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nie można wyliczyć wartości klucza '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nie można wyliczyć podkluczy klucza '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6298,17 +6284,17 @@ msgstr ""
 "Eksport klucza rejestrów: plik \"%s\" już istnieje i nie może zostać "
 "nadpisany."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nie można wyeksportować wartości nieobsługiwanego typu %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Wartiść \"%s\" klucza \"%s\" zignorowana."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6316,42 +6302,42 @@ msgstr ""
 "Nie jest możliwe utworzenie kontrolki rich edit, użyj zamiast tego prostego "
 "'text control'. Przeinstaluj riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nie można wystartować wątku: błąd zapisu TLS."
 
 # ustalić?
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Nie można zmienić priorytetu wątku"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Nie można utworzyć wątku"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Nie można zakończyć wątku"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Nie można czekać na zakończenie wątku"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nie można zawiesić wątku %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nie można wznowić wątku %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Nie można pobrać wskaźnika aktualnego wątku"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6359,7 +6345,7 @@ msgstr ""
 "Zainicjowanie modułu wątków nie powiodło się: nie jest możliwe przydzielenie "
 "indeksu w lokalnej pamięci wątków."
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6390,12 +6376,12 @@ msgstr "Nie udało się wczytanie zasobu \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Nie udało się zablokowanie zasobu \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "budowa %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", wydanie 64-bitowe"
 
@@ -6408,48 +6394,48 @@ msgstr "Nie udało się utworzyć potoku"
 msgid "Failed to redirect the child process IO"
 msgstr "Nie udało się przekierować wejścia/wyjścia procesu potomnego"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Wykonanie polecenia '%s' nie powiodło się"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Nie udało się wczytać mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nie można odczytać nazwy typu z  '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nie można wczytać ikony z '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
 # ustalić?
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Nie można zmienić priorytetu wątku"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Nie udało się wykonać '%s'\n"
@@ -6483,7 +6469,7 @@ msgid "Check to make the font italic."
 msgstr "Zaznacz aby uzyskać kursywę czcionki."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podkreślony"
@@ -6551,17 +6537,32 @@ msgstr "<dowolny Teletype>"
 msgid "File type:"
 msgstr "Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Okno"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomoc"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimalizuj"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Powiększenie"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6578,488 +6579,488 @@ msgstr "Plik %s nie istnieje."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "O %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Inform&acje"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "&Preferencje..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Ukryj %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Aplikacja"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Ukryj inne"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Pokaż wszystko"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "&Wyjście z %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Aplikacja"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Format Gzip nie jest wspierany przez tę wersję biblioteki zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Opis kolumny nie może być zainicjowany."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "&Rozmiar punktu:"
 
 # To jest maska do tworzenia nazw typu NowaNaz1 itd
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nazwa"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Styl"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Waga"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Rodzina czcionki"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Obramowanie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "lekki"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Prawe dostosowanie tekstu."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Obramowanie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Okno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Okno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Okno"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Rozmiar użytkownika"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "MacGrecki"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "Przeglądaj"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "Ponów"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "domyślny"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "jutro"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Prawy"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Styl wypunktowania"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "&Kod znaku:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "&Rozmiar punktu:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Wyrównanie do prawej"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Pytanie"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Prawy"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Prawy"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Dokonaj wyboru:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Właściwość"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Wartość"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Tryb skategoryzowany"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Tryb Alfabetyczny"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Fałsz"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Prawda"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Nieokreślony"
 
@@ -7072,50 +7073,50 @@ msgstr "Błąd właściwości"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Wprowadzono nieprawidłową wartość. Naciśnij ESC by anulować edycję."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Błąd w zasobie: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
-"Niepowodzenie operacji typu \"%s\": właściwość nazwana  \"%s\" jest typu \"%s"
-"\", nie \"%s\"."
+"Niepowodzenie operacji typu \"%s\": właściwość nazwana  \"%s\" jest typu "
+"\"%s\", nie \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Wartość musi wynosić %s lub więcej."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Wartość musi zawierać się pomiędzy %s i %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Wartość musi wynosić %s lub mniej."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Nie %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Wybierz katalog"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Wybierz plik"
 
@@ -7596,121 +7597,121 @@ msgstr "Wstawka"
 msgid "Outset"
 msgstr "Otoczenie"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Zmień styl"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Zmień styl obiektu"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Zmień właściwości"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Zmień styl listy"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Zmień numerację listy"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Wstaw tekst"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Wstaw obraz"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Wstaw obiekt"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Wstaw pole"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Zbyt wiele wezwań EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "pliki"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standardowy/okrągły"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standardowy/okrągły-kontur"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standardowy/prostokątny"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standardowy/kątowy"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standardowy/trójkątny"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "&Właściwości bloku"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Właściwości wielu komórek"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "&Właściwości komórki"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Usuń styl komórki"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 #, fuzzy
 msgid "Delete Row"
 msgstr "Usuń wiersz"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 #, fuzzy
 msgid "Delete Column"
 msgstr "Usuń kolumnęUsuń wybór"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 #, fuzzy
 msgid "Add Row"
 msgstr "Dodaj wiersz"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 #, fuzzy
 msgid "Add Column"
 msgstr "Dodaj kolumnę"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "&Właściwości tabeli"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "&Właściwości obrazu"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "obraz"
 
@@ -7918,24 +7919,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Przeciągnij"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Usuń tekst"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Usuń wypunktowanie"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Tekst nie może być zapisany.."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Zastąp"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Czcionka:"
 
@@ -8905,53 +8906,53 @@ msgstr "Style listy"
 msgid "Box styles"
 msgstr "Style bloku"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Czcionka z której pobrać symbol."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Podzbiór:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Pokazuje podzbiór Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Kod znaku:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Kod znaku."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Zakres do pokazania."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Wstawić"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normalny tekst)"
 
@@ -9138,7 +9139,7 @@ msgstr "Nie można pobrać zdarzeń z kolejki"
 msgid "Media playback error: %s"
 msgstr "Błąd odtwarzania mediów: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Nie udało się przygotowanie odtwarzania \"%s\"."
@@ -9240,22 +9241,22 @@ msgstr "Dane dźwiękowe są w formacie, który nie jest wspierany."
 msgid "Couldn't open audio: %s"
 msgstr "Nie można otworzyć dźwięku: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nie można uzyskać strategii harmonogramowania wątków."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nie można uzyskać zakresu priorytetów strategii harmogramowania %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Ustawienie priorytetu wątku jest ignorowane."
 
 # połączyć?
 # wyciek?
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9263,61 +9264,61 @@ msgstr ""
 "Nie udało połączyć się z wątkiem, potencjalny wyciek pamięci - uruchom "
 "program ponownie"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Błąd podczas ustawiania priorytetu wątku na %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Nie udało się zmienić priorytetu wątku na %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Nie udało się zakończyć wątku."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Zainicjowanie modułu wątków nie powiodło się: nie udało się utworzyć klucza "
 "wątków"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Nie jest możliwe uzyskanie wejścia procesu potomnego"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr ""
 "Błąd zapisu do standardowego strumienia wejściowego (stdin) procesu potomnego"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Nie udało się wykonać '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Rozwidlenie nie powiodło się"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Błąd podczas ustawiania priorytetu procesu"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Nie udało się przekierować wejścia/wyjścia procesu potomnego."
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Nie udało się ustawić nieblokowego potoku, program może się zawiesić."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Nie można pobrać nazwy serwera"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Nie można pobrać oficjalnej nazwy serwera"
 
@@ -9334,12 +9335,12 @@ msgid "Failed to read from wake-up pipe"
 msgstr "Nie udało się czytać z potoku budzącego "
 
 # Pytanie X11
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Niedozwolona specyfikacja \"geometry\" '%s'."
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "Nie można zainicjować wyświetlania. Program kończy pracę."
 
@@ -9353,30 +9354,59 @@ msgstr "Nie udało się zamknąć ekranu \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Nie udało się otworzyć ekranu \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Błąd parsowania XML: '%s' w linii %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nie można wczytać zasobów z pliku '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nie można wczytać zasobów z pliku '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nie można wczytać zasobów z pliku '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Pobranie '%s' do '%s' nie powiodło się."
+
+#~ msgid "Printing "
+#~ msgstr "Drukowanie "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Nie udało się  wstawić tekstu w kontroli."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Proszę wybrać poprawną czcionkę."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Nie udało się wyświelić dokumentu HTML w kodowaniu %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "Nie można zainicjować wyświetlania dla '%s': program kończy pracę."
+
+#~ msgid "Filter"
+#~ msgstr "Filtr"
+
+#~ msgid "Directories"
+#~ msgstr "Katalogi"
+
+#~ msgid "Files"
+#~ msgstr "Pliki"
+
+#~ msgid "Selection"
+#~ msgstr "Wybór"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "nie powiodła się konwersja do kodowania '8-bit'"
@@ -9544,8 +9574,8 @@ msgstr "Pobranie '%s' do '%s' nie powiodło się."
 #~ msgstr "Render daty nie może renderować wartości; typ wartości:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/pt.po
+++ b/locale/pt.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2014-03-07 16:07+0100\n"
 "Last-Translator: Alfredo <.>\n"
 "Language-Team: Portuguese <opensuse-pt@opensuse.org>\n"
@@ -20,11 +20,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Todos os ficheiros (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Todos os ficheiros (*)|*"
 
@@ -42,24 +42,21 @@ msgid "Remaining time:"
 msgstr "Tempo restante : "
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sim"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Não"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "CONFIRMAR"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
@@ -111,7 +108,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Não foi possível criar TextEncodingConverter"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Impressão"
 
@@ -150,7 +147,7 @@ msgstr "&Propriedades do Objeto"
 msgid "Printing"
 msgstr "A Imprimir  ..."
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Símbolos"
 
@@ -219,7 +216,7 @@ msgstr "&Anterior"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Janela"
 
@@ -784,11 +781,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Ctrl-"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "mostra esta mensagem de ajuda"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "gerar mensagens de registo verbosas"
 
@@ -810,84 +807,84 @@ msgstr "Tema não suportado '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificação de modo de ecrã inválida '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, fuzzy, c-format
 msgid "Option '%s' can't be negated"
 msgstr "A opção '%s'não pode ser nagada"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opção longa desconhecida '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opção desconhecida '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracteres inesperados a seguir à opção '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A opção '%s' requer um valor."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Separador esperado depois da opção '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' não é um valor numérico correcto para a opção '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "A opção '%s': '%s' não pode ser convertida para uma data."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parâmetro inesperado '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ou %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "O valor para a opção '%s' tem de ser especificado."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "O parâmetro requerido '%s' não foi especificado."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilização: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "duplo"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -905,7 +902,7 @@ msgid "Can't &Undo "
 msgstr "Não é possível &Desfazer "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfazer"
@@ -915,7 +912,7 @@ msgid "&Redo "
 msgstr "&Refazer "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refazer"
@@ -943,12 +940,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' tem extra '..', ignorado."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -958,103 +955,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "sublinhado"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "hoje"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "ontem"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "amanhã"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primeiro"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "segundo"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "terceiro"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "quarto"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "quinto"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sexto"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sétimo"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "oitavo"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "nono"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "décimo"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "décimo primeiro"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "décimo segundo"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "décimo terceiro"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "décimo quarto"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "décimo quinto"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "décimo sexto"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "décimo sétimo"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "décimo oitavo"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "décimo nono"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vigésimo"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "meio-dia"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "meia noite"
 
@@ -1123,44 +1120,81 @@ msgstr "Falha a executar curl, por favor instale-o no PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Falha ao enviar o relatório de depuração (código do erro %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Gravar Como"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "sem nome"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, fuzzy, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Deseja gravar as alterações ao documento %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Guardar"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Não Gravar"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Deseja gravar as alterações ao documento %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "O texto não pode ser gravado."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Falha ao abrir '%s' para %s"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, fuzzy, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Falha ao gravar imagem de bitmap para ficheiro \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, fuzzy, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Falha ao abrir '%s' para %s"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, fuzzy, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1169,57 +1203,57 @@ msgstr ""
 "O ficheiro '%s' não existe e não pode ser aberto.\n"
 "Este foi removido da lista de ficheiros usados mais recentemente."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Falha na criação da pré-visualização da impressão."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Pré-visualizar Impressão"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, fuzzy, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "sem nome%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Abrir Ficheiro"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Erro de ficheiro"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Lamento, não foi possível abrir este ficheiro."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Lamento, o formato deste ficheiro é desconhecido."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Selecionar um modelo de documento"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Modelos"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Selecionar uma vista de documento"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Vistas"
 
@@ -1253,43 +1287,43 @@ msgstr "Erro de leitura no ficheiro '%s'"
 msgid "Write error on file '%s'"
 msgstr "Erro de escrita no ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "Falha a escoar o ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Erro de pesquisa no ficheiro '%s' (ficheiros grandes não são suportados pelo "
 "stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Erro de pesquisa no ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Não foi possível encontrar a posição atual no ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Falha ao definir permissões do ficheiro temporário"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "impossível remover ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "não é possível garantir as alterações ao ficheiro '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "Não foi possível remover ficheiro temporário '%s'"
@@ -1314,29 +1348,29 @@ msgstr "não foi possível ler do descritor do ficheiro %d"
 msgid "can't write to file descriptor %d"
 msgstr "Não foi possível escrever no descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "Não foi possível escoar o descritor do ficheiro %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "Não foi possível pesquisar no descritor de ficheiro %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "Não foi possível obter posição de pesquisa no descritor do ficheiro %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "Não foi possível encontrar o comprimento do ficheiro no descritor do "
 "ficheiro %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1361,109 +1395,109 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Erro ao ler opções de configuração."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 #, fuzzy
 msgid "Failed to read config options."
 msgstr "Erro ao ler opções de configuração."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "ficheiro '%s': caracter inesperado %c na linha %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "ficheiro '%s', linha %d: '%s' ignorado após cabeçalho de grupo."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "ficheiro '%s', linha %d: '=' esperado."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "ficheiro '%s', linha %d: valor para chave imutável '%s' ignorado."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "ficheiro '%s', linha %d: chave '%s' foi inicialmente encontrada na linha %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Nome de entrada de configuração não pode começar por '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "não foi possível abrir o ficheiro de configuração do utilizador."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "Não foi possível gravar o ficheiro de configuração do utilizador."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Falha na atualização do ficheiro de configuração do utilizador."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Erro ao gravar dados de configuração do utilizador."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "não foi possível apagar o ficheiro de configuração do utilizador '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a entrada '%s' aparece mais do uma vez no grupo '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativa de alteração da chave imutável '%s' ignorada."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" inesperado na posição %d em '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Falha ao copiar o ficheiro '%s' para '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Não foi possível obter permissões do ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Não foi possível sobrepor o ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Falha ao copiar o ficheiro '%s' para '%s'"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Não foi possível definir as permissões do ficheiro '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1472,41 +1506,41 @@ msgstr ""
 "Falha ao renomear o ficheiro de '%s' para '%s' porque o ficheiro de destino "
 "já existe."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, fuzzy, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, fuzzy, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, fuzzy, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Não foi possível criar o directório '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Não foi possível enumerar os ficheiros '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Falha na obtenção do directório de trabalho"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 #, fuzzy
 msgid "Could not set current working directory"
 msgstr "Falha na obtenção do directório de trabalho"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Ficheiros (%s)"
@@ -1533,17 +1567,17 @@ msgstr "Falha a criar nome de ficheiro temporário"
 msgid "Failed to open temporary file."
 msgstr "Falha na abertura de ficheiro temporário."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Falha a modificar o tempo do ficheiro para '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Falha ao tocar no ficheiro '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Falha ao obter tempos do ficheiro para '%s'"
@@ -1552,22 +1586,22 @@ msgstr "Falha ao obter tempos do ficheiro para '%s'"
 msgid "Browse"
 msgstr "Explorar"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Todos os ficheiros (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s ficheiros (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Abrir %s ficheiros"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Gravar %s ficheiro"
@@ -1942,106 +1976,106 @@ msgstr "pré-definição"
 msgid "unknown-%d"
 msgstr "desconhecido %d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "sublinhado"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " rasurado"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " leve"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " leve"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " negrito"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " negrito"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " negrito"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " itálico"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "Rasurado"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "leve"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "leve"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "negrito"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "negrito"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "negrito"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "itálico"
 
@@ -2125,7 +2159,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Falha ao definir modo de transferência FTP para %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2146,7 +2180,7 @@ msgstr "O servidor do FTP não suporta modo passivo."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 #, fuzzy
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Falha de criação de cursor."
@@ -2163,7 +2197,7 @@ msgstr "Personalizar Colunas"
 msgid "&Customize..."
 msgstr "&Personalizar ..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Falha ao abrir '%s' para %s"
@@ -2183,159 +2217,158 @@ msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Impossível gravar imagem inválida."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage não tem a sua wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Impossível escrever o cabeçalho do ficheiro (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Impossível escrever o cabeçalho do ficheiro (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Impossível escrever mapa de cores RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Impossível escrever data."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Impossível alocar memória."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Cabeçalho DIB: Largura da imagem > 32767 pixeis para o ficheiro."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Cabeçalho DIB: Altura da imagem > 32767 pixeis para o ficheiro."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Cabeçalho DIB: Bitdepth desconhecido no ficheiro."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Cabeçalho DIB: Codificação desconhecida no ficheiro."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Cabeçalho DIB: Codificação não coincide com o bitdepth."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Impossível alocar memória."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Cabeçalho DIB: Largura da imagem > 32767 pixeis para o ficheiro."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Cabeçalho DIB: Altura da imagem > 32767 pixeis para o ficheiro."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Cabeçalho DIB: Bitdepth desconhecido no ficheiro."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Cabeçalho DIB: Codificação desconhecida no ficheiro."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Cabeçalho DIB: Codificação não coincide com o bitdepth."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Erro na leitura do DIB da imagem."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Erro a ler máscara DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imagem alta demais para um ícone."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imagem larga demais para um ícone."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Erro a escrever ficheiro de imagem!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índice inválido de ícone."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "A imagem e a máscara têm tamanhos diferentes."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Sem cor usada na imagem a ser mascarada."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, fuzzy, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, fuzzy, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, fuzzy, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Falha na abertura da imagem %d do ficheiro '%s'."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Não foi possível gravar imagem para ficheiro '%s': extensão desconhecida."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Não foi encontrado um manuseador para o tipo de imagem."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Não existe um manuseador para o tipo %d definido."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, fuzzy, c-format
 msgid "Image file is not of type %d."
 msgstr "O ficheiro de imagem não é do tipo %ld."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Não é possível determinar automaticamente o formato da imagem para entrada "
 "não pesquisável."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 #, fuzzy
 msgid "Unknown image data format."
 msgstr "erro no formato do dado"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, fuzzy, c-format
 msgid "This is not a %s."
 msgstr "PCX: este não é um ficheiro PCX."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Não existe um manuseador de imagem para o tipo %s definido."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, fuzzy, c-format
 msgid "Image is not of type %s."
 msgstr "O ficheiro de imagem não é do tipo %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, fuzzy, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Falha ao gravar imagem de bitmap para ficheiro \"%s\"."
@@ -2439,52 +2472,52 @@ msgstr "PNM: O ficheiro parece estar truncado."
 msgid " (in module \"%s\")"
 msgstr " (no módulo \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Erro ao carregar imagem."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Índice inválido para imagem TIFF."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Não é possível alocar memória."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Erro ao ler imagem."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Erro ao gravar imagem."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Erro ao escrever imagem."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Falha de inicialização no post init, a interromper."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2583,7 +2616,7 @@ msgstr "erro de compressão"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Correspondência não encontrada de '{' numa entrada do tipo mime %s."
@@ -2603,7 +2636,7 @@ msgstr "Dependência  \"%s\" do módulo \"%s\" não existe."
 msgid "Module \"%s\" initialization failed"
 msgstr "Falha de inicialização do Módulo \"%s\""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 #, fuzzy
 msgid "Message"
 msgstr "%s mensagem"
@@ -3106,7 +3139,7 @@ msgstr "Erro de Impressão"
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Configuração de página"
 
@@ -3143,19 +3176,15 @@ msgstr "A imprimir página %d de %d ..."
 msgid " (copy %d of %d)"
 msgstr " (cópia %d de %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "A Imprimir ..."
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Primeira Página"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Página anterior"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Página seguinte"
 
@@ -3202,16 +3231,16 @@ msgstr "Página %d de %d"
 msgid "Page %d"
 msgstr "Página %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "erro desconhecido"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expressão regular inválida '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Falha a encontrar resultados na procura por expressão regular: %s"
@@ -3223,21 +3252,21 @@ msgstr ""
 "Renderizador \"%s\" tem uma versão incompatível %d.%d e não pode ser "
 "carregado."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Falhou a extracção de '%s' para '%s'."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Falhou a extracção de '%s' para '%s'."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Falhou a extracção de '%s' para '%s'."
@@ -3246,11 +3275,11 @@ msgstr "Falhou a extracção de '%s' para '%s'."
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Gravar"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Não Gravar"
 
@@ -3335,10 +3364,10 @@ msgid "Clear"
 msgstr "Limpar"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Fechar"
 
@@ -3350,7 +3379,7 @@ msgstr "&Converter"
 msgid "Convert"
 msgstr "Converter"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
@@ -3359,7 +3388,7 @@ msgstr "&Copiar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cor&tar"
@@ -3368,13 +3397,13 @@ msgstr "Cor&tar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Apagar"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Apagar"
@@ -3464,7 +3493,7 @@ msgstr "Disco Rígido"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -3484,7 +3513,7 @@ msgstr "Indentar"
 msgid "&Index"
 msgstr "&Índice"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Índice"
 
@@ -3554,7 +3583,7 @@ msgstr "&Novo"
 msgid "New"
 msgstr "Novo"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Não"
 
@@ -3572,12 +3601,12 @@ msgstr "&Abrir..."
 msgid "Open..."
 msgstr "&Abrir ..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Colar"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Colar"
@@ -3608,7 +3637,7 @@ msgid "Print..."
 msgstr "&Imprimir ..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Propriedades"
 
@@ -3644,10 +3673,6 @@ msgstr "Substituir"
 msgid "Revert to Saved"
 msgstr "Reverter para o Gravado"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Guardar"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Gravar &Como..."
@@ -3657,7 +3682,7 @@ msgstr "Gravar &Como..."
 msgid "Save As..."
 msgstr "Gravar &Como..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecion&ar Todos"
@@ -3771,7 +3796,7 @@ msgstr "&Cima"
 msgid "Up"
 msgstr "Cima"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Sim"
 
@@ -3863,43 +3888,43 @@ msgstr "Gravar documento atual"
 msgid "Save current document with a different filename"
 msgstr "Gravar documento atual com nome diferente"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Conversão código de caracteres '%s' não funciona."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "desconhecido"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "bloco de cabeçalho incompleto no tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "falha de checksum a ler bloco de cabeçalho tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "dados inválidos no cabeçalho tar estendido"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "entrada tar não aberta"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fim de ficheiro inesperado"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s não coube no cabeçalho tar para a entrada '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tamanho incorrecto dado a entrada do tar"
 
@@ -3908,7 +3933,7 @@ msgstr "tamanho incorrecto dado a entrada do tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' é capaz de ser um buffer binário."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Não foi possível carregar o ficheiro."
 
@@ -3922,49 +3947,49 @@ msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "Não foi possível escrever o buffer '%s' para o disco."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Falha na obtenção da hora local do sistema"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "falhou o wxGetTimeOfDay."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' não é uma mensagem válida do catálogo."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 #, fuzzy
 msgid "Invalid message catalog."
 msgstr "'%s' não é uma mensagem válida do catálogo."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, fuzzy, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Não foi possível analisar gramaticalmente Plural-Forms: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "a utilizar catálogo '%s' de '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, fuzzy, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' não é uma mensagem válida do catálogo."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 #, fuzzy
 msgid "Couldn't enumerate translations"
 msgstr "Não foi possível terminar a thread"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Falha ao abrir '%s' para %s"
@@ -3997,7 +4022,7 @@ msgstr "'%s' deve apenas conter caracteres alfabéticos."
 msgid "Error: %s (%d)"
 msgstr "Erro: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -4006,21 +4031,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Não foi possível carregar o ficheiro."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Não são suportadas conversões de cadeias de caracteres"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Não foi possível transferir dados para a janela"
 
@@ -4073,8 +4098,8 @@ msgstr "Create Parameter não encontrado nos Parâmetros RTTI declarados"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Classe de objecto ilegal (Não-wxEvtHandler) como EventSource"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Tipo deve ter conversão enum - long"
 
@@ -4125,80 +4150,80 @@ msgstr "Os objetos devem ter um atributo de id."
 msgid "Doubly used id : %d"
 msgstr "Id usado duplamente : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, fuzzy, c-format
 msgid "Unknown Property %s"
 msgstr "Propriedade desconhecida %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "uma colecção não vazia deve consistir em nós de 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 "cadeia de caracteres de manuseamento de eventos incorrecta, falta um ponto"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "não foi possível re-inicializar o 'zlib deflate stream'"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "não foi possível re-inicializar o 'zlib inflate stream'"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "a assumir que este é um ficheiro zip multi-partes concatenado"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "ficheiro zip inválido"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "não foi possível localizar o directório central no zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "erro a ler directório central de zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "erro ao ler cabeçalho local de zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "mau offset de entrada de ficheiro zip"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "guardado tamanho do ficheiro não no cabeçalho Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "método de compressão Zip não suportado"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "a ler corrente de dados zip (entrada %s): mau comprimento"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "a ler corrente de dados zip (entrada %s): mau crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "erro ao escrever entrada zip '%s': mau comprimento ou crc"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "erro ao escrever entrada zip '%s': mau comprimento ou crc"
@@ -4284,35 +4309,35 @@ msgstr "Arte gráfica por "
 msgid "Translations by "
 msgstr "Traduções por "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 #, fuzzy
 msgid "Version "
 msgstr " Versão "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Sobre o %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licença"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 #, fuzzy
 msgid "Developers"
 msgstr "Desenvolvido por "
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 #, fuzzy
 msgid "Documentation writers"
 msgstr "Documentado por "
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 #, fuzzy
 msgid "Translators"
 msgstr "Traduções por "
@@ -4364,44 +4389,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Falso"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (ou %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Adicionar Coluna"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4412,8 +4436,7 @@ msgid "Left"
 msgstr "Esquerda"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4511,7 +4534,7 @@ msgid "Home directory"
 msgstr "Directório pessoal"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Ambiente de Trabalho"
 
@@ -4524,8 +4547,7 @@ msgstr "Nome do directório ilegal."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Erro"
 
@@ -4709,16 +4731,16 @@ msgstr "Ver ficheiros como uma vista detalhada"
 msgid "Go to parent directory"
 msgstr "Ir para o directório superior"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "O ficheiro '%s' já existe, deseja substituí-lo?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Por favor escolha um ficheiro existente."
 
@@ -4812,7 +4834,7 @@ msgstr "O tamanho do ponto da fonte."
 msgid "Whether the font is underlined."
 msgstr "Se a fonte está sublinhada."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Antevisão:"
@@ -4830,49 +4852,48 @@ msgstr "Clique para cancelar selecção de fonte."
 msgid "Click to confirm the font selection."
 msgstr "Clique para confirmar selecção de fonte."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Escolher fonte"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Directório de ajuda \"%s\" não encontrado."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Ficheiro de ajuda \"%s\" não encontrado."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "A linha %lu do ficheiro de mapa \"%s\" contém uma sintaxe inválida, saltado."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Não foram encontrados mapeamentos válidos no ficheiro \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Não foram encontradas entradas."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Índice de Ajuda"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Entradas relevantes:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Entradas encontradas"
 
@@ -4979,59 +5000,59 @@ msgstr "Não foi possível inicia a impressão."
 msgid "Printing page %d..."
 msgstr "A imprimir a página %d ..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opções da Impressora"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Imprimir para Ficheiro"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Impressora:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Estado:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Todos"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Páginas"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Páginas a Imprimir"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "De:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Para:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Cópias:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Ficheiro PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Configuração da Impressora"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Impressora"
 
@@ -5039,25 +5060,25 @@ msgstr "Impressora"
 msgid "Default printer"
 msgstr "Impressora pré-definida"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Tamanho do papel"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Retrato"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Paisagem"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientação"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opções"
 
@@ -5069,52 +5090,52 @@ msgstr "Imprimir a cores"
 msgid "Print spooling"
 msgstr "Colocação da impressão no buffer"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Comando da impressora:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opções da impressora:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Margem esquerda (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Margem de topo (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Margem direita (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Margem de rodapé (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Impressora ..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Ignorar"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Feito."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Procurar"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Não foi possível localizar a tabulação para o id"
 
@@ -5150,22 +5171,22 @@ msgstr "&Terminar"
 msgid "< &Back"
 msgstr "< &Atrás"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "créditos dos tradutores"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Falha de criação de directório \"%s\""
@@ -5191,12 +5212,12 @@ msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Falha na atualização do ficheiro de configuração do utilizador."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Erro Fatal"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5204,7 +5225,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5212,7 +5233,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Fillho MDI"
 
@@ -5229,35 +5250,27 @@ msgstr "Erro durante a espera de um semáforo"
 msgid "Page Setup"
 msgstr "Configuração de Página"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Falha de inserção de texto no controlo."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Por favor escolha uma fonte válida."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5356,45 +5369,45 @@ msgstr "Não foi possível abrir o ficheiro de conteúdos: %s"
 msgid "Cannot open index file: %s"
 msgstr "Não foi possível abrir ficheiro de índice: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "sem nome"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Não foi possível abrir o livro de ajuda HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Mostrar ajuda à medida que navega nos livros à esquerda."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(marcadores)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Adicionar página atual aos marcadores"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Remover página atual dos marcadores"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Conteúdos"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Procurar"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Mostrar tudo"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5402,19 +5415,19 @@ msgstr ""
 "Mostrar todos os items de índice que contenham a seguinte cadeia. A pesquisa "
 "é insensível à capitulação."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Mostrar todos os items no índice"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Sensível à capitulação"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Apenas palavras completas"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 #, fuzzy
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
@@ -5423,147 +5436,147 @@ msgstr ""
 "Procurar conteúdos de livros de ajuda para todas as ocorrências do texto "
 "digitado acima"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Mostra/esconde painel de navegação"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Ir para trás"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Ir para a frente"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Subir um nível na hierarquia do documento"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Abrir documento HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Imprimir esta página"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Caixa de diálogo do ecrã"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Por favor escolha uma página para mostrar:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Tópicos de Ajuda"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "A Procurar..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Ainda não foi encontrada uma página correspondente"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Foram encontradas %i correspondências"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Ajuda)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Procurar em todos os livros"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opções do Navegador de Ajuda"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Fonte normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fonte Fixa:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Tamanho da Fonte:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "tamanho da fonte"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Face normal <br>e <u>sublinhado</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Face itálico.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Face negrito.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Face negrito itálico.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Tamanho fixo da face.<br> <b>negrito</b> <i>itálico</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negrito itálico <u>sublinhado</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Ajuda de Impressão"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Não foi possível imprimir página vazia."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Ficheiros HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Livros de ajuda(*.htb)|*.htb|Livros de ajuda(*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML projecto de ajuda (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Ficheiro de ajuda HTML comprimido (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i de %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu de %lu"
@@ -5636,32 +5649,6 @@ msgstr ""
 "Houve um problema durante a configuração da página: poderá necessitar de "
 "definir uma impressora pré-definida."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Falha a mostrar documento HTML na codificação %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets não foi possível abrir ecrã para '%s': a sair."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtro"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Directórios"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Ficheiros"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selecção"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Falha na abertura da área de transferência."
@@ -5703,60 +5690,60 @@ msgstr "Execução do comando '%s' terminou com o erro: %ul"
 msgid "Failed to create cursor."
 msgstr "Falha de criação de cursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Falha no registo do servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Falha ao desregistar servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Falha ao criar ligação ao servidor '%s' no tópico '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Falhou o pedido de poke DDE"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Falha ao estabelecer um advise loop com o servidor DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Falha ao terminar o advise loop com o servidor DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Falha ao enviar aviso de notificação DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Falha ne criação da cadeia de caracteres DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "sem erro DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "um pedido para uma transacção de conselho síncrona excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a resposta à transacção causou a definição do bit DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 "um pedido para uma transacção de dados síncrona excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5767,7 +5754,7 @@ msgstr ""
 "ou um identificador inválido instância\n"
 "foi passado a uma função DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5779,46 +5766,46 @@ msgstr ""
 "ou uma aplicação inicaializada como APPCMD_CLIENTONLY tem\n"
 "tentado realizar transacções de servidor."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "um pedido para uma transacção de execução síncrona excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "falhou a validação de um parâmetro pelo DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "uma aplicação DDEML criou uma condição de corrida prolongada."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "falhou uma alocação de memória."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 "a tentativa por parte de um cliente de estabelecer uma conversação falhou."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "falhou uma transacção."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "um pedido para uma transacção de 'poke' síncrona excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "falha numa chamada interna à função PostMessage. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema recursivo."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5828,16 +5815,16 @@ msgstr ""
 "que foi terminada pelo cliente, ou o servidor\n"
 "terminou antes do fim da transacção."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "ocorreu um erro interno no DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "um pedido de término de uma transacção de conselho excedeu o tempo limite."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5847,12 +5834,12 @@ msgstr ""
 "Uma vez que a aplicação retornou de uma chamada de um XTYP_XACT_COMPLETE,\n"
 "o identificador de transacção dessa chamada deixou de ser válido."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Erro DDE desconhecido %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5861,7 +5848,7 @@ msgstr ""
 "de acesso remoto (RAS) não estar instalado neste computador. Por favor "
 "Instale-o."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, fuzzy, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5871,67 +5858,67 @@ msgstr ""
 "demasiado antigo, por favor atualize-o (as seguintes funções necessárias "
 "estão em falta: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Falha na obtenção do texto da mensagem de erro RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "erro desconhecido ( código de erro %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Não foi possível encontrar a ligação telefónica ativa: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Foram encontradas várias ligações telefónicas ativas, a escolher uma "
 "aleatoriamente."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Falha ao estabelecer ligação telefónica: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Falha ao obter nomes de ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Falha na ligação: nenhum serviço ISP para marcar."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Escolha o ISP para marcar"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Por favor escolha ISP a que pretende ligar"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Falha na ligação: falta nome de utilizador/palavra passe."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr ""
 "Não foi possível encontrar a localização do ficheiro do livro de endereços"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, fuzzy, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Falha ao terminar a ligação telefónica: %s "
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Não foi possível desligar - nenhuma ligação telefónica ativa."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Falha ao terminar a ligação telefónica: %s "
@@ -5951,19 +5938,18 @@ msgstr "Falha ao alocar %luKb de memória para dados bitmap."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Não foi possível enumerar os ficheiros na diretoria '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 #, fuzzy
 msgid "Couldn't obtain folder name"
 msgstr "Não foi possível criar um temporizador"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (erro %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Não foi possível adicionar uma imagem à lista de imagens."
 
@@ -5978,7 +5964,7 @@ msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Falha a criar dialogo standard de procura/substitui (código de erro %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, fuzzy, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Execução do comando '%s' terminou com o erro: %ul"
@@ -6022,17 +6008,17 @@ msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 "Não é possível monitorizar a diretoria inexistente \"%s\" para alterações."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Não foi possível criar um temporizador"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Falha ao inicializar o OpenGL"
 
@@ -6040,7 +6026,7 @@ msgstr "Falha ao inicializar o OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6048,7 +6034,7 @@ msgstr ""
 "Funções de ajuda MS HTML não estão disponíveis devido à livraria de ajuda MS "
 "HTML não estar instalada neste computador. por favor instale-a."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Falha na inicialização da ajuda MS HTML."
 
@@ -6057,7 +6043,7 @@ msgstr "Falha na inicialização da ajuda MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "Não é possível apagar o ficheiro INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6179,7 +6165,7 @@ msgstr "Não foi possível registar o formato da área de transferência '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O formato da área de transferência '%d' não existe."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Saltar"
 
@@ -6264,59 +6250,59 @@ msgstr ""
 "apagá-lo vai deixar o seu sistema num estado inutilizável:\n"
 "operação interrompida."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Não é possível apagar a chave '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Não é possível apagar valor '%s' da chave '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Não foi possível ler valor da chave '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Não foi possível definir valor de '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Não foi possível ler valor de '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Não é possível enumerar os valores da chave '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Não é possível enumerar as sub-chaves da chave '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6324,17 +6310,17 @@ msgstr ""
 "Exportação da chave de registo: o ficheiro \"%s\" já existe e não vai ser "
 "sobreposto."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Não foi possível exportar valores de tipo %d não suportado."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "A ignorar valor \"%s\" da chave \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6342,41 +6328,41 @@ msgstr ""
 "Impossível criar um controlo de edição rico, alternativamente usar-se-á um "
 "controlo de texto simples. Por favor reinstale o riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Não é possível iniciar a thread: erro ao escrever o TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Não foi possível definir prioridade da thread"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Não é possível criar a thread"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Não foi possível terminar a thread"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Não é possível esperar pela terminação da thread"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, fuzzy, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Não é possível suspender a thread %x"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, fuzzy, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Não é possível retomar a thread %x"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "impossível obter o ponteiro atual da thread"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6384,7 +6370,7 @@ msgstr ""
 "Falhou a inicialização do módulo da thread: impossível alocar índice no "
 "armazenamento local da thread"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6417,12 +6403,12 @@ msgstr "Falha na leitura de metafile do ficheiro \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Falha no bloqueio do ficheiro de bloqueio '%s'"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, fuzzy, c-format
 msgid "build %lu"
 msgstr "Windows XP (build %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", edição 64 bits"
 
@@ -6434,47 +6420,47 @@ msgstr "Falha ao criar pipeline anónimo"
 msgid "Failed to redirect the child process IO"
 msgstr "Falha no redireccionamento do processo filho ES"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Falhou a execução do comando '%s'"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Falha na abertura do mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Não foi possível ler tipo de nome de '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Não foi possível carregar ícone de '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Não foi possível definir prioridade da thread"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Falha ao executar '%s'\n"
@@ -6508,7 +6494,7 @@ msgid "Check to make the font italic."
 msgstr "Marque para tornar a letra itálica."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Sublinhado"
@@ -6576,17 +6562,32 @@ msgstr "<Qualquer Teletype>"
 msgid "File type:"
 msgstr "Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Janela"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimizar"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Ampl&iar"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6603,492 +6604,492 @@ msgstr "Ficheiro %s não existe."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Sobre o %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "&Sobre o ..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "&Preferências"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Ocultar %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Aplicação"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Ocultar Outros"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Mostrar Tudo"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, fuzzy, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "&Desistir"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Aplicação"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip não suportado nesta versão do zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Não foi possível inicializar o ecrã."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 #, fuzzy
 msgid "Point Size"
 msgstr "Tamanho do &ponto:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 #, fuzzy
 msgid "Face Name"
 msgstr "NovoNome"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 #, fuzzy
 msgid "Weight"
 msgstr "&Peso:"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Família"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Margem"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "leve"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Alinhar texto à direita."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Margem"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Janela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Janela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Janela"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Tamanho Personalizado"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "Explorar"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "&Refazer"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "pré-definição"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "amanhã"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Direita"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Estilo de marcador"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Código de &Caracter:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Tamanho do &ponto:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Alinhar à Direita"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Pergunta"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Direita"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Direita"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 #, fuzzy
 msgid "Make a selection:"
 msgstr "Colar selecção"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 #, fuzzy
 msgid "Property"
 msgstr "&Propriedades"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Modo Alfabético"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Verdadeiro"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 #, fuzzy
 msgid "Unspecified"
 msgstr "Justificado"
@@ -7103,49 +7104,49 @@ msgstr "Erro de Impressão"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Inseriu um valor inválido. Pressione ESC para cancelar a edição."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "O valor deve ser %s ou superior."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, fuzzy, c-format
 msgid "Value must be between %s and %s."
 msgstr "Introduza um número de página entre %d e %d:"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "O valor deve ser %s ou inferior."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, fuzzy, c-format
 msgid "Not %s"
 msgstr "Não %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 #, fuzzy
 msgid "Choose a directory:"
 msgstr "Criar directório"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Escolher um ficheiro"
 
@@ -7632,127 +7633,127 @@ msgstr "Inserir"
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Alterar Estilo"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 #, fuzzy
 msgid "Change Object Style"
 msgstr "Alterar Lista de Estilos"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 #, fuzzy
 msgid "Change Properties"
 msgstr "&Propriedades"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Alterar Lista de Estilos"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renumerar Lista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Inserir Texto"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Inserir Imagem"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 #, fuzzy
 msgid "Insert Object"
 msgstr "Inserir Texto"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 #, fuzzy
 msgid "Insert Field"
 msgstr "Inserir Texto"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Demasiadas chamadas EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "ficheiros"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 #, fuzzy
 msgid "standard/circle"
 msgstr "Standard"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 #, fuzzy
 msgid "standard/square"
 msgstr "Standard"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 #, fuzzy
 msgid "Box Properties"
 msgstr "&Propriedades"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Propriedades da Célula"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 #, fuzzy
 msgid "Set Cell Style"
 msgstr "Apagar Estilo"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Apagar Fila"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Apagar Coluna"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Adicionar Fila"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Adicionar Coluna"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 #, fuzzy
 msgid "Table Properties"
 msgstr "&Propriedades"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 #, fuzzy
 msgid "Picture Properties"
 msgstr "&Propriedades"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "imagem"
 
@@ -7960,25 +7961,25 @@ msgstr "~"
 msgid "Drag"
 msgstr "Arrastar"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Apagar Texto"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 #, fuzzy
 msgid "Remove Bullet"
 msgstr "Remover"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "O texto não pode ser gravado."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Substituir"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Fonte:"
 
@@ -9008,53 +9009,53 @@ msgstr "Estilos da lista"
 msgid "Box styles"
 msgstr "Todos os estilos"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "A fonte de onde se retira o símbolo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subconjunto:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Mostra um sub-conjunto Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "Código de &Caracter:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Código do caracter."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&De:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "O alcance a mostrar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Inserir"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
@@ -9248,7 +9249,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr "Erro de reprodução de multimédia: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, fuzzy, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Falha na abertura do ecrã \"%s\"."
@@ -9348,22 +9349,22 @@ msgstr "Dados de som estão num formato não suportado."
 msgid "Couldn't open audio: %s"
 msgstr "Não foi possível abrir o áudio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Não foi possível obter thread de política de agendamento."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Não foi possível obter a gama de prioridade para a política de agendamento "
 "%d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "A definição de prioridade da thread é ignorada."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9371,62 +9372,62 @@ msgstr ""
 "Falha na associação a uma thread, foi detectada uma potencial fuga de "
 "memória - por favor reinicie o programa"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, fuzzy, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Falha ao definir prioridade de thread %d."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Falha ao definir prioridade de thread %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Falha ao matar a thread."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Falhou a inicialização do módulo da thread: falhou a criação da chave da "
 "thread"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Não foi possível obter a entrada do processo filho"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 #, fuzzy
 msgid "Can't write to child process's stdin"
 msgstr "Falha no encerramento do processo %d"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Falha ao executar '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Falha no fork"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 #, fuzzy
 msgid "Failed to set process priority"
 msgstr "Falha ao definir prioridade de thread %d."
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Falha no redireccionamento do processo filho de entrada/saída"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Não foi possível obter o nome de computador"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Não foi possível obter o nome de computador oficial"
 
@@ -9444,12 +9445,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "Falha na leitura do PID do ficheiro de bloqueio."
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Especificação de geometria inválida '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets não foi possível abrir o ecrã. A sair."
 
@@ -9463,30 +9464,59 @@ msgstr "Falha ao fechar o ecrã \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Falha na abertura do ecrã \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML erro de verificação gramatical: '%s' na linha %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, fuzzy, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Não foi possível carregar recursos do ficheiro '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, fuzzy, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Não foi possível carregar recursos do ficheiro '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Não foi possível carregar recursos do ficheiro '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Falhou a extracção de '%s' para '%s'."
+
+#~ msgid "Printing "
+#~ msgstr "A Imprimir ..."
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Falha de inserção de texto no controlo."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Por favor escolha uma fonte válida."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Falha a mostrar documento HTML na codificação %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets não foi possível abrir ecrã para '%s': a sair."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Directórios"
+
+#~ msgid "Files"
+#~ msgstr "Ficheiros"
+
+#~ msgid "Selection"
+#~ msgstr "Selecção"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "falhou a conversão para codificação de 8-bits"
@@ -9632,8 +9662,8 @@ msgstr "Falhou a extracção de '%s' para '%s'."
 #~ msgstr "Não foi possível inicia a impressão."
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-06-04 15:03-0300\n"
 "Last-Translator: Felipe <felipefplzx@gmail.com>\n"
 "Language-Team: Felipe <felipefplzx@gmail.com>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Todos os arquivos (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Todos os arquivos (*)|*"
 
@@ -39,24 +39,21 @@ msgid "Remaining time:"
 msgstr "Tempo restante:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Sim"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Não"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Cancelar"
@@ -106,7 +103,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Incapaz de criar a porta do término da E/S"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Imprimir"
 
@@ -143,7 +140,7 @@ msgstr "Propriedades do Objeto"
 msgid "Printing"
 msgstr "Imprimindo"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Símbolos"
 
@@ -212,7 +209,7 @@ msgstr "&Anterior"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Janela"
 
@@ -741,11 +738,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "mostrar esta mensagem de ajuda"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "gerar mensagens de log prolixas"
 
@@ -767,84 +764,84 @@ msgstr "Tema não suportado '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Especificação do modo de exibição '%s' inválida."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "A opção '%s' não pode ser negada"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opção longa desconhecida '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opção desconhecida '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Caracteres inesperados seguindo a opção '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "A opção '%s' requer um valor."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Separador esperado após a opção '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' não é um valor numérico correto para a opção '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "A opção '%s': '%s' não pode ser convertida para uma data."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parâmetro inesperado '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ou %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "O valor para a opção '%s' deve ser especificado."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "O parâmetro requerido '%s' não foi especificado."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Uso: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "duplo"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "data"
 
@@ -862,7 +859,7 @@ msgid "Can't &Undo "
 msgstr "Não Consegue &Desfazer "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Desfazer"
@@ -872,7 +869,7 @@ msgid "&Redo "
 msgstr "&Refazer "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Refazer"
@@ -901,12 +898,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' tem extras '..'; ignorados."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "verificado"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "não verificado"
 
@@ -915,103 +912,103 @@ msgstr "não verificado"
 msgid "undetermined"
 msgstr "não determinado"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "hoje"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "ontem"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "amanhã"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "primeiro"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "segundo"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "terceiro"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "quarto"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "quinto"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sexto"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sétimo"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "oitavo"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "nono"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "décimo"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "décimo-primeiro"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "décimo-segundo"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "décimo-terceiro"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "décimo-quarto"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "décimo-quinto"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "décimo-sexto"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "décimo-sétimo"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "décimo-oitavo"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "décimo-nono"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "vigésimo"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "meio-dia"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "meia-noite"
 
@@ -1079,44 +1076,81 @@ msgstr "Falhou em executar o curl, por favor instale-o no PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Falhou em enviar o relatório de debug (código do erro %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Salvar Como"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Descartar mudanças e recarregar a última versão salva?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "sem nome"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Você quer salvar as mudanças em %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Salvar"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Não Salvar"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Você quer salvar as mudanças em %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "O texto não pôde ser salvo."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "O arquivo \"%s\" não pôde ser aberto para gravação."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Falhou em salvar o documento como arquivo \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "O arquivo \"%s\" não pôde ser aberto pra leitura."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Falhou em ler o documento do arquivo \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1125,57 +1159,57 @@ msgstr ""
 "O arquivo '%s' não existe e não pôde ser aberto.\n"
 "Ele foi removido da lista dos arquivos mais usados recentemente."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "A criação da pré-visualização da impressão falhou."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Pré-visualização da Impressão"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "O formato do arquivo '%s' não pôde ser determinado."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "%d sem nome"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Abrir Arquivo"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Erro do arquivo"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Lamento, não pude abrir este arquivo."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Lamento, o formato pra este arquivo é desconhecido."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Selecione um modelo de documento"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Modelos"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Selecione uma visualização do documento"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Visualizações"
 
@@ -1209,42 +1243,42 @@ msgstr "Erro de leitura no arquivo '%s'"
 msgid "Write error on file '%s'"
 msgstr "Erro de gravação no arquivo '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "falhou em limpar o arquivo '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Erro de busca no arquivo '%s' (arquivos grandes não suportados pela stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Erro de busca no arquivo '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Não consegue achar a posição atual no arquivo '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Falhou em definir as permissões do arquivo temporário"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "não consegue remover o arquivo '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "não consegue fazer as mudanças no arquivo '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "não consegue remover o arquivo temporário '%s'"
@@ -1269,27 +1303,27 @@ msgstr "não consegue ler do descritor de arquivos %d"
 msgid "can't write to file descriptor %d"
 msgstr "não consegue gravar no descritor de arquivos %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "não consegue limpar o descritor de arquivos %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "não consegue procurar no descritor de arquivos %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "não consegue obter a posição da busca no descritor de arquivos %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "não consegue achar o tamanho do arquivo no descritor de arquivos %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1309,114 +1343,114 @@ msgstr "não consegue abrir o arquivo de configuração do usuário '%s'."
 #, c-format
 msgid "Changes won't be saved to avoid overwriting the existing file \"%s\""
 msgstr ""
-"As mudanças não serão salvas pra evitar sobrescrever o arquivo existente \"%s"
-"\""
+"As mudanças não serão salvas pra evitar sobrescrever o arquivo existente "
+"\"%s\""
 
 #: ../src/common/fileconf.cpp:421
 msgid "Error reading config options."
 msgstr "Erro ao ler as opções da config."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Falhou em ler as opções de config."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "arquivo '%s': caractere ineperado %c na linha %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "arquivo '%s', linha %zu: '%s' ignorado após o cabeçalho do grupo."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "arquivo '%s', linha %zu: '=' esperado."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "arquivo '%s', linha %zu: valor para a chave imutável '%s' ignorado."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "arquivo '%s', linha %zu: chave '%s' foi achada primeiro na linha %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "O nome da entrada da config não pode iniciar com '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "não pode abrir o arquivo de configuração do usuário."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "não pode gravar o arquivo de configuração do usuário."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Falhou em atualizar o arquivo de configuração do usuário."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Erro ao salvar os dados de configuração do usuário."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "não pode apagar o arquivo de configuração do usuário '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "a entrada '%s' aparece mais do que uma vez no grupo '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativa de mudar a chave imutável '%s' ignorada."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "barra invertida do rastreamento ignorada em '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "inesperado \" na posição %d em '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Falhou em copiar o arquivo '%s' pra '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Impossível obter as permissões pro arquivo '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Impossível sobrescrever o arquivo '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Erro ao copiar o arquivo '%s' para '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Impossível definir as permissões para o arquivo '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1425,40 +1459,40 @@ msgstr ""
 "Falhou em renomear o arquivo '%s' para '%s' porque o arquivo destino já "
 "existe."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "O arquivo '%s' não pôde ser renomeado '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "O arquivo '%s' não pôde ser removido"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "O diretório '%s' não pôde ser criado"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "O diretório '%s' não pôde ser apagado"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Não consegue enumerar os arquivos '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Falhou em obter o diretório de trabalho"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Não pôde definir o diretório de trabalho atual"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Arquivos (%s)"
@@ -1485,17 +1519,17 @@ msgstr "Falhou em criar um nome de arquivo temporário"
 msgid "Failed to open temporary file."
 msgstr "Falhou em abrir o arquivo temporário."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Falhou em modificar as horas do arquivo para '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Falhou em tocar o arquivo '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Falhou em recuperar as horas do arquivo para '%s'"
@@ -1504,22 +1538,22 @@ msgstr "Falhou em recuperar as horas do arquivo para '%s'"
 msgid "Browse"
 msgstr "Procurar"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Todos os arquivos (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "Arquivos %s (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Carrega o arquivo %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Salvar arquivo %s"
@@ -1882,99 +1916,99 @@ msgstr "padrão"
 msgid "unknown-%d"
 msgstr "desconhecido- %d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "sublinhado"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " sublinhado"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " magro"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " extra-leve"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " leve"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " médio"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " semi-negrito"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " negrito"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " extra-negrito"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " pesado"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " extra-pesado"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " itálico"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "riscar"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "magro"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "extra-leve"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "leve"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "médio"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "semi-negrito"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "negrito"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "extra-negrito"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "pesado"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "extra-pesado"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "itálico"
 
@@ -2056,7 +2090,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Falhou em definir o modo de transferência do FTP para %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2077,7 +2111,7 @@ msgstr "O servidor FTP não suporta o modo passivo."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Tamanho do frame do GIF incorreto (%u, %d) para o frame #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Falhou em distribuir a côr pro OpenGL"
 
@@ -2093,7 +2127,7 @@ msgstr "Personalizar Colunas"
 msgid "&Customize..."
 msgstr "&Personalizar..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Falhou em abrir a URL '%s' no navegador padrão"
@@ -2113,158 +2147,157 @@ msgstr "Falhou em carregar a imagem %d do fluxo."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Falhou em carregar os ícones do recurso '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Não consegue salvar a imagem inválida."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: o wxImage não tem uma wxPalette própria."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Não consegue gravar o cabeçalho do arquivo (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Não consegue gravar o cabeçalho do arquivo (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Não consegue gravar o mapa das cores RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Não consegue gravar os dados."
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr "BMP: o cabeçalho tem biClrUsed=%d quando o biBitCount=%d."
-
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: Não consegue distribuir a memória."
 
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr "Cabeçalho do DIB: Largura da imagem > 32767 pixels no arquivo."
 
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr "Cabeçalho do DIB: Altura da imagem > 32767 pixels no arquivo."
 
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "Cabeçalho do DIB: Profundidade dos bits desconhecida no arquivo."
 
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Cabeçalho do DIB: Codificação desconhecida no arquivo."
 
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr ""
 "Cabeçalho do DIB: A codificação não combina com a profundidade dos bits."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr "BMP: o cabeçalho tem biClrUsed=%d quando o biBitCount=%d."
+
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Erro ao ler a imagem do DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Erro ao ler a máscara do DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imagem muito alta para um ícone."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imagem muito larga para um ícone."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Erro ao gravar o arquivo de imagem!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Índice do ícone inválido ."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Imagem e máscara tem tamanhos diferentes."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Nenhuma côr sem uso na imagem sendo mascarada."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Falhou em carregar o bitmap \"%s\" dos recursos."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Falhou em carregar o ícone \"%s\" dos recursos."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Falhou em carregar a imagem do arquivo \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nâo consegue salvar a imagem no arquivo '%s': extensão desconhecida."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Nenhum manipulador achado para o tipo de imagem."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nenhum manipulador de imagem para o tipo %d definido."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "O arquivo de imagem não é do tipo %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Não consegue determinar automaticamente o formato da imagem para entrada de "
 "dados não-procuráveis."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Formato desconhecido dos dados da imagem."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Isto não é um %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nenhum manipulador de imagem para o tipo %s definido."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "A imagem não é do tipo %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Falhou em verificar o formato do arquivo de imagem \"%s\"."
@@ -2368,41 +2401,41 @@ msgstr "PNM: O arquivo parece truncado."
 msgid " (in module \"%s\")"
 msgstr " (no módulo \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Erro ao carregar a imagem."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Índice da imagem TIFF inválido."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TiFF: O tamanho da imagem é anormalmente grande."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Não pôde distribuir a memória."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Erro ao ler a imagem."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unidade de resolução do TIFF desconhecida %d ignorada"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Erro ao salvar a imagem."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Erro ao gravar a imagem."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2411,11 +2444,11 @@ msgstr ""
 "O argumento da linha de comando %d não pôde ser convertido pro Unicode e "
 "será ignorado."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "A inicialização falhou no post init, abortando."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Não consegue definir o locale pro idioma \"%s\"."
@@ -2511,7 +2544,7 @@ msgstr "Erro de compressão do LZMA: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Erro de compressão do LZMA quando limpa a saída dos dados: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' incomparável em uma entrada pro tipo mime %s."
@@ -2531,7 +2564,7 @@ msgstr "A dependência \"%s\" do módulo \"%s\" não existe."
 msgid "Module \"%s\" initialization failed"
 msgstr "A inicialização do módulo \"%s\" falhou"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Mensagem"
 
@@ -3033,7 +3066,7 @@ msgstr "Erro ao imprimir"
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Configuração da página"
 
@@ -3068,19 +3101,15 @@ msgstr "Imprimindo a página %d de %d"
 msgid " (copy %d of %d)"
 msgstr " (cópia %d de %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Imprimindo "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Primeira página"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Página anterior"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Próxima página"
 
@@ -3124,16 +3153,16 @@ msgstr "Página %d de %d"
 msgid "Page %d"
 msgstr "Página %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "erro desconhecido"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expressão regular '%s' inválida: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Falhou em achar a combinação para a expressão regular: %s"
@@ -3145,21 +3174,21 @@ msgstr ""
 "O renderizador \"%s\" tem uma versão incompatível, %d.%d; e não pôde ser "
 "carregado."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Não disponível pra esta plataforma"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Falhou em salvar a senha pro \"%s\": %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Falhou em ler a senha do \"%s\": %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Falhou em apagar a senha do \"%s\": %s."
@@ -3168,11 +3197,11 @@ msgstr "Falhou em apagar a senha do \"%s\": %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Falhou em monitorar os canais de E/S"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Salvar"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Não Salvar"
 
@@ -3253,10 +3282,10 @@ msgid "Clear"
 msgstr "Limpar"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Fechar"
 
@@ -3268,7 +3297,7 @@ msgstr "&Converter"
 msgid "Convert"
 msgstr "Converter"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiar"
@@ -3277,7 +3306,7 @@ msgstr "&Copiar"
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Co&rtar"
@@ -3286,13 +3315,13 @@ msgstr "Co&rtar"
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Apagar"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Apagar"
@@ -3379,7 +3408,7 @@ msgstr "Disco rígido"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Ajuda"
 
@@ -3399,7 +3428,7 @@ msgstr "Recuo"
 msgid "&Index"
 msgstr "&Índice"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Índice"
 
@@ -3468,7 +3497,7 @@ msgstr "&Novo"
 msgid "New"
 msgstr "Novo"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Não"
 
@@ -3485,12 +3514,12 @@ msgstr "&Abrir..."
 msgid "Open..."
 msgstr "Abrir..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Colar"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Colar"
@@ -3520,7 +3549,7 @@ msgid "Print..."
 msgstr "Imprimir..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Propriedades"
 
@@ -3552,10 +3581,6 @@ msgstr "Substituir..."
 msgid "Revert to Saved"
 msgstr "Reverter pro Salvo"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Salvar"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Salvar &Como..."
@@ -3564,7 +3589,7 @@ msgstr "Salvar &Como..."
 msgid "Save As..."
 msgstr "Salvar Como..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecionar &Tudo"
@@ -3671,7 +3696,7 @@ msgstr "&Pra cima"
 msgid "Up"
 msgstr "Pra cima"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Sim"
 
@@ -3759,43 +3784,43 @@ msgstr "Salvar o documento atual"
 msgid "Save current document with a different filename"
 msgstr "Salvar o documento atual com um nome de arquivo diferente"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "A conversão para o conjunto de caracteres '%s' não funciona."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "desconhecido"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "bloco do cabeçalho incompleto no tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "falha do checksum ao ler o bloco do cabeçalho tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "dados inválidos no cabeçalho estendido do tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "entrada do tar não aberta"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fim inesperado do arquivo"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s não encaixou no cabeçalho tar para a entrada '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tamanho incorreto dado para a entrada do tar"
 
@@ -3804,7 +3829,7 @@ msgstr "tamanho incorreto dado para a entrada do tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' é provavelmente um buffer binário."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "O arquivo não pôde ser carregado."
 
@@ -3818,47 +3843,47 @@ msgstr "Falhou em ler o arquivo do texto \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "não pode gravar o buffer '%s' no disco."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Falhou em obter a hora local do sistema"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "o wxGetTimeOfDay falhou."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' não é um catálogo de mensagens válido."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catálogo de mensagens inválido."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Falhou em analisar as Formas-do-Plural: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "usando o catálogo '%s' de '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "O recurso '%s' não é um catálogo de mensagens válido."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Não pôde enumerar as traduções"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Nenhum aplicativo padrão configurado para os arquivos HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Falhou em abrir a URL '%s' no navegador padrão."
@@ -3891,7 +3916,7 @@ msgstr "'%s' contém caractere(s) inválido(s)"
 msgid "Error: %s (%d)"
 msgstr "Erro: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Não há espaço o bastante no disco pro download."
 
@@ -3899,20 +3924,20 @@ msgstr "Não há espaço o bastante no disco pro download."
 msgid "libcurl could not be initialized"
 msgstr "O libcurl não pôde ser inicializado"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "O RunScriptAsync não é suportado"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Erro ao executar o JavaScript: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Esta plataforma não suporta transparência de 2º plano."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Não pôde transferir os dados para a janela"
 
@@ -3964,8 +3989,8 @@ msgstr "Criar Parâmetro %s não achado nos Parâmetros RTTI declarados"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Classe de Objeto Ilegal (Não-wxEvtHandler) como Fonte do Evento"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "O tipo precisa ter conversão enum - long"
 
@@ -4015,82 +4040,82 @@ msgstr "Os objetos devem ter um atributo id"
 msgid "Doubly used id : %d"
 msgstr "ID usada duas vezes : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Propriedade %s Desconhecida"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Uma coleção não vazia deve consistir de nodes do elemento"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "sequência do manipulador de eventos incorreta; ponto desaparecido"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "não pode reinicializar o fluxo de deflação do zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "não pode reinicializar o sistema de inflação do zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Ignorando o registro dos dados extras mal-formados, o arquivo ZIP pode estar "
 "corrompido"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "assumindo que este é um zip multi-partes concatenado"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "arquivo zip inválido"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "não pode achar o diretório central no zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "erro lendo o diretório central do zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "erro lendo o cabeçalho local do zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "offset ruim do arquivo zip para a entrada"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "tamanho do arquivo armazenado não está no cabeçalho do Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "método de compressão do Zip não suportado"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "lendo o fluxo do zip (entrada %s): tamanho ruim"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "lendo o fluxo do zip (entrada %s): crc ruim"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 "erro ao gravar a entrada do zip '%s': o arquivo é muito grande sem o ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "erro gravando a entrada do zip '%s': crc ou tamanho ruim"
@@ -4175,32 +4200,32 @@ msgstr "Arte gráfica de "
 msgid "Translations by "
 msgstr "Traduções de "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versão "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Sobre o %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licença"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Desenvolvedores"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Escritores da documentação"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistas"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Tradutores"
 
@@ -4251,42 +4276,42 @@ msgid "Password:"
 msgstr "Senha:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "verdadeiro"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "falso"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Fileira %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Retrair"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Expandir"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d itens)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Coluna %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4297,7 +4322,7 @@ msgid "Left"
 msgstr "Esquerda"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4393,7 +4418,7 @@ msgid "Home directory"
 msgstr "Diretório home"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Área de trabalho"
 
@@ -4406,8 +4431,7 @@ msgstr "Nome ilegal de diretório."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Erro"
 
@@ -4591,16 +4615,16 @@ msgstr "Visualizar arquivos numa visualização detalhada"
 msgid "Go to parent directory"
 msgstr "Ir para o diretório pai"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "O arquivo '%s' já existe; você realmente quer sobrescrevê-lo?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Por favor escolha um arquivo existente."
 
@@ -4694,7 +4718,7 @@ msgstr "O tamanho do ponto da fonte."
 msgid "Whether the font is underlined."
 msgstr "Se a fonte está sublinhada."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Pré-visualização:"
@@ -4712,49 +4736,48 @@ msgstr "Clique pra cancelar a seleção da fonte."
 msgid "Click to confirm the font selection."
 msgstr "Clique pra confirmar a seleção da fonte."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Escolha uma fonte"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "Não é suportado copiar mais do que um bloco selecionado pra área de trabalho."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "O diretório da ajuda \"%s\" não foi achado."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "O arquivo de ajuda \"%s\" não foi achado."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "A linha %lu do arquivo do mapa \"%s\" tem sintaxe inválida, ignorada."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Nenhum mapeamento válido achado no arquivo \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Não foram achadas entradas."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Índice da Ajuda"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Entradas relevantes:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Entradas achadas"
 
@@ -4858,59 +4881,59 @@ msgstr "Não pôde iniciar a impressão."
 msgid "Printing page %d..."
 msgstr "Imprimindo a página %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opções da impressora"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Imprimir pro Arquivo"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Configurar..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Impressora:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tudo"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Páginas"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Alcance da Impressão"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "De:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Para:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Cópias:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Arquivo do PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Configuração da Impressão"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Impressora"
 
@@ -4918,25 +4941,25 @@ msgstr "Impressora"
 msgid "Default printer"
 msgstr "Impressora padrão"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Tamanho do papel"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Retrato"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Paisagem"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientação"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opções"
 
@@ -4948,52 +4971,52 @@ msgstr "Imprimir em cores"
 msgid "Print spooling"
 msgstr "Buffering da impressão"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Comando da impressora:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opções da impressora:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Margem esquerda (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Margem superior (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Margem direita (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Margem do rodapé (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Impressora..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Pular"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Feito."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Procurar"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Não pôde achar a aba pela id"
 
@@ -5029,11 +5052,11 @@ msgstr "&Concluir"
 msgid "< &Back"
 msgstr "< &Voltar"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "tradutor-créditos"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5043,12 +5066,12 @@ msgstr ""
 "problemas com o manejamento e oscilação da entrada dos dados. Considere "
 "remover a definição GTK_IM_MODULE ou defina como \"ibus\"."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "Incapaz de inicializar o GTK+, o DISPLAY está configurado apropriadamente?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Falhou em mudar o diretório atual para %s"
@@ -5074,11 +5097,11 @@ msgstr "Falhou em adicionar a fonte personalizada \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Falhou em registrar a configuração da fonte usando fontes privadas."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Erro Fatal"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5091,7 +5114,7 @@ msgstr ""
 "definindo\n"
 "a variável do ambiente como GDK_BACKEND=x11 antes de iniciar seu programa."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5104,7 +5127,7 @@ msgstr ""
 "GDK_BACKEND=x11\n"
 "antes de iniciar seu programa."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Filho do MDI"
 
@@ -5120,17 +5143,13 @@ msgstr "Erro enquanto imprimia: "
 msgid "Page Setup"
 msgstr "Configuração da Página"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Falhou em inserir o texto no controle."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 "A recuperação da saída dos dados do script do JavaScript não é suportada com "
 "o WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5138,7 +5157,7 @@ msgstr ""
 "O GTK+ instalado nesta máquina é muito antigo pra suportar a composição de "
 "tela, por favor instale o GTK+ 2.12 ou superior."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5146,17 +5165,13 @@ msgstr ""
 "Composição não suportada por este sistema, por favor ative-a no seu "
 "Gerenciador de Janelas."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Este programa foi compilado com uma versão muito velha do GTK+, por favor "
 "reconstrua com o GTK+ 2.12 ou mais novo."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Por favor escolha uma fonte válida."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5255,45 +5270,45 @@ msgstr "Não consegue abrir o arquivo dos conteúdos: %s"
 msgid "Cannot open index file: %s"
 msgstr "Não consegue abrir o arquivo do índice: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "sem nome"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Não consegue abrir o livro de ajuda em HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Exibe a ajuda conforme você navega pelos livros a esquerda."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(favoritos)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Adicionar a página atual aos favoritos"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Remover a página atual dos favoritos"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Conteúdos"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Achar"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Mostrar tudo"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5301,19 +5316,19 @@ msgstr ""
 "Exibe todos os itens do índice que contém a sub-sequência dada. A busca é "
 "caso sensitivo."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Mostrar todos os itens no índice"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Caso sensitivo"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Só palavras inteiras"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5321,147 +5336,147 @@ msgstr ""
 "Pesquisar conteúdos do(s) livro(s) de ajuda pra todas as ocorrências do "
 "texto que você digitou acima"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Mostrar/ocultar o painel de navegação"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Voltar"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Avançar"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Ir um nível acima na hierarquia do documento"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Abrir documento HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Imprimir esta página"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Exibir o diálogo das opções"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Por favor escolha a página a exibir:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Tópicos da Ajuda"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Procurando..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Nenhuma página que combine ainda foi achada"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Achou %i combinações"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Ajuda)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d de %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu de %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Procurar em todos os livros"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opções de Ajuda do Navegador"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Fonte normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fonte fixa:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Tamanho da fonte:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "tamanho da fonte"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Face normal<br>e <u>sublinhado</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Face em itálico.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Face em negrito.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Face em negrito itálico.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Face do tamanho fixo.<br> <b>negrito</b> <i>itálico</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>negrito itálico <u>sublinhado</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Ajuda com a Impressão"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Não consegue imprimir a página vazia."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Arquivos HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Livros de ajuda (*.htb)|*.htb|Livros de ajuda (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projeto de Ajuda em HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Arquivo de ajuda em HTML Compactado (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i de %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u de %u"
@@ -5542,32 +5557,6 @@ msgstr ""
 "Houve um problema durante a configuração da página: você pode precisar "
 "definir uma impressora padrão."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Falhou em exibir o documento em HTML na codificação %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "O wxWidgets não pôde abrir a tela pro '%s': saindo."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtro"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Diretórios"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Arquivos"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Seleção"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Falhou em abrir a área de transferência."
@@ -5609,59 +5598,59 @@ msgstr "O diálogo da seleção de cores falhou com o erro %0lx."
 msgid "Failed to create cursor."
 msgstr "Falhou em criar o cursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Falhou em registrar o servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Falhou em des-registrar o servidor DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Falhou em criar uma conexão com o servidor '%s' no tópico '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "O pedido para cutucar do DDE falhou"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Falhou em estabelecer um loop de recomendação com o servidor DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Falhou em concluir o loop de recomendação com o servidor DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Falhou em enviar a notificação de recomendação do DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Falhou em criar a sequência do DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "nenhum erro do DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "o tempo de um pedido pra uma transação de recomendação síncrona se esgotou."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "a resposta para a transação fez o bit do DDE_FBUSY ser definido."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "o tempo de um pedido pra uma transação de dados síncrona se esgotou."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5672,7 +5661,7 @@ msgstr ""
 "ou um identificador de instância inválido\n"
 "foi passado para uma função DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5684,44 +5673,44 @@ msgstr ""
 "um aplicativo inicializado como APPCMD_CLIENTONLY tentou \n"
 "realizar transações de servidor."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 "o tempo de um pedido pra uma transação de execução síncrona se esgotou."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "um parâmetro falhou em ser validado pelo DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "um aplicativo DDEML criou uma condição de corrida prolongada."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "uma distribuição de memória falhou."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "uma tentativa de um cliente de estabelecer uma conversação falhou."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "um transação falhou."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "o tempo de um pedido pra uma transação de cutucão síncrona se esgotou."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "uma chamada interna para a função PostMessage falhou. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema na re-entrada."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5731,15 +5720,15 @@ msgstr ""
 "que foi encerrada pelo cliente ou o servidor\n"
 "encerrou antes de completar uma transação."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "Um erro interno ocorreu no DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "o tempo pra encerrar uma transação de recomendação se esgotou."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5749,12 +5738,12 @@ msgstr ""
 "Uma vez que o aplicativo retornou de um callback XTYP_XACT_COMPLETE\n"
 "o identificador da transação para aquele callback não é mais válido."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Erro DDE desconhecido %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5762,7 +5751,7 @@ msgstr ""
 "As funções de discagem estão indisponíveis porque o serviço de acesso remoto "
 "(RAS) não está instalado nesta máquina. Por favor instale-o."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5772,64 +5761,64 @@ msgstr ""
 "antiga, por favor atualize (a seguinte função requerida está desaparecida: "
 "%s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Falhou em recuperar o texto da mensagem de erro do RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "Erro desconhecido (código do erro %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Não consegue achar uma conexão dial-up ativa: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Várias conexões dial-up ativas achadas, escolhendo uma aleatoriamente."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Falhou em estabelecer uma conexão dial-up: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Falhou em obter os nomes dos ISPs: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Falhou em conectar: nenhum ISP para discar."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Escolha um ISP pra discar"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Por favor escolha com qual ISP vocé quer se conectar"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Falhou em conectar: faltando o nome de usuário/senha."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Não consegue achar o local do arquivo do livro de endereços"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Falhou em iniciar a conexão dial-up: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Não consegue desligar - nenhuma conexão dial-up ativa."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Falhou em finalizar a conexão dial-up: %s"
@@ -5849,18 +5838,17 @@ msgstr "Falhou em distribuir %luKb de memória pros dados do bitmap."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Não consegue enumerar os arquivos no diretório '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Não pôde obter o nome da pasta"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(erro %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Não pôde adicionar uma imagem a lista de imagens."
 
@@ -5874,7 +5862,7 @@ msgstr "Falhou em carregar o metafile do arquivo \"%s\"."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Falhou em criar o diálogo achar/substituir padrão (código do erro %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "O diálogo do arquivo falhou com o código de erro %0lx."
@@ -5916,16 +5904,16 @@ msgstr "Incapaz de configurar a observação para '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Não consegue monitorar o diretório não-existente \"%s\" por mudanças."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "O OpenGL 3.0 ou superior não é suportado pelo driver do OpenGL."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Não pôde criar o contexto do OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Falhou em inicializar o OpenGL"
 
@@ -5934,7 +5922,7 @@ msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 "Não pôde registrar o carregador das fontes do DirectWrite personalizado."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5942,7 +5930,7 @@ msgstr ""
 "As funções de Ajuda do MS HTML não estão disponíveis porque a biblioteca de "
 "Ajuda do MS HTML não está instalada nesta máquina. Por favor instale-a."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Falhou em inicializar a Ajuda do MS HTML."
 
@@ -5951,7 +5939,7 @@ msgstr "Falhou em inicializar a Ajuda do MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "Não consegue apagar o arquivo INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6072,7 +6060,7 @@ msgstr "Não pôde registrar o formato da área de transferência '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "O formato '%d' da área de transferência não existe."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Ignorar"
 
@@ -6157,59 +6145,59 @@ msgstr ""
 "apagando-a deixará seu sistema num estado inutilizável:\n"
 "operação abortada."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Não consegue apagar a chave '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Não consegue apagar o valor '%s' da chave '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Não consegue ler o valor da chave '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Não consegue definir o valor de '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "O valor do registro \"%s\" não é numérico (mas do tipo %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "O valor do registro \"%s\" não é binário (mas do tipo %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "O valor do registro \"%s\" não é de texto (mas do tipo %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Não consegue ler o valor de '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Não consegue enumerar os valores da chave '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Não consegue enumerar as sub-chaves da chave '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6217,17 +6205,17 @@ msgstr ""
 "Exportando a chave de registro: o arquivo \"%s\" já existe e não será "
 "sobrescrito."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Não consegue exportar o valor do tipo não suportado %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorando o valor \"%s\" da chave \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6235,41 +6223,41 @@ msgstr ""
 "Impossível criar um controle de edição rico, usando o controle de texto "
 "simples ao invés disso. Por favor reinstale o riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Não consegue iniciar o thread: erro ao gravar o TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Não consegue definir a prioridade do thread"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Não consegue criar o thread"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Não pôde encerrar o thread"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Não consegue esperar pelo término do thread"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Não consegue suspender o thread %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Não consegue resumir o thread %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Não pôde obter o ponteiro atual do thread"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6277,7 +6265,7 @@ msgstr ""
 "A inicialização do módulo dos threads falhou: impossível distribuir o índice "
 "no armazém local dos threads"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6308,12 +6296,12 @@ msgstr "Falhou em carregar o recurso \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Falhou em trancar o recurso \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", edição de 64 bits"
 
@@ -6325,46 +6313,46 @@ msgstr "Falhou em criar um pipe anônimo"
 msgid "Failed to redirect the child process IO"
 msgstr "Falhou em redirecionar a E/S do processo filho"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "A execução do comando '%s' falhou"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Falhou em carregar o mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Não consegue ler o nome do tipo de '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Não consegue carregar o ícone do '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "Falhou em achar o nível da emulação da visualização da web no registro"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Falhou em definir a visualização da web como nível da emulação moderna"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "Falhou em resetar a visualização da web pro nível de emulação padrão"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Não pode executar o script do JavaScript sem um documento HTML válido"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Não pôde obter o objeto do JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "falhou em avaliar"
 
@@ -6397,7 +6385,7 @@ msgid "Check to make the font italic."
 msgstr "Marque pra fazer a fonte ficar em itálico."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "&Sublinhado"
@@ -6464,15 +6452,33 @@ msgstr "<Qualquer Teletipo>"
 msgid "File type:"
 msgstr "Tipo de Arquivo:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Janela"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimizar"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zoom"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Trazer Tudo pra Frente"
 
@@ -6489,463 +6495,463 @@ msgstr "O arquivo da fonte \"%s\" não existe."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "O arquivo fonte \"%s\" não pode ser usado como não está dentro do diretório "
 "fonte \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Sobre o %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Sobre..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferências..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Serviços"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Esconder %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Esconder Aplicativo"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Esconder os Outros"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Mostrar Tudo"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Sair %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Sair do Aplicativo"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "A impressão não é suportada pelo controle da rede do sistema"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "A operação de impressão não pôde ser inicializada"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Tamanho do Ponto"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nome da Face"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Estilo"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Peso"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Família"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "BordaAtiva"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "CaptionAtivo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "FaceDoBotão"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "DestaqueDoBotão"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "SombraDoBotão"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "TextoDoBotão"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "TextoDoCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlEscuro"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlClaro"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "TextoCinza"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Destacar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "DestacarTexto"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "BordaInativa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "CaptionInativo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "TextoDoCaptionInativo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Barra de Rolagem"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Dica da ferramenta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "TextoDaDicaDaFerramenta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Janela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "FrameDaJanela"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "TextoDaJanela"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Personalizado"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Preto"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Castanho"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Marinho"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Púrpura"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Azul petróleo"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Cinza"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Oliva"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Marrom"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Azul"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fúcsia"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Vermelho"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Laranja"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Prata"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Lima"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Aqua"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Amarelo"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Branco"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Padrão"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Seta"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Seta da Direita"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Em branco"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Bullseye"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Caractere"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Cruz"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Mão"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Botão Esquerdo"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Botão do Meio"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Nenhuma Entrada"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Pincel do Paint"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Lápis"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Ponto a Esquerda"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Ponto a Direita"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Seta da Pergunta"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Botão Direito"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Dimensionamento NE-SO"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Dimensionamento N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Dimensionamento NO-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Dimensionamento O-L"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Dimensionamento"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Lata de spray"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Aguardar"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Observar"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Aguardar a Seta"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Fazer uma seleção:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Propriedade"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valor"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Modo Categorizado"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Modo Alfabético"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falso"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Verdadeiro"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Não especificado"
 
@@ -6958,12 +6964,12 @@ msgstr "Erro da Propriedade"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Você inseriu um valor inválido. Pressione ESC pra cancelar a edição."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Erro no recurso: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6972,36 +6978,36 @@ msgstr ""
 "A operação do tipo \"%s\" falhou: A propriedade rotulada \"%s\" é do tipo "
 "\"%s\", NÃO \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Base desconhecida %d. A base 10 será usada."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "O valor deve ser %s ou maior."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "O valor deve estar entre %s e %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "O valor deve ser %s ou menor."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Não %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Escolha um diretório:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Escolha um arquivo"
 
@@ -7468,117 +7474,117 @@ msgstr "Inserir"
 msgid "Outset"
 msgstr "Começo"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Mudar o Estilo"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Mudar o Estilo do Objeto"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Mudar Propriedades"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Mudar o Estilo da Lista"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renumerar a Lista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Inserir Texto"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Inserir Imagem"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Inserir Objeto"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Inserir Campo"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Chamadas demais do EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "arquivos"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "padrão/círculo"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "padrão/círculo-contorno"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "padrão/quadrado"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "padrão/diamante"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "padrão/triângulo"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Propriedades da Caixa"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Propriedades Múltiplas das Células"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Propriedades da Célula"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Definir o Estilo da Célula"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Apagar a Fileira"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Apagar a Coluna"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Adicionar Fileira"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Adicionar Coluna"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Propriedades da Tabela"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Propriedades da Foto"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "imagem"
 
@@ -7786,24 +7792,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Arrastar"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Apagar o Texto"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Remover a Bala"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "O texto não pôde ser salvo."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Substituir"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Fonte:"
 
@@ -8772,53 +8778,53 @@ msgstr "Estilos das listas"
 msgid "Box styles"
 msgstr "Estilos de caixa"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "A fonte da qual tomar o símbolo."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subset:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Mostra um subset do Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Código dos caracteres:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "O código do caractere."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&De:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "O alcance a mostrar."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Texto normal)"
 
@@ -9003,7 +9009,7 @@ msgstr "Incapaz de obter eventos do kqueue"
 msgid "Media playback error: %s"
 msgstr "Erro do playback da mídia: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Falhou em preparar a reprodução do \"%s\"."
@@ -9103,22 +9109,22 @@ msgstr "Os dados do som estão num formato não suportado."
 msgid "Couldn't open audio: %s"
 msgstr "Não pôde abrir o áudio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Não consegue recuperar a norma de conduta do agendamento dos threads."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Não consegue obter o alcance da prioridade para a norma de conduta do "
 "agendamento do %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "A configuração da prioridade do thread é ignorada."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9126,60 +9132,60 @@ msgstr ""
 "Falhou em se juntar a um thread, vazamento potencial de memória detectado - "
 "por favor reinicie o programa"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Falhou em definir o nível de concordância do thread em %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Falhou em definir a prioridade do thread %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Falhou em concluir um thread."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "A inicialização do módulo dos threads falhou: falhou em criar a chave do "
 "thread"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Impossível obter a entrada do processo filho"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Não consegue gravar como processo criança do stdin"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Falhou em executar o '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "A bifurcação falhou"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Falhou em definir a prioridade do processo"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Falhou em redirecionar a entrada/saída do processo filho"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Falhou em configurar o pipe não-bloqueador, o programa poderia travar."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Não consegue obter o nome do host"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Não consegue obter o nome oficial do host"
 
@@ -9195,12 +9201,12 @@ msgstr "Falhou em trocar o wake up pipe para o modo não bloqueador"
 msgid "Failed to read from wake-up pipe"
 msgstr "Falhou em ler do wake-up pipe"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Inválida a especificação da geometria '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "O wxWidgets não pôde abrir a tela. Saindo."
 
@@ -9214,30 +9220,59 @@ msgstr "Falhou em fechar a exibição \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Falhou em abrir a exibição \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Erro de análise do XML: '%s' na linha %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Não consegue carregar os recursos de '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Não consegue abrir os recursos de '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Não consegue carregar os recursos do arquivo '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Falhou em criar %s \"%s\"."
+
+#~ msgid "Printing "
+#~ msgstr "Imprimindo "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Falhou em inserir o texto no controle."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Por favor escolha uma fonte válida."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Falhou em exibir o documento em HTML na codificação %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "O wxWidgets não pôde abrir a tela pro '%s': saindo."
+
+#~ msgid "Filter"
+#~ msgstr "Filtro"
+
+#~ msgid "Directories"
+#~ msgstr "Diretórios"
+
+#~ msgid "Files"
+#~ msgstr "Arquivos"
+
+#~ msgid "Selection"
+#~ msgstr "Seleção"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "conversão para a codificação de 8 bits falhou"
@@ -9413,8 +9448,8 @@ msgstr "Falhou em criar %s \"%s\"."
 #~ msgstr "O renderizador da data não pode renderizar o valor; tipo de valor:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/ro.po
+++ b/locale/ro.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Cătălin Răceanu <cata_sr@yahoo.com>\n"
 "Language-Team: ro.ro\n"
@@ -16,11 +16,11 @@ msgstr ""
 "X-Poedit-KeywordsList: _\n"
 "X-Generator: Poedit 3.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Toate fișierele (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Toate fișierele (*)|*"
 
@@ -37,24 +37,21 @@ msgid "Remaining time:"
 msgstr "Timp rămas:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Da"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nu"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Anulează"
@@ -104,7 +101,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Nu se poate crea portul I/O de completare"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Tipărire"
 
@@ -141,7 +138,7 @@ msgstr "Proprietăți Obiect"
 msgid "Printing"
 msgstr "Tipărește"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simboluri"
 
@@ -210,7 +207,7 @@ msgstr "&Anterior"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Fereastră"
 
@@ -739,11 +736,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "afișează acest mesaj de ajutor"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "generează mesaje detaliate pentru jurnal"
 
@@ -765,84 +762,84 @@ msgstr "Temă nesuportată '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Specificația de afișare '%s' este invalidă."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Opțiunea '%s' nu poate fi negată"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Opțiune lungă necunoscută '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Opțiune %s necunoscută"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "După opțiunea '%s' apar caractere în plus."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opțiunea '%s' necesită o valoare."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Lipsește separatorul după opțiunea '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' este o valoare numerică incorectă pentru opțiunea '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opțiunea '%s': '%s' nu poate fi convertită la o dată."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametru neașteptat '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (sau %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Valoarea pentru opțiunea '%s' trebuie specificată."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Parametrul necesar '%s' nu a fost specificat."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Utlizare: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "numeric"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "double"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "dată"
 
@@ -860,7 +857,7 @@ msgid "Can't &Undo "
 msgstr "Nu se poate an&ula "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "An&ulează"
@@ -870,7 +867,7 @@ msgid "&Redo "
 msgstr "&Repetă "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Repetă"
@@ -902,12 +899,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' are '..' în plus, sunt ignorate."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "bifată"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "debifată"
 
@@ -916,103 +913,103 @@ msgstr "debifată"
 msgid "undetermined"
 msgstr "nedeterminată"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "astăzi"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "ieri"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "mâine"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "prima"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "secundă"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "al(a) treilea(treia)"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "al(a) patrulea(patra)"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "al(a) cincelea(cincea)"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "al(a) șaselea(șasea)"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "al(a) șaptelea(șaptea)"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "al(a) optulea(opta)"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "al(a) nouălea(noua)"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "al(a) zecelea(zecea)"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "al(a) unsprezecelea(unsprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "al(a) doisprezecelea(doisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "al(a) treisprezecelea(treisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "al(a) paisprezecelea(paisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "al(a) cincisprezecealea(cincisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "al(a) șaisprezecelea(șaisprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "al(a) șaptesprezecelea(șaptesprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "al(a) optsprezecelea(optsprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "al(a) nouăsprezecelea(nouăsprezecea)"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "al(a) douăzecelea(douăzecea)"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "amiază"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "miezul nopții"
 
@@ -1052,8 +1049,8 @@ msgstr "Generarea raportului de debug a eșuat."
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
-"Procesarea raportului de depanare a eșuat, fișierele răman în directorul \"%s"
-"\"."
+"Procesarea raportului de depanare a eșuat, fișierele răman în directorul "
+"\"%s\"."
 
 #: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
@@ -1080,44 +1077,81 @@ msgstr "A eșuat executarea curl, trebuie instalat în PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "A eșuat transferul raportului de debug (cod de eroare %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Salvează ca"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Anulează modificările și reîncarcă ultima versiune salvată?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "nedenumit"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vreți să salvați modificările în %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Salvare"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nu salva"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vreți să salvați modificările în %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Textul nu a putut fi salvat."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Fișierul \"%s\" nu a putut fi deschis pentru scriere."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "A eșuat salvarea documentului în fișierul \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Fișierul \"%s\" nu a putut fi deschis pentru citire."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "A eșuat citirea documentului din fișierul \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1126,57 +1160,57 @@ msgstr ""
 "Fișierul '%s' nu există și nu a putut fi deschis\n"
 "A fost șters din lista fișierelor recent folosite."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Previzualizarea tipăririi a eșuat."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Previzualizare tipărire"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formatul fișierului '%s' nu a putut fi determinat."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "nedenumit%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Deschide fișier"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Eroare de fișier"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Nu a putut fi deschis acest fișier."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Formatul pentru acest fișier este necunoscut."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Selectează un șablon de document"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Șabloane"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Selectează o vizualizare pentru document"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Vizualizări"
 
@@ -1210,43 +1244,43 @@ msgstr "Eroare la citirea fișierului '%s'"
 msgid "Write error on file '%s'"
 msgstr "Eroare la scriere în fișierul '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "transmitere eșuată către fișierul '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Eroare la căutare în fișierul '%s' (fișierele mari nu sunt suportate de "
 "stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Eroare la căutare în fișierul '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nu se poate determina poziția curentă în fișierul '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "A eșuat setarea permisiunilor pentru fișierul temporar"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nu poate fi șters fișierul '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nu pot fi memorate schimbările în fișierul '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nu poate fi șters fișierul temporar '%s'"
@@ -1271,28 +1305,28 @@ msgstr "nu se poate citi din descriptorul de fișier %d"
 msgid "can't write to file descriptor %d"
 msgstr "nu se poate scrie în descriptorul de fișier %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nu se poate transmite către descriptorul de fisier %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nu se poate căuta în descriptorul de fișier %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nu se poate obține poziția de căutare pentru descriptorul de fișier %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 "nu poate fi determinată lungimea fișierului pentru descriptorul de fișier %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1320,108 +1354,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Eroare la citirea opțiunilor de configurare."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "A eșuat citirea opțiunilor de configurare."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fișierul '%s': caracter neașteptat %c pe linia %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "fișierul '%s', linia %zu: '%s' ignorat după antetul de grup."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fișierul '%s', linia %zu: '=' era așteptat."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "fișierul '%s', linia %zu: valoarea cheii imuabile '%s' ignorată."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 "fișierul '%s', linia %zu: cheia '%s' a fost găsită mai întâi la linia %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Numele intrării de configurare nu poate începe cu '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "nu poate fi deschis fișierul de configurare al utilizatrului."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "nu poate fi scris fișierul de configurare al utilizatorului."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "A eșuat actualizarea fișierului de configurare pentru utilizator."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Eroare la salvarea datelor de configurare ale utilizatorului."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "nu poate fi șters fișierul de configurare '%s' pentru utilizator"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "intrarea '%s' apare mai mult de odată în grupul '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "tentativă ignorată de a schimba cheia imuabilă '%s'."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "caracter \\ terminal ignorat în '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "caracter \" neașteptat la poziția %d în '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "A eșuat copierea fișierului '%s' la '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Sunt imposibil de obținut permisiunile pentru fișierul '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Este imposibilă suprascrierea fișierul '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "A eșuat copierea fișierului '%s' la '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Este imposibilă setarea permisiunilor pentru fișierul '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1430,40 +1464,40 @@ msgstr ""
 "A eșuat redenumirea fișierului '%s' în '%s' pentru că fișierul destinație "
 "există deja."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Fișierul '%s' nu a putut fi redenumit '%s'."
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Fișierul '%s' nu a putut fi șters"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Directorul '%s' nu a putut fi creat"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Directorul '%s' nu a putut fi șters"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nu pot fi enumerate fișierele '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "A eșuat obținerea directorului de lucru"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "A eșuat setarea directorului de lucru"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Fișiere (%s)"
@@ -1490,17 +1524,17 @@ msgstr "A eșuat crearea unui nume de fișier temporar"
 msgid "Failed to open temporary file."
 msgstr "A eșuat deschiderea fișierului temporar."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "A eșuat modificarea timpilor fișierului pentru '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "A eșuat modificarea timpilor fișierului '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "A eșuat obținerea timpilor fișierului pentru '%s'"
@@ -1509,22 +1543,22 @@ msgstr "A eșuat obținerea timpilor fișierului pentru '%s'"
 msgid "Browse"
 msgstr "Răsfoiește"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Toate fișierele (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "fișiere %s (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Încarcă fișier %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Salvează fișier %s"
@@ -1887,99 +1921,99 @@ msgstr "implicit"
 msgid "unknown-%d"
 msgstr "necunoscut-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "subliniat"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " tăiat"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " subțire"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " foarte ușor"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " ușor"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " mediu"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " ușor îngroșat"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " îngroșat"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " foarte îngroșat"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " apăsat"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " foarte apăsat"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " cursiv"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "tăiat"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "subțire"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "foarte ușor"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "ușor"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "mediu"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "ușor îngroșat"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "îngroșat"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "foarte îngroșat"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "apăsat"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "foarte apăsat"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "cursiv"
 
@@ -2062,7 +2096,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "A eșuat setarea modului de transfer FTP la %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2083,7 +2117,7 @@ msgstr "Serverul FTP nu suportă modul pasiv."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Cadru GIF cu dimensiunea (%u, %d) incorectă pentru cadrul #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "A eșuat alocarea culorii pentru OpenGL"
 
@@ -2099,7 +2133,7 @@ msgstr "Personalizează coloane"
 msgid "&Customize..."
 msgstr "&Personalizează..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "A eșuat deschiderea URL-ului \"%s\" in browser-ul implicit"
@@ -2119,157 +2153,156 @@ msgstr "A eșuat încărcarea imaginii %d din fluxul de date."
 msgid "Failed to load icons from resource '%s'."
 msgstr "A eșuat încărcarea iconiței din resursa \"%s\"."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nu a putut fi salvată imaginea invalidă."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nu are un obiect wxPalette propriu."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nu a putut fi scris antetul (Bitmap) fișierului."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nu a putut fi scris antetul (BitmapInfo) fișierului."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nu a putut fi scrisă harta RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nu au putut fi scrise datele."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nu a putut fi alocată memorie."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Antet DIB: Lațimea imaginii > 32767 pixeli pentru fișier."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Antet DIB: Inălțimea imaginii > 32767 pixeli pentru fișier."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Antet DIB: Adâncime de biți necunoscută în fișier."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Antet DIB: Codificare necunoscută in fișier."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Antet DIB: Codificarea nu corespunde adâncimii de biți."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: antetul are biClrUsed=%d când biBitCount=%d."
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Nu a putut fi alocată memorie."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Antet DIB: Lațimea imaginii > 32767 pixeli pentru fișier."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Antet DIB: Inălțimea imaginii > 32767 pixeli pentru fișier."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Antet DIB: Adâncime de biți necunoscută în fișier."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Antet DIB: Codificare necunoscută in fișier."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Antet DIB: Codificarea nu corespunde adâncimii de biți."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Eroare la citirea DIB pentru imagine."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Eroare la citirea maștii DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Imagine prea înaltă pentru o pictogramă."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Imagine prea lată pentru o pictogramă."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Eroare la scrierea fișierului imagine!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Index de pictogramă invalid."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Imaginea și masca au dimensiuni diferite."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Nicio culoare nefolosită din imagine nu este mascată."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "A eșuat încărcarea imaginii \"%s\" din resurse."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "A eșuat încărcarea iconiței \"%s\" din resurse."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "A eșuat încărcarea imaginii din fișierul \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nu se poate salva imaginea în fișierul '%s': extensie necunoscută."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Nu a fost găsit niciun manipulator pentru tipul de imagine."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nu a fost definit niciun manipulator de imagine pentru tipul %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Fișierul imagine nu e de tipul %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Formatul imaginii nu poate fi determinat automat pentru input ce nu poate fi "
 "examinat."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Format de imagine necunoscut."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Acesta nu este un %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nu a fost definit niciun manipulator de imagine pentru tipul %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Imaginea nu e de tipul %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "A eșuat detectarea formatului fișierului imagine \"%s\"."
@@ -2372,41 +2405,41 @@ msgstr "PNM: Fișierul pare trunchiat."
 msgid " (in module \"%s\")"
 msgstr " (în modulul \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Eroare la încărcarea imaginii."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Indexul imaginii TIFF este invalid."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Dimensiunea imaginii este anormal de mare."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nu s-a putut aloca memorie."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Eroare la citirea imaginii."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Unitatea de rezoluție TIFF necunoscută %d ignorată"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Eroare la salvarea imaginii."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Eroare la scrierea imaginii."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2415,11 +2448,11 @@ msgstr ""
 "Argumentul %d din linia de comandă nu a putut fi convertit la Unicode și va "
 "fi ignorat."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Inițializare eșuată în post-init, se anulează."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nu se poate seta locala la limba \"%s\"."
@@ -2515,7 +2548,7 @@ msgstr "Eroare de comprimare LZMA: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Eroare de comprimare LZMA la transmiterea către output: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' fără pereche într-o intrare pentru tipul mime %s."
@@ -2535,7 +2568,7 @@ msgstr "Dependința \"%s\" a modulului \"%s\" nu există."
 msgid "Module \"%s\" initialization failed"
 msgstr "Inițializarea modulului \"%s\" a eșuat"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Mesaj"
 
@@ -3037,7 +3070,7 @@ msgstr "Eroare de tipărire"
 msgid "Print"
 msgstr "Print"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Setări pagină"
 
@@ -3072,19 +3105,15 @@ msgstr "Tipărire pagina %d din %d"
 msgid " (copy %d of %d)"
 msgstr " (copia %d din %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Tipărire "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Prima pagină"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Pagina anterioară"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Pagina următoare"
 
@@ -3128,16 +3157,16 @@ msgstr "Pagina %d din %d"
 msgid "Page %d"
 msgstr "Pagina %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "eroare necunoscută"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Expresie regulată invalidă '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "A eșuat găsirea unui rezultat pentru expresia regulată: %s"
@@ -3149,21 +3178,21 @@ msgstr ""
 "Renderer-ul \"%s\" are versiunea incompatibilă %d.%d și nu a putut fi "
 "încărcat."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Indisponibil pentru această platformă"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Salvarea parolei pentru '%s' a eșuat: '%s'."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Citirea parolei pentru '%s' a eșuat: '%s'."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Ștergerea parolei pentru '%s' a eșuat: '%s'."
@@ -3172,11 +3201,11 @@ msgstr "Ștergerea parolei pentru '%s' a eșuat: '%s'."
 msgid "Failed to monitor I/O channels"
 msgstr "A eșuat monitorizarea canalelor I/O"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Salvează"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Nu salva"
 
@@ -3257,10 +3286,10 @@ msgid "Clear"
 msgstr "Clear"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Închide"
 
@@ -3272,7 +3301,7 @@ msgstr "&Transformă"
 msgid "Convert"
 msgstr "Transformă"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Copiază"
@@ -3281,7 +3310,7 @@ msgstr "&Copiază"
 msgid "Copy"
 msgstr "Copiază"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Decupează"
@@ -3290,13 +3319,13 @@ msgstr "&Decupează"
 msgid "Cut"
 msgstr "Decupează"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "Ște&rge"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Șterge"
@@ -3383,7 +3412,7 @@ msgstr "Harddisk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Ajutor"
 
@@ -3403,7 +3432,7 @@ msgstr "Indentare"
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Index"
 
@@ -3472,7 +3501,7 @@ msgstr "&Nou"
 msgid "New"
 msgstr "Nou"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nu"
 
@@ -3489,12 +3518,12 @@ msgstr "&Deschide..."
 msgid "Open..."
 msgstr "Deschide..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Li&pire"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Lipire"
@@ -3524,7 +3553,7 @@ msgid "Print..."
 msgstr "Tipărire..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Proprietăți"
 
@@ -3556,10 +3585,6 @@ msgstr "Înlocuire..."
 msgid "Revert to Saved"
 msgstr "Revenire la versiunea salvată"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Salvare"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "S&alvare ca..."
@@ -3568,7 +3593,7 @@ msgstr "S&alvare ca..."
 msgid "Save As..."
 msgstr "Salvare ca..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Selecte&ază tot"
@@ -3675,7 +3700,7 @@ msgstr "S&us"
 msgid "Up"
 msgstr "Sus"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Da"
 
@@ -3763,43 +3788,43 @@ msgstr "Salvează documentul curent"
 msgid "Save current document with a different filename"
 msgstr "Salvează documentul curent cu un nume diferit de fișier"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Conversia la setul de caractere '%s' nu funcționează."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "necunoscut"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "bloc de antet incomplet în tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "suma de control eronată în blocul antet pentru tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "date incorecte în antetul extins tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "intrarea tar nu a fost deschisă"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "sfârșit de fișier neașteptat"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s nu a corespuns antetului tar pentru înregistrarea '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "dimensiune incorectă dată pentru intrarea tar"
 
@@ -3808,7 +3833,7 @@ msgstr "dimensiune incorectă dată pentru intrarea tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' este probabil un buffer binar."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Fișierul nu a putut fi încărcat."
 
@@ -3822,47 +3847,47 @@ msgstr "A eșuat citirea fișierului text \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "nu se poate scrie buffer-ul %s pe disc."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "A eșuat obținerea timpului local al sistemului"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay a eșuat."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' nu este un catalog de mesaje valid."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catalog de mesaje invalid."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Nu se pot interpreta formele de plural:'%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "folosește catalogul '%s' din '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Resursa '%s' nu este un catalog de mesaje valid."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Nu au putut fi enumerate traducerile"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Nu există aplicație implicită configurată pentru fișierele HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "A eșuat deschiderea URL-ului \"%s\" in browser-ul implicit."
@@ -3895,7 +3920,7 @@ msgstr "'%s' conține caracter(e) invalid(e)"
 msgid "Error: %s (%d)"
 msgstr "Eroare: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Spațiul liber pe disc nu este suficient pentru download."
 
@@ -3903,20 +3928,20 @@ msgstr "Spațiul liber pe disc nu este suficient pentru download."
 msgid "libcurl could not be initialized"
 msgstr "libcurl nu a putut fi inițializat"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync nu este suportat"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Eroare la rularea JavaScript: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Această platformă nu suportă transparență pentru fundal."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Nu s-au putut transfera datele către fereastră"
 
@@ -3970,8 +3995,8 @@ msgstr "Create Parameter %s nu a fost găsit între parametrii RTTI declarați"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Obiect de tip nepermis (Non-wxEvtHandler) ca Sursă a Evenimentului"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Tipul trebuie să aibă o conversie enum - long"
 
@@ -4021,82 +4046,82 @@ msgstr "Obiectele trebuie să aibă un atribut id"
 msgid "Doubly used id : %d"
 msgstr "Id folosit de două ori : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Proprietate %s necunoscută"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "O colecție care nu e goală trebuie să conțină noduri 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 "șir de caractere incorect pentru un manipulator de evenimente, lipsește un "
 "punct"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nu se poate reinițializa fluxul de compresie zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nu se poate reinițializa fluxul de decompresie zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Intrarea în plus și malformată este ignorată, fișierul ZIP poate fi compromis"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "presupunând că acesta este un zip concatenat din mai multe părți"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "fișier zip invalid"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "nu a găsit directorul central in zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "eroare la citirea directorului central din zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "eroare la citirea antetului local din zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "deplasament eronat pentru intrarea fișierului zip"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "lungimea fișierului conținut nu este in antetul Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "metodă de comprimare Zip nesuportată"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "citire flux zip (intrarea %s): lungime eronată"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "citire flux zip (intrarea %s): crc eronat"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "eroare la scrierea intrării zip '%s': fișier prea mare fără ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "eroare la scrierea intrării zip '%s': eroare de crc sau lungime"
@@ -4182,32 +4207,32 @@ msgstr "Arta grafică de "
 msgid "Translations by "
 msgstr "Traduceri de "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Versiunea "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Despre %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licență"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Dezvoltatori"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autorii documentației"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artiști"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Traducători"
 
@@ -4258,43 +4283,42 @@ msgid "Password:"
 msgstr "Parolă:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "adevărat"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "fals"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Rândul %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Contractă"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Expandează"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elemente)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Coloana %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4305,8 +4329,7 @@ msgid "Left"
 msgstr "Stânga"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4403,7 +4426,7 @@ msgid "Home directory"
 msgstr "Director acasă"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Spațiu de lucru"
 
@@ -4416,8 +4439,7 @@ msgstr "Nume ilegal de director."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Eroare"
 
@@ -4602,16 +4624,16 @@ msgstr "Afișează detaliat fișierele"
 msgid "Go to parent directory"
 msgstr "Spre directorul părinte"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Fișierul '%s' există deja, sigur vreți să fie suprascris?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Confirmă"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Alegeți un fișier existent."
 
@@ -4705,7 +4727,7 @@ msgstr "Dimensiunea în puncte a fontului."
 msgid "Whether the font is underlined."
 msgstr "Determină sublinierea."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Previzualizare:"
@@ -4723,49 +4745,48 @@ msgstr "Clic pentru a anula selectarea fontului."
 msgid "Click to confirm the font selection."
 msgstr "Clic pentru a confirma selectarea fontului."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Alege font"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "Copierea în clipboard a mai multor blocuri selectate nu este suportată."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Directorul de ajutor \"%s\" nu a fost găsit."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Fișierul de ajutor \"%s\" nu a fost găsit."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Linia %lu a fișierului hartă \"%s\" are sintaxa incorectă, sărită."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Nu au fost găsite asocieri valide în fișierul \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Nu s-au găsit intrări."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Index ajutor"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Intrări relevante:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Intrări găsite"
 
@@ -4870,59 +4891,59 @@ msgstr "Nu s-a putut începe tipărirea."
 msgid "Printing page %d..."
 msgstr "Se tipărește pagina %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opțiuni imprimantă"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Tipărește în fișier"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Setări..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Imprimantă:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Stare:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tot"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Pagini"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Interval de tipărire"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "De la:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Către:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Copii:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Fișier PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Setări tipărire"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Imprimantă"
 
@@ -4930,25 +4951,25 @@ msgstr "Imprimantă"
 msgid "Default printer"
 msgstr "Imprimantă implicită"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Dimensiune hârtie"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Vertical"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Orizontal"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientare"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opțiuni"
 
@@ -4960,52 +4981,52 @@ msgstr "Tipărește color"
 msgid "Print spooling"
 msgstr "Tipărire cu buffer"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Comandă imprimantă:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opțiuni imprimantă:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Margine stânga (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Margine sus (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Margine dreapta (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Marginea de jos (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Imprimantă..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Omite"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Necunoscut"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Gata."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Caută"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Nu s-a putut găsi indentarea pentru id"
 
@@ -5041,11 +5062,11 @@ msgstr "&Termină"
 msgid "< &Back"
 msgstr "< Î&napoi"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "merite de traducere"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5055,11 +5076,11 @@ msgstr ""
 "în probleme de input și flickering. Considerați resetarea GTK_IM_MODULE sau "
 "setarea la \"ibus\"."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nu se poate inițializa GTK+, este variabila DISPLAY setată corect?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Schimbarea directorului curent la \"%s\" a eșuat"
@@ -5086,11 +5107,11 @@ msgid "Failed to register font configuration using private fonts."
 msgstr ""
 "A eșuat înregistrarea configurării de font ce folosește fonturi private."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Eroare Fatală"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5101,7 +5122,7 @@ msgstr ""
 "trebuie instalate bibliotecile EGL și recompilat sau rulat sub X11 setând\n"
 "variabila de mediu GDK_BACKEND=x11 înainte de a porni programul."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5113,7 +5134,7 @@ msgstr ""
 "limitare setând variabila de mediu GDK_BACKEND=x11 înaintea pornirii "
 "programului."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Copil MDI"
 
@@ -5129,16 +5150,12 @@ msgstr "Eroare la tipărire: "
 msgid "Page Setup"
 msgstr "Setări pagină"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "A eșuat inserarea textului în control."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 "Obținerea outputului de la scriptul JavaScript nu este suportată cu WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5146,7 +5163,7 @@ msgstr ""
 "GTK+ instalat pe această mașină este prea vechi pentru a suporta compunerea "
 "ecranului, instalați GTK+ 2.12 sau ulterior."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5154,17 +5171,13 @@ msgstr ""
 "Compunerea nu este suportată de acest sistem, trebuie activată din Managerul "
 "de Ferestre."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Acest program a fost compilat cu o versiune de GTK+ prea veche, recompilați "
 "cu GTK+ 2.12 sau mai recent."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Alegeți un font valid."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5263,45 +5276,45 @@ msgstr "Nu se poate deschide fișierul de cuprins: %s"
 msgid "Cannot open index file: %s"
 msgstr "Nu se poate deschide fișierul index: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "nedenumit"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nu se poate deschide manualul HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Afișează manualul de ajutor în timp ce răsfoiești cărțile din stânga."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(însemne)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Adaugă pagina curentă la însemne"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Șterge pagina curentă dintre semnele de carte"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Cuprins"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Caută"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Arată tot"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5309,19 +5322,19 @@ msgstr ""
 "Afișează toate elementele index care conțin șirul de caractere dat. "
 "Majusculele nu sunt semnificative pentru căutare."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Afișează toate elementele din index"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Cu majuscule semnificative"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Numai cuvinte întregi"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5329,147 +5342,147 @@ msgstr ""
 "Caută în conținutul cărții(-lor) de ajutor toate aparițiile textului "
 "introdus mai sus"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Afișează/ascunde panoul de navigare"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Înapoi"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Înainte"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "În sus un nivel în ierarhia documentelor"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Deschide document HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Tipărește această pagină"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Afișează dialogul de opțiuni"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Alegeți pagina de afișat:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Subiecte de ajutor"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Caută..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Nicio pagină corespunzătoare găsită încă"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "S-au găsit %i rezultate"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Ajutor)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d din %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu din %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Caută în toate cărțile"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Ajutor pentru opțiunile bowser-ului"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Font normal:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Font fix:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Dimensiune font:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "dimensiune font"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Font normal<br>și <u>subliniat</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Cursiv.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Îngroșat.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Îngroșat cursiv.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Font cu dimensiune fixă.<br> <b>îngroșat</b> <i>cursiv</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>îngroșat cursiv <u>subliniat</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Ajutor pentru tipărire"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Nu se poate tipări o pagină goală."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Fișiere HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Manuale de ajutor (*.htb)|*.htb|Manuale de ajutor (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Fișier HTML Manual comprimat (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i din %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u din %u"
@@ -5550,32 +5563,6 @@ msgstr ""
 "A fost o problemă în timpul setării paginii: se poate să trebuiască setată o "
 "imprimantă implicită."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "A eșuat afișarea documentului HTML în codificarea %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets nu a putut deschide ecranul pentru '%s': se închide."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtru"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Directoare"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Fișiere"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Selecție"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "A eșuat deschiderea memoriei clipboard."
@@ -5617,58 +5604,58 @@ msgstr "Dialogul de selecție a culorii a eșuat cu eroarea %0lx."
 msgid "Failed to create cursor."
 msgstr "A eșuat crearea unui cursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "A eșuat înregistrarea server-ului DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "A eșuat înlăturarea înregistrării serverului DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "A eșuat crearea conexiunii cu serverul '%s' pentru subiectul '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Cererea DDE de test a eșuat"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "A eșuat stabilirea unei bucle de informare cu serverul DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "A eșuat terminarea buclei de informare cu serverul DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "A eșuat trimiterea notificării DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "A eșuat crearea șirului DDE de caractere"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "nicio eroare DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "o cerere pentru o tranzacție sincronă de informare a expirat."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "răspunsul la tranzacție a determinat setarea bitului DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "o cerere pentru o tranzacție sincronă de date a expirat."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5680,7 +5667,7 @@ msgstr ""
 "sau un identificator de instanță invalid\n"
 "a fost pasat unei funcții DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5692,43 +5679,43 @@ msgstr ""
 "sau o aplicație inițializată ca APPCMD_CLIENTONLY\n"
 "a încercat să execute o tranzacție de server."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "o cerere pentru o tranzacție sincronă de execuție a expirat."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "un parametru nu a fost validat de DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "o aplicație DDEML a creat o condiție de rulare concurentă prelungită."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "o alocare de memorie a eșuat."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "o tentativă a unui client de a stabili o conversație a eșuat."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "o tranzacție a eșuat."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "o cerere pentru o tranzacție sincronă de test a expirat."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "un apel intern către funcția PostMessage a eșuat. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problema de reentranță."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5738,15 +5725,15 @@ msgstr ""
 "într-o conversație întreruptă de client, sau serverul\n"
 "a terminat înainte de încheierea tranzacției."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "o eroare internă a survenit în DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "o cerere de încheiere a unei tranzacții de informare a expirat."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5756,12 +5743,12 @@ msgstr ""
 "La revenirea din funcția de apel invers XTYP_XACT_COMPLETE,\n"
 "identificatorul de tranzacție al funcției nu mai este valid."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Eroare DDE necunoscută %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5769,7 +5756,7 @@ msgstr ""
 "Funcțiile de dialup nu sunt disponibile pentru că serviciul de acces la "
 "distanță (RAS) nu este instalat. Trebuie să îl instalați."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5779,65 +5766,65 @@ msgstr ""
 "mașină este prea veche, trebuie sa îl actualizați (următoarea funcție "
 "necesară lipsește: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "A eșuat obținerea textului din mesajul de eroare RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "eroare necunoscută (cod de eroare %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nu se poate determina conexiunea dialup activă: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "S-au găsit mai multe conexiuni dialup active, se alege una la întâmplare."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "A eșuat stabilirea unei conexiuni dialup: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "A eșuat obținerea numelor ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "A eșuat conectarea: nu există niciun ISP pentru apelare."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Alege ISP pentru a forma"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Alegeți ISP-ul la care vreți să vă conectați"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "A eșuat conectarea: lipsește utilizator/parola."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Nu se poate determina locația fișierului agendă"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "A eșuat inițializarea conexiunii dialup: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nu se poate închide - nu există o conexiune dialup activă."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "A eșuat terminarea conexiunii dialup: %s"
@@ -5857,18 +5844,17 @@ msgstr "A eșuat alocarea a %luKb de memorie pentru bitmap."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nu se pot enumera fișierele din directorul '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Nu a putut fi obtinut numele directorului"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(eroarea %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Nu s-a putut adăuga o imagine la lista de imagini."
 
@@ -5884,7 +5870,7 @@ msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "A eșuat crearea dialogului standard de căutare/înlocuire (cod de eroare %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialogul pentru fișiere a eșuat cu eroarea %0lx."
@@ -5926,16 +5912,16 @@ msgstr "Nu se poate seta monitor pentru '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Directorul inexistent \"%s\" nu poate fi monitorizat pentru schimbari."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 sau ulterior nu este suportat de driverul OpenGL."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Nu a putut fi creat un context OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "A eșuat inițializarea OpenGL"
 
@@ -5945,7 +5931,7 @@ msgstr ""
 "Nu a putut fi înregistrat încărcătorul de fonturi personalizat pentru "
 "DirectWrite."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5953,7 +5939,7 @@ msgstr ""
 "Funcțiile MS HTML Help nu sunt disponibile pentru că librăria MS HTML Help "
 "nu este instalată pe această mașină. Trebuie instalată."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "A eșuat inițializarea sistemului de ajutor MS HTML Help."
 
@@ -5962,7 +5948,7 @@ msgstr "A eșuat inițializarea sistemului de ajutor MS HTML Help."
 msgid "Can't delete the INI file '%s'"
 msgstr "Nu se poate șterge fișierul INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -6084,7 +6070,7 @@ msgstr "Nu s-a putut înregistra formatul de clipboard '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Formatul '%d' pentru memoria de clipboard nu există."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Omite"
 
@@ -6170,59 +6156,59 @@ msgstr ""
 "ștergerea ei va lăsa sistemul intr-o stare inutilizabilă:\n"
 "operație anulată."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nu se poate șterge cheia '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nu se poate șterge valoarea '%s' din cheia '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nu se poate citi valoarea cheii '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nu se poate seta valoarea '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Valoarea \"%s\" din Registry nu este numerică (ci de tip %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Valoarea \"%s\" din Registry nu este binară (ci de tip %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Valoarea \"%s\" din Registry nu este text (ci de tip %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nu se poate citi valoarea lui '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nu se pot enumera valorile cheii '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nu se pot enumera sub-cheile cheii '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6230,17 +6216,17 @@ msgstr ""
 "Exportare cheie de regiștri: fișierul \"%s\" există deja și nu va fi "
 "suprascris."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nu se poate exporta valoarea de tipul nesuportat %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Este ignorată valoarea \"%s\" a cheii \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6248,41 +6234,41 @@ msgstr ""
 "Este imposibilă crearea unui control de tip rich edit, se înlocuiește cu un "
 "control simplu de text. Trebuie reinstalat riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nu se poate porni firul de execuție: eroare la scrierea TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Nu se poate seta prioritatea pentru fire de execuție"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Nu se poate crea firul de execuție"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Nu a putut fi terminat firul de execuție"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Nu se poate aștepta terminarea firului de execuție"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nu se poate suspenda firul de execuție %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nu poate continua firul de execuție %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Nu s-a putut obține pointerul pentru firul de execuție curent"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6290,7 +6276,7 @@ msgstr ""
 "Inițializarea modulului pentru fire de execuție a eșuat: indexul nu poate fi "
 "alocat în memoria locală a firului de execuție"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6323,12 +6309,12 @@ msgstr "A eșuat încărcarea resursei \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "A eșuat blocarea resursei \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "build %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", ediție 64-bit"
 
@@ -6340,46 +6326,46 @@ msgstr "A eșuat crearea unui canal (pipe) anonim"
 msgid "Failed to redirect the child process IO"
 msgstr "A eșuat redirectarea IO ale procesului copil"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Executarea comenzii '%s' a eșuat"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "A eșuat încărcarea mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nu se poate citi denumirea tipului din '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nu se poate încărca pictograma din '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "Nu a fost găsit nivelul de emulare pentru web view în Registry"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Setarea web view la un nivel de emulare modern a eșuat"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "Resetarea web view la un nivel de emulare modern a eșuat"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Nu poate fi rulat un script JavaScript fără un document HTML valid"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Nu se poate obține obiectul JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "a eșuat evaluarea"
 
@@ -6412,7 +6398,7 @@ msgid "Check to make the font italic."
 msgstr "Bifează pentru a face fontul cursiv."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Subliniat"
@@ -6479,15 +6465,33 @@ msgstr "<Oricare Teletype>"
 msgid "File type:"
 msgstr "Tip de fișier:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Window"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ajutor"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimizare"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Mărire"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Totul în față"
 
@@ -6504,463 +6508,463 @@ msgstr "Fișierul de font %s nu există."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Fișierul de font %s nu poate fi folosit pentru că nu este în directorul de "
 "fonturi \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Despre %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Despre..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Preferințe..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Servicii"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Ascunde %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Ascunde Aplicația"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Ascunde Restul"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Arată Tot"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Părăsește %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Părăsește Aplicația"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Tipărirea nu este suportată pentru controlul web al sistemului"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Operațiunea de tipărire nu a putut fi inițializată"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Dimensiune în puncte"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Nume font"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Grosime"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "ActiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "ActiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ButtonFace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ButtonHighlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ButtonShadow"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ButtonText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "GrayText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Highlight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "HighlightText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Meniu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Tooltip"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "TooltipText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Window"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "WindowFrame"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Personalizare"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Negru"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Maroniu"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Navy"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Mov"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Bej"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Gri"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Verde"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Măsliniu"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Maro"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Albastru"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuchsia"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Roșu"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Portocaliu"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Argintiu"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Lime"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Albastru deschis"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Galben"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Alb"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Implicit"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Săgeată"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Săgeată Dreapta"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Gol"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Țintă"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Cursor"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Cruce"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Mână"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Buton Stânga"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Lupă"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Buton Mijloc"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Nicio Intrare"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Pensulă"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Creion"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Punct Stânga"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Punct Dreapta"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Săgeată Întrebare"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Buton Dreapta"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Redimensionare NE-SV"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Redimensionare N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Redimensionare NV-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Redimensionare V-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Redimensionare"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Tub Spray"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Așteptare"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Urmărire"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Săgeată Așteptare"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Selectează:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Proprietate"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Valoare"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "După categorie"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "După  alfabet"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Fals"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Adevărat"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Nespecificat"
 
@@ -6974,12 +6978,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Ați introdus o valoare incorectă. Apăsati ESC pentru anularea editării."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Eroare în resurse: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6988,36 +6992,36 @@ msgstr ""
 "Operația de tipul \"%s\" a eșuat: Proprietatea  \"%s\" este de tipul \"%s\", "
 "NU \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Baza %d necunoscută. Baza 10 va fi folosită."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Valoarea trebuie să fie %s sau mai mare."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Valoarea trebuie să fie între %s și %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Valoarea trebuie să fie %s sau mai mică."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Nu %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Alege un director:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Alege un fișier"
 
@@ -7484,117 +7488,117 @@ msgstr "Spre interior"
 msgid "Outset"
 msgstr "Spre exterior"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Schimbă stilul"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Schimbă Stilul Obiectului"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Schimbă Proprietățile"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Schimbă stilul listei"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Renumerotează lista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Inserează text"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Inserează imagine"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Inserează Obiect"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Inserează Câmp"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Prea multe apeluri EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "fișiere"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standard/cerc"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standard/contur-cerc"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standard/pătrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standard/romb"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standard/triunghi"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Proprietăți Casetă"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Proprietăți pentru celule multiple"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Proprietăți pentru celulă"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Aplică stilul de celulă"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Șterge rând"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Șterge coloană"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Adaugă rând"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Adaugă coloană"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Proprietăți Tabelă"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Proprietăți Imagine"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "imagine"
 
@@ -7802,24 +7806,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Trage"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Șterge text"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Elimină marcator"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Textul nu a putut fi salvat."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Înlocuiește"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Font:"
 
@@ -8788,53 +8792,53 @@ msgstr "Stiluri de listă"
 msgid "Box styles"
 msgstr "Stiluri casetă"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Fontul din care se va extrage simbolul."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Subset:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Afișează un subset Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Cod caracter:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Codul caracterului."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&De la:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Intervalul de afișat."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Inserează"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Text normal)"
 
@@ -9023,7 +9027,7 @@ msgstr "Nu se pot citi evenimente din kqueue"
 msgid "Media playback error: %s"
 msgstr "Eroare de redare media: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "A eșuat pregătirea redării \"%s\"."
@@ -9123,22 +9127,22 @@ msgstr "Formatul datelor de sunet nu este suportat."
 msgid "Couldn't open audio: %s"
 msgstr "Nu s-a putut deschide fișierul audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nu se poate obține politica de planificare a firului de execuție."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 "Nu se poate obține intervalul de priorități pentru politica de planificare "
 "%d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Prioritatea setată pentru firul de excuție este ignorată."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9146,61 +9150,61 @@ msgstr ""
 "A eșuat sincronizarea cu un fir de execuție, posibilă scurgere de memorie "
 "detectată - programul trebuie repornit"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "A eșuat setarea nivelului de concurență la %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "A eșuat setarea priorității %d pentru firul de execuție."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "A eșuat terminarea unui fir de execuție."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Inițializarea modulului pentru fire de execuție a eșuat: cheia pentru firul "
 "de execuție nu a putut fi creată"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Sunt imposibil de obținut intrările procesului copil"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Nu se poate scrie la stdin-ul procesului copil"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "A eșuat executarea '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "A eșuat apelul fork"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "A eșuat setarea priorității procesului"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "A eșuat redirectarea intrărilor/ieșirilor pentru procesul copil"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "A eșuat setarea unui canal (pipe) non-blocant, programul poate fi suspendat."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Nu se poate obține numele mașinii gazdă"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Nu se poate obține numele oficial al mașinii gazdă"
 
@@ -9219,12 +9223,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr "A eșuat citirea din canalul de răspuns (wake-up pipe)"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Specificația de geometrie '%s' este invalidă"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nu a putut deschide ecranul. Se închide."
 
@@ -9238,30 +9242,59 @@ msgstr "A eșuat închiderea ecranului \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "A eșuat deschiderea ecranului \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Eroare la analiza XML: '%s' la linia %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nu se pot încărca resursele din '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nu se poatet deschide fișierul resursă '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nu se pot încărca resursele din fișierul '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Crearea %s \"%s\" a eșuat."
+
+#~ msgid "Printing "
+#~ msgstr "Tipărire "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "A eșuat inserarea textului în control."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Alegeți un font valid."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "A eșuat afișarea documentului HTML în codificarea %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nu a putut deschide ecranul pentru '%s': se închide."
+
+#~ msgid "Filter"
+#~ msgstr "Filtru"
+
+#~ msgid "Directories"
+#~ msgstr "Directoare"
+
+#~ msgid "Files"
+#~ msgstr "Fișiere"
+
+#~ msgid "Selection"
+#~ msgstr "Selecție"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "conversia la codificare pe 8 biți a eșuat"
@@ -9430,15 +9463,15 @@ msgstr "Crearea %s \"%s\" a eșuat."
 #~ msgstr "Renderer-ul de date nu poate reda valoarea; tipul valorii: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"
 #~ "%s %1"
 #~ msgstr ""
-#~ "Vreți să suprascrieți comanda folosită la fișierele %s cu extensia \"%s"
-#~ "\" ?\n"
+#~ "Vreți să suprascrieți comanda folosită la fișierele %s cu extensia "
+#~ "\"%s\" ?\n"
 #~ "Valoarea curentă este \n"
 #~ "%s, \n"
 #~ "Valoarea nouă este \n"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2018-09-06 07:55+0500\n"
 "Last-Translator: Alexander Kovalenko <nktch@yandex.ru>\n"
 "Language-Team: wxWidgets translators <wx-translators@wxwidgets.org>\n"
@@ -15,15 +15,15 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Все файлы (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Все файлы (*)|*"
 
@@ -40,24 +40,21 @@ msgid "Remaining time:"
 msgstr "Оставшееся время:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Да"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Нет"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Отмена"
@@ -107,7 +104,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Невозможно создать порт завершения ввода/вывода"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Распечатка"
 
@@ -144,7 +141,7 @@ msgstr "Свойства объекта"
 msgid "Printing"
 msgstr "Печать"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Символы"
 
@@ -214,7 +211,7 @@ msgstr "&Предыдущий"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Окно"
 
@@ -744,11 +741,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "показать это справочное сообщение"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "генерировать подробные сообщения отладки"
 
@@ -770,84 +767,84 @@ msgstr "Неподдерживаемая тема '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Неправильная спецификация режима экрана '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Параметр '%s' не может быть отрицательным"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Неизвестный длинный параметр '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Неизвестный параметр '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Неожиданные символы, следующие за опцией '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Параметр '%s' требует значение."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Разделитель, ожидаемый после параметра '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' - некорректное числовое значение для параметра '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Параметр '%s': '%s' не может быть преобразован в дату."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Неожиданный параметр '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (или %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Значение параметра '%s' должно быть определено."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Обязательный параметр '%s' не определён."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Использование: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "двухместный"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "дата"
 
@@ -865,7 +862,7 @@ msgid "Can't &Undo "
 msgstr "О&тменить невозможно "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Отменить"
@@ -875,7 +872,7 @@ msgid "&Redo "
 msgstr "&Вернуть "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Вернуть"
@@ -904,12 +901,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' содержит лишние '..', игнорировано."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "выбрано"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "сброшенный"
 
@@ -918,103 +915,103 @@ msgstr "сброшенный"
 msgid "undetermined"
 msgstr "неопределён"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "сегодня"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "вчера"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "завтра"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "первый"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "второй"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "третий"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "четвёртый"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "пятый"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "шестой"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "седьмой"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "восьмой"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "девятый"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "десятый"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "одиннадцатый"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "двенадцатый"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "тринадцатый"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "четырнадцатый"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "пятнадцатый"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "шестнадцатый"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "семнадцатый"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "восемнадцатый"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "девятнадцатый"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "двадцатый"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "полдень"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "полночь"
 
@@ -1082,44 +1079,81 @@ msgstr "Невозможно выполнить curl, установите ег�
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Не удалось отправить отчёт об отладке (код ошибки %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Сохранить как"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Отменить изменения и загрузить повторно последнюю сохранённую версию?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "без_имени"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Сохранить изменения в %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Сохранить"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Не сохранять"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Сохранить изменения в %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Не удалось сохранить текст."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Невозможно открыть файл '%s' для записи."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Не удалось сохранить документ в файл \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Не удалось открыть файл '%s' для чтения."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Не удалось прочесть документ из файла \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1128,57 +1162,57 @@ msgstr ""
 "Файл '%s' не существует и его открыть нельзя.\n"
 "Он был удалён из списка последних использованных файлов."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Сбой при создании предпросмотра печати."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Предпросмотр печати"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Не удалось определить формат файла '%s' ."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "без_имени%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Открыть файл"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Ошибка файла"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Этот файл открыть нельзя."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Формат этого файла неизвестен."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Выбрать шаблон документа"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Шаблоны"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Выбрать вид документа"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Виды"
 
@@ -1212,41 +1246,41 @@ msgstr "Ошибка чтения файла '%s'"
 msgid "Write error on file '%s'"
 msgstr "Ошибка записи в файл '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "ошибка сброса буфера файла '%s'."
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Ошибка смещения в файле '%s' (большие строки не поддерживаются stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Ошибка смещения в файле '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Не удаётся найти текущую позицию в файле '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Невозможно установить разрешения временному файлу"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ошибка удаления файла '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "невозможно записать изменения в файл '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "ошибка удаления временного файла '%s'"
@@ -1271,27 +1305,27 @@ msgstr "ошибка чтения файла с дескриптором %d"
 msgid "can't write to file descriptor %d"
 msgstr "невозможно записать в файл с дескриптором %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "невозможно сбросить буфер файла с дескриптором %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "невозможно переместиться по файлу с дескриптором %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "невозможно получить текущую позицию файла с дескриптором %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "невозможно найти длину файла с дескриптором %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "невозможно определить достижение конца файла с дескриптором %d"
@@ -1316,108 +1350,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Ошибка чтения параметров настройки."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Не удалось прочесть параметры конфигурации."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "файл '%s': непредвиденный символ %c в строке %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "файл '%s', строка %zu: '%s' игнорируется после заголовка группы."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "файл '%s', строка %zu: '=' ожидается."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "файл '%s', строка %zu: значение для неизменяемого ключа '%s' игнорируется."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "файл '%s', строка %zu: ключ '%s' был впервые найден в строке %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Имя поля в файле конфигурации не может начинаться с '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "невозможно открыть файл конфигурации пользователя."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "невозможно записать файл конфигурации пользователя."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Не удалось обновить пользовательский файл конфигурации."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Ошибка сохранения данных конфигурации пользователя."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "невозможно удалить файл конфигурации пользователя '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "запись '%s' появляется более одного раза в группе '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "попытка изменить неизменяемый ключ '%s' проигнорирована."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "косая черта в '%s' игнорируется"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "неожиданный \" в позиции %d в '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Сбой копирования файла '%s' в '%s'."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Невозможно получить разрешения файла '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Невозможно переписать файл '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Ошибка копирования файла '%s' в '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Невозможно установить разрешения файлу '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1425,40 +1459,40 @@ msgid ""
 msgstr ""
 "Не удалось переименовать файл '%s' в '%s' - файл назначения уже существует."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Файл '%s' не может быть переименован в '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Не удалось записать в файл: %s"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Не удалось создать каталог  '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Не удалось удалить каталог  '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Не удаётся перечислить файлы '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Не удалось получить рабочий каталог"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Не удалось установить текущий рабочий каталог"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Файлы (%s)"
@@ -1485,17 +1519,17 @@ msgstr "Сбой формирования имени временного фай
 msgid "Failed to open temporary file."
 msgstr "Не удалось открыть временный файл."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Ошибка изменения времени файла '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Не удалось открыть файл '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Не удалось извлечь время файла '%s'"
@@ -1504,22 +1538,22 @@ msgstr "Не удалось извлечь время файла '%s'"
 msgid "Browse"
 msgstr "Обзор"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Все файлы (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s файлы (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Загрузить файл %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Сохранить файл %s"
@@ -1882,105 +1916,105 @@ msgstr "по-умолчанию"
 msgid "unknown-%d"
 msgstr "неизвестный-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "подчёркнутый"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " перечёркивание"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " лёгкий"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " лёгкий"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " полужирный"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " полужирный"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " полужирный"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " курсив"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "перечёркивание"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "светлый"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "светлый"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "нормальный"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "жирный"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "жирный"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "жирный"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "курсив"
 
@@ -2061,7 +2095,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Не удалось установить режим передачи FTP в %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2082,7 +2116,7 @@ msgstr "Сервер FTP не поддерживает пассивный реж
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Неправильный GIF размер кадра (%u, %d) для frame #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Не удалось разместить цвет для OpenGL"
 
@@ -2098,7 +2132,7 @@ msgstr "Настроить столбцы"
 msgid "&Customize..."
 msgstr "&Настроить..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Не удалось открыть URL-адрес \"%s\" в браузере по умолчанию."
@@ -2118,156 +2152,155 @@ msgstr "Не удалось загрузить изображение %d из п
 msgid "Failed to load icons from resource '%s'."
 msgstr "Не удалось загрузить значки из ресурса '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: невозможно сохранить недействительное изображение."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage не имеет собственного wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: невозможно записать заголовок файла (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: невозможно записать заголовок файла (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: невозможно записать цветовую карту RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: невозможно записать данные."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: невозможно выделить память."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Заголовок DIB: ширина изображения > 32767 пикселей для файла."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Заголовок DIB: высота изображения > 32767 пикселей для файла."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Заголовок DIB: неизвестная битовая глубина в файле."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Заголовок DIB: неизвестная кодировка файла."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Заголовок DIB: кодировка не совпадает с битовойглубиной."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: невозможно выделить память."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Заголовок DIB: ширина изображения > 32767 пикселей для файла."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Заголовок DIB: высота изображения > 32767 пикселей для файла."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Заголовок DIB: неизвестная битовая глубина в файле."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Заголовок DIB: неизвестная кодировка файла."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Заголовок DIB: кодировка не совпадает с битовойглубиной."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Ошибка при чтении изображения DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: ошибка чтения маски DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: изображение слишком высоко для значка."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: изображение слишком широкое для значка."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: ошибка записи файла изображения!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: неверный индекс значка."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Изображение и маска имеют различные размеры."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Нет неиспользованного цвета в маскируемом изображении."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Не удалось загрузить растровое изображение '%s' из ресурсов."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Невозможно загрузить значок '%s' из ресурсов."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Не удалось загрузить изображение из файла '%s'."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 "Невозможно сохранить изображение в файл '%s': неизвестное расширение файла."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Не найден обработчик для этого типа изображения."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Не определён обработчик для изображения типа %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Файл изображения не тип %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Не удаётся автоопределить формат изображения для ввода без поиска."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Неизвестный формат данных изображения."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Это не %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Не определён обработчик для изображения типа %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Изображение не тип %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Не удалось проверить Формат файла изображения \"%s'."
@@ -2370,41 +2403,41 @@ msgstr "PNM: файл кажется усечённым."
 msgid " (in module \"%s\")"
 msgstr " (в модуле \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: ошибка загрузки изображения."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Недопустимый индекс изображения TIFF."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: размер изображения ненормально большой."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: не удалось выделить память."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: ошибка чтения изображения."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Неизвестная единица разрешения TIFF %d игнорирована"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: ошибка сохранения изображения."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: ошибка записи изображения."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2413,11 +2446,11 @@ msgstr ""
 "Аргумент командной строки %d не может быть преобразован в Юникод и "
 "проигнорирован."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Сбой инициализации в post init, прерывание."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Не удалось установить локали для языка \"%s\"."
@@ -2517,7 +2550,7 @@ msgstr "ошибка сжатия"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Незакрытая скобка '{' в записи для mime типа %s."
@@ -2537,7 +2570,7 @@ msgstr "Зависимость \"%s\" модуль \"%s\" не существу�
 msgid "Module \"%s\" initialization failed"
 msgstr "Ошибка инициализации модуля '%s'"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Сообщение"
 
@@ -3039,7 +3072,7 @@ msgstr "Ошибка печати"
 msgid "Print"
 msgstr "Печать"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Настройки страницы"
 
@@ -3074,19 +3107,15 @@ msgstr "Печать страницы %d из %d"
 msgid " (copy %d of %d)"
 msgstr " (копия %d из %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Печать "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Первая страница"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Предыдущая страница"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Следующая станица"
 
@@ -3130,16 +3159,16 @@ msgstr "Страница %d из %d"
 msgid "Page %d"
 msgstr "Страница %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "неизвестная ошибка"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Неверное регулярное выражение '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Не удалось найти соответствие для регулярного выражения: %s"
@@ -3150,21 +3179,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Визуализатор '%s' имеет несовместимую версию %d.%d и не может быть загружен."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Не удалось сохранить пароль для  '%s/%s': %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Не удалось прочесть пароль для  '%s/%s': %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Не удалось удалить пароль для  '%s/%s': %s."
@@ -3173,11 +3202,11 @@ msgstr "Не удалось удалить пароль для  '%s/%s': %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Не удалось отследить каналы ввода-вывода"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Не сохранять"
 
@@ -3261,10 +3290,10 @@ msgid "Clear"
 msgstr "Очистить"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Закрыть"
 
@@ -3276,7 +3305,7 @@ msgstr "&Конвертировать"
 msgid "Convert"
 msgstr "Преобразовать"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Копировать"
@@ -3285,7 +3314,7 @@ msgstr "&Копировать"
 msgid "Copy"
 msgstr "Копировать"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Вырезать"
@@ -3294,13 +3323,13 @@ msgstr "&Вырезать"
 msgid "Cut"
 msgstr "Вырезать"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Удалить"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Удалить"
@@ -3389,7 +3418,7 @@ msgstr "Жёсткий диск"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Справка"
 
@@ -3409,7 +3438,7 @@ msgstr "Отступ"
 msgid "&Index"
 msgstr "&Индекс"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Индекс"
 
@@ -3478,7 +3507,7 @@ msgstr "&Новый"
 msgid "New"
 msgstr "Новый"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Нет"
 
@@ -3495,12 +3524,12 @@ msgstr "&Открыть..."
 msgid "Open..."
 msgstr "Открыть..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Вст&авить"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Вставить"
@@ -3530,7 +3559,7 @@ msgid "Print..."
 msgstr "Печать..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Свойства"
 
@@ -3564,10 +3593,6 @@ msgstr "Заменить"
 msgid "Revert to Saved"
 msgstr "Откатить к сохранённому"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Сохранить"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Сохранить &как..."
@@ -3577,7 +3602,7 @@ msgstr "Сохранить &как..."
 msgid "Save As..."
 msgstr "Сохранить &как..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Выделить вс&ё"
@@ -3684,7 +3709,7 @@ msgstr "&Вверх"
 msgid "Up"
 msgstr "Выше"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Да"
 
@@ -3775,43 +3800,43 @@ msgstr "Сохранить текущий документ"
 msgid "Save current document with a different filename"
 msgstr "Сохранить текущий документ с другим именем"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Преобразование кодировки в '%s' не работает."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "неизвестный"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "неполный заголовок блока tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "ошибка контрольной суммы читая заголовок блока tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "недопустимые данные в расширенном заголовке tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "запись tar не открыта"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "неожиданный конец файла"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s не соответствует заголовок tar для записи '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "неправильные размеры даны для записи tar"
 
@@ -3820,7 +3845,7 @@ msgstr "неправильные размеры даны для записи tar
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' возможно является двоичным буфером."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Не удалось загрузить файл."
 
@@ -3834,47 +3859,47 @@ msgstr "Не удалось прочесть документ из файла \"
 msgid "can't write buffer '%s' to disk."
 msgstr "ошибка записи буфера '%s' на диск."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Не удалось получить локальное системное время"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "ошибка wxGetTimeOfDay."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' - неверный каталог сообщений."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Неверный каталог сообщений."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Не удалось разобрать формы нножественного числа: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "используется каталог '%s' из '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Ресурс '%s' не является допустимым каталогом сообщений."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Не удалось перечислить переводы"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Приложение по умолчанию не настроено для HTML-файлов."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Не удалось открыть URL-адрес \"%s\" в браузере по умолчанию."
@@ -3907,7 +3932,7 @@ msgstr "'%s' содержит недопустмые знаки"
 msgid "Error: %s (%d)"
 msgstr "Ошибка: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3916,20 +3941,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Не удалось загрузить файл."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Эта платформа не поддерживает прозрачность фона."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Невозможно передать данные в окно"
 
@@ -3981,8 +4006,8 @@ msgstr "Параметр создания %s не найден в объявле
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Недопустимый класс объекта (не wxEvtHandler) как источник события"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Тип должен иметь преобразование enum-long"
 
@@ -4034,79 +4059,79 @@ msgstr "Объекты должны иметь атрибут id"
 msgid "Doubly used id : %d"
 msgstr "Повторно используемый id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Неизвестное свойство %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Непустая коллекция должна состоять из узлов 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "неверная строка обработчика события, отсутствует точка"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "невозможно переинициализировать поток распаковки zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "невозможно переинициализировать поток сжатия zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "подразумевается, что это объединение многотомного zip-архива"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "неверный zip-файл"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "невозможно найти центральный каталог в zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "ошибка чтения центрального каталога zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "ошибка чтения локального заголовка zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "неверное смещение zip-файла к записи"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "сохранённая длина файла не находится в заголовке Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "неподдерживаемый метод сжатия Zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "чтение потока zip (точка входа %s): неверная длина"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "чтение потока zip (точка входа %s): неверная контрольная сумма"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "ошибка записи элемента zip '%s': неверная длина или контрольная сумма"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "ошибка записи элемента zip '%s': неверная длина или контрольная сумма"
@@ -4191,32 +4216,32 @@ msgstr "Графика "
 msgid "Translations by "
 msgstr "Переводы "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Версия "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "О программе %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Лицензии"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Разработчики"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Авторы документации"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Художники"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Переводчики"
 
@@ -4267,43 +4292,42 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "истинно"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "ложно"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Строка %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Свернуть"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Расширить"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d элементов)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Колонка %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4314,8 +4338,7 @@ msgid "Left"
 msgstr "Слева"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4411,7 +4434,7 @@ msgid "Home directory"
 msgstr "Начальный каталог"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Рабочий стол"
 
@@ -4424,8 +4447,7 @@ msgstr "Недопустимое имя каталога."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Ошибка"
 
@@ -4610,16 +4632,16 @@ msgstr "Просмотр файлов в виде подробного спис�
 msgid "Go to parent directory"
 msgstr "Перейти в родительский каталог"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Файл '%s' уже существует, вы точно хотите его переписать?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Подтвердите"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Выберите существующий файл."
 
@@ -4713,7 +4735,7 @@ msgstr "Размер шрифта."
 msgid "Whether the font is underlined."
 msgstr "Либо шрифт подчёркнут."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Предпросмотр:"
@@ -4731,49 +4753,48 @@ msgstr "Щёлкните для отмены выбора шрифта'."
 msgid "Click to confirm the font selection."
 msgstr "Щёлкните 'подтвердить смену шрифта'."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Выберите шрифт"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Каталог справки '%s' не найден."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Файл справки '%s' не найден."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "Строка %lu файла сопоставления  '%s' имеет неверный синтаксис и пропущена."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Не найдены допустимые сопоставления в файле '%s'."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Запись не найдена."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Индекс справки"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Подходящие записи:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Найдено записей"
 
@@ -4877,59 +4898,59 @@ msgstr "Невозможно начать печать."
 msgid "Printing page %d..."
 msgstr "Печать страницы %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Параметры принтера"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Печать в файл"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Настройки..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Принтер:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Состояние:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Всё"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Страницы"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Интервал печати"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "От:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "До:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Копии:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Файл PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Настройки печати"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Принтер"
 
@@ -4937,25 +4958,25 @@ msgstr "Принтер"
 msgid "Default printer"
 msgstr "Принтер по-умолчанию"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Размер бумаги"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Портрет"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Пейзаж"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Ориентация"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Параметры"
 
@@ -4967,52 +4988,52 @@ msgstr "Печать в цвете"
 msgid "Print spooling"
 msgstr "Очередь печати"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Команда принтера:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Параметры принтера:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Левое поле (мм):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Верхняя граница (мм):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Правое поле (мм):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Нижнее поле (мм):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Принтер..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Пропустить"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Готово."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Поиск"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Невозможно найти закладку для id"
 
@@ -5048,22 +5069,22 @@ msgstr "&Завершить"
 msgid "< &Back"
 msgstr "< &Назад"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Список переводчиков"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Не удалось инициализировать GTK+, ДИСПЛЕЙ настроен правильно?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Ошибка смены текущего каталога на '%s'"
@@ -5089,12 +5110,12 @@ msgstr "Не удалось прочесть документ из файла \"
 msgid "Failed to register font configuration using private fonts."
 msgstr "Не удалось обновить пользовательский файл конфигурации."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Ошибка файла"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5102,7 +5123,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5110,7 +5131,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Дочерний MDI"
 
@@ -5126,15 +5147,11 @@ msgstr "Ошибка при печати: "
 msgid "Page Setup"
 msgstr "Настройки страницы"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Не удалось вставить текст в элемент управления."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5142,7 +5159,7 @@ msgstr ""
 "GTK + установленный на этом компьютере слишком стар для поддержки композиции "
 "экрана, установите GTK + 2,12 или новее."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5150,17 +5167,13 @@ msgstr ""
 "Композитинг не поддерживается этой системой, включите его в своём оконном "
 "менеджере."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Эта программа была скомпилирована со слишком старой версией GTK+,  "
 "пересоберите её с GTK+ 2.12 или новее."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Выберите допустимый шрифт."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5259,45 +5272,45 @@ msgstr "Невозможно открыть файл содержания: %s"
 msgid "Cannot open index file: %s"
 msgstr "Невозможно открыть файл индекса: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "без имени"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Невозможно открыть книгу справки HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Отображает справку при просмотре книг слева."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(закладки)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Добавить текущую страницу в закладки"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Удалить текущую страницу из закладок"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Содержание"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Найти"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Показать всё"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5305,165 +5318,165 @@ msgstr ""
 "Показать все элементы индекса с заданной подстрокой. При поиске регистр не "
 "учитывается."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Показать все элементы в индексе"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Чувствителен к регистру"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Только слова целиком"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Поиск содержимого книги справки для всех вхождений введённого текста"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Показать/скрыть панель навигации"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Перейти назад"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Перейти вперёд"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Перейти на один уровень вверх в иерархии документа"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Открыть документ HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Напечатать эту страницу"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Открыть диалог настройки параметров"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Выберите страницу для отображения:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Содержание справки"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Поиск..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Не найдена соответствующая страница"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Найдено %i соответствий"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Справка)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d из %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu из %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Поиск во всех книгах"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Параметры просмотра помощи"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Нормальный шрифт:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Фиксированный шрифт:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Размер шрифта:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "размер шрифта"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Нормальный шрифт<br>и <u>подчёркнутый</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Курсив.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Жирный.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Жирный курсив.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Шрифт фиксированного размера.<br> <b>жирный</b> <i>курсив</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>жирный курсив <u>подчёркнутый</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Печать помощи"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Невозможно напечатать пустую страницу."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Файлы HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Книги справки (*.htb)|*.htb|Книги справки (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Проект справки HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Сжатый файл справки HTML (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i из %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u из %u"
@@ -5544,32 +5557,6 @@ msgstr ""
 "Возникла проблема при настройке страницы: необходимо задать принтер по-"
 "умолчанию."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Не удалось отобразить документ HTML в кодировке %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets не удалось открыть дисплей для '%s': выход."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Фильтр"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Каталоги"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Файлы"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Выделение"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Не удалось открыть буфер обмена."
@@ -5611,58 +5598,58 @@ msgstr "В диалоговом окне выбора цвета произош�
 msgid "Failed to create cursor."
 msgstr "Ошибка создания курсора."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Не удалось зарегистрировать сервер DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Не удалось отменить регистрацию DDE сервера '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Невозможно создать подключение к серверу '%s' по теме '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Ошибка запроса DDE poke"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Невозможно установить 'advise loop' с DDE сервером"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Не удалось завершить 'advise loop' у DDE сервера"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Невозможно послать advise уведомление DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Ошибка создания строки DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "нет ошибки DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "тайм-аут запроса для синхронной консультации."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "ответ на транзакцию вызвал бит DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "тайм-аут запроса на синхронную транзакцию данных."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5674,7 +5661,7 @@ msgstr ""
 "или неверный идентификатор экземпляра\n"
 "был передан в функцию DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5686,43 +5673,43 @@ msgstr ""
 "или приложение, инициализированное как APPCMD_CLIENTONLY,\n"
 "пыталось осуществить серверную транзакцию."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "тайм-аут запроса для синхронной транзакции Execute."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "не удалось проверить параметр с помощью DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "приложение DDEML создало длительный race condition."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "ошибка выделения памяти."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "не удалась попытка клиента установить диалог."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "транзакция завершилась с ошибкой."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "тайм-аут запроса на синхронную транзакцию."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "внутренний вызов функции PostMessage не удался. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "проблема повторного входа."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5732,15 +5719,15 @@ msgstr ""
 "который был прерван клиентом, либо работа сервера\n"
 "была остановлена до завершения транзакции."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "в DDEML произошла внутренняя ошибка."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "тайм-аут запроса на завершение проводки рекомендаций."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5750,12 +5737,12 @@ msgstr ""
 "Как только приложение вернётся из обратного вызова XTYP_XACT_COMPLETE,\n"
 "идентификатор транзакции для этого обратного вызова более недействителен."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Неизвестная ошибка DDE %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5763,7 +5750,7 @@ msgstr ""
 "Функции набора номера недоступны, так как сервис удалённого доступа (RAS) не "
 "установлен на этой машине. Установите его."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5772,65 +5759,65 @@ msgstr ""
 "Версия службы удаленного доступа (RAS), установленная на этом компьютере, "
 "слишком старая, обновите её (отсутствует следующая необходимая функция: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Не удалось получить текст сообщения об ошибке RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "неизвестная ошибка (код ошибки %08x)"
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Невозможно найти активное модемное соединение: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Найдено несколько активных соединений, выбираем одно случайным образом."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Невозможно установить модемное соединение: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Не удалось получить имена ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Невозможно подключиться: нет ISP для набора номера."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Выберите провайдера для набора номера"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Выберите ISP, к которому хотите подключиться"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Невозможно подключиться: отсутствует имя/пароль."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Файл с адресной книжкой не найден"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Не удалось установить модемное соединение: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Невозможно повесить трубку - нет активного модемного соединения."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Не удалось завершить модемное подключение: %s"
@@ -5850,18 +5837,17 @@ msgstr "Не удалось выделить %lu Кб памяти для рас
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Не удаётся перечислить файлы в каталоге '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Не удалось получить имя папки"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (ошибка %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Невозможно добавить изображение в список изображений."
 
@@ -5875,7 +5861,7 @@ msgstr "Невозможно загрузить метафайл из файла
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Невозможно создать стандартный диалог поиска/замены (код ошибки %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "В файловом диалоговом окне произошла ошибка с кодом %0lx."
@@ -5917,17 +5903,17 @@ msgstr "Не удалось настроить отслеживание '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Невозможно контролировать несуществующий каталог '%s' для изменений."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 "OpenGL 3,0 или более поздней версии не поддерживается драйвером OpenGL."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Не удалось создать контекст OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Невозможно инициализировать OpenGL"
 
@@ -5935,7 +5921,7 @@ msgstr "Невозможно инициализировать OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5943,7 +5929,7 @@ msgstr ""
 "Функции справки MS HTML недоступны, так как библиотека справки MS HTML не "
 "установлена на этой машине. Установите её."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Ошибка инициализации справки MS HTML."
 
@@ -5952,7 +5938,7 @@ msgstr "Ошибка инициализации справки MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "Невозможно удалить INI-файл '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Невозможно получить информацию об элементе списка %d."
@@ -6072,7 +6058,7 @@ msgstr "Невозможно зарегистрировать формат бу�
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Формат буфера обмена '%d' не существует."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Пропустить"
 
@@ -6157,76 +6143,76 @@ msgstr ""
 "его удаление приведёт вашу систему в нерабочее состояние:\n"
 "операция прервана."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Невозможно удалить ключ '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Невозможно удалить значение '%s' из ключа '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Невозможно прочесть значение ключа '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Невозможно установить значение '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Значение реестре '%s' не числовое (но имеет тип %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Значение реестра  '%s' не является двоичным (но имеет тип %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Значение реестра  '%s' не является текстом (но имеет тип %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Невозможно прочесть значение '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Невозможно пересчитать значения ключа '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Невозможно пересчитать подключи ключа '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Экспорт ключа реестра: файл '%s' уже существует и не будет перезаписан."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Экспорт значения неподдерживаемого типа %d невозможен."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Значение \"%s\" ключа \"%s\" проигнорировано."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6234,41 +6220,41 @@ msgstr ""
 "Невозможно создать расширенный элемент управления редактированием с помощью "
 "простого текстового элемента управления. Переустановите riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Невозможно запустить выполнение потока: ошибка записи TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Невозможно установить приоритет потока"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Невозможно создать поток"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Не могу завершить поток"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Невозможно дождаться окончания выполнения потока"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Не удалось приостановить поток %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Не удалось возобновить поток %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Невозможно получить указатель на текущий поток"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6276,7 +6262,7 @@ msgstr ""
 "Ошибка инициализации модуля потоков: невозможно выделить индекс в локальном "
 "пространстве потока"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6307,12 +6293,12 @@ msgstr "Не удалось загрузить ресурс \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Не удалось заблокировать ресурс \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "сборка %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-бит редакция"
 
@@ -6324,47 +6310,47 @@ msgstr "Ошибка при создании anonymous pipe"
 msgid "Failed to redirect the child process IO"
 msgstr "Не удалось перенаправить ввод/вывод порожденного процесса"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Ошибка выполнения команды '%s'"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Невозможно загрузить mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Чтение имени типа из '%s' невозможно!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Невозможно загрузить значок из '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Невозможно установить приоритет потока"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Не удалось выполнить '%s'\n"
@@ -6398,7 +6384,7 @@ msgid "Check to make the font italic."
 msgstr "Установите флажок, чтобы сделать шрифт курсивом."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Подчёркнутый"
@@ -6466,17 +6452,32 @@ msgstr "<Любой телетайп>"
 msgid "File type:"
 msgstr "Телетайп"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Окно"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Справка"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "&Свернуть"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Увеличить"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6493,492 +6494,492 @@ msgstr ": файл не существует!"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "О программе %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "О программе..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Параметры..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Службы"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Скрыть %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Приложение"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Скрыть остальные"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Показать всё"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Выход из %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Приложение"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip не поддерживается этой версией zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Размер точки"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Название семейства"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Стиль"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Вес"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Семейство"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "АктивнаяГраница"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "АктивныйЗаголовок"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ВерхКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ПодсветкаКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ТеньКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ButtonText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "СерыйТекст"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Подсветка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Выделить текст"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "НеактивнаяГраница"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Меню"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Полоса прокрутки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Подсказка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "ТекстПодсказки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Окно"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "РамкаОкна"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "WindowText"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Задать"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Чёрный"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Каштановый"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Синий"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Фиолетовый"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Сине-зелёный"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Серый"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Зелёный"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Оливковый"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Коричневый"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Голубой"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Пурпурный"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Красный"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Оранжевый"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Серебряный"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Лайм"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Аква"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Жёлтый"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Белый"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "По умолчанию"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Стрелка"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Стрелка вправо"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Поле имени должно быть заполнено"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Яблочко"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Знак"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Через"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Рука"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Левая кнопка"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Лупа"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Средняя кнопка"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Нет записи"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Кисть отрисовки"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Карандаш"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Точка слева"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Точка вправо"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Вопрос"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Правая кнопка"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Изменение размеров NE-SW"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Размеры N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Изменение размеров NW-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "D♯/E♭"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Изменение размеров"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Аэрозоль"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Подождите"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Отслеживание"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Стрелка ожидания"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Сделайте выбор:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Свойство"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Значение"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Режим По категориям"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Алфавитный режим"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Ложно"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Истинное"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Не указано"
 
@@ -6992,12 +6993,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Вы ввели недопустимое значение. Нажмите  ESC, чтобы отменить изменения."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Ошибка в ресурс: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7006,36 +7007,36 @@ msgstr ""
 "Операция типа '%s' не удалась: свойство с меткой '%s' имеет тип '%s', а не "
 "'%s'."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Значение должно быть %s или более."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Значение должно быть между %s и %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Значение должно быть %s или менее."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Не %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Выберите каталог:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Выберите файл"
 
@@ -7502,117 +7503,117 @@ msgstr "Вставка"
 msgid "Outset"
 msgstr "Начальный этап"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Изменение стиля"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Изменить стиль объекта"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Изменить свойства"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Изменить стиль списка"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Перенумеровать список"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Вставить текст"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Вставить изображение"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Вставить объект"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Вставить поле"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Слишком много звонков EndStyle !"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "файлы"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "стандартный/круг"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "стандартный/круг-контур"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "стандартный/квадрат"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "стандартный/ромб"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "стандартный/треугольник"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Свойства поля"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Свойства нескольких ячеек"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Свойства ячейки"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Задать стиль ячейки"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Удалить строку"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Удалить колонку"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Добавить строку"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Добавить колонку"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Свойства таблицы"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Свойства рисунка"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "изображения"
 
@@ -7820,24 +7821,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Перетащить"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Удалить текст"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Удалить маркер"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Не удалось сохранить текст."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Заменить"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Шрифт:"
 
@@ -8806,53 +8807,53 @@ msgstr "Список стилей"
 msgid "Box styles"
 msgstr "Стили полей"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Шрифт, из которого следует взять символ."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Подмножество:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Показывает Unicode подмножество."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "Код &символа:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Код символа."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&От:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Юникод"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Диапазон отображения."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Обычный текст)"
 
@@ -9038,7 +9039,7 @@ msgstr "Не удалось получать события от kqueue"
 msgid "Media playback error: %s"
 msgstr "Ошибка проигрывания мультимедиа: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Не удалось подготовить проигрывание '%s'."
@@ -9138,20 +9139,20 @@ msgstr "Данные звука имеют неподдерживаемый фо
 msgid "Couldn't open audio: %s"
 msgstr "Невозможно открыть аудио: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Невозможно извлечь политику планировки потока."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Невозможно получить диапазон приоритетов для политики планирования %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Установка приоритета потока проигнорирована."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9159,58 +9160,58 @@ msgstr ""
 "Не удалось соединиться с потоком, обнаружена потенциальная утечка памяти - "
 "перезапустите программу"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Не удалось задать уровень параллелизма потоков %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Не удалось установить приоритет потока %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Не удалось завершить поток."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Ошибка инициализации модуля потоков: не удалось создать ключ потока"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Невозможно получить ввод дочернего процесса"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Не удаётся записать в стандартный ввод дочернего процесса"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Не удалось выполнить '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Ветка не удалась"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Не удалось установить приоритет процесса"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Не удалось перенаправить ввод/вывод порожденного процесса"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Не удалось настроить неблокирующий канал, программа может зависать."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Невозможно получить имя хоста"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Невозможно получить официальное имя хоста"
 
@@ -9226,12 +9227,12 @@ msgstr "Не удалось переключить Звонок трубы не�
 msgid "Failed to read from wake-up pipe"
 msgstr "Не удалось прочесть из канала пробуждения"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Неправильная спецификация геометрии '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets не удалось открыть дисплей. Выход."
 
@@ -9245,30 +9246,59 @@ msgstr "Не удалось закрыть дисплей \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Не удалось открыть дисплей \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Ошибка разбора XML: '%s' в строке %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Не удалось загрузить ресурсы из '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Невозможно открыть файл ресурсов '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Невозможно загрузить ресурсы из файла '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Не удалось создать '%s' в '%s'."
+
+#~ msgid "Printing "
+#~ msgstr "Печать "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Не удалось вставить текст в элемент управления."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Выберите допустимый шрифт."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Не удалось отобразить документ HTML в кодировке %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets не удалось открыть дисплей для '%s': выход."
+
+#~ msgid "Filter"
+#~ msgstr "Фильтр"
+
+#~ msgid "Directories"
+#~ msgstr "Каталоги"
+
+#~ msgid "Files"
+#~ msgstr "Файлы"
+
+#~ msgid "Selection"
+#~ msgstr "Выделение"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "не удалось преобразование в 8-бит кодировку"

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2020-10-19 12:24+0200\n"
 "Last-Translator: Jozef Matta <jozef.m923@gmail.com>\n"
 "Language-Team: Slovak <sk-i18n@lists.linux.sk>\n"
@@ -19,11 +19,11 @@ msgstr ""
 "X-Generator: Poedit 2.4.1\n"
 "X-Poedit-Bookmarks: -1,1760,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Všetky súbory (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Všetky súbory (*)|*"
 
@@ -40,24 +40,21 @@ msgid "Remaining time:"
 msgstr "Zostávajúci čas:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Áno"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nie"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Zrušiť"
@@ -107,7 +104,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Nemožno vytvoriť port dokončenia I/O"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Vytlačiť"
 
@@ -144,7 +141,7 @@ msgstr "Vlastnosti objektu"
 msgid "Printing"
 msgstr "Tlačí sa"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symboly"
 
@@ -213,7 +210,7 @@ msgstr "&Predchádzajúci"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Okno"
 
@@ -743,11 +740,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "zobrazovať túto správu Pomocníka"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "tvoriť výrečné správy záznamu"
 
@@ -769,84 +766,84 @@ msgstr "Nepodporovaná téma '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Neplatná špecifikácia režimu zobrazenia '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Možnosť '%s' nemôže byť negovaná"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Neznámy dlhý parameter '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Neznámy parameter '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Neočakávané znaky po voľbe '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Možnosť '%s' vyžaduje hodnotu."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Za voľbou '%s' sa očakáva oddeľovač."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' nie je správna číselná hodnota voľby '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Možnosť '%s': '%s' nemožno konvertovať na dátum."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Očakávaný parameter '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (alebo %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Je potrebné zadať hodnotu voľby '%s'."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Požadovaný parameter '%s' nebol zadaný."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Použitie: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "počet"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dvojité"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "dátum"
 
@@ -864,7 +861,7 @@ msgid "Can't &Undo "
 msgstr "Nemožno &Späť "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Späť"
@@ -874,7 +871,7 @@ msgid "&Redo "
 msgstr "&Vpred "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Vpred"
@@ -902,12 +899,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' obsahuje prebytočné '..', ignorované."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "skontrolované"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "nezaškrtnuté"
 
@@ -916,103 +913,103 @@ msgstr "nezaškrtnuté"
 msgid "undetermined"
 msgstr "neurčené"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "dnes"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "včera"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "zajtra"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "prvý"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "sekunda"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tretieho"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "štvrtého"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "piateho"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "šiesteho"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "siedmeho"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "ôsmeho"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "deviateho"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "desiateho"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "deviateho"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dvanásteho"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "trinásteho"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "štrnásteho"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "pätnásteho"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "šestnásteho"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "sedemnásteho"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "osemnásteho"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "devätnásteho"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "dvadsiateho"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "poludnie"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "polnoc"
 
@@ -1078,44 +1075,81 @@ msgstr "Zlyhalo zvlnenie, nainštalujte ho, prosím, do premennej PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Zlyhalo vynovenie hlásenia o chybe (chybový kód %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Uložiť ako"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Zahodiť zmeny a znovu načítať poslednú uloženú verziu?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "nepomenované"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Chcete uložiť zmeny do %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Uložiť"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Neukladať"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Chcete uložiť zmeny do %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Nemožno uložiť text."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Zlyhalo otvorenie súboru '%s' na zápis."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Zlyhalo uloženie dokumentu do súboru '%s'."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Zlyhalo otvorenie súboru '%s' na čítanie."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1124,57 +1158,57 @@ msgstr ""
 "Súbor '%s' neexistuje a nebolo možné ho otvoriť.\n"
 "Bol odstránený zo zoznamu naposledy použitých súborov."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Vytvorenie ukážky tlače zlyhalo."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Náhľad pred tlačou"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formát súboru '%s' sa nepodarilo určiť."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "nemenované%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Otvoriť súbor"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Chyba súboru"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Prepáčte, nebolo možné otvoriť tento súbor."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Prepáčte, formát tohto súboru je neznámy."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Vybrať šablónu dokumentu"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Šablóny"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Vybrať náhľad dokumentu"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Náhľady"
 
@@ -1208,42 +1242,42 @@ msgstr "Chyba pri čítaní súboru '%s'"
 msgid "Write error on file '%s'"
 msgstr "Chyba zápisu do súboru '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "nepodarilo sa vyprázdniť súbor '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Chyba presunu na pozíciu v súbore '%s' (stdio nepodporuje veľké súbory)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Chyba presunu na pozíciu v súbore '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nemožno zistiť súčasnú pozíciu v súbore '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Zlyhalo nastavenie oprávnenia dočasného súboru"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "nemožno odstrániť súbor '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "nemožno vykonať zmeny v súbore '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "nemožno odstrániť dočasný súbor '%s'"
@@ -1268,27 +1302,27 @@ msgstr "nemôže čítať z popisovača súborov %d"
 msgid "can't write to file descriptor %d"
 msgstr "nemožno zapisovať do popisovača súboru %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "nemožno vyprázdniť popisovač súboru %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "nemožno hľadať v popisovači súboru %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "nemožno nájsť pozíciu v popisovači súboru %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "nemožno nájsť dĺžku súboru v popisovači súboru %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "nemožno určiť, či sa v popisovači %d dosiahol koniec súboru"
@@ -1312,107 +1346,107 @@ msgstr "Zmeny nebudú uložené, aby sa zabránilo prepísaniu súboru '%s'"
 msgid "Error reading config options."
 msgstr "Chyba pri čítaní konfiguračných volieb."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Zlyhalo načítanie možností konfigurácie."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "súbor „%s“: neočakávaný znak %c v riadku %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "súbor '%s', riadok %zu: '%s' ignorovaný za hlavičkou skupiny."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "súbor '%s', riadok %zu: '=' sa očakáva."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "súbor '%s', riadok %zu: hodnota pre nemenný kľúč '%s' je ignorovaná."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "súbor '%s', riadok %zu: kľúč '%s' bol prvýkrát nájdený na riadku %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Záznam konfigurácie nemôže začínať '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "nemožno otvoriť konfiguračný súbor používateľa."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "nemožno zapísať konfiguračný súbor používateľa."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Chyba pri ukladaní používateľských konfiguračných údajov."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "nemožno odstrániť konfiguračný súbor používateľa '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "položka '%s' sa v skupine '%s' vyskytuje viackrát"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "pokus o zmenu nemenného kľúča '%s' bol ignorovaný."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "koncová spätná lomka ignorovaná v ' %s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\"neočakávané\" na pozícii %d v '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Zlyhalo skopírovanie súboru '%s' do '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nemožno získať povolenia pre súbor '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nemožno prepísať súbor '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Chyba pri kopírovaní súboru '%s' do '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nemožno nastaviť povolenia pre súbor '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1421,40 +1455,40 @@ msgstr ""
 "Zlyhalo premenovanie súboru '%s' na '%s', pretože cieľový názov súboru už "
 "existuje."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Súbor '%s' nemožno premenovať na '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Súbor '%s' sa nepodarilo odstrániť"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Nemožno vytvoriť priečinok '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Nemožno odstrániť priečinok '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nemožno vymenovať súbory '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Zlyhalo zistenie pracovného priečinku"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Nemožno nastaviť súčasný pracovný priečinok"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Súborov (%s)"
@@ -1481,17 +1515,17 @@ msgstr "Zlyhalo vytvorenie dočasného mena súboru"
 msgid "Failed to open temporary file."
 msgstr "Zlyhalo otvorenie dočasného súboru."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Zlyhala zmena času súboru '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Zlyhal styk so súborom '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Zlyhalo získanie čas súboru '%s'"
@@ -1500,22 +1534,22 @@ msgstr "Zlyhalo získanie čas súboru '%s'"
 msgid "Browse"
 msgstr "Prehľadávať"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Všetky súbory (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s súborov (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Načítať súbor %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Uložiť súbor %s"
@@ -1878,105 +1912,105 @@ msgstr "pôvodné"
 msgid "unknown-%d"
 msgstr "neznáme-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "podčiarknuté"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " preškrtnuté"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " tenké"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " tenké"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " tučné"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " tučné"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " tučné"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kurzíva"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "preškrtnuté"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "tenké"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "tenké"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normálne"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "tučné"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "tučné"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "tučné"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kurzíva"
 
@@ -2057,7 +2091,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Zlyhalo nastavenie FTP prenosového režimu na %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2078,7 +2112,7 @@ msgstr "FTP server nepodporuje pasívny režim."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Nekorektná veľkosť snímky GIF (%u, %d) pre snímku #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Zlyhalo vymedzenie farby pre OpenGL"
 
@@ -2095,7 +2129,7 @@ msgstr "Prispôsobiť stĺpce"
 msgid "&Customize..."
 msgstr "&Prispôsobiť ..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Zlyhalo otvorenie adresy URL '%s' v predvolenom prehliadači."
@@ -2115,155 +2149,154 @@ msgstr "Zlyhalo načítanie obrázok %d z prúdu."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Zlyhalo načítanie ikony zo zdroja '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nemožno uložiť neplatný obrázok."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nemá vlastnú wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nemožno zapísať hlavičku (Bitmap) súboru."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nemožno zapísať hlavičku (BitmapInfo) súboru."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nemožno zapísať mapu RGB farieb."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nemožno zapísať údaje."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nemožno vymedziť pamäť."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Hlavička DIB: Šírka obrázka v súbore > 32767 pixelov."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Hlavička DIB: Výška obrázka v súbore > 32767 pixelov."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Hlavička DIB: Neznáma bitová hĺbka v súbore."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Hlavička DIB: Neznáme kódovanie v súbore."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Hlavička DIB: Kódovanie nezodpovedá bitovej hĺbke."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Nemožno vymedziť pamäť."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Hlavička DIB: Šírka obrázka v súbore > 32767 pixelov."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Hlavička DIB: Výška obrázka v súbore > 32767 pixelov."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Hlavička DIB: Neznáma bitová hĺbka v súbore."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Hlavička DIB: Neznáme kódovanie v súbore."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Hlavička DIB: Kódovanie nezodpovedá bitovej hĺbke."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Chyba pri čítaní obrázka DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Chyba pri čítaní masky DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Obrázok je na ikonu príliš vysoký."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Obrázok je na ikonu príliš široký."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Chyba pri zapisovaní súboru obrázka!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Neplatný index ikony."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Obrázok a maska majú rôzne veľkosti."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Na obrázku nie je namaskovaná žiadna nepoužitá farba."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Zlyhalo načítanie bitmapy '%s' zo zdrojov."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Zlyhalo načítanie ikony '%s' zo zdrojov."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Zlyhalo načítanie obrázku zo súboru '%s'."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nemožno uložiť obrázok do súboru '%s': neznáma prípona súboru."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Pre typ obrázka sa nenašiel žiadny obslužný program."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nie je definovaný žiadny obslužný program obrázkov pre typ %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Súbor obrázka nie je typu %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Nemožno automaticky určiť formát obrázka pre neviditeľný vstup."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Neznámy formát údajov obrázka."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Toto nie je %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Nie je definovaný žiadny obslužný program obrázkov pre typ %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Obrázok nie je typu %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Zlyhalo uloženie bitmapového obrázku do súboru '%s'."
@@ -2365,41 +2398,41 @@ msgstr "PNM: Súbor vyzerá byť orezaný."
 msgid " (in module \"%s\")"
 msgstr " (v module '%s')"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Chyba pri načítaní obrázka."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Neplatný index obrázka TIFF."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Veľkosť obrázka je neobvykle veľká."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Nemožno vymedziť pamäť."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Chyba pri čítaní obrázka."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Neznáma jednotka rozlíšenia TIFF %d je ignorovaná"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Chyba pri ukladaní obrázka."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Chyba pri zápise obrázka."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2408,11 +2441,11 @@ msgstr ""
 "Argument príkazového riadku %d nemožno previesť na Unicode a preto bude "
 "ignorovaný."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicializácia zlyhala v príspevku init, prerušuje sa."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nemožno nastaviť miestne prostredie pre jazyk '%s'."
@@ -2512,7 +2545,7 @@ msgstr "chyba kompresie"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nespárovaná '{' v zázname mime typu %s."
@@ -2532,7 +2565,7 @@ msgstr "Závislosť '%s' modulu '%s' neexistuje."
 msgid "Module \"%s\" initialization failed"
 msgstr "Inicializácia modulu '%s' zlyhala"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Správa"
 
@@ -3034,7 +3067,7 @@ msgstr "Chyba tlače"
 msgid "Print"
 msgstr "Tlačiť"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Nastavenie strany"
 
@@ -3069,19 +3102,15 @@ msgstr "Tlačí sa stránka %d z %d"
 msgid " (copy %d of %d)"
 msgstr " (kópia %d z %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Tlačí sa "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Prvá stránka"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Predošlá strana"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Ďalšia stránka"
 
@@ -3125,16 +3154,16 @@ msgstr "Strana %d z %d"
 msgid "Page %d"
 msgstr "Strana %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "neznáma chyba"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Neplatný regulárny výraz '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Zlyhalo nájdenie výsledku regulárneho výrazu : %s"
@@ -3145,21 +3174,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Vykresľovacie jadro '%s' má nekompatibilnú verziu %d.%d a nemožno ho načítať."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Uloženie hesla pre \"%s / %s\" zlyhalo: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Čítanie hesla pre \"%s / %s\" zlyhalo: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Odstránenie hesla pre \"%s / %s\" zlyhalo: %s."
@@ -3168,11 +3197,11 @@ msgstr "Odstránenie hesla pre \"%s / %s\" zlyhalo: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Zlyhalo monitorovanie I/O kanálov"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Uložiť"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Neukladať"
 
@@ -3256,10 +3285,10 @@ msgid "Clear"
 msgstr "Zmazať"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Zatvoriť"
 
@@ -3271,7 +3300,7 @@ msgstr "&Konvertovať"
 msgid "Convert"
 msgstr "Konvertovať"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopírovať"
@@ -3280,7 +3309,7 @@ msgstr "&Kopírovať"
 msgid "Copy"
 msgstr "Kopírovať"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Vystrihnúť"
@@ -3289,13 +3318,13 @@ msgstr "&Vystrihnúť"
 msgid "Cut"
 msgstr "Vystrihnúť"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Odstrániť"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Odstrániť"
@@ -3384,7 +3413,7 @@ msgstr "Pevný disk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Pomoc"
 
@@ -3404,7 +3433,7 @@ msgstr "Odsadenie"
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Index"
 
@@ -3473,7 +3502,7 @@ msgstr "&Nový"
 msgid "New"
 msgstr "Nový"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nie"
 
@@ -3490,12 +3519,12 @@ msgstr "&Otvoriť..."
 msgid "Open..."
 msgstr "Otvoriť..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Prilepiť"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Prilepiť"
@@ -3525,7 +3554,7 @@ msgid "Print..."
 msgstr "Tlačiť ..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Vlastnosti"
 
@@ -3559,10 +3588,6 @@ msgstr "Nahradiť"
 msgid "Revert to Saved"
 msgstr "Návrat k uloženej verzii"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Uložiť"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Uložiť &ako..."
@@ -3572,7 +3597,7 @@ msgstr "Uložiť &ako..."
 msgid "Save As..."
 msgstr "Uložiť &ako..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Vybrať &všetko"
@@ -3679,7 +3704,7 @@ msgstr "&Hore"
 msgid "Up"
 msgstr "Hore"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "Á&no"
 
@@ -3770,43 +3795,43 @@ msgstr "Uložiť aktuálny dokument"
 msgid "Save current document with a different filename"
 msgstr "Uložiť aktuálny dokument pod odlišným názvom"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konverzia do znakovej sady '%s' nefunguje."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "neznáme"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "neplatný blok hlavičky v tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "zlyhanie kontrolného súčtu pri čítaní bloku hlavičky tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "neplatné dáta v rozšírenej tar hlavičke"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "položka tar nebola otvorená"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "neočakávaný koniec súboru"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s sa nehodilo do tar hlavičky záznamu '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "bola zadaná neplatná veľkosť tar záznamu"
 
@@ -3815,7 +3840,7 @@ msgstr "bola zadaná neplatná veľkosť tar záznamu"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' je pravdepodobne binárny buffer."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Súbor nmožno načítať."
 
@@ -3829,47 +3854,47 @@ msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
 msgid "can't write buffer '%s' to disk."
 msgstr "nemožno zapísať zásobník '%s' na disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Zlyhalo zistenie miestneho systémového času"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay zlyhal."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' nie je platný katalóg správ."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Neplatný katalóg správ."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Zlyhala analýza množného čísla: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "použitím katalógu '%s' z '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Zdroj '%s' nie je platným katalógom správ."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Nemožno vymenovať preklady"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Pre súbory HTML nie je nakonfigurovaná žiadna predvolená aplikácia."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Zlyhalo otvorenie adresy URL '%s' v predvolenom prehliadači."
@@ -3902,7 +3927,7 @@ msgstr "'%s' obsahuje nepovolené znaky"
 msgid "Error: %s (%d)"
 msgstr "Chyba: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3911,21 +3936,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Súbor nie je možné načítať."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Konverzie reťazcov nie sú podporované"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Táto platforma nepodporuje priehľadnosť pozadia."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Nemožno preniesť dáta do okna"
 
@@ -3977,8 +4002,8 @@ msgstr "Parameter vytvárania %s nebol nájdený v deklarovaných parametroch RT
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Trieda nelegálneho objektu (Non-wxEvtHandler) ako zdroj udalosti"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Typ musí mať enum - dlhú konverziu"
 
@@ -4028,79 +4053,79 @@ msgstr "Objekty musia mať ID atribút"
 msgid "Doubly used id : %d"
 msgstr "Duplicitne použitý id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Neznáme vlastnosť %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Neprázdna kolekcia musí pozostávať z uzlov 'element'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "nesprávny reťazec obsluhy udalosti, chýba bodka"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "nemožno znova inicializovať vypustený prúd zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "nemožno znova inicializovať nafúknutý prúd zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "za predpokladu, že sa jedná o viacdielny zreťazený zips"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "neplatný zip súbor"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "nemožno nájsť centrálny priečinok v zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "chyba pri čítaní zip centrálneho priečinka"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "chyba pri čítaní zip miestnej hlavičky"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "zlý posuv súboru zip pri vstupe"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "uložená dĺžka súboru nie je v hlavičke Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "nepodporovaná metóda kompresie Zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "čítanie toku zip (záznam %s): chybná dĺžka"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "čítanie toku zip (záznam %s): chyba crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "chyba pri zápise záznamu zip „%s“: zlý crc alebo dĺžka"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "chyba pri zápise záznamu zip „%s“: zlý crc alebo dĺžka"
@@ -4184,32 +4209,32 @@ msgstr "Grafické umenie podľa "
 msgid "Translations by "
 msgstr "Preložil "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Verzia "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "O aplikácii %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licencia"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Vývojári"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autori dokumentácie"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Účinkujúci"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Prekladatelia"
 
@@ -4260,43 +4285,42 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "pravda"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "nepravda"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Riadok %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Zvinúť"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Rozvinúť"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d položiek)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Stĺpec %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4307,8 +4331,7 @@ msgid "Left"
 msgstr "Zľava"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4406,7 +4429,7 @@ msgid "Home directory"
 msgstr "Domáci priečinok"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Plocha"
 
@@ -4419,8 +4442,7 @@ msgstr "Neplatný názov adresára."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Chyba"
 
@@ -4605,16 +4627,16 @@ msgstr "Zobraziť súbory v detailnom pohľade"
 msgid "Go to parent directory"
 msgstr "Ísť do nadradeného priečinka"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Súbor '%s' už existuje, naozaj ho chcete prepísať?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Potvrdiť"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Vyberte, prosím, existujúci súbor."
 
@@ -4708,7 +4730,7 @@ msgstr "Veľkosť bodu písma."
 msgid "Whether the font is underlined."
 msgstr "Či je písmo podčiarknuté."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Náhľad:"
@@ -4726,48 +4748,47 @@ msgstr "Kliknite pre zrušenie výberu písma."
 msgid "Click to confirm the font selection."
 msgstr "Kliknite pre potvrdenie výberu písma."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Vybrať písmo"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Priečinok Pomocníka '%s' nenájdený."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Súbor Pomocníka '%s' nenájdený."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Riadok %lu mapového súboru '%s' má neplatnú syntax, preskočené."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "V súbore '%s' sa nenašli žiadne platné priradenia."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Neboli nájdené žiadne záznamy."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Index Pomocníka"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevantné položky:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Nájdených záznamov"
 
@@ -4871,59 +4892,59 @@ msgstr "Nemožno začať tlačiť."
 msgid "Printing page %d..."
 msgstr "Tlačí sa stránka %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Voľby tlačiarne"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Tlačiť do súboru"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Nastavenie..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Tlačiareň:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Stav:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Všetky"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Strán"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Rozsah tlače"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kópie:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Súbor PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Nastavenie tlače"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Tlačiareň"
 
@@ -4931,25 +4952,25 @@ msgstr "Tlačiareň"
 msgid "Default printer"
 msgstr "Predvolená tlačiareň"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Paper size"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Portrét"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Krajinka"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientácia"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Možnosti"
 
@@ -4961,52 +4982,52 @@ msgstr "Tlačiť farebne"
 msgid "Print spooling"
 msgstr "Zaradenie tlače"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Príkaz tlačiarne:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Voľby tlačiarne:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Ľavý okraj (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Horný okraj (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Pravý okraj (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Spodný okraj (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Tlačiareň..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Preskočiť"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Neznámy"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Hotovo."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Hľadať"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Nemožno nájsť tabulátor pre id"
 
@@ -5042,22 +5063,22 @@ msgstr "&Dokončiť"
 msgid "< &Back"
 msgstr "< &Späť"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "prekladatelia"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nemožno inicializovať GTK+, je DISPLAY nastavený správne?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Zmena súčasného priečinka na '%s' zlyhala"
@@ -5083,12 +5104,12 @@ msgstr "Zlyhalo načítanie dokument zo súboru '%s'."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Zlyhala aktualizácia používateľského konfiguračného súboru."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Osudová chyba"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5096,7 +5117,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5104,7 +5125,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI potomok"
 
@@ -5120,15 +5141,11 @@ msgstr "Chyba pri tlači: "
 msgid "Page Setup"
 msgstr "Nastavenie strany"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Zlyhalo vloženie textu do ovládacieho prvku."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5136,7 +5153,7 @@ msgstr ""
 "GTK + nainštalovaný v tomto počítači je príliš starý na to, aby podporoval "
 "vytváranie obrazoviek, nainštalujte si GTK + 2.12 alebo novší."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5144,17 +5161,13 @@ msgstr ""
 "Skladanie nie je podporované v tomto systéme, povoľte ho prosím v Správcovi "
 "okien."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Tento program bol skompilovaný s príliš starou verziou GTK+. Znova ju "
 "zostavte s GTK+ 2.12 alebo novšou verziou."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Vyberte, prosím, platné písmo."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5253,45 +5266,45 @@ msgstr "Nemožno otvoriť súbor s obsahom: %s"
 msgid "Cannot open index file: %s"
 msgstr "Nemožno otvoriť indexový súbor: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "nepomenované"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nemožno otvoriť HTML príručku: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Zobrazí pomocníka počas prehliadania kníh vľavo."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(záložky)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Pridať aktuálnu stránku medzi záložky"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Odstráni aktuálnu stránku zo záložiek"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Obsah"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Hľadať"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Zobraziť všetko"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5299,166 +5312,166 @@ msgstr ""
 "Zobraziť všetky položky indexu, ktoré obsahujú daný podreťazec. Vyhľadávanie "
 "rozlišuje malé a veľké písmená."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Zobrazí všetky položky v indexe"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Rozlišovať malé/veľké"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Iba celé slová"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 "Vyhľadá v obsahu pomocníka všetky výskyty textu, ktorý ste napísali vyššie"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Zobrazí/skryje navigačný panel"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Ísť späť"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Ísť vpred"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Ísť o úroveň vyššie v hierarchii dokumentov"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Otvorte dokument HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Vytlačiť túto stránku"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Zobraziť dialóg nastavení"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Vyberte, prosím, stránku, ktorá sa má zobraziť:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Témy Pomocníka"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Hľadá sa..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Zatiaľ sa nenašla žiadna zodpovedajúca stránka"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Nájdených %i zhôd"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Pomoc)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d z %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu z %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Hľadá vo všetkých knihách"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Možnosti prehliadača Pomocníka"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normálne písmo:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Písmo s pevnou šírkou:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Veľkosť písma:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "veľkosť písma"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normálna plôška<br> a <u>podčiarknuté</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kurzívou.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Hrubé.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Hrubé kurzívou.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Písmo s pevnou šírkou.<br> <b>tučné</b> <i>kurzíva</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>Hrubé kurzívou, <u>podčiarknuté</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Pomocník pre tlač"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Nemožno vytlačiť prázdnu stránku."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML súbory (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Knihy Pomocníka (*.htb)|*.htb|Knihy Pomocníka (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Help Project (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimovaný HTML súbor Pomocníka (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i z %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u z %u"
@@ -5536,32 +5549,6 @@ msgstr ""
 "Počas nastavenia stránky nastal problém: zrejme treba nastaviť štandardnú "
 "tlačiareň."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Zlyhalo zobrazenie HTML dokumentu v kódovaní %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets nemohol otvoriť displej pre '%s': ukončuje sa."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filter"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Priečinky"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Súbory"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Výber"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Zlyhalo otvorenie schránky."
@@ -5603,58 +5590,58 @@ msgstr "Dialógové okno výberu farby zlyhalo s chybou %0lx."
 msgid "Failed to create cursor."
 msgstr "Zlyhalo vytvorenie kurzora."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Zlyhalo zaregistrovanie DDE serveru '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Zlyhalo zrušenie registrácie DDE servera '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Zlyhalo vytvorenie spojenia so serverom '%s' na tému '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Požiadavka DDE poke zlyhala"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Zlyhalo nadviazanie pomocného spojenia s DDE serverom"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Zlyhalo ukončenie pomocného spojenia s DDE serverom"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Zlyhalo zaslanie DDE oznámenia"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Zlyhalo vytvorenie DDE reťazca"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "žiadna DDE chyba."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "vypršala platnosť žiadosti o synchrónnu transakciu upozornenia."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odpoveď na transakciu spôsobila nastavenie bitu DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "vypršal časový limit žiadosti o synchrónnu dátovú transakciu."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5665,7 +5652,7 @@ msgstr ""
 "alebo neplatný identifikátor inštancie\n"
 "bol odovzdaný funkcii DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5677,43 +5664,43 @@ msgstr ""
 "alebo aplikácia inicializovaná ako APPCMD_CLIENTONLY\n"
 "sa pokúsil vykonať transakcie so serverom."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "vypršal čas na žiadosť o transakciu synchrónneho vykonania."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parameter sa nepodarilo overiť pomocou DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "aplikácia DDEML vytvorila podmienku predĺženej trasy."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "vymedzenie pamäte zlyhalo."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "pokus klienta o nadviazanie konverzácie zlyhal."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "transakcia zlyhala."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "časový limit žiadosti o synchrónnu transakciu poke."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "zlyhalo interné volanie do funkcie PostMessage. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problém s opakovaným zhrnutím."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5723,15 +5710,15 @@ msgstr ""
 "ktorý bol ukončený klientom alebo serverom\n"
 "ukončená pred dokončením transakcie."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "v súbore DDEML sa vyskytla interná chyba."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "platnosť žiadosti o ukončenie transakcie s oznámením vypršala."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5741,12 +5728,12 @@ msgstr ""
 "Len čo sa aplikácia vráti z XTYP_XACT_COMPLETE spätného volania,\n"
 "identifikátor transakcie pre dané spätné volanie už nie je platný."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Neznáma chyba DDE %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5754,7 +5741,7 @@ msgstr ""
 "Funkcie vytáčaného spojenia nie sú dostupné, lebo služba vzdialeného "
 "prístupu (RAS) nie je na tomto stroji nainštalovaná. Prosím, nainštalujte ju."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5763,67 +5750,67 @@ msgstr ""
 "Verzia služby vzdialeného prístupu (RAS) nainštalovaná v tomto počítači je "
 "príliš stará. Aktualizujte ju (chýba nasledujúca požadovaná funkcia: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Zlyhalo získanie textu chybovej správy RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "neznáma chyba (chybový kód %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nemožno nájsť aktívne vytáčané spojenie: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Bolo nájdených niekoľko aktívnych vytáčaných spojení, vyberám náhodne jedno."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Zlyhalo nadviazanie vytáčaného spojenia: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Zlyhalo získanie zoznamu názvov poskytovateľov pripojenia: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 "Zlyhalo pripojenie: nie je žiadny poskytovateľ, ktorého by bolo možné "
 "vytočiť."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Vyberte ISP na vytočenie"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Vyberte, prosím, poskytovateľa, ku ktorému sa chcete pripájať"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Zlyhalo pripojenie: chýba používateľské meno/heslo."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Nemožno nájsť umiestnenie súboru so zoznamom kontaktov"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Zlyhalo nadviazanie telefonického pripojenia: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nemožno zavesiť - nie je aktívne žiadne vytáčané spojenie."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Zlyhalo ukončenie vytáčaného spojenia: %s"
@@ -5843,18 +5830,17 @@ msgstr "Zlyhalo vymedzenie %lukb pamäte pre údaje bitmapy."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nemožno vymenovať súbory v adresári '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Nemožno získať názov priečinka"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (chyba %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Nemožno pridať obrázok do zoznamu obrázkov."
 
@@ -5869,7 +5855,7 @@ msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Zlyhalo vytvorenie štandardného dialógu hľadať/nahradiť (chybový kód %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Súborový dialóg zlyhal s kódom chyby %0lx."
@@ -5911,16 +5897,16 @@ msgstr "Nemožno nastaviť sledovanie pre \"%s\""
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nemožno sledovať zmeny v neexistujúcom priečinku '%s'."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 alebo novší nie je ovládačom OpenGL podporovaný."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Nemožno vytvoriť kontext OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Zlyhala inicializácia OpenGL"
 
@@ -5928,7 +5914,7 @@ msgstr "Zlyhala inicializácia OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5936,7 +5922,7 @@ msgstr ""
 "Funkcie pomocníka MS HTML nie sú k dispozícii, pretože v tomto zariadení nie "
 "je nainštalovaná knižnica pomocníka MS HTML. Nainštalujte si ho."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Zlyhala inicializácia Pomocníka MS HTML."
 
@@ -5945,7 +5931,7 @@ msgstr "Zlyhala inicializácia Pomocníka MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "Nemožno zmazať INI súbor '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nemožno získať informácie o riadiacej položke zoznamu %d."
@@ -6065,7 +6051,7 @@ msgstr "Nemožno  zaregistrovať formát schránky '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Formát schránky '%d' neexistuje."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Preskočiť"
 
@@ -6150,76 +6136,76 @@ msgstr ""
 "jeho zmazanie by zanechalo systém v nepoužiteľnom stave:\n"
 "operácia bola zrušená."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nemožno zmazať kľúč '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nemožno zmazať hodnotu '%s' z kľúča '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nemožno prečítať hodnotu kľúča '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nemožno nastaviť hodnotu '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Hodnota registra '%s' nie je číselná (ale typu %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Hodnota registra '%s' nie je binárna (ale typu %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Hodnota registra '%s' nie je text (ale typu %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nemožno prečítať hodnotu '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nemožno vymenovať hodnoty kľúča '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nemožno vymenovať podkľúče kľúča '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Exportovanie kľúča registra: súbor '%s' už existuje a nebude prepísaný."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nemožno exportovať hodnotu nepodporovaného typu %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorovanie hodnoty '%s' kľúča '%s'."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6227,41 +6213,41 @@ msgstr ""
 "Nemožno vytvoriť ovládací prvok formátu RTF použitím jednoduchého "
 "ovládacieho prvku textu. Preinštalujte, prosím, riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nemožno sputiť vlákno: chyba zápisu TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Nemožno nastaviť prioritu vlákna"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Nemožno vytvoriť vlákno"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Nemožno ukončiť vlákno"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Nemožno čakať na ukončenie vlákna"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nemožno pozastaviť vlákno %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nemožno znovu získať vlákno %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Nemožno získať ukazovateľ na súčasné vlákno"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6269,7 +6255,7 @@ msgstr ""
 "Zlyhala inicializácia modulu vlákien: nebolo možné alokovať index v lokálnom "
 "priestore vlákna"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6300,12 +6286,12 @@ msgstr "Zlyhalo načítanie zdroja '%s'."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Zlyhalo uzamknutie zdroja '%s'."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "zostava %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bitové vydanie"
 
@@ -6317,47 +6303,47 @@ msgstr "Zlyhalo vytvorenie anonymného potrubia"
 msgid "Failed to redirect the child process IO"
 msgstr "Zlyhalo presmerovanie V/V detského procesu"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Vykonávanie príkazu '%s' zlyhalo"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Zlyhalo načítanie mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nemožno prečítať názov typu z '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nemožno načítať ikonu z '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Nemožno nastaviť prioritu vlákna"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Zlyhalo vykonanie '%s'\n"
@@ -6391,7 +6377,7 @@ msgid "Check to make the font italic."
 msgstr "Zaškrtnite pre kurzívu."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podčiarknuté"
@@ -6459,17 +6445,32 @@ msgstr "<ľubovoľné terminálové>"
 msgid "File type:"
 msgstr "Ďalekopis"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Okno"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomocník"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Mi&nimalizovať"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Priblížiť"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6486,493 +6487,493 @@ msgstr "Súbor %s neexistuje."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "O aplikácii %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "&O aplikácii..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Predvoľby..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Služby"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Skryť %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Aplikácia"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Skryť ostatné"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Zobraziť všetko"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Ukončiť %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Aplikácia"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Táto verzia zlib nepodporuje Gzip"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Nebolo možné inicializovať obrazovku."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Veľkosť bodu"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Názov plôšky"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Štýl"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Hrúbka"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Rodina"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "Priestor aplikácie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "Aktívny okraj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "Aktívny nadpis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "Plocha tlačidla"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "Zvýraznenie tlačidla"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "Tieň tlačidla"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "Text tlačidla"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "Text popisku"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "Tmavý ovládač"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "Svetlý ovládač"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "Sivý text"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Zvýraznenie"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Zvýrazniť text"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "Neaktívny okraj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "Neaktívny popisok"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "Neaktívny text popisku"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Ponuka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Posuvník"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Popis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "Text popisu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Okno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "Rám okna"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "Text okna"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Vlastné"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Čierna"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Gaštanová"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Námorníctvo"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Fialová"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Modrozelená"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Sivá"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Zelená"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Olivový"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Hnedá"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Modrá"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Červeno fialová"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Červená"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Oranžová"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Strieborná"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Riadok"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Aqua"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Žltá"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Biela"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Predvolené"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Šípka"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Šípka vpravo"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Prázdna"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Stredový znak"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Znak"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Krížom"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Ruka"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Ľavé tlačidlo"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Zväčšovač"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Stredné tlačidlo"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Nevstupovať"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Maľba štetcom"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Ceruzka"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Bod vľavo"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Bod vpravo"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Šípka otázky"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Pravé tlačidlo"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Úprava veľkosti SV-JZ"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Úprava veľkosti S-J"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Úprava veľkosti SZ-JV"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Úprava veľkosti Z-V"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Úprav veľkosti"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Rozprašovač"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Čakajte"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Sledovať"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Šípka čakania"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Vytvoriť výber:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Vlastnosť"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Hodnota"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategorizovaný režim"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Abecedný režim"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Nepravda"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Pravda"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Nešpecifikované"
 
@@ -6985,12 +6986,12 @@ msgstr "Chyba vlastnosti"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "Zadali ste neplatnú hodnotu. Stlačením ESC editáciu zrušíte."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Chyba v zdroji: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6998,36 +6999,36 @@ msgid ""
 msgstr ""
 "Zadanie typu '%s' zlyhalo: Vlastnosť s označením '%s' je typu '%s', NIE '%s'."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Hodnota musí byť %s alebo vyššia."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Hodnota musí byť medzi %s a %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Hodnota musí byť %s alebo nižšia."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Bez %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Vybrať priečinok:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Vybrať súbor"
 
@@ -7494,117 +7495,117 @@ msgstr "Vložiť"
 msgid "Outset"
 msgstr "Napred"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Zmeniť štýl"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Zmeniť štýl objektu"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Zmeniť vlastnosti"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Zmeniť štýl zoznamu"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Prečíslovať zoznam"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Vložiť text"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Vložiť obrázok"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Vložiť objekt"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Vložiť pole"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Príliš veľa volaní EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "súborov"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "štandardné/kruh"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "štandardné/obrys kruhu"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "štandardné/štvorec"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "štandardné/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "štandardné/trojuholník"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Vlastnosti schránky"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Vlastnosti viacerých buniek"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Vlastnosti bunky"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Nastaviť štýl bunky"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Odstrániť riadok"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Odstrániť stĺpec"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Pridať riadok"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Pridať stĺpec"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Vlastnosti tabuľky"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Vlastnosti obrázka"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "obrázok"
 
@@ -7812,24 +7813,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Ťahať"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Odstrániť text"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Odstrániť oddeľovač"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Nemožno uložiť text."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Nahradiť"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Písmo:"
 
@@ -8798,53 +8799,53 @@ msgstr "Štýly zoznamu"
 msgid "Box styles"
 msgstr "Štýly schránky"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Písmo pre použitie symbolu."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Podmnožina:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Zobrazí náhľad podsadu Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Kód znaku:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Kód znaku."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Obraziť rozsah."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Vložiť"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normálny text)"
 
@@ -9030,7 +9031,7 @@ msgstr "Nemožno načítať udalosti z kqueue"
 msgid "Media playback error: %s"
 msgstr "Chyba prehrávania médií: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Zlyhala príprava hry '%s'."
@@ -9130,20 +9131,20 @@ msgstr "Zvukové údaje sú v nepodporovanom formáte."
 msgid "Couldn't open audio: %s"
 msgstr "Nemožno otvoriť audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nemožno získať plánovaciu politiku vlákna."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nemožno získať rozsah priorít pre plánovaciu politiku %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Nastavenie priority vlákna bolo ignorované."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9151,60 +9152,60 @@ msgstr ""
 "Zlyhalo pridanie vlákna, zistený potenciálny výpadok pamäte - reštartujte, "
 "prosím, program"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Zlyhalo nastavenie úrovne súbežnosti vlákna na %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Zlyhalo nastavenie priority vlákna %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Zlyhalo ukončenie vlákna."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Zlyhala inicializácia modulu vlákien: nepodarilo sa vytvoriť kľúč vlákna"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Nemožno získať podradený vstup procesu"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Nemožno zapisovať do podriadeného procesu stdin"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Zlyhalo vykonanie '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Zlyhala vidlica"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Zlyhalo nastavenie priority procesu"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Zlyhalo presmerovanie vstupu/výstupu detského procesu"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Zlyhalo nastavenie neblokujúceho potrubia, program môže prestať reagovať."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Nemožno získať názov hostiteľa"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Nemožno získať oficálny názov hostiteľa"
 
@@ -9220,12 +9221,12 @@ msgstr "Zlyhalo prepnutie prebudenia potrubia do neblokujúceho režimu"
 msgid "Failed to read from wake-up pipe"
 msgstr "Zlyhalo načítanie prebudenie potrubia"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Neplatná špecifikácia geometrie '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nemohol otvoriť displej. Ukončuje sa."
 
@@ -9239,30 +9240,59 @@ msgstr "Zlyhalo zatvorenie zobrazenia '%s'"
 msgid "Failed to open display \"%s\"."
 msgstr "Zlyhalo otvorenie zobrazenia '%s'."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Chyba parsovania XML: '%s' na riadku %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nemožno načítať zdroje zo '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nemožno otvoriť zdroje súboru '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nemožno načítať zdroje zo súboru '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Vytváranie %s '%s' zlyhalo."
+
+#~ msgid "Printing "
+#~ msgstr "Tlačí sa "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Zlyhalo vloženie textu do ovládacieho prvku."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Vyberte, prosím, platné písmo."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Zlyhalo zobrazenie HTML dokumentu v kódovaní %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nemohol otvoriť displej pre '%s': ukončuje sa."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Priečinky"
+
+#~ msgid "Files"
+#~ msgstr "Súbory"
+
+#~ msgid "Selection"
+#~ msgstr "Výber"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "zlyhal prevod na 8-bitové kódovanie"
@@ -9412,15 +9442,15 @@ msgstr "Vytváranie %s '%s' zlyhalo."
 #~ msgstr "Nebolo možné začať tlačiť."
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"
 #~ "%s %1"
 #~ msgstr ""
-#~ "Chcete prepísať príkaz, ktorý sa používa na %s súborov s príponou \"%s"
-#~ "\" ?\n"
+#~ "Chcete prepísať príkaz, ktorý sa používa na %s súborov s príponou "
+#~ "\"%s\" ?\n"
 #~ "Súčasná hodnota je \n"
 #~ "%s, \n"
 #~ "Nová hodnota je is \n"

--- a/locale/sl.po
+++ b/locale/sl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-06-19 13:07+0200\n"
 "Last-Translator: Martin Srebotnjak <miles@filmsi.net>\n"
 "Language-Team: Martin Srebotnjak <miles@filmsi.net>\n"
@@ -10,18 +10,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || n"
-"%100==4 ? 3 : 0);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 1 : n%100==2 ? 2 : n%100==3 || "
+"n%100==4 ? 3 : 0);\n"
 "X-Poedit-SourceCharset: iso-8859-1\n"
 "X-Generator: Poedit 3.1\n"
 
 # generic/filedlgg.cpp:825
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Vse datoteke (*.*)|*.*"
 
 # generic/filedlgg.cpp:825
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Vse datoteke (*)|*"
 
@@ -40,14 +40,12 @@ msgstr "Preostali čas:"
 # common/dlgcmn.cpp:109
 # common/dlgcmn.cpp:116
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Da"
 
 # common/dlgcmn.cpp:111
 # common/dlgcmn.cpp:121
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
@@ -61,8 +59,8 @@ msgstr "Ne"
 # generic/proplist.cpp:511
 # html/helpfrm.cpp:909
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "V redu"
 
@@ -78,8 +76,7 @@ msgstr "V redu"
 # generic/wizard.cpp:192
 # html/helpfrm.cpp:910
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Prekliči"
@@ -141,7 +138,7 @@ msgstr "Ni mogoče ustvariti ročice vrat dokončanja V/I."
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Izpis"
 
@@ -193,7 +190,7 @@ msgstr "Lastnosti predmeta"
 msgid "Printing"
 msgstr "Tiskanje poteka"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simboli"
 
@@ -281,7 +278,7 @@ msgstr "&Prejšnji"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Okno"
 
@@ -867,11 +864,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "SurovaKrmilka-"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "pokaži to sporočilo pomoči"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "ustvari obširna dnevniška sporočila"
 
@@ -895,99 +892,99 @@ msgid "Invalid display mode specification '%s'."
 msgstr "Napačna specifikacija načina prikaza '%s'."
 
 # common/filefn.cpp:1086
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Možnosti »%s« ni mogoče negirati."
 
 # common/cmdline.cpp:496
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nepoznana dolga opcija '%s'"
 
 # common/cmdline.cpp:518
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nepoznana opcija '%s'"
 
 # common/cmdline.cpp:712
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Parametru '%s' sledijo nepričakovani znaki."
 
 # common/cmdline.cpp:610
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Možnost '%s' zahteva vrednost."
 
 # common/cmdline.cpp:627
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Po možnosti '%s' je pričakovano ločilo."
 
 # common/cmdline.cpp:657
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "»%s« ni pravilna numerična vrednost za možnost »%s«."
 
 # common/cmdline.cpp:671
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Možnosti '%s':'%s' ni mogoče pretvoriti v datum."
 
 # common/cmdline.cpp:712
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Nepričakovan parameter '%s'"
 
 # common/cmdline.cpp:735
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ali %s)"
 
 # common/cmdline.cpp:740
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Vrednost opcije '%s' mora biti podana."
 
 # common/cmdline.cpp:761
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Zahtevani parameter '%s' ni bil podan."
 
 # common/cmdline.cpp:797
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Uporaba: %s"
 
 # common/cmdline.cpp:910
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
 # common/cmdline.cpp:911
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "št"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "dvojno"
 
 # common/cmdline.cpp:912
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "datum"
 
@@ -1011,7 +1008,7 @@ msgstr "Nemogoča &razveljavitev"
 
 # common/docview.cpp:1951
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Razveljavi"
@@ -1025,7 +1022,7 @@ msgstr "&Ponovi "
 # common/docview.cpp:1945
 # common/docview.cpp:1956
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ponovi"
@@ -1057,12 +1054,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "»%s« ima dodaten »..«, prezrto."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "potrjeno"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "nepotrjeno"
 
@@ -1072,111 +1069,111 @@ msgstr "nepotrjeno"
 msgid "undetermined"
 msgstr "nedoločeno"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "danes"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "včeraj"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "jutri"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "prvi"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "drugi"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tretji"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "četrti"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "peti"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "šesti"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sedmi"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "osmi"
 
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "deveti"
 
 # generic/helpwxht.cpp:159
 # html/helpfrm.cpp:303
 # html/helpfrm.cpp:312
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "deseti"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "enajsti"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "dvanajsti"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "trinajsti"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "štirinajsti"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "petnajsti"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "šestnajsti"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "sedemnajsti"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "osemnajsti"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "devetnajsti"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "dvajseti"
 
 # html/helpdata.cpp:644
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "opoldne"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "opolnoči"
 
@@ -1233,8 +1230,8 @@ msgstr "Tvorba poročila o razhroščevanju ni uspela."
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
-"Obdelava poročila o razhroščevanju ni uspela, datoteke so ostale v mapi \"%s"
-"\"."
+"Obdelava poročila o razhroščevanju ni uspela, datoteke so ostale v mapi "
+"\"%s\"."
 
 #: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
@@ -1262,52 +1259,93 @@ msgid "Failed to upload the debug report (error code %d)."
 msgstr "Poročila o razhroščevanju ni bilo mogoče prenesti (koda napake %d)"
 
 # common/docview.cpp:249
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Shrani kot"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Želite opustiti spremembe in ponovno naložiti nazadnje shranjeno različico?"
 
 # common/docview.cpp:406
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "neimenovana"
 
 # common/docview.cpp:440
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Ali želite shraniti spremembe dokumenta %s?"
 
+# generic/logg.cpp:473
+# generic/logg.cpp:774
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Shrani"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Ne shrani"
+
+# common/docview.cpp:440
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Ali želite shraniti spremembe dokumenta %s?"
+
+# common/textcmn.cpp:121
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Besedila ni mogoče shraniti."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
 # generic/dirdlgg.cpp:550
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Datoteke \"%s\" ni mogoče odpreti za pisanje."
 
 # common/ffile.cpp:182
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Neuspešno shranjevanje dokumenta v datoteko \"%s\"."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Datoteke \"%s\" ni mogoče odpreti za branje."
 
 # common/ffile.cpp:182
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Dokumenta iz datoteke \"%s\" ni mogoče prebrati."
 
 # common/docview.cpp:1676
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1316,73 +1354,73 @@ msgstr ""
 "Datoteka '%s' ne obstaja in je ni mogoče odpreti.\n"
 "Izbisana je bila iz seznama zadnjih uporabljenih datotek."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Tvorba predogleda tiskanja ni uspela."
 
 # common/docview.cpp:897
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Predogled tiskanja"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Vrste datoteke '%s' ni mogoče ugotoviti."
 
 # common/docview.cpp:1188
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "neimenovana%d"
 
 # common/docview.cpp:1206
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Odpri datoteko"
 
 # common/docview.cpp:296
 # common/docview.cpp:332
 # common/docview.cpp:1388
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Datotečna napaka"
 
 # common/docview.cpp:342
 # common/docview.cpp:354
 # common/docview.cpp:1390
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Oprostite, te datoteke ni moč odpreti."
 
 # common/docview.cpp:342
 # common/docview.cpp:354
 # common/docview.cpp:1390
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Oprostite, ta zapis datoteke je neznan."
 
 # common/docview.cpp:1469
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Izberi predlogo dokumenta"
 
 # common/docview.cpp:1469
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Šablone"
 
 # common/docview.cpp:1494
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Izberi pogled dokumenta"
 
 # common/docview.cpp:1494
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Pogledi"
 
@@ -1425,18 +1463,18 @@ msgid "Write error on file '%s'"
 msgstr "Napaka pri pisanju datoteke »%s«"
 
 # common/ffile.cpp:182
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "ne morem izprazniti datoteke '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Najdi napako na datoteki '%s' (velike datoteke niso podprte v stdio)"
 
 # common/ffile.cpp:221
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Napaka pri iskanju v datoteki '%s'"
@@ -1446,13 +1484,13 @@ msgstr "Napaka pri iskanju v datoteki '%s'"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # common/ffile.cpp:234
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Trenutne pozicije v datoteki »%s« ni mogoče najti."
 
 # common/ffile.cpp:182
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Neuspešno nastavljanje pravic za trenutno datoteko"
 
@@ -1462,7 +1500,7 @@ msgstr "Neuspešno nastavljanje pravic za trenutno datoteko"
 #
 # common/file.cpp:552
 # common/file.cpp:562
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "ni mogoče odstraniti datoteke '%s'"
@@ -1473,7 +1511,7 @@ msgstr "ni mogoče odstraniti datoteke '%s'"
 #
 # common/file.cpp:557
 # common/file.cpp:567
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "ni mogoče uveljaviti sprememb datoteke '%s'"
@@ -1484,7 +1522,7 @@ msgstr "ni mogoče uveljaviti sprememb datoteke '%s'"
 #
 # common/file.cpp:580
 # common/file.cpp:583
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "ni mogoče odstraniti začasne datoteke '%s'"
@@ -1518,31 +1556,31 @@ msgid "can't write to file descriptor %d"
 msgstr "ni mogoče pisati na deskriptor %d"
 
 # common/file.cpp:319
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "ni mogoče izprazniti deskriptorja %d"
 
 # common/file.cpp:359
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "ni mogoče iskati na datotečnem deskriptorju %d"
 
 # common/file.cpp:373
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "ni mogoče najti iskalne pozicije v datotečnem deskriptorju %d"
 
 # common/file.cpp:404
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "ni mogoče najti dolžine datoteke na datotečnem deskriptorju %d"
 
 # common/file.cpp:438
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1571,64 +1609,64 @@ msgid "Error reading config options."
 msgstr "Napaka pri branju konfiguracijskih možnosti."
 
 # generic/dirdlgg.cpp:552
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Napaka pri branju konfiguracijskih možnosti."
 
 # common/fileconf.cpp:449
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "datoteka »%s«: nepričakovan znak %c v vrstici %zu."
 
 # common/fileconf.cpp:481
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "datoteka »%s«, vrstica %zu: »%s« je bil ignoriran po skupinski glavi."
 
 # common/fileconf.cpp:510
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "datoteka »%s«, vrstica %zu: »=» pričakovan."
 
 # common/fileconf.cpp:526
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "datoteka »%s«, vrstica %zu: vrednost nespremenljivega ključa »%s« ignorirana."
 
 # common/fileconf.cpp:536
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "datoteka »%s«, vrstica %zu: ključ »%s« je bil že najden v vrstici %d."
 
 # common/fileconf.cpp:760
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Vstopno konfiguracijsko ime se ne more začeti s »%c«."
 
 # common/fileconf.cpp:800
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "ni mogoče odpreti uporabniške konfiguracijske datoteke."
 
 # common/fileconf.cpp:807
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "ni mogoče zapisati uporabniške konfiguracijske datoteke."
 
 # common/fileconf.cpp:800
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Uporabniške konfiguracijske datoteke ni mogoče posodobiti."
 
 # generic/dirdlgg.cpp:552
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Napaka pri shranjevanju podatkov nastavitev uporabnika."
 
@@ -1637,63 +1675,63 @@ msgstr "Napaka pri shranjevanju podatkov nastavitev uporabnika."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # common/fileconf.cpp:920
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "ni mogoče uzbrisati uporabniške datoteke '%s'"
 
 # common/fileconf.cpp:1437
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "vnos '%s' se pojavi večkrat v skupini '%s'"
 
 # common/fileconf.cpp:1450
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "poskus spremembe nestremenjivega ključa '%s' je bil ignoriran."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "leva poševnica na koncu v »%s« prezrta"
 
 # common/fileconf.cpp:1557
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "nepričakovan \" na poziciji %d v '%s'."
 
 # common/ffile.cpp:182
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Datoteke »%s« ni mogoče kopirati v »%s«"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Pravic za datoteko »%s« ni mogoče dobiti."
 
 # common/ffile.cpp:182
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Datoteke »%s« ni mogoče prepisati."
 
 # common/ffile.cpp:182
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Napaka pri kopiranju datoteke »%s« v »%s«."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Pravic za datoteko »%s« ni mogoče nastaviti."
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1702,48 +1740,48 @@ msgstr ""
 "Datoteke''%s' ni mogoče preimenovati v '%s', ker ciljna datoteka že obstaja."
 
 # common/filefn.cpp:1086
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Datoteke »%s« ni mogoče preimenovati v »%s«."
 
 # common/filefn.cpp:1086
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Datoteke »%s« ni mogoče odstraniti."
 
 # common/filefn.cpp:1086
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Mape »%s« ni mogoče ustvariti."
 
 # common/filefn.cpp:1086
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Mape »%s« ni mogoče izbrisati."
 
 # common/filefn.cpp:1287
 # msw/dir.cpp:294
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Oštevilčenje datotek »%s« ni možno"
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Delovne mape ni mogoče pridobiti."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Delovne mape ni mogoče določiti."
 
 # generic/filedlgg.cpp:825
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Datoteke (%s)"
@@ -1781,19 +1819,19 @@ msgid "Failed to open temporary file."
 msgstr "Začasne datoteke ni mogoče odpreti."
 
 # common/ffile.cpp:182
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Sprememba datotečnih časov za »%s« ni uspela."
 
 # common/ffile.cpp:182
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Datoteke »%s« se ni mogoče dotakniti."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Neuspešno pridobivanje datotečnih časov za '%s'"
@@ -1803,27 +1841,27 @@ msgid "Browse"
 msgstr "Prebrskaj"
 
 # generic/filedlgg.cpp:825
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Vse datoteke (%s)|%s"
 
 # generic/filedlgg.cpp:825
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "datoteke %s (%s)|%s"
 
 # generic/filedlgg.cpp:1270
 # msw/filedlg.cpp:483
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Naloži datoteko %s"
 
 # generic/filedlgg.cpp:1286
 # msw/filedlg.cpp:484
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Shrani datoteko %s"
@@ -2191,113 +2229,113 @@ msgid "unknown-%d"
 msgstr "nepoznan-%d"
 
 # generic/fontdlgg.cpp:242
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "podčrtano"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " prečrtano"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr "tanko"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " rahlo"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " rahlo"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr "srednje"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " polkrepko"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " krepko"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr "zelo krepko"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr "debelo"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr "zelo debelo"
 
 # generic/fontdlgg.cpp:213
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " ležeče"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "prečrtano"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "tanko"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "rahlo"
 
 # generic/fontdlgg.cpp:216
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "svetlo"
 
 # generic/fontdlgg.cpp:212
 # generic/fontdlgg.cpp:215
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "navadno"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "srednje"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "polkrepko"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "krepko"
 
 # generic/fontdlgg.cpp:217
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "zelo krepko"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "debelo"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "zelo debelo"
 
 # generic/fontdlgg.cpp:213
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "ležeče"
 
@@ -2390,7 +2428,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Prenosnega načina FTP ni mogoče nastaviti na %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2413,7 +2451,7 @@ msgstr "Nepravilna velikost okvira GIF (%u, %d) za okvir #%u"
 
 # common/imagbmp.cpp:266
 # common/imagbmp.cpp:278
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Barve za OpenGL ni mogoče dodeliti."
 
@@ -2432,7 +2470,7 @@ msgid "&Customize..."
 msgstr "Prila&godi ..."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Odpiranje URL-ja »%s« v privzetem brskalniku ni uspelo"
@@ -2456,178 +2494,177 @@ msgid "Failed to load icons from resource '%s'."
 msgstr "Ikon iz vira »%s« ni mogoče naložiti."
 
 # common/imagbmp.cpp:62
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: nepravilne slike ni mogoče shraniti."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nima lastne wxPalette."
 
 # common/imagbmp.cpp:131
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: datotečne glave (Bitmap) ni mogoče zapisati."
 
 # common/imagbmp.cpp:131
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: datotečne glave (BitmapInfo) ni mogoče zapisati."
 
 # common/imagbmp.cpp:154
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: barvnega zemljevida RGB ni mogoče shraniti."
 
 # common/imagbmp.cpp:154
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: podatkov ni mogoče zapisati"
 
-#: ../src/common/imagbmp.cpp:533
-#, c-format
-msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
-msgstr "BMP: glava ima biClrUsed=%d, ko je biBitCount=%d."
-
 # common/imagbmp.cpp:266
 # common/imagbmp.cpp:278
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
 msgid "BMP: Couldn't allocate memory."
 msgstr "BMP: pomnilnika ni mogoče alocirati."
 
 # common/imagbmp.cpp:214
-#: ../src/common/imagbmp.cpp:1094
+#: ../src/common/imagbmp.cpp:1055
 msgid "DIB Header: Image width > 32767 pixels for file."
 msgstr "Glava DIB: širina slike > 32767 pikslov za datoteko."
 
 # common/imagbmp.cpp:220
-#: ../src/common/imagbmp.cpp:1102
+#: ../src/common/imagbmp.cpp:1063
 msgid "DIB Header: Image height > 32767 pixels for file."
 msgstr "Glava DIB: višina slike > 32767 pikslov za datoteko."
 
 # common/imagbmp.cpp:234
-#: ../src/common/imagbmp.cpp:1122
+#: ../src/common/imagbmp.cpp:1093
 msgid "DIB Header: Unknown bitdepth in file."
 msgstr "Glava DIB: neznana bitna globina v datoteki."
 
 # common/imagbmp.cpp:243
-#: ../src/common/imagbmp.cpp:1177
+#: ../src/common/imagbmp.cpp:1167
 msgid "DIB Header: Unknown encoding in file."
 msgstr "Glava DIB: neznano kodiranje v datoteki."
 
 # common/imagbmp.cpp:257
-#: ../src/common/imagbmp.cpp:1209
+#: ../src/common/imagbmp.cpp:1176
 msgid "DIB Header: Encoding doesn't match bitdepth."
 msgstr "Glava DIB: kodiranje se ne ujema z bitno globino."
 
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1192
+#, c-format
+msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
+msgstr "BMP: glava ima biClrUsed=%d, ko je biBitCount=%d."
+
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Error in reading image DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: napaka pri branju maske DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: slika je previsoka za ikono."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: slika je preširoka za ikono."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: napaka pri pisanju v datoteko slike!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: neveljaven indeks ikone."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Slika in maska imata različno velikost."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Nobena neuporabljena barva v sliki ni maskirana."
 
 # common/ffile.cpp:182
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Bitne slike \"%s\" iz virov ni mogoče naložiti."
 
 # common/ffile.cpp:182
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Ikone \"%s\" iz virov ni mogoče naložiti."
 
 # common/ffile.cpp:182
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Slike iz datoteke \"%s\" ni mogoče naložiti."
 
 # common/image.cpp:653
 # common/image.cpp:673
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Slike ni mogoče shraniti v datoteko »%s«: neznana končnica."
 
 # common/image.cpp:758
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Upravljalca za vrsto slike ni mogoče najti."
 
 # common/image.cpp:766
 # common/image.cpp:800
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Za vrsto %d ni določen noben upravljalec slik."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Datoteka slike ni vrste %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Ni mogoče samodejno določiti obliko slike za vnos brez iskanja."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Neznana vrsta slikovnih podatkov."
 
 # common/imagpcx.cpp:434
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "To ni %s."
 
 # common/image.cpp:784
 # common/image.cpp:816
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Za vrsto %s ni določen noben upravljalec slik."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Slika ni vrste %s."
 
 # common/ffile.cpp:182
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Neuspešno preverjanje zapisa slikovne datoteke \"%s\"."
@@ -2751,48 +2788,48 @@ msgid " (in module \"%s\")"
 msgstr " (v modulu \"%s\")"
 
 # common/imagtiff.cpp:163
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: napaka pri nalaganju slike."
 
 # common/imagtiff.cpp:171
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Neveljaven indeks slike TIFF."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: slika je nenaravno velika."
 
 # common/imagtiff.cpp:192
 # common/imagtiff.cpp:203
 # common/imagtiff.cpp:314
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: spomina ni mogoče alocirati."
 
 # common/imagtiff.cpp:214
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: napaka pri branju slike."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Neznana enota ločljivosti TIFF %d bo prezrta"
 
 # common/imagtiff.cpp:291
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: napaka pri shranjevanju slike."
 
 # common/imagtiff.cpp:338
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: napaka pri zapisovanju slike."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2800,11 +2837,11 @@ msgid ""
 msgstr ""
 "Argumenta ukazne vrstice %d ni mogoče pretvoriti v Unicode, zato bo prezrt."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicializacija ni uspela v po-inicializaciji, sledi prekinitev."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Jezika programa ni mogoče nastaviti na \"%s\"."
@@ -2910,7 +2947,7 @@ msgid "LZMA compression error when flushing output: %s"
 msgstr "Napaka stiskanja LZMA pri odpravi izhoda: %s"
 
 # common/mimecmn.cpp:161
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Neujemajoči '{' v vnosu za vsto mime %s."
@@ -2930,7 +2967,7 @@ msgstr "Odvisnost \"%s\" od modula \"%s\" ne obstaja."
 msgid "Module \"%s\" initialization failed"
 msgstr "Inicializacija modula \"%s\" ni uspela"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Sporočilo"
 
@@ -3458,7 +3495,7 @@ msgid "Print"
 msgstr "Tiskanje"
 
 # generic/prntdlgg.cpp:604
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Nastavitev strani"
 
@@ -3496,24 +3533,18 @@ msgstr "Tiskanje strani %d od %d ..."
 msgid " (copy %d of %d)"
 msgstr " (kopija %d od %d)"
 
-# common/prntbase.cpp:106
-# common/prntbase.cpp:148
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Tiskanje poteka"
-
 # html/helpfrm.cpp:515
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Prva stran"
 
 # html/helpfrm.cpp:512
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Prejšnja stran"
 
 # html/helpfrm.cpp:515
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Naslednja stran"
 
@@ -3567,16 +3598,16 @@ msgid "Page %d"
 msgstr "Stran %d"
 
 # generic/progdlgg.cpp:241
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "neznana napaka"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Neveljaven pravilni izraz '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Ujemanje v regularnem izrazu neuspešno: %s"
@@ -3588,21 +3619,21 @@ msgstr ""
 "Prikazovalnik \"%s\" je nezdružljive različice %d.%d in ga ni mogoče "
 "naložiti."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Ni na voljo za to platformo"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Shranjevanje gesla za »%s« ni uspelo: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Branje gesla za »%s« ni uspelo: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Brisanje gesla za »%s« ni uspelo: %s."
@@ -3613,11 +3644,11 @@ msgstr "V/I kanalov ni bilo mogoče nadzirati"
 
 # generic/logg.cpp:473
 # generic/logg.cpp:774
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Shrani"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Ne shrani"
 
@@ -3723,10 +3754,10 @@ msgstr "Počisti"
 # generic/progdlgg.cpp:307
 # generic/proplist.cpp:518
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Zapri "
 
@@ -3744,7 +3775,7 @@ msgstr "&Pretvori"
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiraj"
@@ -3753,7 +3784,7 @@ msgstr "&Kopiraj"
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Izreži"
@@ -3762,13 +3793,13 @@ msgstr "&Izreži"
 msgid "Cut"
 msgstr "Izreži"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Izbriši"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Izbriši"
@@ -3869,7 +3900,7 @@ msgstr "Trdi disk"
 # msw/mdi.cpp:1283
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Pomoč"
 
@@ -3894,7 +3925,7 @@ msgid "&Index"
 msgstr "&Kazalo"
 
 # html/helpfrm.cpp:372
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3975,7 +4006,7 @@ msgstr "Nov"
 
 # common/dlgcmn.cpp:111
 # common/dlgcmn.cpp:121
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Ne"
 
@@ -4006,13 +4037,13 @@ msgid "Open..."
 msgstr "Odpri ..."
 
 # common/cmdline.cpp:912
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Prilepi"
 
 # common/cmdline.cpp:912
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Prilepi"
@@ -4047,7 +4078,7 @@ msgstr "Natisni ..."
 
 # html/helpfrm.cpp:512
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Lastnosti"
 
@@ -4089,12 +4120,6 @@ msgstr "Povrni v shranjeno"
 
 # generic/logg.cpp:473
 # generic/logg.cpp:774
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Shrani"
-
-# generic/logg.cpp:473
-# generic/logg.cpp:774
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Shrani kot ..."
@@ -4107,7 +4132,7 @@ msgstr "Shrani kot ..."
 
 # common/docview.cpp:1371
 # common/docview.cpp:1422
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Izberi &vse"
@@ -4227,7 +4252,7 @@ msgstr "Navzgor"
 
 # common/dlgcmn.cpp:109
 # common/dlgcmn.cpp:116
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Da"
 
@@ -4326,44 +4351,44 @@ msgstr "Shrani trenutni dokument"
 msgid "Save current document with a different filename"
 msgstr "Shrani trenutni dokument pod drugim imenom datoteke."
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Pretvorba v nabor znakov »%s« ne deluje."
 
 # generic/progdlgg.cpp:241
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "nepoznan"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "nepopolni blok glave v tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "napaka preverjanja preizkusne vsote pri branju bloka glave tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "neveljavni podatki v razširjeni glavi tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "vnos tar ni odprt"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "nepričakovan konec datoteke"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ne ustreza glavi tar za vnos »%s«"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "nepravilna velikost za vnos tar"
 
@@ -4373,7 +4398,7 @@ msgid "'%s' is probably a binary buffer."
 msgstr "»%s« je verjetno binarni medpomnilnik."
 
 # common/textcmn.cpp:94
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Datoteke ni mogoče naložiti."
 
@@ -4394,55 +4419,55 @@ msgid "can't write buffer '%s' to disk."
 msgstr "medpomnilnika '%s' ni možno zapisati na disk."
 
 # common/timercmn.cpp:196
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Lokalnega sistemskega časa ni mogoče razbrati."
 
 # common/timercmn.cpp:267
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay ni uspela."
 
 # common/intl.cpp:412
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "»%s« ni veljaven katalog sporočil."
 
 # common/intl.cpp:412
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Neveljaven katalog sporočil."
 
 # html/helpdata.cpp:353
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Množinskih oblik ni mogoče razčleniti: »%s«"
 
 # common/intl.cpp:379
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "uporabljen je katalog »%s« iz »%s«."
 
 # common/intl.cpp:412
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Vir '%s' ni veljaven katalog sporočil."
 
 # msw/thread.cpp:958
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Prevodov ni mogoče oštevilčiti."
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Za datoteke HTML ni nastavljen privzeti program."
 
 # generic/dirdlgg.cpp:550
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "URL-ja \"%s\" ni mogoče odpreti v privzetem brskalniku."
@@ -4480,7 +4505,7 @@ msgstr "»%s« vsebuje neveljavne znake"
 msgid "Error: %s (%d)"
 msgstr "Napaka: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Za prenos ni dovolj prostora na disku."
 
@@ -4489,21 +4514,21 @@ msgstr "Za prenos ni dovolj prostora na disku."
 msgid "libcurl could not be initialized"
 msgstr "libcurl ni bilo mogoče inicializirati"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync ni podprt"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Napaka pri izvajanju JavaScripta: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Ta platforma ne podpira prosojnosti ozadja."
 
 # common/wincmn.cpp:784
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Podatkov ni mogoče prenesti v okno."
 
@@ -4556,8 +4581,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Neveljavni razred predmetov (ne wxEvtHandler) kot izvor dogodka."
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Tip mora imeti pretvorbo enum - long"
 
@@ -4609,41 +4634,41 @@ msgid "Doubly used id : %d"
 msgstr "Dvojno uporabljen id: %d"
 
 # common/cmdline.cpp:518
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Neznana lastnost %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Neprazno zbirko morajo tvoriti vozli 'elementov'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "nepravilen niz ročice dogodka, manjka pika"
 
 # html/helpfrm.cpp:1174
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "ni mogoče ponovno incializirati upadalnega toka zlib"
 
 # html/helpfrm.cpp:1174
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "ni mogoče ponovno incializirati napihovalnega toka zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Prezrt neustrezno oblikovan dodatni podatkovni zapis, datoteka ZIP je morda "
 "poškodovana"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "predvidevajoč, da gre za povezan večdelni zip"
 
 # common/ffile.cpp:101
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "neveljavna datoteka zip"
 
@@ -4652,47 +4677,47 @@ msgstr "neveljavna datoteka zip"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # common/ffile.cpp:234
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "ni mogoče najti osrednje mape v datoteki zip"
 
 # generic/dirdlgg.cpp:552
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "napaka pri branju osrednje mape zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "napaka pri branju lokalne glave zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "slab odmik zipfile od vnosa"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "dolžine shranjene datoteke ni v glavi Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "nepodprta metoda stiskanja Zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "branje toka zip (vnos %s): napačna dolžina"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "branje toka zip (vnos %s): napačen crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "napaka pri pisanju vnosa zip »%s«: datoteka prevelika brez ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "napaka pri pisanju vnosa zip '%s': slab crc ali dolžina"
@@ -4783,32 +4808,32 @@ msgstr "Avtor grafik "
 msgid "Translations by "
 msgstr "Prevajalci"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Različica "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "O programu %s ..."
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licenca"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Razvijalci"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Avtorji dokumentacije "
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Oblikovalci"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Prevajalci"
 
@@ -4863,44 +4888,44 @@ msgid "Password:"
 msgstr "Geslo:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "je resnično"
 
 # generic/filedlgg.cpp:534
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "ni resnično"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Vrstica %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Strni"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Razpostri"
 
 # common/cmdline.cpp:735
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elementov)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Stolpec %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4912,7 +4937,7 @@ msgstr "Levo"
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -5016,7 +5041,7 @@ msgid "Home directory"
 msgstr "Domača mapa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Namizje"
 
@@ -5042,8 +5067,7 @@ msgstr "Neveljavno ime mape."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Napaka"
 
@@ -5270,18 +5294,18 @@ msgid "Go to parent directory"
 msgstr "Pojdi v starševsko mapo"
 
 # generic/filedlgg.cpp:1074
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Datoteka %s že obstaja, jo resnično želite prepisati?"
 
 # generic/filedlgg.cpp:1077
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Potrdi"
 
 # generic/filedlgg.cpp:1092
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Prosimo, izberite obstoječo datoteko."
 
@@ -5391,7 +5415,7 @@ msgid "Whether the font is underlined."
 msgstr "Če je pisava podčrtana ali ne."
 
 # html/helpfrm.cpp:903
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Predogled:"
@@ -5409,54 +5433,53 @@ msgstr "Kliknite za preklic izbire pisave."
 msgid "Click to confirm the font selection."
 msgstr "Kliknite za potrditev izbire pisave."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Izberite pisavo"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "Kopiranje več kot enega izbranega bloka na odložišče ni podprto."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Mape pomoči \"%s\" ni mogoče najti."
 
 # common/intl.cpp:374
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Datoteke pomoči \"%s\" ni mogoče najti."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Vrstica %lu datoteke \"%s\" ima neveljavno skladnjo; preskočeno."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ni veljavnih preslikav v datoteki \"%s\"."
 
 # generic/helphtml.cpp:314
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Vnosa ni mogoče najti."
 
 # generic/helphtml.cpp:319
 # generic/helphtml.cpp:320
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indeks pomoči"
 
 # generic/helphtml.cpp:319
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Ustrezni naslovi:"
 
 # generic/helphtml.cpp:320
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Najdeni vnosi"
 
@@ -5587,75 +5610,75 @@ msgid "Printing page %d..."
 msgstr "Tiskanje strani %d ..."
 
 # generic/prntdlgg.cpp:149
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Možnosti tiskalnika"
 
 # generic/dcpsg.cpp:2265
 # generic/prntdlgg.cpp:150
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Pošli v datoteko"
 
 # generic/prntdlgg.cpp:155
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Nastavitve ..."
 
 # generic/prntdlgg.cpp:682
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Tiskalnik:"
 
 # generic/logg.cpp:598
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Stanje:"
 
 # generic/prntdlgg.cpp:163
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Vse"
 
 # generic/prntdlgg.cpp:164
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Strani"
 
 # generic/prntdlgg.cpp:172
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Obseg tiskanja"
 
 # generic/prntdlgg.cpp:187
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Od:"
 
 # generic/prntdlgg.cpp:191
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Za:"
 
 # generic/prntdlgg.cpp:196
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Št. kopij"
 
 # generic/prntdlgg.cpp:272
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript datoteka"
 
 # generic/prntdlgg.cpp:408
 # generic/prntdlgg.cpp:415
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Nastavitev tiskanja"
 
 # generic/prntdlgg.cpp:113
 # generic/prntdlgg.cpp:127
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Tiskalnik"
 
@@ -5666,34 +5689,34 @@ msgstr "Privzeti tiskalnik"
 # generic/prntdlgg.cpp:433
 # generic/prntdlgg.cpp:615
 # generic/prntdlgg.cpp:804
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Velikost papirja"
 
 # generic/dcpsg.cpp:2261
 # generic/prntdlgg.cpp:440
 # generic/prntdlgg.cpp:636
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Portet"
 
 # generic/dcpsg.cpp:2262
 # generic/prntdlgg.cpp:441
 # generic/prntdlgg.cpp:637
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Ležeče"
 
 # generic/prntdlgg.cpp:443
 # generic/prntdlgg.cpp:638
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Usmeritev"
 
 # generic/prntdlgg.cpp:447
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Možnosti"
 
@@ -5708,51 +5731,51 @@ msgid "Print spooling"
 msgstr "Čakalna vrsta tiskanja"
 
 # generic/prntdlgg.cpp:459
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Ukaz tiskalniku:"
 
 # generic/prntdlgg.cpp:463
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Možnosti tiskalnika:"
 
 # generic/prntdlgg.cpp:649
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Levi rob (mm):"
 
 # generic/prntdlgg.cpp:650
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Zgornji rob (mm):"
 
 # generic/prntdlgg.cpp:661
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Desni rob (mm):"
 
 # generic/prntdlgg.cpp:662
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Spodnji rob (mm):"
 
 # generic/prntdlgg.cpp:682
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Tiskalnik ..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Pres&koči"
 
 # generic/progdlgg.cpp:241
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "neznan"
 
 # generic/progdlgg.cpp:313
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Končano."
 
@@ -5760,12 +5783,12 @@ msgstr "Končano."
 # html/helpfrm.cpp:414
 # html/helpfrm.cpp:434
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Iskanje"
 
 # generic/tabg.cpp:1042
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Tabulatorja za id ni mogoče najti."
 
@@ -5810,11 +5833,11 @@ msgstr "&Dokončaj"
 msgid "< &Back"
 msgstr "< &Nazaj"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Zasluge prevajalcev"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5824,7 +5847,7 @@ msgstr ""
 "ravnanjem z vnosom in utripanje. Razmislite o GTK_IM_MODULE ali nastavitvi "
 "na »ibus«."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "GTK+ ni mogoče inicializirati, je spremenljivka DISPLAY nastavljena pravilno?"
@@ -5834,7 +5857,7 @@ msgstr ""
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:399
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Sprememba iz trenutne mape v »%s« je spodletela."
@@ -5866,11 +5889,11 @@ msgstr "Prilagoditve pisave z uporabo zasebnih pisav ni mogoče registrirati."
 # common/docview.cpp:296
 # common/docview.cpp:332
 # common/docview.cpp:1388
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Usodna napaka"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5883,7 +5906,7 @@ msgstr ""
 "z\n"
 "nastavitvijo spremenljivka okolja GDK_BACKEND=x11 pred zagonom programa."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5894,7 +5917,7 @@ msgstr ""
 "to obšli z nastavitvijo spremenljivke okolja GDK_BACKEND=x11 pred\n"
 "zagonom programa."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Otrok MDI"
 
@@ -5912,16 +5935,11 @@ msgstr "Napaka pri tiskanju: "
 msgid "Page Setup"
 msgstr "Nastavitev strani"
 
-# generic/dirdlgg.cpp:550
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "V kontrolnik ni bilo mogoče vstaviti besedila."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "Pridobivanje izhoda skripta JavaScript ni podprto z WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5929,25 +5947,20 @@ msgstr ""
 "GTK+, nameščen na tem računalniku, je prestar, da bi podpiral zaslonsko "
 "skladanje, namestiti morate GTK+ 2.12 ali novejšega."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "Sestavljanja ta sistem ne podpira, omogočite ga v svojem upravitelju oken."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
-"Program je bil preveden z zastarelo različico GTK+, ponovno ga zgradite z GTK"
-"+ 2.12 ali novejšim."
-
-# generic/filedlgg.cpp:1092
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Prosimo, izberite veljavno pisavo."
+"Program je bil preveden z zastarelo različico GTK+, ponovno ga zgradite z "
+"GTK+ 2.12 ali novejšim."
 
 # generic/dirdlgg.cpp:550
 #: ../src/html/chm.cpp:138
@@ -6072,57 +6085,57 @@ msgid "Cannot open index file: %s"
 msgstr "Indeksne datoteke ni mogoče odpreti: %s"
 
 # html/helpdata.cpp:644
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "neimanovana"
 
 # html/helpdata.cpp:657
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Knjige s HTML pomočjo ni mogoče odpreti: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Prikaže pomoč med brskanjem po knjigah na levi."
 
 # html/helpfrm.cpp:276
 # html/helpfrm.cpp:783
 # html/helpfrm.cpp:1330
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(zaznamki)"
 
 # html/helpfrm.cpp:270
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Dodaj trenutno stran med zaznamke"
 
 # html/helpfrm.cpp:269
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Odstrani trenutno stran iz zaznamkov"
 
 # generic/helpwxht.cpp:159
 # html/helpfrm.cpp:303
 # html/helpfrm.cpp:312
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Vsebina"
 
 # html/helpfrm.cpp:340
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Poišči"
 
 # html/helpfrm.cpp:331
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Pokaži vse"
 
 # html/helpfrm.cpp:366
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -6131,22 +6144,22 @@ msgstr ""
 "glede na velikost črk."
 
 # html/helpfrm.cpp:365
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Pokaži vse predmete v indeksu"
 
 # html/helpfrm.cpp:398
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Razlikovanje malih/velikih črk"
 
 # html/helpfrm.cpp:406
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Samo cele besede"
 
 # html/helpfrm.cpp:416
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -6154,70 +6167,70 @@ msgstr ""
 "Iskanje v knjigah s pomočjo za vse pojavitve zgoraj natipkanega besedila"
 
 # html/helpfrm.cpp:496
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Pokaži/skrij navigacijski pano"
 
 # html/helpfrm.cpp:501
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Pojdi nazaj"
 
 # html/helpfrm.cpp:504
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Pojdi naprej"
 
 # html/helpfrm.cpp:509
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Pojdi nivo višje v hierarhiji dokumenta"
 
 # html/helpfrm.cpp:523
 # html/helpfrm.cpp:1183
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Odpri dokument HTML"
 
 # html/helpfrm.cpp:529
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Natisni to stran"
 
 # html/helpfrm.cpp:535
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Pokaži pogovorno okno z možnostmi"
 
 # generic/filedlgg.cpp:1092
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Prosimo, izberite stran za prikaz:"
 
 # generic/helpwxht.cpp:251
 # html/helpctrl.cpp:38
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Teme pomoči"
 
 # html/helpfrm.cpp:628
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Iskanje v teku ..."
 
 # html/helpfrm.cpp:628
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Ujemajoča stran še ni najdena."
 
 # html/helpfrm.cpp:637
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Najdenih %i ujemanj"
 
 # html/helpfrm.cpp:679
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Pomoč)"
 
@@ -6225,7 +6238,7 @@ msgstr "(Pomoč)"
 # html/helpfrm.cpp:719
 # html/helpfrm.cpp:1277
 # html/helpfrm.cpp:1304
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d od %lu"
@@ -6234,88 +6247,88 @@ msgstr "%d od %lu"
 # html/helpfrm.cpp:719
 # html/helpfrm.cpp:1277
 # html/helpfrm.cpp:1304
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu od %lu"
 
 # html/helpfrm.cpp:735
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Išči v vseh knjigah"
 
 # html/helpfrm.cpp:872
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Možnosti brskalnika pomoči"
 
 # html/helpfrm.cpp:881
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Običajna pisava:"
 
 # html/helpfrm.cpp:889
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Nespremenljiva pisava:"
 
 # html/helpfrm.cpp:899
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Velikost pisave"
 
 # html/helpfrm.cpp:899
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "velikost pisave"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Običajna pisava<br>in <u>podčrtana</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Ležeča pisava.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Kepka pisava.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Krepka ležeča pisava.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Pisava nespremenljive velikosti.<br> <b>krepko</b> <i>ležeče</i>"
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>krepko ležeče <u>podčrtano</u></i></b><br>"
 
 # html/helpfrm.cpp:1172
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Pomoč pri tiskanju"
 
 # html/helpfrm.cpp:1174
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Prazne strani ni mogoče natisniti."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Datoteke HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "knjige pomoči (*.htb)|*.htb|knjige pomoči (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "projekt pomoči HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "datoteka stisnjene pomoči HTML (*.chm)|*.chm|"
 
@@ -6323,7 +6336,7 @@ msgstr "datoteka stisnjene pomoči HTML (*.chm)|*.chm|"
 # html/helpfrm.cpp:719
 # html/helpfrm.cpp:1277
 # html/helpfrm.cpp:1304
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i od %u"
@@ -6332,7 +6345,7 @@ msgstr "%i od %u"
 # html/helpfrm.cpp:719
 # html/helpfrm.cpp:1277
 # html/helpfrm.cpp:1304
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u od %u"
@@ -6418,38 +6431,6 @@ msgstr ""
 "Med pripravo strani je prišlo do težave: morda morate nastaviti privzeti "
 "tiskalnik."
 
-# html/winpars.cpp:364
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Dokumenta HTML, kodiranega v %s, ni mogoče prikazati."
-
-# common/docview.cpp:306
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets ne more odpreti zaslona za '%s': izhod iz programa."
-
-# generic/filedlgg.cpp:534
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Končnica"
-
-# generic/fontdlgg.cpp:207
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Mape"
-
-# generic/filedlgg.cpp:534
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Datoteke"
-
-# generic/dirdlgg.cpp:191
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Izbira"
-
 # msw/clipbrd.cpp:102
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
@@ -6503,70 +6484,70 @@ msgid "Failed to create cursor."
 msgstr "Kazalke ni mogoče ustvariti."
 
 # msw/dde.cpp:285
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Registracija strežnika DDE »%s« ni uspela."
 
 # msw/dde.cpp:301
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Odjava strežnika DDE »%s« ni uspela."
 
 # msw/dde.cpp:401
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Povezava s strežnikom »%s« na temo »%s« ni uspela."
 
 # msw/dde.cpp:597
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Zahteva za poke DDE ni uspela."
 
 # msw/dde.cpp:616
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Vzpostavitev usklajevalne zanke s strežnikom DDE ni uspela."
 
 # msw/dde.cpp:635
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Ustavitev usklajevalne zanke s strežnikom DDE ni uspela."
 
 # msw/dde.cpp:661
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Pošiljanje usklajevalne transakcije DDE ni uspelo."
 
 # msw/dde.cpp:934
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Niza DDE ni mogoče ustvariti."
 
 # msw/dde.cpp:972
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "ni napake DDE."
 
 # msw/dde.cpp:976
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "zahteva za sinhrono usklajevalno transakcijo je časovno potekla."
 
 # msw/dde.cpp:979
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "odziv na transakcijo je povzročil, da je nastavljen bit DDE_FBUSY."
 
 # msw/dde.cpp:982
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "zahteva za sinhrono podatkovno transakcijo je časovno potekla."
 
 # msw/dde.cpp:985
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -6578,7 +6559,7 @@ msgstr ""
 "neveljaven določitelj instance."
 
 # msw/dde.cpp:988
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -6591,52 +6572,52 @@ msgstr ""
 "poskusila izvesti strežniške transakcije."
 
 # msw/dde.cpp:991
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "zahteva za sinhrono izvajalno transakcijo je časovno potekla."
 
 # msw/dde.cpp:994
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML ni uspešno potrdil veljavnosti parametra."
 
 # msw/dde.cpp:997
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "Program DDEML je ustvaril podaljšano stanje sledenja."
 
 # msw/dde.cpp:1000
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "alokacija spomina ni uspela."
 
 # msw/dde.cpp:1003
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "poskus odjemalca, da bi vzpostavil pogovor, ni uspel."
 
 # msw/dde.cpp:1006
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "transakcija ni uspela"
 
 # msw/dde.cpp:1009
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "zahteva za sinhrono transakcijo poke je časovno potekla."
 
 # msw/dde.cpp:1012
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "notranji klic funkcije PostMessage ni uspel."
 
 # msw/dde.cpp:1015
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "napaka ponovnega vstopa."
 
 # msw/dde.cpp:1018
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -6647,17 +6628,17 @@ msgstr ""
 "prekinil odjemalec ali strežnik."
 
 # msw/dde.cpp:1021
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "v DDEML je prišlo do notranje napake."
 
 # msw/dde.cpp:1024
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "zahteva za prekinitev usklajevalne transakcije je časovno potekla."
 
 # msw/dde.cpp:1027
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -6668,13 +6649,13 @@ msgstr ""
 "identifikator transakcije za ta povratni klic ni več veljaven."
 
 # msw/dde.cpp:1030
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Neznana napaka DDE %08x"
 
 # msw/dialup.cpp:354
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -6682,7 +6663,7 @@ msgstr ""
 "Funkcije klicne povezave niso na voljo, ker storitev oddaljenega dostopa "
 "(RAS) na tem računalniku ni nameščena. Prosimo, namestite jo."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -6693,79 +6674,79 @@ msgstr ""
 "%s)."
 
 # msw/dialup.cpp:463
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Besedila sporočila o napaki RAS ni mogoče pridobiti."
 
 # msw/dialup.cpp:466
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "neznana napaka (koda napake %08x)."
 
 # msw/dialup.cpp:518
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Aktivne klicne povezave ni mogoče najti: %s"
 
 # msw/dialup.cpp:539
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Najdenih je več aktivnih klicnih povezav, izbrana bo naključna med njimi."
 
 # msw/dialup.cpp:639
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Klicna povezava ni bila uspešno vzpostavljena: %s"
 
 # msw/dialup.cpp:699
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Neuspešno pridobivanje imen ISP: %s"
 
 # msw/dialup.cpp:747
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Neuspela povezava: ni ISP za klicanje"
 
 # msw/dialup.cpp:767
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Izberite ponudnika spletnih storitev, ki ga želite poklicati."
 
 # msw/dialup.cpp:768
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 "Prosimo, izberite ponudnika spletnih storitev, s katerim se želite povezati."
 
 # msw/dialup.cpp:801
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Neuspela povezava: manjkajoče uporabniško ime/geslo."
 
 # msw/dialup.cpp:832
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Ni možno najti mesta datoteke adresarja"
 
 # msw/dialup.cpp:933
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Inicializacija klicne povezave ni uspela: %s"
 
 # msw/dialup.cpp:925
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Povezave ni mogoče prekiniti - ni aktivne klicne povezave."
 
 # msw/dialup.cpp:933
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Prekinitev klicne povezave ni uspela: %s"
@@ -6789,12 +6770,12 @@ msgid "Cannot enumerate files in directory '%s'"
 msgstr "Oštevilčenje datotek v mapi »%s« ni možno."
 
 # msw/timer.cpp:96
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Imena mape ni mogoče pridobiti"
 
 # common/log.cpp:242
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(napaka %d: %s)"
@@ -6804,9 +6785,8 @@ msgstr "(napaka %d: %s)"
 # msw/imaglist.cpp:152
 # msw/imaglist.cpp:174
 # msw/imaglist.cpp:187
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Na seznam slik ni mogoče dodati slike."
 
@@ -6823,7 +6803,7 @@ msgstr ""
 "Standardnega najdi/zamenjaj pogovornega okna ni bilo uspešno ustvarjeno "
 "(koda napake %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Pogovorno okno izbirnika datotek je spodletelo, napaka %0lx."
@@ -6868,17 +6848,17 @@ msgstr "Datoteki »%s« ni mogoče določiti opazovanja."
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Sprememb v neobstoječi mapi »%s« ni mogoče spremljati."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "Gonilnik OpenGL ne podpira OpenGL 3.0 ali novejšega."
 
 # msw/timer.cpp:96
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Konteksta OpenGL ni mogoče ustvariti"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGl neuspešno inicializiran."
 
@@ -6886,7 +6866,7 @@ msgstr "OpenGl neuspešno inicializiran."
 msgid "Could not register custom DirectWrite font loader."
 msgstr "Nalagalnika pisave DirectWrite po meri ni mogoče registrirati."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -6894,7 +6874,7 @@ msgstr ""
 "Funkcije MS HTML Help niso na voljo, ker knjižnica MS HTML Help ni nameščena "
 "na tem računalniku. Prosimo, namestite jo."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Pomoč MS HTML neuspešno inicializirana."
 
@@ -6909,7 +6889,7 @@ msgid "Can't delete the INI file '%s'"
 msgstr "Datoteke INI »%s« ni mogoče izbrisati."
 
 # msw/listctrl.cpp:616
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Podatkov o kontrolnem elementu seznama %d ni mogoče pridobiti."
@@ -7061,7 +7041,7 @@ msgstr "Registracija oblike zapisa odložišča »%s« ni uspela."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Oblika zapisa odložišča '%d' ne obstaja."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Preskoči"
 
@@ -7174,13 +7154,13 @@ msgstr ""
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:658
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Ključa »%s« ni mogoče izbrisati."
 
 # msw/registry.cpp:683
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Vrednosti »%s« ni mogoče izbrisati iz ključa »%s«."
@@ -7191,8 +7171,8 @@ msgstr "Vrednosti »%s« ni mogoče izbrisati iz ključa »%s«."
 #
 # msw/registry.cpp:774
 # msw/registry.cpp:813
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Vrednosti ključa »%s« ni mogoče prebrati."
@@ -7203,23 +7183,23 @@ msgstr "Vrednosti ključa »%s« ni mogoče prebrati."
 #
 # msw/registry.cpp:799
 # msw/registry.cpp:923
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Vrednosti ključa »%s« ni mogoče nastaviti."
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Vrednost registra »%s« ni numerična (temveč vrste %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Vrednost registra »%s« ni binarna (temveč vrste %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Vrednost registra »%s« ni besedilna (temveč vrste %s)"
@@ -7229,7 +7209,7 @@ msgstr "Vrednost registra »%s« ni besedilna (temveč vrste %s)"
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:899
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Vrednosti »%s« ni mogoče prebrati."
@@ -7239,18 +7219,18 @@ msgstr "Vrednosti »%s« ni mogoče prebrati."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/registry.cpp:975
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Vrednosti ključa »%s« ni mogoče prešteti."
 
 # msw/registry.cpp:1020
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Podključev ključa »%s« ni mogoče prešteti."
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -7258,18 +7238,18 @@ msgstr ""
 "Izvoz registrskega ključa: datoteka \"%s\" že obstaja in ne bo prepisana."
 
 # msw/registry.cpp:490
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Vrednosti nepodprtega tipa %d ni mogoče izvoziti."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Neupoštevanje vrednosti \"%s\" ključa \"%s\"."
 
 # msw/textctrl.cpp:219
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -7279,12 +7259,12 @@ msgstr ""
 "namestite riched32.dll"
 
 # msw/thread.cpp:433
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Niti ni mogoče začeti: napaka pri pisanju TLS."
 
 # msw/thread.cpp:485
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Prioritet niti ni bilo mogoče nastaviti."
 
@@ -7293,39 +7273,39 @@ msgstr "Prioritet niti ni bilo mogoče nastaviti."
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 # msw/thread.cpp:519
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Niti ni mogoče ustvariti."
 
 # msw/thread.cpp:958
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Niti ni mogoče končati."
 
 # msw/thread.cpp:871
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Ustavitve niti ni mogoče pričakati."
 
 # msw/thread.cpp:537
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Niti %lx ni mogoče začasno ustaviti."
 
 # msw/thread.cpp:552
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Niti %lx ni mogoče nadaljevati"
 
 # msw/thread.cpp:578
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Trenutnega kazalca niti ni mogoče dobiti"
 
 # msw/thread.cpp:1071
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -7334,7 +7314,7 @@ msgstr ""
 "shrambi niti"
 
 # msw/thread.cpp:1083
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -7369,12 +7349,12 @@ msgstr "Vira \"%s\" ni mogoče naložiti."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Vira \"%s\" ni mogoče zakleniti."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "gradnja %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bitna izdaja"
 
@@ -7389,52 +7369,52 @@ msgid "Failed to redirect the child process IO"
 msgstr "Preusmeritev otroških procesov IO ni uspela."
 
 # msw/utilsexc.cpp:585
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Izvajanje ukaza »%s« ni uspelo."
 
 # generic/dirdlgg.cpp:550
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Nalaganje mpr.dll ni uspelo."
 
 # html/helpdata.cpp:353
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Imena tipa ni mogoče prebrati iz »%s«!"
 
 # common/filefn.cpp:1287
 # msw/dir.cpp:294
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nalaganje ikone z »%s« ni možno."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "Iskanje ravni emulacije spletnega pogleda v registru ni uspelo"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Nastavitev spletnega pogleda na sodobno raven emulacije ni uspela"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "Ponastavitev spletnega pogleda na standardno raven emulacije ni uspela"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Skripta JavaScript ni mogoče zagnati brez veljavnega HTML dokumenta"
 
 # msw/thread.cpp:485
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Predmeta JavaScript ni mogoče pridobiti"
 
 # common/ffile.cpp:182
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "ni bilo mogoče oceniti"
 
@@ -7471,7 +7451,7 @@ msgstr "Označite za ležečo pisavo."
 
 # generic/fontdlgg.cpp:242
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podčrtano"
@@ -7545,15 +7525,40 @@ msgstr "<poljubna strojna>"
 msgid "File type:"
 msgstr "Vrsta datoteke:"
 
-#: ../src/osx/cocoa/menu.mm:281
+# msw/mdi.cpp:1287
+# msw/mdi.cpp:1294
+# msw/window.cpp:2286
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Okno"
+
+# common/dlgcmn.cpp:144
+# generic/proplist.cpp:528
+# html/helpfrm.cpp:208
+# msw/mdi.cpp:1283
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomoč"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Pomanjšaj"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Povečaj"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Pomakni vse v ospredje"
 
@@ -7572,206 +7577,206 @@ msgstr "Datoteka pisave »%s« ne obstaja."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Datoteke pisave »%s« ni mogoče uporabiti, saj je ni v mapi pisave »%s«."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "O programu %s ..."
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "O programu …"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Možnosti ..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Storitve"
 
 # generic/helpwxht.cpp:251
 # html/helpctrl.cpp:38
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Skrij %s"
 
 # generic/dirdlgg.cpp:191
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Skrij program"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Skrij druge"
 
 # html/helpfrm.cpp:331
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Pokaži vse"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Izhod iz %s"
 
 # generic/dirdlgg.cpp:191
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Izhod iz programa"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Sistemski spletni nadzor ne podpira tiskanja"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Operacije tiskanja ni bilo mogoče inicializirati"
 
 # html/helpfrm.cpp:899
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Velikost točke"
 
 # generic/filedlgg.cpp:610
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Ime pisave"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Slog"
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Debelina"
 
 # html/helpfrm.cpp:899
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Družina"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "Delovna površina programa"
 
 # generic/fontdlgg.cpp:208
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "DejavnaObroba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "DejavniNapis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "PloskevGumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "PoudarekGumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "SencaGumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "BesediloGumba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "BesediloNapisa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "KrmilnikTemno"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "KrmilnikSvetlo"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "SivoBesedilo"
 
 # generic/fontdlgg.cpp:216
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Poudari"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "PoudariBesedilo"
 
 # generic/fontdlgg.cpp:208
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "NedejavnaObroba"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "NedejavenNapis"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "BesediloNedejavnegaNapisa"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Meni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Drsnik"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Orodni namig"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "BesediloOrodnegaNamiga"
 
@@ -7779,7 +7784,7 @@ msgstr "BesediloOrodnegaNamiga"
 # msw/mdi.cpp:1294
 # msw/window.cpp:2286
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Okno"
 
@@ -7787,7 +7792,7 @@ msgstr "Okno"
 # msw/mdi.cpp:1294
 # msw/window.cpp:2286
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "OkvirOkna"
 
@@ -7795,270 +7800,270 @@ msgstr "OkvirOkna"
 # msw/mdi.cpp:1294
 # msw/window.cpp:2286
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "BesediloOkna"
 
 # html/helpfrm.cpp:899
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Po meri"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Črna"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Kostanjeva"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Mornarska"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Škrlatna"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Modrozelena"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Siva"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Zelena"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Oljčna"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Rjava"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Modra"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuksija"
 
 # common/docview.cpp:1945
 # common/docview.cpp:1956
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Rdeča"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Oranžna"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Srebrna"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Limetna"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Aqua"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Rumena"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Bela"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Privzeto"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Puščica"
 
 # generic/fontdlgg.cpp:216
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Smerna tipka desno"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Prazno"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Tarča"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Znak"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Križec"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Roka"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Levi gumb"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Povečevalo"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Srednji gumb"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Ni vnosa"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Čopič"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Pisalo"
 
 # html/helpfrm.cpp:899
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Usmeri levo"
 
 # generic/fontdlgg.cpp:216
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Usmeri desno"
 
 # generic/logg.cpp:1023
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Vprašaj s puščico"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Desni gumb"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Določanje velikosti SV-JZ"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Določanje velikosti S-J"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Določanje velikosti SZ-JV"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Določanje velikosti Z-V"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Določanje velikosti"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Pršilka"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Čakaj"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Opazuj"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Puščica čakanja"
 
 # generic/dirdlgg.cpp:191
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Opravite izbor:"
 
 # html/helpfrm.cpp:512
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Lastnost"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Vrednost"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategoriziran način"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Abecedni način"
 
 # generic/filedlgg.cpp:534
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Ne velja"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Resnično"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Nedoločeno"
 
@@ -8073,12 +8078,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Vnesli ste neveljavno vrednost. Pritisnite ubežnico za preklic urejanja."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Napaka v viru: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -8087,37 +8092,37 @@ msgstr ""
 "Operacija »%s« je spodletela: lastnost z oznako »%s« je vrste »%s« in NE "
 "»%s«."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Neznana osnova %d. Uporabili bomo osnovo 10."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vrednost mora biti enaka %s ali višja."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Vnesite številko strani med %s in %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vrednost mora biti enaka %s ali manjša."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Ni %s"
 
 # generic/dirdlgg.cpp:572
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Izberite mapo:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Izberite datoteko"
 
@@ -8595,124 +8600,124 @@ msgstr "Vstavek"
 msgid "Outset"
 msgstr "Izraščeno"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Spremeni slog"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Spremeni slog predmeta"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Spremeni lastnosti"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Spremeni slog seznama"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Ponovno oštevilči seznam"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Vstavi besedilo"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Vstavi sliko"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Vstavi predmet"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Vstavi polje"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Preveč klicev EndStyle!"
 
 # generic/filedlgg.cpp:534
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "datotek"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "navadno/krog"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "navadno/oris-kroga"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "navadno/kvadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "navadno/karo"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "navadno/trikotnik"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Lastnosti polja"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Lastnosti več vrstic"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Lastnosti celice"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Določite slog celice"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Izbriši vrstico"
 
 # generic/dirdlgg.cpp:191
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Izbriši stolpec"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Dodaj vrstico"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Dodaj stolpec"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Lastnosti tabele"
 
 # html/helpfrm.cpp:512
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Lastnosti slike"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "slika"
 
@@ -8922,26 +8927,26 @@ msgstr "~"
 msgid "Drag"
 msgstr "Povleci"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Izbriši besedilo"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Odstrani oznako"
 
 # common/textcmn.cpp:121
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Besedila ni mogoče shraniti."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Zamenjaj"
 
 # html/helpfrm.cpp:899
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Pisava:"
 
@@ -9966,56 +9971,56 @@ msgstr "Slogi seznama"
 msgid "Box styles"
 msgstr "Slogi polja"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Pisava, iz katere naj bodo prikazani posebni znaki."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Podmnožica:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Pokaže podmnožico Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Koda znaka:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Koda znaka."
 
 # generic/prntdlgg.cpp:187
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Od:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Prikazano območje."
 
 # html/helpfrm.cpp:372
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Vstavi"
 
 # html/helpfrm.cpp:881
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(navadno besedilo)"
 
@@ -10221,7 +10226,7 @@ msgid "Media playback error: %s"
 msgstr "Napaka pri predvajanju datoteke: %s"
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Predvajanja »%s« ni mogoče pripraviti."
@@ -10349,20 +10354,20 @@ msgstr "Zvočni podatki so v nepodprtem zapisu."
 msgid "Couldn't open audio: %s"
 msgstr "Zvoka ni mogoče odpreti: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Ni mogoče pridobiti politiko razporejanja niti."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Za politiko razporejanja %d ni mogoče pridobiti razpona prioritet."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Nastavitev prioritete niti je ignorirana."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -10371,62 +10376,62 @@ msgstr ""
 "ponovno zaženite program"
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Ravni sočasnosti niti ni bilo mogoče nastaviti na %lu."
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Prioritete niti %d ni bilo mogoče nastaviti."
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Niti ni mogoče prekiniti."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Inicializacija modula niti ni uspela: ključa niti ni mogoče ustvariti"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Vhoda podrejenega procesa ni mogoče pridobiti."
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Ni mogoče pisati v stdin podrejenega procesa"
 
 # common/ffile.cpp:182
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' ni mogoče izvesti\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Razcepitev ni uspela"
 
 # generic/dirdlgg.cpp:550
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Prioritete procesa ni bilo mogoče nastaviti."
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Preusmeritev vhoda/izhoda podrejenega procesa ni uspela."
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Neuspešno vzpostavljena neblokirana cev, program se lahko obesi."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Imena gostitelja ni mogoče dobiti"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Imena uradnega gostitelja ni mogoče dobiti"
 
@@ -10444,13 +10449,13 @@ msgid "Failed to read from wake-up pipe"
 msgstr "Branje iz cevi z bujenjem ni uspelo."
 
 # generic/filedlgg.cpp:1043
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Neveljavna specifikacija geometrije '%s'"
 
 # common/docview.cpp:306
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets ne more odpreti zaslona. Izhod."
 
@@ -10466,30 +10471,69 @@ msgstr "Zaprtje prikaza »%s« ni uspelo."
 msgid "Failed to open display \"%s\"."
 msgstr "Zaslona \"%s\" ni mogoče odpreti."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Napaka razčlenjevanja XML: '%s' v vrstici %d"
 
 # common/ffile.cpp:101
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Virov iz datoteke »%s« ni mogoče naložiti."
 
 # common/ffile.cpp:101
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Datoteke virov »%s« ni mogoče odpreti."
 
 # common/ffile.cpp:101
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Ni mogoče naložiti virov iz datoteke »%s«."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Ustvarjanje %s »%s« ni uspelo."
+
+# common/prntbase.cpp:106
+# common/prntbase.cpp:148
+#~ msgid "Printing "
+#~ msgstr "Tiskanje poteka"
+
+# generic/dirdlgg.cpp:550
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "V kontrolnik ni bilo mogoče vstaviti besedila."
+
+# generic/filedlgg.cpp:1092
+#~ msgid "Please choose a valid font."
+#~ msgstr "Prosimo, izberite veljavno pisavo."
+
+# html/winpars.cpp:364
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Dokumenta HTML, kodiranega v %s, ni mogoče prikazati."
+
+# common/docview.cpp:306
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets ne more odpreti zaslona za '%s': izhod iz programa."
+
+# generic/filedlgg.cpp:534
+#~ msgid "Filter"
+#~ msgstr "Končnica"
+
+# generic/fontdlgg.cpp:207
+#~ msgid "Directories"
+#~ msgstr "Mape"
+
+# generic/filedlgg.cpp:534
+#~ msgid "Files"
+#~ msgstr "Datoteke"
+
+# generic/dirdlgg.cpp:191
+#~ msgid "Selection"
+#~ msgstr "Izbira"

--- a/locale/sq.po
+++ b/locale/sq.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-06-25 11:38+0300\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language-Team: <wx-translators@wxwidgets.org>\n"
@@ -14,11 +14,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.4.2\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Krejt kartelat (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Krejt kartelat (*)|*"
 
@@ -35,24 +35,21 @@ msgid "Remaining time:"
 msgstr "Kohë e mbetur:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Po"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Jo"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Anuloje"
@@ -102,7 +99,7 @@ msgid "Unable to create I/O completion port"
 msgstr "S’arrihet të krijohet portë plotësimi I/O"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr ""
 
@@ -139,7 +136,7 @@ msgstr "Veti Objekti"
 msgid "Printing"
 msgstr "Po shtypet"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simbole"
 
@@ -208,7 +205,7 @@ msgstr "&I mëparshmi"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Dritare"
 
@@ -333,73 +330,61 @@ msgid "Escape"
 msgstr "Tasti Escape"
 
 #: ../src/common/accelcmn.cpp:68
-#| msgid "Cancel"
 msgctxt "keyboard key"
 msgid "Cancel"
 msgstr "Tasti Cancel"
 
 #: ../src/common/accelcmn.cpp:69
-#| msgid "Clear"
 msgctxt "keyboard key"
 msgid "Clear"
 msgstr "Tasti Clear"
 
 #: ../src/common/accelcmn.cpp:70
-#| msgid "Menu"
 msgctxt "keyboard key"
 msgid "Menu"
 msgstr "Tasti Menu"
 
 #: ../src/common/accelcmn.cpp:71
-#| msgid "Pause"
 msgctxt "keyboard key"
 msgid "Pause"
 msgstr "Tasti Pause"
 
 #: ../src/common/accelcmn.cpp:72
-#| msgid "Capital"
 msgctxt "keyboard key"
 msgid "Capital"
 msgstr "Tasti Capital"
 
 #: ../src/common/accelcmn.cpp:73
-#| msgid "Select"
 msgctxt "keyboard key"
 msgid "Select"
 msgstr "Tasti Select"
 
 #: ../src/common/accelcmn.cpp:74
-#| msgid "Print"
 msgctxt "keyboard key"
 msgid "Print"
 msgstr "Tasti Print"
 
 #: ../src/common/accelcmn.cpp:75
-#| msgid "Execute"
 msgctxt "keyboard key"
 msgid "Execute"
 msgstr "Tasti Execute"
 
 #: ../src/common/accelcmn.cpp:76
-#| msgid "Snapshot"
 msgctxt "keyboard key"
 msgid "Snapshot"
 msgstr "Tasti Snapshot"
 
 #: ../src/common/accelcmn.cpp:77
-#| msgid "Help"
 msgctxt "keyboard key"
 msgid "Help"
 msgstr "Tasti Help"
 
 #: ../src/common/accelcmn.cpp:78
-#| msgid "Add"
 msgctxt "keyboard key"
 msgid "Add"
 msgstr "Tasti Add"
 
 #: ../src/common/accelcmn.cpp:79
-#| msgid "Separator"
 msgctxt "keyboard key"
 msgid "Separator"
 msgstr "Tasti Separator"
@@ -445,7 +430,6 @@ msgid "Scroll Lock"
 msgstr "Tasti Scroll Lock"
 
 #: ../src/common/accelcmn.cpp:86
-#| msgid "Space"
 msgctxt "keyboard key"
 msgid "KP_Space"
 msgstr "Tasti KP_Space"
@@ -461,43 +445,36 @@ msgid "KP_Tab"
 msgstr "Tasti KP_Tab"
 
 #: ../src/common/accelcmn.cpp:87
-#| msgid "Num Tab"
 msgctxt "keyboard key"
 msgid "Num Tab"
 msgstr "Tasti Num Tab"
 
 #: ../src/common/accelcmn.cpp:88
-#| msgid "Enter"
 msgctxt "keyboard key"
 msgid "KP_Enter"
 msgstr "Tasti KP_Enter"
 
 #: ../src/common/accelcmn.cpp:88
-#| msgid "Num Enter"
 msgctxt "keyboard key"
 msgid "Num Enter"
 msgstr "Tasti Num Enter"
 
 #: ../src/common/accelcmn.cpp:89
-#| msgid "Home"
 msgctxt "keyboard key"
 msgid "KP_Home"
 msgstr "Tasti KP_Home"
 
 #: ../src/common/accelcmn.cpp:89
-#| msgid "Num Home"
 msgctxt "keyboard key"
 msgid "Num Home"
 msgstr "Tasti Num Home"
 
 #: ../src/common/accelcmn.cpp:90
-#| msgid "Left"
 msgctxt "keyboard key"
 msgid "KP_Left"
 msgstr "Tasti KP_Left"
 
 #: ../src/common/accelcmn.cpp:90
-#| msgid "Num left"
 msgctxt "keyboard key"
 msgid "Num left"
 msgstr "Tasti Num left"
@@ -508,55 +485,46 @@ msgid "KP_Up"
 msgstr "Tasti KP_Up"
 
 #: ../src/common/accelcmn.cpp:91
-#| msgid "Num Up"
 msgctxt "keyboard key"
 msgid "Num Up"
 msgstr "Tasti Num Up"
 
 #: ../src/common/accelcmn.cpp:92
-#| msgid "Right"
 msgctxt "keyboard key"
 msgid "KP_Right"
 msgstr "Tasti KP_Right"
 
 #: ../src/common/accelcmn.cpp:92
-#| msgid "Num Right"
 msgctxt "keyboard key"
 msgid "Num Right"
 msgstr "Tasti Num Right"
 
 #: ../src/common/accelcmn.cpp:93
-#| msgid "Down"
 msgctxt "keyboard key"
 msgid "KP_Down"
 msgstr "Tasti KP_Down"
 
 #: ../src/common/accelcmn.cpp:93
-#| msgid "Num Down"
 msgctxt "keyboard key"
 msgid "Num Down"
 msgstr "Tasti Num Down"
 
 #: ../src/common/accelcmn.cpp:94
-#| msgid "PageUp"
 msgctxt "keyboard key"
 msgid "KP_PageUp"
 msgstr "Tasti KP_PageUp"
 
 #: ../src/common/accelcmn.cpp:94
-#| msgid "Num Page Up"
 msgctxt "keyboard key"
 msgid "Num Page Up"
 msgstr "Tasti Num Page Up"
 
 #: ../src/common/accelcmn.cpp:95
-#| msgid "PageDown"
 msgctxt "keyboard key"
 msgid "KP_PageDown"
 msgstr "Tasti KP_PageDown"
 
 #: ../src/common/accelcmn.cpp:95
-#| msgid "Num Page Down"
 msgctxt "keyboard key"
 msgid "Num Page Down"
 msgstr "Tasti Num Page Down"
@@ -567,7 +535,6 @@ msgid "KP_Prior"
 msgstr "Tasti KP_Prior"
 
 #: ../src/common/accelcmn.cpp:97
-#| msgid "Next"
 msgctxt "keyboard key"
 msgid "KP_Next"
 msgstr "Tasti KP_Next"
@@ -578,7 +545,6 @@ msgid "KP_End"
 msgstr "Tasti KP_End"
 
 #: ../src/common/accelcmn.cpp:98
-#| msgid "Num End"
 msgctxt "keyboard key"
 msgid "Num End"
 msgstr "Tasti Num End"
@@ -589,31 +555,26 @@ msgid "KP_Begin"
 msgstr "Tasti KP_Begin"
 
 #: ../src/common/accelcmn.cpp:99
-#| msgid "Num Begin"
 msgctxt "keyboard key"
 msgid "Num Begin"
 msgstr "Tasti Num Begin"
 
 #: ../src/common/accelcmn.cpp:100
-#| msgid "Insert"
 msgctxt "keyboard key"
 msgid "KP_Insert"
 msgstr "Tasti KP_Insert"
 
 #: ../src/common/accelcmn.cpp:100
-#| msgid "Num Insert"
 msgctxt "keyboard key"
 msgid "Num Insert"
 msgstr "Tasti Num Insert"
 
 #: ../src/common/accelcmn.cpp:101
-#| msgid "Delete"
 msgctxt "keyboard key"
 msgid "KP_Delete"
 msgstr "Tasti KP_Delete"
 
 #: ../src/common/accelcmn.cpp:101
-#| msgid "Num Delete"
 msgctxt "keyboard key"
 msgid "Num Delete"
 msgstr "Tasti Num Delete"
@@ -624,7 +585,6 @@ msgid "KP_Equal"
 msgstr "Tasti KP_Equal"
 
 #: ../src/common/accelcmn.cpp:102
-#| msgid "Num ="
 msgctxt "keyboard key"
 msgid "Num ="
 msgstr "Tasti Num ="
@@ -635,7 +595,6 @@ msgid "KP_Multiply"
 msgstr "Tasti KP_Multiply"
 
 #: ../src/common/accelcmn.cpp:103
-#| msgid "Num *"
 msgctxt "keyboard key"
 msgid "Num *"
 msgstr "Tasti Num *"
@@ -646,19 +605,16 @@ msgid "KP_Add"
 msgstr "Tasti KP_Add"
 
 #: ../src/common/accelcmn.cpp:104
-#| msgid "Num +"
 msgctxt "keyboard key"
 msgid "Num +"
 msgstr "Tasti Num +"
 
 #: ../src/common/accelcmn.cpp:105
-#| msgid "Separator"
 msgctxt "keyboard key"
 msgid "KP_Separator"
 msgstr "Tasti KP_Separator"
 
 #: ../src/common/accelcmn.cpp:105
-#| msgid "Num ,"
 msgctxt "keyboard key"
 msgid "Num ,"
 msgstr "Tasti Num ,"
@@ -669,79 +625,66 @@ msgid "KP_Subtract"
 msgstr "Tasti KP_Subtract"
 
 #: ../src/common/accelcmn.cpp:106
-#| msgid "Num -"
 msgctxt "keyboard key"
 msgid "Num -"
 msgstr "Tasti Num -"
 
 #: ../src/common/accelcmn.cpp:107
-#| msgid "Decimal"
 msgctxt "keyboard key"
 msgid "KP_Decimal"
 msgstr "Tasti KP_Decimal"
 
 #: ../src/common/accelcmn.cpp:107
-#| msgid "Num ."
 msgctxt "keyboard key"
 msgid "Num ."
 msgstr "Tasti Num ."
 
 #: ../src/common/accelcmn.cpp:108
-#| msgid "Divide"
 msgctxt "keyboard key"
 msgid "KP_Divide"
 msgstr "Tasti KP_Divide"
 
 #: ../src/common/accelcmn.cpp:108
-#| msgid "Num /"
 msgctxt "keyboard key"
 msgid "Num /"
 msgstr "Tasti Num /"
 
 #: ../src/common/accelcmn.cpp:109
-#| msgid "Windows 7"
 msgctxt "keyboard key"
 msgid "Windows_Left"
 msgstr "Tasti Windows_Left"
 
 #: ../src/common/accelcmn.cpp:110
-#| msgid "Windows Vista"
 msgctxt "keyboard key"
 msgid "Windows_Right"
 msgstr "Tasti Windows_Right"
 
 #: ../src/common/accelcmn.cpp:111
-#| msgid "Windows ME"
 msgctxt "keyboard key"
 msgid "Windows_Menu"
 msgstr "Tasti Windows_Menu"
 
 #: ../src/common/accelcmn.cpp:112
-#| msgid "Command"
 msgctxt "keyboard key"
 msgid "Command"
 msgstr "Tasti Command"
 
 #: ../src/common/accelcmn.cpp:186
-#| msgid "ctrl"
 msgctxt "keyboard key"
 msgid "ctrl"
 msgstr "Tasti ctrl"
 
 #: ../src/common/accelcmn.cpp:188
-#| msgid "alt"
 msgctxt "keyboard key"
 msgid "alt"
 msgstr "Tasti alt"
 
 #: ../src/common/accelcmn.cpp:190
-#| msgid "Shift+"
 msgctxt "keyboard key"
 msgid "shift"
 msgstr "Tasti shift"
 
 #: ../src/common/accelcmn.cpp:192
-#| msgid "rawctrl"
 msgctxt "keyboard key"
 msgid "rawctrl"
 msgstr "Tasti rawctrl"
@@ -752,7 +695,6 @@ msgid "num "
 msgstr "Tasti num "
 
 #: ../src/common/accelcmn.cpp:258 ../src/common/accelcmn.cpp:356
-#| msgid "F"
 msgctxt "keyboard key"
 msgid "F"
 msgstr "Tasti F"
@@ -768,40 +710,35 @@ msgid "KP_"
 msgstr "Tasti KP_"
 
 #: ../src/common/accelcmn.cpp:281 ../src/common/accelcmn.cpp:365
-#| msgid "SPECIAL"
 msgctxt "keyboard key"
 msgid "SPECIAL"
 msgstr "Tasti SPECIAL"
 
 #: ../src/common/accelcmn.cpp:343
-#| msgid "Alt+"
 msgctxt "keyboard key"
 msgid "Alt+"
 msgstr "Tasti Alt+"
 
 #: ../src/common/accelcmn.cpp:345
-#| msgid "Ctrl+"
 msgctxt "keyboard key"
 msgid "Ctrl+"
 msgstr "Tasti Ctrl+"
 
 #: ../src/common/accelcmn.cpp:347
-#| msgid "Shift+"
 msgctxt "keyboard key"
 msgid "Shift+"
 msgstr "Tasti Shift+"
 
 #: ../src/common/accelcmn.cpp:350
-#| msgid "RawCtrl+"
 msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "Tasti RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "shfaq këtë mesazh ndihme"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "prodho mesazhe fjalamanë regjistrimi"
 
@@ -823,84 +760,84 @@ msgstr "Temë '%s' e pambuluar."
 msgid "Invalid display mode specification '%s'."
 msgstr "Specifikim i pavlefshëm mënyre ekrani '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Mundësia '%s' s’mund të mohohet"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Mundësi e gjatë '%s' e panjohur"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Mundësi e panjohur '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Shenja të papritura në vijim të mundësisë '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Mundësia '%s' lyp një vlerë."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Pas mundësisë '%s' pritej ndarës."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' s’është vlerë numerike e saktë për mundësinë '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Mundësi '%s': '%s' s’mund të shndërrohet në datë."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Parametër '%s' i papritur"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ose %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Vlera për mundësinë '%s' duhet përcaktuar."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "S’është përcaktuar parametri i domosdoshëm '%s'."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Përdorim: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "datë"
 
@@ -918,7 +855,7 @@ msgid "Can't &Undo "
 msgstr "S’&zhbëhet Dot "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Zhbëje"
@@ -928,7 +865,7 @@ msgid "&Redo "
 msgstr "&Ribëje "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Ribëje"
@@ -956,12 +893,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ka '..' ekstra, u shpërfill."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "me shenjë"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "pa shenjë"
 
@@ -970,103 +907,103 @@ msgstr "pa shenjë"
 msgid "undetermined"
 msgstr "e papërcaktuar"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "sot"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "dje"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "nesër"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "i pari"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "i dyti"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "i treti"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "i katërti"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "i pesti"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "i gjashti"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "i shtati"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "i teti"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "i nënti"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "i dhjeti"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "i njëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "i dymbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "i trembëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "i katërmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "i pesëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "i gjashtëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "i shtatëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "i tetëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "i nëntëmbëdhjeti"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "i njëzeti"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "mesditë"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "mesnatë"
 
@@ -1134,45 +1071,82 @@ msgstr "S’u arrit të përmbushej curl-i, ju lutemi, instalojeni në PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "S’u arrit të ngarkohej raporti i diagnostikimit (kod gabimi %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Ruaje Si"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "Të hidhen tej ndryshimet dhe të ringarkohet versioni i fundit i ruajtur?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "pa emër"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Doni të ruhen ndryshimet te %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Ruaje"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Mos e Ruaj"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Doni të ruhen ndryshimet te %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Teksti s’u ruajt dot."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Kartela “%s” s’u hap dot për shkrim."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "S’u arrit të ruhej dokument te kartela “%s”."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Kartela “%s” s’u hap dot për lexim."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "S’u arrit të lexohej dokument prej kartelës “%s”."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1181,57 +1155,57 @@ msgstr ""
 "Kartela '%s' s’ekziston, ndaj s’mund të hapej.\n"
 "Është hequr nga lista e kartelave më të përdorura së fundi."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Krijimi i paraparjes së shtypjes dështoi."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Paraparje Shtypjeje"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "S’u përcaktua dot formati i kartelës '%s'."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "i paemër%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Hap Kartelë"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Gabim kartele"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Na ndjeni, s’u hap dot kjo kartelë."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Na ndjeni, formati i kësaj kartele është i panjohur."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Përzgjidhni një gjedhe dokumenti"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Gjedhe"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Përzgjidhni parje dokumenti"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Pamje"
 
@@ -1265,42 +1239,42 @@ msgstr "Gabim leximi në kartelën '%s'"
 msgid "Write error on file '%s'"
 msgstr "Gabim shkrimi në kartelën '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "s’u arrit të zbrazej kartela '%s'"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Gabim kërkimi te kartela '%s' (kartela të mëdha të pambuluara nga stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Gabim kërkimi te kartela '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "S’gjendet dot pozicioni i tanishëm te kartela '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "S’u arrit të caktoheshin leje kartele të përkohshme"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "s’hiqet dot kartelë '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "s’kryhen dot ndryshimet te kartelë '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "s’hiqet dot kartelë të përkohshme '%s'"
@@ -1325,27 +1299,27 @@ msgstr "s’lexohet dot prej përshkruesi kartele %d"
 msgid "can't write to file descriptor %d"
 msgstr "s’shkruhet dot te përshkrues kartele %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "s’zbrazet dot përshkrues kartele %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "s’shihet dot te përshkrues kartele %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "s’gjendet dot gjatësi kartele te përshkrues kartele %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1372,108 +1346,108 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Gabim në lexim mundësish formësimi."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "S’u arrit të lexoheshin mundësi formësimi."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "kartela '%s': shenjë e papritur %c te rreshti %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "kartela '%s', rreshti %zu: '%s' u shpërfill pas kryesh grupi."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "kartela '%s', rreshti %zu: pritej '='."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "kartela '%s', rreshti %zu: u shpërfill vlerë për kyç të pandryshueshëm '%s'."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "kartela '%s', rreshti %zu: kyçi '%s' u gjet së pari te rreshti %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Emër zëri formësimi s’mund të fillojë me '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "s’hapet dot kartelë formësimi e përdoruesit."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "s’shkruhet dot kartelë formësimi e përdoruesit."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "S’u arrit të përditësohej kartelë përdoruesi për formësimin."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Gabim në ruajtje të dhënash formësimi të përdoruesit."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "s’fshihet dot kartelë formësimi e përdoruesit '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "zëri '%s' duket në më shumë se një grup '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "u shpërfill përpjekja për ndryshim kyçi të pandryshueshëm '%s'."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "u shpërfill pjerrake së prapthi në fund te '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "\" të papritura në pozicionin %d te '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "S’u arrit të kopjohej kartela '%s' te '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "E pamundur të kihen leje për kartelë '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "E pamundur të mbishkruhet kartela '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Gabim në kopjimin e kartelës '%s' te '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "E pamundur të caktohen leje për kartelën '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1482,40 +1456,40 @@ msgstr ""
 "S’u arrit të riemërtohej kartela '%s' si '%s', ngaqë kartela vendmbërritje "
 "ekziston tashmë."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Kartela '%s' s’u riemërtua dot si '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "S’u hoq dot kartela '%s'"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "S’u krjiua dot drejtoria '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "S’u fshi dot drejtoria '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "S’numërtohen dot kartela '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "S’u arrit të merrej drejtoria e punës"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "S’u caktua dot drejtori e tanishme e punës"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Kartela (%s)"
@@ -1542,17 +1516,17 @@ msgstr "S’u arrit të krijohej emër kartele të përkohshme"
 msgid "Failed to open temporary file."
 msgstr "S’u arrit të hapej kartelë e përkohshme."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "S’u arrit të ndryshoheshin kohë kartele për '%s'"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "S’u arrit të kryhej “touch” për kartelën '%s'"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "S’u arrit të merreshin kohë kartele për '%s'"
@@ -1561,22 +1535,22 @@ msgstr "S’u arrit të merreshin kohë kartele për '%s'"
 msgid "Browse"
 msgstr "Shfletoni"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Krejt kartelat (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s kartela (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Ngarko kartelë %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Ruaje kartelën %s"
@@ -1939,99 +1913,99 @@ msgstr "parazgjedhje"
 msgid "unknown-%d"
 msgstr "i/e panjohur-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "nënvijëzuar"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " hequrvije"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " të holla"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " tejet të holla"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " mesatare"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " gjysmë të trasha"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " të trasha"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " tejet të trasha"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " të pjerrëta"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "hequrvije"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "të holla"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normale"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "mesatare"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "gjysmë të trasha"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "të trasha"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "tejet të trasha"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "të pjerrta"
 
@@ -2113,7 +2087,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "S’u arrit të caktohej mënyrë shpërnguljesh FTP si %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2134,7 +2108,7 @@ msgstr "Shërbyesi FTP s’mbulon mënyrë pasive."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Madhësi e pasaktë kuadri GIF (%u, %d) për kuadrin #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "S’u arrit të jepej ngjyrë për OpeGL"
 
@@ -2151,7 +2125,7 @@ msgstr "Përshtatni Shtylla"
 msgid "&Customize..."
 msgstr "&Përshtateni…"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "S’u arrit të hapej URL-ja “%s” në shfletuesin parazgjedhje"
@@ -2171,157 +2145,156 @@ msgstr "S’u arrit të ngarkohej figurë %d prej rrjedhe."
 msgid "Failed to load icons from resource '%s'."
 msgstr "S’u arrit të shtoheshin ikona prej burimi '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: S’u ruajt dot figurë e pavlefshme."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage s’ka wxPalette të vetën."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: S’u shkrua dot krye kartele (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: S’u shkrua dot krye kartele (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: S’u shkrua dot hartë ngjyrash RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: S’u shkruan dot të dhëna."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: S’u sigurua dot kujtesë."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Krye DIB: Gjerësi figure > 32767 piksel për kartelë."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Krye DIB: Lartësi figure > 32767 piksel për kartelë."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Krye DIB: “Bitdepth” i panjohur në kartelë."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Krye DIB: Kodim i panjohur në kartelë."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Krye DIB: Kodimi s’përputhet me “bitdepth”."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: kryet kanë biClrUsed=%d, ndërkohë që biBitCount=%d."
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: S’u sigurua dot kujtesë."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Krye DIB: Gjerësi figure > 32767 piksel për kartelë."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Krye DIB: Lartësi figure > 32767 piksel për kartelë."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Krye DIB: “Bitdepth” i panjohur në kartelë."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Krye DIB: Kodim i panjohur në kartelë."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Krye DIB: Kodimi s’përputhet me “bitdepth”."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Gabim në lexim DIB figure."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Gabim në lexim maske DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Figurë shumë e lartë për ikonë."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Figurë shumë e gjerë për ikonë."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Gabim gjatë shkrimit të kartelës figurë!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: tregues i pavlefshëm ikone."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Figura dhe maska kanë madhësi të ndryshme."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Pa maskim ngjyre të papërdorur në figurë."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "S’u arrit të ngarkohej bitmap “%s” prej burimesh."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "S’u arrit të ngarkohej ikonë “%s” prej burimesh."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "S’u arrit të ngarkohej figurë prej kartelës “%s”."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "S’ruhet dot figurë te kartela '%s': zgjatim i panjohur."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "S’u gjet trajtues për llojin e figurave."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "S’është përcaktuar trajtues figurash për llojin %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Kartela figurë s’është e llojit %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Formati i figurës s’përcaktohet dot automatikisht prej input-i te i cili "
 "s’kërkohet dot."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Format i panjohur të dhënash figure."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Kjo s’është %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "S’është përcaktuar trajtues figurash për llojin %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Figura s’është e llojit %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "S’u arrit të kontrollohej format kartele figurash “%s”."
@@ -2424,41 +2397,41 @@ msgstr "PNM: Kartela duket si e cunguar."
 msgid " (in module \"%s\")"
 msgstr " (në modulin “%s”)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Gabim në ngarkim figure."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Tregues i pavlefshëm figurash TIFF."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Madhësia e figurës është në mënyrë anormale e madhe."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: S’u sigurua dot kujtesë."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Gabim në lexim figure."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "U shpërfill njësi e panjohur qartësie TIFF %d"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Gabim në ruajtje figure."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Gabim në shkrim figure."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2467,11 +2440,11 @@ msgstr ""
 "S’u shndërrua dot në Unikod argumenti %d për rresht urdhrash dhe do të "
 "shpërfillet."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Gatitja në post init dështoi, po ndërpritet."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "S’caktohet dot gjuha '%s' si vendore."
@@ -2565,7 +2538,7 @@ msgstr "Gabim ngjeshjeje LZMA: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Gabim ngjeshjeje LZMA, kur spastrohej output-i: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "'{' pa shoqe te një zë për lloj mime %s."
@@ -2585,7 +2558,7 @@ msgstr "Varësia “%s” e modulit “%s” s’ekziston."
 msgid "Module \"%s\" initialization failed"
 msgstr "Gatitja e modulit “%s” dështoi"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Mesazh"
 
@@ -3087,7 +3060,7 @@ msgstr "Gabim Shtypjeje"
 msgid "Print"
 msgstr "Shtyp"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Rregullim faqeje"
 
@@ -3122,19 +3095,15 @@ msgstr "Po shtypet faqja %d nga %d"
 msgid " (copy %d of %d)"
 msgstr " (kopje %d e %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Po shtypet "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Faqja e parë"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Faqja e mëparshme"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Faqe pasuese"
 
@@ -3178,16 +3147,16 @@ msgstr "Faqe %d nga %d"
 msgid "Page %d"
 msgstr "Faqe %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "gabim i panjohur"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Shprehje e rregullt e pavlefshme '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "S’u arrit të gjendej përputhje për shprehje të rregullt: %s"
@@ -3197,21 +3166,21 @@ msgstr "S’u arrit të gjendej përputhje për shprehje të rregullt: %s"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "Vizatuesi “%s” ka version %d.%d të papërputhshëm dhe s’u ngarkua dot."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Jo e passhme për këtë platformë"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "S’u arrit të ruhej fjalëkalimi për “%s”: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "S’u arrit të lexohej fjalëkalimi për “%s”: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "S’u arrit të fshihet fjalëkalimi për “%s”: %s."
@@ -3220,11 +3189,11 @@ msgstr "S’u arrit të fshihet fjalëkalimi për “%s”: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "S’u arrit të mbikëqyreshin kanale I/O"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Ruaje"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Mos e Ruaj"
 
@@ -3305,10 +3274,10 @@ msgid "Clear"
 msgstr "Spastroje"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Mbylle"
 
@@ -3320,7 +3289,7 @@ msgstr "&Shndërroje"
 msgid "Convert"
 msgstr "Shndërroje"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopjoje"
@@ -3329,7 +3298,7 @@ msgstr "&Kopjoje"
 msgid "Copy"
 msgstr "Kopjoje"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "P&rije"
@@ -3338,13 +3307,13 @@ msgstr "P&rije"
 msgid "Cut"
 msgstr "Prije"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Fshije"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Fshije"
@@ -3431,7 +3400,7 @@ msgstr "HD"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Ndihmë"
 
@@ -3451,7 +3420,7 @@ msgstr "Shmangie brendazi"
 msgid "&Index"
 msgstr "&Tregues"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Tregues"
 
@@ -3520,7 +3489,7 @@ msgstr "I &ri"
 msgid "New"
 msgstr "I ri"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Jo"
 
@@ -3537,12 +3506,12 @@ msgstr "&Hapni…"
 msgid "Open..."
 msgstr "Hapni…"
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Ngjite"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Ngjitje"
@@ -3572,7 +3541,7 @@ msgid "Print..."
 msgstr "Shtypni…"
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Veti"
 
@@ -3604,10 +3573,6 @@ msgstr "Zëvendësoni…"
 msgid "Revert to Saved"
 msgstr "Riktheje tek i Ruajturi"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Ruaje"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Ruajeni &Si…"
@@ -3616,7 +3581,7 @@ msgstr "Ruajeni &Si…"
 msgid "Save As..."
 msgstr "Ruajeni Si…"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Përzgjidhni &Krejt"
@@ -3723,7 +3688,7 @@ msgstr "&Sipër"
 msgid "Up"
 msgstr "Sipër"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Po"
 
@@ -3811,43 +3776,43 @@ msgstr "Ruaj dokumentin e tanishëm"
 msgid "Save current document with a different filename"
 msgstr "Ruajeni dokumentin e tanishëm nën një tjetër emër kartele"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Shndërrimi në shkronjat '%s' nuk funksionon."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "i/e panjohur"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "bllok i paplotë kryesh në tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "dështim checksum-i në lexim blloku kryesh tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "të dhëna të pavlefshme në krye të zgjeruara tar-i"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "zë tar i pahapur"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "fund i papritur kartele"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s s’u përputh dot me krye tar për zërin '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "u dha madhësi i pasaktë për zë tar"
 
@@ -3856,7 +3821,7 @@ msgstr "u dha madhësi i pasaktë për zë tar"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' ka gjasa të jetë shtytëz dyore."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Kartela s’u ngarkua dot."
 
@@ -3870,47 +3835,47 @@ msgstr "S’u arrit të lexohej kartela tekst “%s”."
 msgid "can't write buffer '%s' to disk."
 msgstr "s’shkruhet dot shtytëza '%s' në disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "S’u arrit të merrej koha vendore e sistemit"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay dështoi."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' s’është katalog i vlefshëm mesazhesh."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Katalog i pavlefshëm mesazhi."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "S’u arrit të përtypeshin Plural-Forms: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "po përdoret katalog '%s' prej '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Burimi '%s' s’është katalog i vlefshëm mesazhesh."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "S’u numërtuan dot përkthimet"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "S’ka aplikacion parazgjedhje të formësuar për kartela HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "S’u arrit të hapej URL-ja “%s” në shfletuesin parazgjedhje."
@@ -3943,7 +3908,7 @@ msgstr "'%s' përmban shenjë(a) të pavlefshme"
 msgid "Error: %s (%d)"
 msgstr "Gabim: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Hapësirë disku e pamjaftueshme për shkarkim."
 
@@ -3951,21 +3916,20 @@ msgstr "Hapësirë disku e pamjaftueshme për shkarkim."
 msgid "libcurl could not be initialized"
 msgstr "S’u gatit dot përshkrim libcurl"
 
-#: ../src/common/webview.cpp:246
-#| msgid "String conversions not supported"
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "S’mbulohet RunScriptAsync"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Gabim në xhirim JavaScript-i: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Kjo platformë nuk mbulon tejdukshmëri sfondesh."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "S’u shpërngulën dot të dhëna te dritare"
 
@@ -4017,8 +3981,8 @@ msgstr "S’u gjet Parametër Create %s te Parametra RTTI të deklaruar"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Klasë e Paligjshme Objektesh (Non-wxEvtHandler) si Burim Akti"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Lloji duhet të ketë shndërrim “enum - long”"
 
@@ -4068,81 +4032,81 @@ msgstr "Objektet duhet të kenë një atribut id"
 msgid "Doubly used id : %d"
 msgstr "Id i përdorur dy herë : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Veti %s e Panjohur"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Një koleksion jo i zbrazët duhet të përbëhet nga nyje 'elementësh'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "varg i pasaktë trajtuesi aktesh, mungon një pikë"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "s’rigatitet dot rrjedhë zlib “deflate”"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "s’rigatitet dot rrjedhë zlib “inflate”"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Po shpërfillet zë i keqformuar të dhënash ekstra, kartela ZIP mund të jetë e "
 "dëmtuar"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "po merret si e mirëqenë që kjo është zip shumëpjesësh i vargëzuar"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "kartelë zip e pavlefshme"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "s’gjendet dot drejtori qendrore te zip-i"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "gabim në lexim drejtorie qendrore zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "gabim në lexim kryesh vendore zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "gjatësi kartele jo e depozituar te kryet ZIP"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "metodë e pambuluar ngjeshjeje Zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "po lexohet rrjedhë zip (zëri %s): gjatësi e gabuar"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "po lexohet rrjedhë zip (zëri %s): crc e gabuar"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "gabim në shkrim zëri zip '%s': kartelë shumë e madhe pa ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "gabim në shkrim zëri zip '%s': crc ose gjatësi e gabuar"
@@ -4226,32 +4190,32 @@ msgstr "Art grafik nga "
 msgid "Translations by "
 msgstr "Përkthime nga "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Rreth %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licencë"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Zhvillues"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Shkrues dokumentimi"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Artistë"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Përkthyes"
 
@@ -4302,42 +4266,42 @@ msgid "Password:"
 msgstr "Fjalëkalim:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "true"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "false"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Rreshti %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Tkurre"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Zgjeroje"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d elementë)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Shtylla %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4348,7 +4312,7 @@ msgid "Left"
 msgstr "Majtas"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4444,7 +4408,7 @@ msgid "Home directory"
 msgstr "Drejtori krye"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Desktop"
 
@@ -4457,8 +4421,7 @@ msgstr "Emër i paligjshëm drejtorie."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Gabim"
 
@@ -4642,16 +4605,16 @@ msgstr "Shihini kartelat nën pamjen me hollësitë"
 msgid "Go to parent directory"
 msgstr "Shko te drejtoria mëmë"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Ka tashmë një kartelë %s, doni vërtet të mbishkruhet?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Ripohojeni"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Ju lutem, zgjidhni një kartelë ekzistuese."
 
@@ -4745,7 +4708,7 @@ msgstr "Madhësia e shkronjave në pikë."
 msgid "Whether the font is underlined."
 msgstr "Nëse janë apo jo të nënvizuara shkronjat."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Paraparje:"
@@ -4763,51 +4726,50 @@ msgstr "Klikoni që të anulohet përzgjedhjeje shkronjash."
 msgid "Click to confirm the font selection."
 msgstr "Klikoni për ripohim përzgjedhjeje shkronjash."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Zgjidhni shkronja"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "Nuk mbulohet kopjimi në të papastër i më shumë se një blloku të përzgjedhur."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "S’u gjet drejtori ndihme “%s”."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "S’u gjet kartelë ndihme “%s”."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "Rreshti %lu i kartelës së hartës “%s” pat sintaksë të pavlefshme, u "
 "anashkalua."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "S’u gjetën përshoqërime të vlefshme te kartela “%s”."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "S’u gjetën zëra."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Tregues i Ndihmës"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Zëra me peshë:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "U gjetën zëra"
 
@@ -4913,59 +4875,59 @@ msgstr "S’u nis dot shtypje."
 msgid "Printing page %d..."
 msgstr "Po shtypet faqja %d…"
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Mundësi shtypësi"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Shtype në Kartelë"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Rregullim…"
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Shtypës:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Gjendje:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Krejt"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Faqe"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Interval Shtypjeje"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Prej:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Për:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopje:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Kartelë PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Rregullim Shtypjeje"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Shtypës"
 
@@ -4973,25 +4935,25 @@ msgstr "Shtypës"
 msgid "Default printer"
 msgstr "Shtypës parazgjedhje"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Madhësi letre"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Portret"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Së gjeri"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Drejtim"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Mundësi"
 
@@ -5003,52 +4965,52 @@ msgstr "Shtyp me ngjyra"
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Urdhër shtypësi:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Mundësi shtypësi:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Mënjanë majtas (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Mënjanë në krye (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Mënjanë djathtas (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Mënjanë fundi (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Shtypës…"
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Anashkaloje"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "I panjohur"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "U bë."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Kërko"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "S’u gjet dot skedë për id"
 
@@ -5084,11 +5046,11 @@ msgstr "&Përfundoje"
 msgid "< &Back"
 msgstr "< &Mbrapsht"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "kredite përkthyesish"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5098,11 +5060,11 @@ msgstr ""
 "probleme me trajtimin e çka jepet dhe dridhje të figurës. Shihni mundësinë e "
 "çaktivizimit të GTK_IM_MODULE, ose vënien e tij si “ibus”."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "S’arrihet të gatitet GTK+, a është caktuar saktë DISPLAY?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "S’u arrit të ndryshohej drejtoria e tanishme si “%s”"
@@ -5129,11 +5091,11 @@ msgid "Failed to register font configuration using private fonts."
 msgstr ""
 "S’u arrit të regjistrohej formësim shkronjash që përdor shkronja private."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Gabim Fatal"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5146,7 +5108,7 @@ msgstr ""
 "vënë\n"
 "ndryshoren e mjedisit GDK_BACKEND=x11 para se të nisni programin tuaj."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5159,7 +5121,7 @@ msgstr ""
 "para se\n"
 "të nisni programin tuaj."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Pjellë MDI"
 
@@ -5175,15 +5137,11 @@ msgstr "Gabim teksa shtypej: "
 msgid "Page Setup"
 msgstr "Rregullim Faqeje"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "S’u arrit të futej tekst te kontrolli."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "Me WebKit v1 s’mbulohet marrje output-i programthi JavaScript"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5191,7 +5149,7 @@ msgstr ""
 "GTK+ i instaluar në këtë makinë është shumë i vjetër për të mbuluar hartim "
 "skenash, ju lutemi, instaloni GTK+ 2.12 ose të mëvonshëm."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5199,17 +5157,13 @@ msgstr ""
 "Hartimi nuk mbulohet nga ky sistem, ju lutemi, aktivizojeni te Window "
 "Manager juaj."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Ky program qe përpiluar me një version shumë të vjetër të GTK+, ju lutemi, "
 "rimontojeni me GTK+ 2.12 ose më të ri."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Ju lutemi, zgjidhni shkronja të vlefshme."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5308,45 +5262,45 @@ msgstr "S’hapet dot kartelë lëndësh: %s"
 msgid "Cannot open index file: %s"
 msgstr "S’hapet dot kartelë treguesi: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "paemër"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "S’hapet dot libër HTML ndihme: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Shfaq ndihmën teksa shfletoni librat në të majtë."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(faqerojtës)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Shto te faqerojtësit faqen e çastit"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Hiq prej faqerojtësish faqen e tanishme"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Lëndë"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Gjej"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Shfaqi krejt"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5354,19 +5308,19 @@ msgstr ""
 "Shfaq tërë zërat e treguesit që përmbajnë nënvargun e dhënë. Kërkim ashtu si "
 "është shkruar."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Shfaq tërë objektet në tregues"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Siç është shkruajtur"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Vetëm fjalë të plota"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5374,148 +5328,148 @@ msgstr ""
 "Kërko në lëndën e librit(ve) të ndihmës për krejt hasjet e tekstit që "
 "shtypët më sipër"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Shfaq/fshih panel lëvizjeje"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Shko prapa"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Shko përpara"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Shko një shkallë më sipër në hierarki dokumenti"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Hap dokument HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Shtyp këtë faqe"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Dialog mundësish paraqitjeje"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Ju lutemi, zgjidhni faqen për shfaqje:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Tema Ndihme"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Po kërkohet…"
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Ende s’u gjet faqe me përputhje"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "U gjetën %i përputhje"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Ndihmë)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d nga %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu nga %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Kërko në tërë librat"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Mundësi Shfletuesi Ndihme"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Shkronja normale:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Shkronja të fiksuara:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Madhësi shkronjash:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "madhësi shkronjash"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normale<br>dhe <u>të nënvijëzuara</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Shkronja të pjerrëta.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Shkronja të trasha.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Shkronja të pjerrëta të trasha.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 "Shkronja me madhësi të fiksuar.<br> <b>të trasha</b> <i>të pjerrëta</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>të pjerrëta të trasha <u>të nënvizuara</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Ndihmë për Shtypjen"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "S’shtypet dot faqe e zbrazët."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Kartela HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Libra ndihme (*.htb)|*.htb|Libra ndihme (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Projekt Ndihme HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Kartelë e ngjeshur HTML ndihme HTML (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i nga %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u nga %u"
@@ -5595,32 +5549,6 @@ msgstr ""
 "Pati një problem gjatë ujdisjes së faqes: mund t’ju duhet të caktoni një "
 "shtypës parazgjedhje."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "S’u arrit të shfaqej dokument HTML në kodimin %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets s’hapi dot ekranin për '%s': po dilet."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtër"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Drejtori"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Kartela"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Përzgjedhje"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "S’u arrit të hapej e papastra."
@@ -5662,58 +5590,58 @@ msgstr "Dialogu i përzgjedhjes së ngjyrës dështoi me gabimin %0lx."
 msgid "Failed to create cursor."
 msgstr "S’u arrit të krijohej kursor."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "S’u arrit të regjistrohej shërbyesi DDE '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "S’u arrit të çregjistrohej shërbyesi DDE '%s'"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "S’u arrit të krijohej lidhje te shërbyes '%s' mbi temën '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "S’u arrit të vendosej një qerthull këshillimi me shërbyesin DDE"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "S’u arrit të përfundohej qerthull këshillimi me shërbyesin DDE"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "S’u arrit të dërgohej njoftim këshillues DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "S’u arrit të krijohej varg DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "pa gabim DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "një kërkese për transaksion të njëkohshëm “advise” i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "përgjigja te transaksioni shkaktoi caktimin e bitit DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "një kërkese për transaksion të njëkohshëm të dhënash i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5724,7 +5652,7 @@ msgstr ""
 "ose funksionit DDEML iu kalua një\n"
 "identifikues i pavlefshëm instancash."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5736,43 +5664,43 @@ msgstr ""
 "ose një aplikacion i filluar si APPCMD_CLIENTONLY \n"
 "u përpoq të kryejë transaksion shërbyesish."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "një kërkese për transaksion të njëkohshëm “execute” i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "dështoi vleftësimi nga DDEML i një parametri."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "dështoi një caktim kujtese."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "dështoi një përpjekje klienti për të vendosur bisedë."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "dështoi një transaksion."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "një kërkese për transaksion të njëkohshëm “poke” i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "dështoi një thirrje e brendshme për funksionin PostMessage. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "problem rihyrjeje."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5782,15 +5710,15 @@ msgstr ""
 "një bisedë që u përfundua nga klienti, ose shërbyesi\n"
 "e mbylli me aq, para se të plotësohej transaksioni."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "te DDEML ndodhi një gabim i brendshëm."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "një kërkese për përfundim transaksioni këshille i mbaroi koha."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5800,12 +5728,12 @@ msgstr ""
 "Pasi aplikacioni jetë përgjigjur me një callback XTYP_XACT_COMPLETE,\n"
 "identifikuesi i transaksionit për atë callback s’është më i vlefshëm."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Gabim i panjohur DDE %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5813,7 +5741,7 @@ msgstr ""
 "S’janë të passhëm funksione “dial up”, ngaqë shërbimi i hyrjes së largëti "
 "(RAS) s’është i instaluar në këtë makinë. Ju lutemi, instalojeni."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5823,64 +5751,64 @@ msgstr ""
 "është shumë i vjetër, ju lutemi, përmirësojeni (mungon funksioni vijues i "
 "domosdoshëm: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "S’u arrit të merrej tekst mesazhi gabimi RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "gabim i panjohur (kod gabimi %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "S’gjendet dot lidhje “dialup” aktive: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "U gjetën disa lidhje dialup vepruese, po zgjidhet një kuturu."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "S’u arrit të vendosej lidhjeje “dialup”: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "S’u arrit të merreshin emra ISP-sh: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "S’u arrit të lidhej: pa ISP për thirrje."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Zgjidhni ISP për t’i rënë numrit"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Ju lutemi, zgjidhni te cili ISP doni të lidheni"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "S’u arrit të lidhej: mungon emër përdoruesi/fjalëkalim."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "S’gjendet dot vendi i kartelës së librit të adresave"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "S’u arrit të nisej lidhje “dialup”: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "S’bëhet dot mbyllje - s’ka lidhje “dialup” aktive."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "S’u arrit të ndërpritej lidhja “dialup”: %s"
@@ -5900,19 +5828,17 @@ msgstr "S’u arrit të jepeshin %luKb kujtesë për të dhëna bitmap."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "S’numërtohen dot kartela në drejtori '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "S’u mor dot emër dosjeje"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
-#| msgid " (error %ld: %s)"
 msgid "(error %d: %s)"
 msgstr "(gabim %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "S’u shtua dot një figurë te lista e figurave."
 
@@ -5926,7 +5852,7 @@ msgstr "S’u arrit të ngarkohej “metafile” prej kartelës “%s”."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "S’u arrit të krijohej dialogu standard gjej/zëvendëso (kod gabimi %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dialogu i kartelës dështoi me kod gabimi %0lx."
@@ -5967,16 +5893,16 @@ msgstr "S’arrihet të ujdiset mbikëqyrës për '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "S’mund të mbikëqyret për ndryshime drejtori “%s” që s’ekziston."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 ose i mëvonshëm nuk mbulohet nga përudhësi OpenGL."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "S’u krijua dot kontekst OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "S’u arrit të gatitej OpeGL-i"
 
@@ -5984,7 +5910,7 @@ msgstr "S’u arrit të gatitej OpeGL-i"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "S’u regjistrua dot ngarkues shkronjash vetjake DirectWrite."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5992,7 +5918,7 @@ msgstr ""
 "Funksionet MS HTML Help nuk janë të passhëm, ngaqë libraria MS HTML Help "
 "s’është e instaluar në këtë makinë. Ju lutemi, instalojeni."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "S’u arrit të gatitej Ndihmë MS HTML."
 
@@ -6001,7 +5927,7 @@ msgstr "S’u arrit të gatitej Ndihmë MS HTML."
 msgid "Can't delete the INI file '%s'"
 msgstr "S’fshihet dot kartela INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "S’u morën dot të dhëna rreth objekti kontrolli liste %d."
@@ -6121,7 +6047,7 @@ msgstr "S’u regjistrua dot format të papastre '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Formati '%d' për të papastrën s’ekziston."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Anashkaloje"
 
@@ -6206,59 +6132,59 @@ msgstr ""
 "të sistemit, fshirja e tij do ta lërë sistemin tuaj në gjendje\n"
 "të paqëndrueshme: veprimi u ndërpre."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "S’fshihet dot kyç '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "S’fshihet dot vlerë '%s' prej kyçit '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "S’lexohet dot vlerë kyçi '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "S’caktohet dot vlerë e '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Vlera “%s” e regjistrit s’është numerike (por e llojit %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Vlera “%s” e regjistrit s’është dyore (por e llojit %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Vlera “%s” e regjistrit s’është tekst (por e llojit %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "S’lexohet dot vlera e '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "S’numërtohen dot vlera kyçi '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "S’numërtohen dot nënkyçe të kyçit '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6266,17 +6192,17 @@ msgstr ""
 "Po eksportohet kyç regjistri: kartela “%s” ekziston tashmë dhe s’do të "
 "mbishkruhet."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "S’eksportohet dot vlerë lloji të pambuluar %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Po shpërfillet vlera “%s” e kyçit “%s”."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6284,41 +6210,41 @@ msgstr ""
 "E pamundur të krijohet kontroll përpunimi të pasur, në vend të tij po "
 "përdoret kontroll teksti të thjeshtë. Ju lutemi, riinstaloni riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "S’fillohet dot rrjedhë: gabim në shkrim TLS-je."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "S’caktohet dot përparësi rrjedhe"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "S’krijohet dot rrjedhë"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "S’u përfundua dot rrjedhë"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "S’pritet dot për përfundim rrjedhe"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "S’pezullohet dot rrjedha %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "S’rimerret dot rrjedha %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6326,7 +6252,7 @@ msgstr ""
 "Gatitja e modulit të rrjedhës dështoi: e pamundur të jepet tregues te depo "
 "vendore rrjedhe"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6357,12 +6283,12 @@ msgstr "S’u arrit të ngarkohej burimi “%s”."
 msgid "Failed to lock resource \"%s\"."
 msgstr "S’u arrit të kyçej burimi “%s”."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "monto %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", varianti 64-bitësh"
 
@@ -6374,48 +6300,48 @@ msgstr "S’u arrit të krijohej kanal i paemër"
 msgid "Failed to redirect the child process IO"
 msgstr "S’u arrit të ridrejtohej IO procesi pjellë"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Dështoi përmbushja e urdhrit '%s'"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "S’u arrit të ngarkohej mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "S’lexohet dot emër lloji prej '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "S’ngarkohet dot ikonë prej '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "S’u arrit të gjendet te regjistri shkallë emulimi parjeje web"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "S’u arrit të caktohet emulim modern si shkallë për parje web"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 "S’u arrit të rikthehet te parazgjedhja standarde shkalla e emulimit për "
 "parje web"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "S’xhirohet dot programth JavaScript pa një dokument HTML të vlefshëm"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "S’merret dot objekt JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "s’u arrit të bëhej vlerësim"
 
@@ -6448,7 +6374,7 @@ msgid "Check to make the font italic."
 msgstr "I vini shenjë për t’i bërë shkronjat të pjerrëta."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Nënvijëzuar"
@@ -6515,15 +6441,33 @@ msgstr "<Çfarëdo Teletype>"
 msgid "File type:"
 msgstr "Lloj kartele:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Dritare"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Ndihmë"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Minimizoje"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
-msgstr ""
+msgstr "Zmadhoje"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Silli të Tëra Para"
 
@@ -6540,466 +6484,463 @@ msgstr "Kartela e shkronjave “%s” s’ekziston."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Kartela e shkronjave “%s” s’mund të përdoret, ngaqë s’gjendet brenda "
 "drejtorisë së shkronjave “%s”."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Rreth %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Rreth…"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Parapëlqime…"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Shërbime"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Fshihe %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Fshihe Aplikacionin"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Fshihi të Tjerat"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Shfaqi Krejt"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Mbylleni %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Mbylle Aplikacionin"
 
-#: ../src/osx/webview_webkit.mm:285
-#| msgid "Gzip not supported by this version of zlib"
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Shtypja nuk mbulohet nga kontrolli web i sistemit"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "S’u gatit dot veprimi i shtypjes"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Emër Shkronjash"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Madhësi"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familje"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Theksim"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Rrëshqitës"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Ndihmëz"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Dritare"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr ""
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Vetjake"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "E zezë"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Ngjyrë gështenje"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Blu"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "E purpurt"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Blu e gjelbër"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Gri"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "E gjelbër"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Ulli"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Kafe"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Blu"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuksia"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "E kuqe"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Portokalli"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "E argjendtë"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Qitro"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Blu e gjelbër"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "E verdhë"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "E bardhë"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Parazgjedhje"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Shigjetë"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Shigjetë Djathtas"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "E zbrazët"
 
-#: ../src/propgrid/advprops.cpp:1658
-#| msgid "Bullet style"
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Bullseye"
 
-#: ../src/propgrid/advprops.cpp:1659
-#| msgid "Character"
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Shenjë"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Kryq"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Dorë"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Butoni Majtas"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Zmadhues"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Butoni i Mesit"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Pa Zë"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Penel"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Laps"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Trego Majtas"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Trego Djathtas"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Butoni Djathtas"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Ripërmasim VL-JP"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Ripërmasim V-J"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Ripërmasim VP-JL"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Ripërmasim P-L"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Ripërmasim"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Sprei"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Pritni"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Bëni një përzgjedhje:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Veti"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Vlerë"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Mënyrë e Kategorizuar"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Mënyrë Alfabetike"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "False"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "True"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "E papërcaktuar"
 
@@ -7013,12 +6954,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Keni dhënë vlerë të pavlefshme. Shtypni tastin ESC që të anulohet përpunimi."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Gabim në burim: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7027,36 +6968,36 @@ msgstr ""
 "Veprimi “%s” i shtypjes dështoi: Vetia e etiketuar me “%s” është e llojit "
 "“%s”, JO “%s”."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Bazë e panjohur %d. Do të përdoret 10 si bazë."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vlera duhet të jetë %s ose më e madhe."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Vlera duhet të jetë mes %s dhe %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vlera duhet të jetë %s ose më e vogël."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Jo %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Zgjidhni një drejtori:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Zgjidhni një kartelë"
 
@@ -7523,117 +7464,117 @@ msgstr "Brendazi"
 msgid "Outset"
 msgstr "Jashtazi"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Ndryshoni Stil"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Ndryshoni Stil Objekti"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Ndryshoni Veti"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Ndryshoni Stil Liste"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Rinumërto Listën"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Futni Tekst"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Futni Figurë"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Futni Objekt"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Futni Fushë"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Shumë thirrje EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "kartela"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standard/rreth"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standard/përvijim-rrethor"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standard/katror"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standard/romb"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standard/trikëndësh"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Veti Kuadrati"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Veti Kutize"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Caktoni Stil Kutize"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Fshije Rreshtin"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Fshije Shtyllën"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Shtoni Rresht"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Shtoni Shtyllë"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Veti Tabele"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Veti Fotoje"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "figurë"
 
@@ -7841,24 +7782,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Tërhiqeni"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Fshije Tekstin"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Hiqe Topthin"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Teksti s’u ruajt dot."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Zëvendësoje"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Shkronja:"
 
@@ -8827,53 +8768,53 @@ msgstr "Stile liste"
 msgid "Box styles"
 msgstr "Stile kuadrati"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Shkronjat prej nga të merret simboli."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Nëngrup:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Shfaq një nëngrup Unikod."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "Kod &shenjash:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Kodi i shenjave."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Nga:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unikod"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Intervali për shfaqje."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Tasti Insert"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Tekst normal)"
 
@@ -9057,7 +8998,7 @@ msgstr "S’arrihet të merret akte prej kqueue"
 msgid "Media playback error: %s"
 msgstr "Gabim në luajtje mediash: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "S’u arrit të përgatitej për luajtje “%s”."
@@ -9157,20 +9098,20 @@ msgstr "Të dhëna tingulli janë në format të pambuluar."
 msgid "Couldn't open audio: %s"
 msgstr "S’u hap dot audio: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "S’merret dot rregull planifikimi rrjedhe."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "S’merret dot interval përparësie për rregull planifikimi %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "U shpërfill ujdisje përparësish rrjedhash."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9178,59 +9119,59 @@ msgstr ""
 "S’u arrit të merrej pjesë në një rrjedhë, u zbulua rrjedhje potenciale "
 "kujtese - ju lutemi, rinisni programin"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "S’u arrit të caktohej përparësie rrjedhe %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "S’u arrit të përfundohej një rrjedhë."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Gatitja e modulit të rrjedhës dështoi: s’u arrit të krijohej kyç rrjedhe"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "E pamundur të merret “input” procesi pjelle"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "S’shkruhet dot te stdin procesi pjelle"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "S’u arrit të përmbushej '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Degëzimi dështoi"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "S’u arrit të caktohej përparësi procesi"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "S’u arrit të ridrejtohej input/output procesi pjellë"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "S’u arrit të ujdisej kanal jobllokues, programi mund të ngecë."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "S’merret dot strehëemër"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "S’merret dot strehëemër zyrtar"
 
@@ -9246,12 +9187,12 @@ msgstr "S’u arrit të kalohej kanal zgjimi në mënyrën jobllokuese"
 msgid "Failed to read from wake-up pipe"
 msgstr "S’u arrit të lexohej prej kanali zgjimi"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Specifikim i pavlefshëm gjeometrie '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets s’hapi dot ekranin. Po dilet."
 
@@ -9265,30 +9206,59 @@ msgstr "S’u arrit të mbyllej ekrani '%s'"
 msgid "Failed to open display \"%s\"."
 msgstr "S’u arrit të hapej ekrani “%s”."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Gabim përtypjeje XML: '%s' te rresht %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "S’ngarkohen dot burime prej kartele '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "S’hapet dot kartelë burimesh %s."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "S’ngarkohen dot burime prej kartele '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Krijimi i %s “%s” dështoi."
+
+#~ msgid "Printing "
+#~ msgstr "Po shtypet "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "S’u arrit të futej tekst te kontrolli."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Ju lutemi, zgjidhni shkronja të vlefshme."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "S’u arrit të shfaqej dokument HTML në kodimin %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets s’hapi dot ekranin për '%s': po dilet."
+
+#~ msgid "Filter"
+#~ msgstr "Filtër"
+
+#~ msgid "Directories"
+#~ msgstr "Drejtori"
+
+#~ msgid "Files"
+#~ msgstr "Kartela"
+
+#~ msgid "Selection"
+#~ msgstr "Përzgjedhje"
 
 #~ msgid " (while overwriting an existing item)"
 #~ msgstr " (teksa mbishkruhet një element ekzistues)"
@@ -9449,15 +9419,15 @@ msgstr "Krijimi i %s “%s” dështoi."
 #~ msgstr "Vizatuesi i datave s’vizaton dot vlerën; lloj vlere: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"
 #~ "%s %1"
 #~ msgstr ""
-#~ "Doni të mbishkruhet urdhri i përdorur mbi kartelat %s me zgjatim \"%s"
-#~ "\" ?\n"
+#~ "Doni të mbishkruhet urdhri i përdorur mbi kartelat %s me zgjatim "
+#~ "\"%s\" ?\n"
 #~ "Vlera e çastit është \n"
 #~ "%s, \n"
 #~ "Vlera e re është \n"

--- a/locale/sr.po
+++ b/locale/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WX Widgets\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-12-07 21:12+0100\n"
 "Last-Translator: Nikola Jović <wwenikola123@gmail.com>\n"
 "Language-Team: Nikola Jović <wwenikola123@gmail.com>\n"
@@ -15,15 +15,15 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Poedit 1.6.10\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Sve datoteke (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Sve datoteke (*)|*"
 
@@ -40,24 +40,21 @@ msgid "Remaining time:"
 msgstr "Preostalo vreme:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Da"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ne"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "U redu"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Otkaži"
@@ -107,7 +104,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Nemoguće napraviti I/O completion port"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Štampanje"
 
@@ -144,7 +141,7 @@ msgstr "Svojstva objekta"
 msgid "Printing"
 msgstr "Štampanje"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simboli"
 
@@ -213,7 +210,7 @@ msgstr "&Prethodna"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Prozor"
 
@@ -742,11 +739,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "Prikaži ovu poruku pomoći"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "Generiši detaljne poruke dnevnika"
 
@@ -768,84 +765,84 @@ msgstr "Tema nije podržana '%s'."
 msgid "Invalid display mode specification '%s'."
 msgstr "Neispravna specifikacija režima prikaza '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Opcija '%s' ne može biti negativna"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Nepoznata duga opcija '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Nepoznata opcija '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Neočekivani znakovi koji prate opciju '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Opcija '%s' zahteva vrednost."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Očekuje se separator nakon opcije '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' nije ispravna brojčana vrednost za opciju '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Opcija '%s': '%s' ne može biti pretvoreno u datum."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Neočekivani parametar '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ili %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Vrednost za opciju '%s' mora biti određena."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Neophodni parametar '%s' nije određen."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Način korišćenja: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "double"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "Datum"
 
@@ -863,7 +860,7 @@ msgid "Can't &Undo "
 msgstr "Nemoguće &poništiti"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Poništi"
@@ -873,7 +870,7 @@ msgid "&Redo "
 msgstr "pono&vi"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "Pono&vi"
@@ -903,12 +900,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' ima dodatne '..', biće ignorisane."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "Označeno"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "Nije označeno"
 
@@ -917,103 +914,103 @@ msgstr "Nije označeno"
 msgid "undetermined"
 msgstr "Nije određeno"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "Danas"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "Juče"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "Sutra"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "Prvi"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "Drugi"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "Treći"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "Četvrti"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "Peti"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "Šesti"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "Sedmi"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "Osmi"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "Deveti"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "Deseti"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "Jedanaesti"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "Dvanaesti"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "Trinaesti"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "Četrnaesti"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "Petnaesti"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "Šesnaesti"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "Sedamnaesti"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "Osamnaesti"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "Devetnaesti"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "Dvadeseti"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "Podne"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "Ponoć"
 
@@ -1085,44 +1082,81 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Nemoguće otpremiti izveštaj o otklanjanju grešaka (kod greške %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Sačuvaj kao"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Odbaciti promene i učitati poslednju sačuvanu verziju?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "Bez imena"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Da li želite da sačuvate promene u %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Sačuvaj"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Nemoj da sačuvaš"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Da li želite da sačuvate promene u %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Tekst nije mogao biti sačuvan."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Datoteka \"%s\" ne može biti otvorena za pisanje."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Neuspešno čuvanje dokumenta u datoteku \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Datoteka \"%s\" ne može biti otvorena za čitanje."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Čitanje dokumenta iz datoteke \"%s\" nije uspelo."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1131,57 +1165,57 @@ msgstr ""
 "Datoteka '%s' ne postoji i ne može se otvoriti.\n"
 "Uklonjena je iz liste nedavno korišćenih datoteka."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Pravljenje pregleda štampanja nije uspelo."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Pregled štampanja"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Format datoteke '%s' ne može biti određen."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "Bez imena %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Otvori datoteku"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Greška datoteke"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Žao nam je, ova datoteka se ne može otvoriti."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Žao nam je, format ove datoteke je nepoznat."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Izaberi šablon dokumenta"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Šabloni"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Izaberi prikaz dokumenta"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Prikazi"
 
@@ -1215,41 +1249,41 @@ msgstr "Greška u čitanju datoteke '%s'"
 msgid "Write error on file '%s'"
 msgstr "Greška u pisanju datoteke '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "Čišćenje datoteke '%s' nije uspelo"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Greška u pretrazi datoteke '%s' (stdio ne podržava velike datoteke )"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Greška u pretrazi datoteke '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Nemoguće pronaći trenutnu poziciju u datoteci '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Postavljanje privremenih dozvola datoteke nije uspelo"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "Nemoguće ukloniti datoteku '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "Nemoguće izvršiti promene na datoteci '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "Nemoguće ukloniti privremenu datoteku '%s'"
@@ -1274,28 +1308,28 @@ msgstr "Nemoguće čitati iz opisivača datoteke %d"
 msgid "can't write to file descriptor %d"
 msgstr "Nemoguće pisati u opisivač datoteke %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "Nemoguće očistiti opisivač datoteke  %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "Nemoguće pretraživati na opisivaču datoteke %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 "Nemoguće preuzeti informaciju o poziciji pretrage za opisivač datoteke %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "Nemoguće pronaći dužinu datoteke na opisivaču datoteke %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "Nemoguće odrediti da li je dostignut kraj datoteke na opisivaču %d"
@@ -1321,107 +1355,107 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Greška u čitanju opcija konfiguracije."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Čitanje opcija konfiguracije nije uspelo."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "Datoteka'%s': Neočekivani znak %c u redu %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "Datoteka'%s', red %zu: '%s' ignorisan nakon zaglavlja grupe."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "Datoteka'%s', red %zu: '=' se očekuje."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "Datoteka '%s', red %zu: Vrednost za immutable ključ '%s' ignorisana."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "Datoteka '%s', red %zu: Ključ '%s' je prvi put pronađen u redu %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Ime unosa konfiguracije ne može početi sa '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "Nemoguće otvoriti datoteku korisničke konfiguracije."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "Nemoguće pisati u datoteci sa korisničkom konfiguracijom."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Ažuriranje datoteke sa korisničkom konfiguracijom nije uspelo."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Greška pri čuvanju podataka korisničke konfiguracije."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "Nemoguće obrisati datoteku korisničke konfiguracije '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "Unos '%s' se pojavljuje više od jednog puta u grupi '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "Pokušaj da se promeni immutable ključ '%s' biće ignorisan."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "Prateća obrnuta kosa crta će biti ignorisana u '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "Neočekivani \" na poziciji %d u '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kopiranje datoteke '%s' u '%s' nije uspelo"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Nemoguće preuzeti dozvole za datoteku '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Nemoguće zameniti datoteku '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Greška pri kopiranju datoteke '%s' u '%s'."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Nemoguće postaviti dozvole za datoteku '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1430,40 +1464,40 @@ msgstr ""
 "Preimenovanje datoteke '%s' u '%s' nije uspelo zato što datoteka na ovoj "
 "destinaciji već postoji."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Datoteka '%s' ne može biti preimenovana '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Datoteka '%s' ne može biti uklonjena"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Direktorijum '%s' ne može biti napravljen"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Direktorijum '%s' ne  može biti obrisan"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Nemoguća enumeracija datoteka '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Preuzimanje radnog direktorijuma nije uspelo"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Postavljanje trenutnog radnog direktorijuma nije uspelo"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Datoteke (%s)"
@@ -1490,17 +1524,17 @@ msgstr "Pravljenje privremenog imena datoteke nije uspelo"
 msgid "Failed to open temporary file."
 msgstr "Otvaranje privremene datoteke nije uspelo."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Izmena vremena  za datoteku '%s' nije uspela"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Dodirivanje datoteke '%s' nije uspelo"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Preuzimanje vremena za datoteku '%s' nije uspelo"
@@ -1509,22 +1543,22 @@ msgstr "Preuzimanje vremena za datoteku '%s' nije uspelo"
 msgid "Browse"
 msgstr "Potraži"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Sve datoteke (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s datoteke (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Učitaj datoteku %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Sačuvaj datoteku %s"
@@ -1887,99 +1921,99 @@ msgstr "Podrazumevano"
 msgid "unknown-%d"
 msgstr "Nepoznato -%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "Podvučeno"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr "Precrtano"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr "Tanko"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr "Izuzetno svetlo"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr "Svetlo"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr "Srednje"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr "Polu podebljano"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr "Podebljano"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr "Izuzetno podebljano"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr "Masno"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr "Izuzetno masno"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr "Iskošeno"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "Precrtano"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "Tanko"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "IzuzetnoSvetlo"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "Svetlo"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "Normalno"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "Srednje"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "PoluPodebljano"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "Podebljano"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "IzuzetnoPodebljano"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "Masno"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "IzuzetnoMasno"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "Iskošeno"
 
@@ -2061,7 +2095,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Neuspešno podešavanje režima FTP transfera na %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2082,7 +2116,7 @@ msgstr "FTP server ne podržava pasivni režim."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Neispravna veličina okvira  GIF-a (%u, %d) za okvir #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Dodeljivanje boje za OpenGL nije uspelo"
 
@@ -2099,7 +2133,7 @@ msgstr "Prilagodi kolone"
 msgid "&Customize..."
 msgstr "&Prilagodi..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Otvaranje adrese \"%s\" u podrazumevanom pretraživaču nije uspelo"
@@ -2119,157 +2153,156 @@ msgstr "Neuspešno učitavanje slike %d iz strima."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Neuspešno učitavanje ikona iz resursa '%s'."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Nemoguće sačuvati neispravnu sliku."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage nema svoj wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Nemoguće pisanje zaglavlja datoteke (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Nemoguće pisanje zaglavlja datoteke (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Nemoguće pisanje mape RGB boja"
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Nemoguće pisanje podataka."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Nemoguće dodeljivanje memorije."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB zaglavlje: širina slike> 32767 piksela za datoteku."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB zaglavlje: visina slike> 32767 piksela za datoteku."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB zaglavlje: Nepoznata bit-dubina u datoteci."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB zaglavlje: nepoznato kodiranje datoteke."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB zaglavlje: kodiranje se ne podudara sa bit-dubinom."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: Zaglavlje ima biClrUsed=%d a biBitCount=%d."
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Nemoguće dodeljivanje memorije."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB zaglavlje: širina slike> 32767 piksela za datoteku."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB zaglavlje: visina slike> 32767 piksela za datoteku."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB zaglavlje: Nepoznata bit-dubina u datoteci."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB zaglavlje: nepoznato kodiranje datoteke."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB zaglavlje: kodiranje se ne podudara sa bit-dubinom."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Greška u čitanju DIB-a slike."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: greška u čitanju DIB maske."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: slika previsoka za ikonicu."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: slika preširoka za ikonicu."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: greška pri pisanju datoteke slike!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: neispravan indeks ikonice."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Slika i maska imaju različite veličine."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Nema boje koja se ne koristi u slici koja se maskira."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Nemoguće učitati bitmap \"%s\" iz resursa."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Nemoguće učitati ikonicu \"%s\" iz resursa."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Nemoguće učitati sliku iz datoteke \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Nemoguće sačuvati sliku u datoteku '%s': nepoznata ekstenzija."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Nije pronađen obrađivač za vrstu slike."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Nije određen obrađivač za vrstu slika %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Datoteka slike nije vrste %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Nemoguće automatski odrediti format slike za unos koji nije moguće "
 "pretražiti."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Nepoznat format podataka slike."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Ovo nije %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Obrađivač slike za vrstu %s nije određen."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Slika nije vrste %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Neuspešna provera formata datoteke slike \"%s\"."
@@ -2371,41 +2404,41 @@ msgstr "PNM: datoteka izgleda prekinuto."
 msgid " (in module \"%s\")"
 msgstr " (u modulu \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: greška pri učitavanju slike."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Neispravan TIFF indeks slike."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: slika je abnormalno velika."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: nemoguće dodeliti memoriju."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: greška pri čitanju slike."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Nepoznata TIFF jedinica rezolucije %d je ignorisana"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: greška pri čuvanju slike."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: greška pri pisanju slike."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2414,11 +2447,11 @@ msgstr ""
 "Argument komandne linije %d nije mogao biti pretvoren u unikodni i biće "
 "ignorisan."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Inicijalizacija nije uspela u post init, otkazivanje."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Nemoguće podesiti lokalizaciju na jezik \"%s\"."
@@ -2514,7 +2547,7 @@ msgstr "Greška LZMA kompresovanja: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Greška LZMA kompresovanja pri čišćenju izlaza: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Nema podudaranja za '{' u unosu za mime vrstu %s."
@@ -2534,7 +2567,7 @@ msgstr "Zavisnost \"%s\" modula \"%s\" ne postoji."
 msgid "Module \"%s\" initialization failed"
 msgstr "Neuspešna inicijalizacija modula \"%s\""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Poruka"
 
@@ -3036,7 +3069,7 @@ msgstr "Greška pri štampanju"
 msgid "Print"
 msgstr "Štampaj"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Podešavanje stranice"
 
@@ -3071,19 +3104,15 @@ msgstr "Štampanje stranice %d od %d"
 msgid " (copy %d of %d)"
 msgstr " (kopija %d od %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Štampanje"
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Prva stranica"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Prethodna stranica"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Sledeća stranica"
 
@@ -3127,16 +3156,16 @@ msgstr "Stranica %d od %d"
 msgid "Page %d"
 msgstr "Stranica %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "Nepoznata greška"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Neispravan regularan izraz '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Neuspešno pronalaženje podudaranja za regularni izraz: %s"
@@ -3147,21 +3176,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Renderer \"%s\" ima nekompatibilnu verziju %d.%d i nije mogao biti učitan."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Nije dostupno za ovu platformu"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Čuvanje lozinke za \"%s\" nije uspelo: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Čitanje lozinke za \"%s\" nije uspelo: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Brisanje lozinke za \"%s\" nije uspelo: %s."
@@ -3170,11 +3199,11 @@ msgstr "Brisanje lozinke za \"%s\" nije uspelo: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Nemoguće posmatrati I/O kanale"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Sačuvaj"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Nemoj da sačuvaš"
 
@@ -3255,10 +3284,10 @@ msgid "Clear"
 msgstr "Očisti"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Zatvori"
 
@@ -3270,7 +3299,7 @@ msgstr "&Pretvori"
 msgid "Convert"
 msgstr "Pretvori"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Kopiraj"
@@ -3279,7 +3308,7 @@ msgstr "&Kopiraj"
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Iseci"
@@ -3288,13 +3317,13 @@ msgstr "&Iseci"
 msgid "Cut"
 msgstr "Iseci"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Obriši"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Obriši"
@@ -3381,7 +3410,7 @@ msgstr "Hard disk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Pomoć"
 
@@ -3401,7 +3430,7 @@ msgstr "Uvlačenje"
 msgid "&Index"
 msgstr "&Indeks"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Indeks"
 
@@ -3470,7 +3499,7 @@ msgstr "&Novo"
 msgid "New"
 msgstr "Novo"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Ne"
 
@@ -3487,12 +3516,12 @@ msgstr "&Otvori..."
 msgid "Open..."
 msgstr "Otvori..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Nalepi"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Nalepi"
@@ -3522,7 +3551,7 @@ msgid "Print..."
 msgstr "Štampaj..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Svojstva"
 
@@ -3554,10 +3583,6 @@ msgstr "Zameni..."
 msgid "Revert to Saved"
 msgstr "Vrati na sačuvano"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Sačuvaj"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Sačuvaj &kao..."
@@ -3566,7 +3591,7 @@ msgstr "Sačuvaj &kao..."
 msgid "Save As..."
 msgstr "Sačuvaj kao..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Izaberi &sve"
@@ -3673,7 +3698,7 @@ msgstr "&Gore"
 msgid "Up"
 msgstr "Gore"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Da"
 
@@ -3761,43 +3786,43 @@ msgstr "Sačuvaj trenutni dokument"
 msgid "Save current document with a different filename"
 msgstr "Sačuvaj trenutni dokument sa drugim nazivom datoteke"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Pretvaranje u set znakova '%s' ne radi."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "Nepoznato"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "Nepotpun blok zaglavlja  u TAR-u"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "Neuspešno čitanje kontrolnih podataka tar bloka zaglavlja"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "Neispravni podaci u proširenom TAR zaglavlju"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "TAR unos nije otvoren"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "Neočekivani kraj datoteke"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s ne odgovara tar zaglavlju za unos '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "Neispravna veličina određena za tar unos"
 
@@ -3806,7 +3831,7 @@ msgstr "Neispravna veličina određena za tar unos"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' je verovatno binarni kanal."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Datoteka nije mogla biti učitana."
 
@@ -3820,47 +3845,47 @@ msgstr "Neuspešno čitanje tekstualne datoteke \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "Nemoguće upisati kanal '%s' na disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Neuspešno preuzimanje lokalnog sistemskog vremena"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay nije uspeo."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' nije ispravan katalog poruka."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Neispravan katalog poruka."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Neuspešno raščlanjivanje formi množina: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "Koristi se katalog '%s' iz '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Resurs '%s' nije ispravan katalog poruka."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Nemoguća enumeracija prevoda"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Nije podešena podrazumevana aplikacija za HTML datoteke."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr ""
@@ -3894,7 +3919,7 @@ msgstr "'%s' sadrži neispravne znakove"
 msgid "Error: %s (%d)"
 msgstr "Greška: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Nema dovoljno slobodnog prostora na disku za preuzimanje."
 
@@ -3902,20 +3927,20 @@ msgstr "Nema dovoljno slobodnog prostora na disku za preuzimanje."
 msgid "libcurl could not be initialized"
 msgstr "libcurl se ne može inicijalizovati"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync nije podržan"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Greška pri pokretanju JavaScript-a: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Ova platforma ne podržava neprovidnu pozadinu."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Nemoguće prebaciti podatke u prozor"
 
@@ -3967,8 +3992,8 @@ msgstr "Parametar create %s nije pronađen u naglašenim RTTI parametrima"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Neispravna klasa objekata (Non-wxEvtHandler) kao izvor događaja"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Vrsta mora da ima enum - long pretvaranje"
 
@@ -4018,81 +4043,81 @@ msgstr "Objekti moraju da imaju ID atribut"
 msgid "Doubly used id : %d"
 msgstr "ID se koristi duplo: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Nepoznato svojstvo %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Kolekcija koja nije prazna mora da sadrži 'element' veze"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "Neispravan niz za event handler, nedostaje tačka"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "Nemoguće reinicijalizovati zlib deflate strim"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "Nemoguće reinicijalizovati zlib inflate strim"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Ignorisanje snimljenih podataka pogrešne forme, ZIP datoteka je možda "
 "oštećena"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "Pretpostavljanje da je ovo zip datoteka iz više delova"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "Neispravna zip datoteka"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "Nemoguće pronaći centralni direktorijum u zipu"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "Greška pri čitanju centralnog direktorijuma zipa"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "Greška pri čitanju lokalnog zip zaglavlja"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "Loš offset zip datoteke za unos"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "Dužina sačuvanih datoteka nije u zip zaglavlju"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "Metod kompresije zip datoteke nije podržan"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "Čitanje zip strima (unos %s): loša dužina"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "Čitanje zip strima (unos %s): loš crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "Greška pri pisanju zip unosa '%s': datoteka je prevelika bez ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "Greška pri pisanju zip unosa '%s': loš CRC ili dužina"
@@ -4178,32 +4203,32 @@ msgstr "Grafički dizajn od strane"
 msgid "Translations by "
 msgstr "Prevodi od strane"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Verzija"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "O %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licenca"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Programeri"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Autori dokumentacije"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Ilustratori"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Prevodioci"
 
@@ -4254,43 +4279,42 @@ msgid "Password:"
 msgstr "Lozinka:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "Tačno"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "Netačno"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Red %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Skupi"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Proširi"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d stavki)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Kolona %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4301,8 +4325,7 @@ msgid "Left"
 msgstr "Levo"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4398,7 +4421,7 @@ msgid "Home directory"
 msgstr "Početni direktorijum"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Radna površina"
 
@@ -4411,8 +4434,7 @@ msgstr "Neispravno ime direktorijuma."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Greška"
 
@@ -4597,16 +4619,16 @@ msgstr "Prikaži datoteke u detaljnom prikazu"
 msgid "Go to parent directory"
 msgstr "Vrati se u prvobitni direktorijum"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Datoteka '%s' već postoji, da li zaista želite da je zamenite?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Potvrdi"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Molimo izaberite postojeću datoteku."
 
@@ -4700,7 +4722,7 @@ msgstr "Veličina fonta."
 msgid "Whether the font is underlined."
 msgstr "Da li je font podvučen."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Pregled:"
@@ -4718,49 +4740,48 @@ msgstr "Kliknite da otkažete izbor fonta."
 msgid "Click to confirm the font selection."
 msgstr "Kliknite da potvrdite izbor fonta."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Izaberite font"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 "Kopiranje više od jednog izabranog bloka u privremenu memoriju nije podržano."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Direktorijum pomoći \"%s\" nije pronađen."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Datoteka pomoći \"%s\" nije pronađena."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Red %lu datoteke mape \"%s\" ima neispravnu sintaksu, biće preskočen."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ispravna mapiranja nisu pronađena u datoteci \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Nema pronađenih unosa."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Indeks pomoći"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevantne stavke:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Pronađene stavke"
 
@@ -4864,59 +4885,59 @@ msgstr "Nemoguće započeti štampanje."
 msgid "Printing page %d..."
 msgstr "Štampanje stranice %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Opcije štampača"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Štampaj u datoteku"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Podešavanje..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Štampač:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Sve"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Stranice"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Opseg štampanja"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopije:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript datoteka"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Podešavanje štampanja"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Štampač"
 
@@ -4924,25 +4945,25 @@ msgstr "Štampač"
 msgid "Default printer"
 msgstr "Podrazumevani štampač"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Veličina papira"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Uspravno"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Horizontalno"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orijentacija"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Opcije"
 
@@ -4954,52 +4975,52 @@ msgstr "Štampaj u boji"
 msgid "Print spooling"
 msgstr "Spooliranje štampanja"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Komande štampača:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Opcije štampača:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Leva margina (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Gornja margina (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Desna margina (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Donja margina (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Štampač..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Preskoči"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Nepoznato"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Gotovo."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Pretraži"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Nemoguće pronaći karticu za ID"
 
@@ -5035,11 +5056,11 @@ msgstr "&Završi"
 msgid "< &Back"
 msgstr "< &Nazad"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Nikola Jović <wwenikola123@gmail.com>, 2022."
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5049,11 +5070,11 @@ msgstr ""
 "probleme sa obradom unosa i treperenjem. Razmotrite o uklanjanju "
 "GTK_IM_MODULA ili podešavanju na \"ibus\"."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Nemoguće inicijalizovati GTK+, da li je display ispravno podešen?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Menjanje trenutnog direktorijuma na \"%s\" nije uspelo"
@@ -5080,11 +5101,11 @@ msgid "Failed to register font configuration using private fonts."
 msgstr ""
 "Registracija konfiguracije fonta korišćenjem privatnih fontova nije uspela."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Fatalna greška"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5097,7 +5118,7 @@ msgstr ""
 "backendom podešavanjem \n"
 "varijabli okruženja GDK_BACKEND=x11 pre nego što pokrenete vaš program."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5109,7 +5130,7 @@ msgstr ""
 "podešavanjem varijable okruženja GDK_BACKEND=x11 pre\n"
 "pokretanja vašeg programa."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI child"
 
@@ -5125,15 +5146,11 @@ msgstr "Greška pri štampanju:"
 msgid "Page Setup"
 msgstr "Podešavanje stranice"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Ubacivanje teksta u kontrolu nije uspelo."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "Preuzimanje JavaScript izlaza skripte nije podržano uz WebKit v1"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5141,7 +5158,7 @@ msgstr ""
 "GTK+ koji je instaliran na ovom računaru je prestar da bi podržavao deljenje "
 "ekrana, molimo instalirajte GTK+ 2.12 ili noviji."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5149,17 +5166,13 @@ msgstr ""
 "Deljenje nije podržano od strane ovog sistema, molimo omogućite ga u vašem "
 "upravljaču prozora."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Ovaj program je kompajliran sa prestarom GTK+ verzijom, molimo ponovo "
 "kompajlirajte uz GTK+ 2.12 ili noviji."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Molimo izaberite ispravan font."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5258,45 +5271,45 @@ msgstr "Nemoguće otvoriti datoteku sadržaja: %s"
 msgid "Cannot open index file: %s"
 msgstr "Nemoguće otvoriti datoteku indeksa: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "Neimenovano"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Nemoguće otvoriti knjigu HTML pomoći: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Prikazuje pomoć dok se krećete po knjigama na levoj strani."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(oznake)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Dodaj trenutnu stranicu u oznake"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Ukloni trenutnu stranicu iz oznaka"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Sadržaj"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Pronađi"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Prikaži sve"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5304,166 +5317,166 @@ msgstr ""
 "Prikaži sve stavke indeksa koje sadrže zadani pojam. Pretraga nije osetljiva "
 "na veličinu slova."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Prikaži sve stavke u indeksu"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Osetljivo na veličinu slova"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Samo cele reči"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 "Pretražuje sadržaj knjiga pomoći za sve pojave teksta kojeg ste upisali"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Prikaži/sakrij panel navigacije"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Nazad"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Napred"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Pomeri se gore jedan nivo u hierarhiji dokumenta"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Otvori HTML dokument"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Štampaj ovu stranicu"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Prikaži dijalog opcija"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Molimo izaberite stranicu za prikazivanje:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Teme pomoći"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Pretraživanje..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Nijedna stranica koja se podudara još uvek nije pronađena"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Pronađeno %i podudaranja"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(pomoć)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d od %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu od %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Pretraži u svim knjigama"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Opcije pretraživača pomoći"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normalni font:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fiksni font:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Veličina fonta:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "Veličina fonta"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normalni font<br>i<u>podvučeno</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Iskošeni font.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Podebljani font.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Podebljano iskošeni font.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Font fiksne veličine.<br> <b>podebljano</b> <i>iskošeno</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>Podebljano iskošeno<u>Podvučeno</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Pomoć za štampanje"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Nemoguće štampati praznu stranicu."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML datoteke (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Knjige pomoći (*.htb)|*.htb|knjige pomoći (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML projekat pomoći (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Kompresovana HTML datoteka pomoći (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i od %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u od %u"
@@ -5544,32 +5557,6 @@ msgstr ""
 "Došlo je do problema pri podešavanju stranice: možda ćete morati da podesite "
 "podrazumevani štampač."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Prikazivanje HTML dokumenta u %s kodiranju nije uspelo"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets nije mogao da otvori prikazivanje za '%s': Izlaz."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filtriranje"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Direktorijumi"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Datoteke"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Izbor"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Otvaranje privremene memorije nije uspelo."
@@ -5611,58 +5598,58 @@ msgstr "Došlo je do greške u dijalogu izbora boje %0lx."
 msgid "Failed to create cursor."
 msgstr "Pravljenje kursora nije uspelo."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Registracija DDE servera '%s' nije uspela"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Deregistracija DDE servera '%s' nije uspela"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Neuspešno pravljenje veze sa serverom '%s' na temi '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE poke zahtev nije uspeo"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Ostvarivanje advise loopa sa DDE serverom nije uspelo"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Prekidanje advise loopa sa DDE serverom nije uspelo"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Slanje DDE advise obaveštenja nije uspelo"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Pravljenje DDE niza nije uspelo"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "Nema DDE greške."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "Zahtev za sinhronu advise transakciju je istekao."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "Odgovor na transakciju je izazvao da DDE_FBUSY bit bude postavljen."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "Zahtev za sinhronu transakciju podataka je istekao."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5674,7 +5661,7 @@ msgstr ""
 "ili je neispravan instance identifier\n"
 "prosleđen DDEML funkciji."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5686,43 +5673,43 @@ msgstr ""
 "ili je aplikacija inicijalizovana kao APPCMD_CLIENTONLY\n"
 "pokušala da izvrši serverske transakcije."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "Zahtev za sinhronu izvršnu transakciju je istekao."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "Parametar nije uspešno potvrđen od strane DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "DDEML je napravila produženi race condition."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "Dodeljivanje memorije nije uspelo."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "Pokušaj klijenta da ostvari razgovor nije uspeo."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "Transakcija nije uspela."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "Zahtev za sinhronu poke transakciju je istekao."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "Interni poziv PostMessage funkciji nije uspeo. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "Problem pri ponovnom ulaženju."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5732,15 +5719,15 @@ msgstr ""
 "koji je završen od strane klijenta, ili ju je server\n"
 "završio pre potpune transakcije."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "Došlo je do interne greške u DDEML-u."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "Zahtev za završetak advise transakcije je istekao."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5750,12 +5737,12 @@ msgstr ""
 "Nakon što se aplikacija vrati iz XTYP_XACT_COMPLETE callbacka,\n"
 "identifikator transakcije iz tog callbacka više ne važi."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Nepoznata DDE greška %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5763,7 +5750,7 @@ msgstr ""
 "Dial up funkcije nisu dostupne zato što servis daljinskog pristupa (RAS) "
 "nije instaliran na ovom uređaju. Molimo instalirajte ga."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5773,65 +5760,65 @@ msgstr ""
 "uređaju je prestara, molimo ažurirajte je (sledeća neophodna funkcija "
 "nedostaje: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Neuspešno preuzimanje teksta RAS poruke sa greškom"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "Nepoznata greška (kod greške %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Nemoguće pronaći aktivnu dialup vezu: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Više aktivnih dialup veza je pronađeno, jedna će nasumično biti izabrana."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Neuspešno uspostavljanje dialup veze: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Neuspešno preuzimanje imena servisnih provajdera: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Neuspešno povezivanje: nema servisnog provajdera za biranje."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Izaberite servisnog provajdera za biranje"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Molimo izaberite sa kojim  servisnim provajderom želite da se povežete"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Neuspešno povezivanje: Nedostaje korisničko ime ili lozinka."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Nemoguće pronaći lokaciju  datoteke adresara"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Neuspešno uspostavljanje dialup veze: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Nemoguće prekinuti - nema aktivne dialup veze."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Nemoguće prekinuti dialup vezu: %s"
@@ -5851,18 +5838,17 @@ msgstr "Neuspešno dodeljivanje %luKb memorije za bitmap podatke."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Nemoguća enumeracija datoteka u direktorijumu '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Nemoguće dobiti ime foldera"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(Greška %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Nemoguće dodati sliku u listu slika."
 
@@ -5878,7 +5864,7 @@ msgstr ""
 "Neuspešno pravljenje standardnog dijaloga pronalaženja uz zamenu (kod greške "
 "%d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Došlo je do greške u dijalogu datoteke uz kod %0lx."
@@ -5919,16 +5905,16 @@ msgstr "Nemoguće podesiti praćenje za '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Nemoguće pratiti promene u nepostojećem direktorijumu \"%s\"."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0 ili noviji nije podržan od strane OpenGL drajvera."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Nemoguće napraviti OpenGL kontekst"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Neuspešna OpenGL inicijalizacija"
 
@@ -5936,7 +5922,7 @@ msgstr "Neuspešna OpenGL inicijalizacija"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "Nemoguće registrovati prilagođeni DirectWrite čitač fontova."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5944,7 +5930,7 @@ msgstr ""
 "MS HTML funkcije pomoći su  nedostupne zato što MS HTML biblioteka pomoći "
 "nije instalirana na ovom uređaju. Molimo instalirajte je."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Neuspešna inicijalizacija MS HTML pomoći."
 
@@ -5953,7 +5939,7 @@ msgstr "Neuspešna inicijalizacija MS HTML pomoći."
 msgid "Can't delete the INI file '%s'"
 msgstr "Nemoguće obrisati INI datoteku '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Nemoguće preuzeti informacije o kontrolnoj stavki liste %d."
@@ -6073,7 +6059,7 @@ msgstr "Nemoguće registrovati format privremene memorije '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Format privremene memorije '%d' ne postoji."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Preskoči"
 
@@ -6158,76 +6144,76 @@ msgstr ""
 "njegovo brisanje će izazvati nemogućnost korišćenja sistema:\n"
 "radnja otkazana."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Nemoguće obrisati ključ '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Nemoguće obrisati vrednost '%s' iz ključa '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Nemoguće pročitati vrednost ključa '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Nemoguće postaviti vrednost za '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Vrednost registra \"%s\" nije brojčana (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Vrednost registra \"%s\" nije binarna (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Vrednost registra \"%s\" nije tekstualna (ali je vrste %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Nemoguće pročitati vrednost za '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Nemoguća enumeracija vrednosti ključa '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Nemoguća enumeracija podključeva ključa '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Izvoz ključa registra: datoteka \"%s\" već postoji i neće biti zamenjena."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Nemoguće izvoziti vrednosti vrste koja nije podržana %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorisanje vrednosti \"%s\" ključa \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6235,41 +6221,41 @@ msgstr ""
 "Nemoguće napraviti kontrolu za obogaćeno uređivanje, umesto toga koristi se "
 "jednostavna tekstualna kontrola. Molimo ponovo instalirajte riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Nemoguće započeti thread: greška pri TLS pisanju."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Nemoguće postaviti prioritet za thread"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Nemoguće napraviti thread"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Nemoguće završiti thread"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Nemoguće čekati završetak za thread"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Nemoguće pauzirati thread %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Nemoguće nastaviti thread %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Nemoguće preuzeti trenutni pointer za thread"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6277,7 +6263,7 @@ msgstr ""
 "Neuspešna inicijalizacija modula za thread: nemoguće dodeliti indeks u "
 "thread lokalnom skladištu"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6310,12 +6296,12 @@ msgstr "Neuspešno učitavanje resursa \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Neuspešno zaključavanje resursa \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "Verzija %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bitno izdanje"
 
@@ -6327,46 +6313,46 @@ msgstr "Neuspešno pravljenje anonimnog pipe-a"
 msgid "Failed to redirect the child process IO"
 msgstr "Neuspešno preusmeravanje child proces IO-a"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Izvršavanje komande '%s' nije uspelo"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Neuspešno učitavanje datoteke mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Nemoguće učitati ime vrste iz '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Nemoguće učitati ikonicu iz '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "Neuspešno pronalaženje nivoa emulacije web prikaza u registru"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Neuspešno postavljanje web prikaza na moderni nivo emulacije"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "Neuspešno vraćanje web prikaza na standardni nivo emulacije"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Nemoguće pokrenuti JavaScript skriptu bez ispravnog HTML dokumenta"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Nemoguće preuzeti JavaScript objekat"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "Neuspešno ocenjivanje"
 
@@ -6399,7 +6385,7 @@ msgid "Check to make the font italic."
 msgstr "Označite da bi ste iskosili font."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Podvučeno"
@@ -6466,15 +6452,33 @@ msgstr "<Bilo koji pisaća mašina>"
 msgid "File type:"
 msgstr "Vrsta datoteke:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Prozor"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Pomoć"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Umanji"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zumiraj"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Prikaži sve"
 
@@ -6491,463 +6495,463 @@ msgstr "Datoteka fonta \"%s\" ne postoji."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "Datoteka fonta \"%s\" se  ne može koristiti budući da nije u direktorijumu "
 "fontova \"%s\"."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "O %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "O..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Podešavanja..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Servisi"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Sakrij %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Sakrij aplikaciju"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Sakrij drugo"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Prikaži sve"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Zatvori %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Zatvori aplikaciju"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Štampanje nije podržano od strane sistemske web kontrole"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Radnja štampanja se ne može inicijalizovati"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Veličina pointa"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Ime fonta"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Debljina"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Porodica"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "Radni prostor aplikacije"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "Aktivan okvir"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "Aktivan podnaslov"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "Font dugmeta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "Označavanje dugmeta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "Senka dugmeta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "Tekst dugmeta"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "Tekst podnaslova"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "Tamna kontrola"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "Svetla kontrola"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "Sivi tekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Označavanje"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "Označen tekst"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "Neaktivan okvir"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "Neaktivan podnaslov"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "Tekst neaktivnog podnaslova"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Meni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Klizna traka"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Opis alata"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "Tekst opisa alata"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Prozor"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "Okvir prozora"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "Tekst prozora"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Prilagođena"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Crna"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Kestenjasta"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Morsko plava"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Ljubičasta"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Plavozelena"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Siva"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Zelena"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Maslinasta"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Braon"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Plava"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuksija"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Crvena"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Narandžasta"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Srebrna"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Kreč"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Akva"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Žuta"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Bela"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Podrazumevani"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Strelica"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Strelica desno"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Prazan"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Meta"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Znak"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Kružić"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Ruka"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Beam"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Levo dugme"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Lupa"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Srednje dugme"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Nema unosa"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Četkica"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Olovka"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Pokazuje levo"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Pokazuje desno"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Strelica upitnika"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Desno dugme"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Veličina NE-SW"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Veličina N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Veličina NW-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Veličina W-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Veličina"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Sprej"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Čekanje"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Sat"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Strelica za čekanje"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Izaberite:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Svojstvo"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Vrednost"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Režim kategorizacije"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Režim alfabetizacije"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Netačno"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Tačno"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Neodređeno"
 
@@ -6961,12 +6965,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Upisali ste neispravnu vrednost. Pritisnite esc da otkažete uređivanje."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Greška u resursu: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6975,36 +6979,36 @@ msgstr ""
 "Radnja sa vrstama \"%s\" nije uspela: Svojstvo sa oznakom \"%s\" je vrste "
 "\"%s\", ne \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Nepoznata osnova %d. Osnova 10 će se koristiti."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Vrednost mora biti %s ili veća."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Vrednost mora biti između %s i %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Vrednost mora biti %s ili manja."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Ne %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Izaberite direktorijum:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Izaberite datoteku"
 
@@ -7471,117 +7475,117 @@ msgstr "Suženi"
 msgid "Outset"
 msgstr "Prošireni"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Promeni stil"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Promeni stil objekata"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Promeni svojstva"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Promeni stil liste"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Ponovi nabrajanje liste"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Ubaci tekst"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Ubaci sliku"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Ubaci objekat"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Ubaci polje"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Previše EndStyle poziva!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "Datoteke"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "Standardna/krug"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "Standardna/krug kontura"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "Standardna/kvadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "Standardna/romb"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "Standardna/trougao"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Svojstva okvira"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Svojstva za više ćelija"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Svojstva ćelije"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Podesi stil ćelije"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Obriši red"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Obriši kolonu"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Dodaj red"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Dodaj kolonu"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Svojstva tabele"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Svojstva slike"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "Slika"
 
@@ -7789,24 +7793,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Prevuci"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Obriši tekst"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Ukloni nabrajanje"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Tekst nije mogao biti sačuvan."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Zameni"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Font:"
 
@@ -8775,53 +8779,53 @@ msgstr "Stilovi liste"
 msgid "Box styles"
 msgstr "Stilovi okvira"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Font iz kojeg treba uzeti simbol."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Podskup:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Prikazuje unikodni podskup."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Kod znaka:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Kod znaka."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Iz:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unikodni"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Opseg za prikazivanje."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Ubaci"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(standardan tekst)"
 
@@ -9005,7 +9009,7 @@ msgstr "Nemoguće preuzeti događaje iz kqueue"
 msgid "Media playback error: %s"
 msgstr "Greška pri reprodukciji medija: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Neuspešna priprema reprodukcije \"%s\"."
@@ -9105,20 +9109,20 @@ msgstr "Podaci zvuka su u formatu koji nije podržan."
 msgid "Couldn't open audio: %s"
 msgstr "Nemoguće otvoriti zvučni zapis: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Nemoguće preuzeti polisu rasporeda threadova."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Nemoguće preuzeti opseg prioriteta za polisu rasporeda %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Podešavanje prioriteta threadova se ignoriše."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9126,59 +9130,59 @@ msgstr ""
 "Neuspešno pridruživanje threadu, otkriveno potencialno zauzeće memorije - "
 "molimo ponovo  pokrenite program"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Neuspešno podešavanje nivoa istovremenosti threada na %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Neuspešno podešavanje prioriteta threada %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Neuspešan završetak threada."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "Neuspešna inicijalizacija modula threada: neuspešno pravljenje ključa threada"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Nemoguće preuzeti unos manjeg procesa"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Nemoguće pisati u stdin manjeg procesa"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Neuspešno pokretanje '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Fork je neuspešan"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Neuspešno podešavanje prioriteta procesa"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Neuspešno preusmeravanje ulaza/izlaza manjeg procesa"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Nemoguće podesiti non-blocking pipe, program će možda čekati."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Nemoguće preuzeti ime hosta"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Nemoguće preuzeti zvanično ime hosta"
 
@@ -9195,12 +9199,12 @@ msgstr "Neuspešno prebacivanje wake up pipe-a u non-blocking režim"
 msgid "Failed to read from wake-up pipe"
 msgstr "Neuspešno čitanje iz wake-up pipe-a"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Neispravna geometrijska specifikacija '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets nije mogao da pristupi ekranu. Izlaz."
 
@@ -9214,30 +9218,59 @@ msgstr "Neuspešno zatvaranje ekrana \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Neuspešno otvaranje ekrana \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Greška XML raščlanjivanja: '%s' u redu %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Nemoguće učitati resurse iz '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Nemoguće otvoriti datoteku resursa '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Nemoguće učitati resurse iz datoteke '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Pravljenje %s \"%s\" nije uspelo."
+
+#~ msgid "Printing "
+#~ msgstr "Štampanje"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Ubacivanje teksta u kontrolu nije uspelo."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Molimo izaberite ispravan font."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Prikazivanje HTML dokumenta u %s kodiranju nije uspelo"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets nije mogao da otvori prikazivanje za '%s': Izlaz."
+
+#~ msgid "Filter"
+#~ msgstr "Filtriranje"
+
+#~ msgid "Directories"
+#~ msgstr "Direktorijumi"
+
+#~ msgid "Files"
+#~ msgstr "Datoteke"
+
+#~ msgid "Selection"
+#~ msgstr "Izbor"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "Pretvaranje u 8-bitno kodiranje nije uspelo"

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2014-02-23 11:45+0100\n"
 "Last-Translator: Jonas Rydberg <jonas@drevo.se>\n"
 "Language-Team: wxWidgets translators <wx-translators@googlegroups.com>\n"
@@ -12,11 +12,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Alla filer (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Alla filer (*)|*"
 
@@ -33,24 +33,21 @@ msgid "Remaining time:"
 msgstr "Återstående tid: "
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Ja"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Nej"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "OK"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Avbryt"
@@ -100,7 +97,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Kunde inte skapa I/O-avslutningsport"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Utskrift"
 
@@ -137,7 +134,7 @@ msgstr "Objektegenskaper"
 msgid "Printing"
 msgstr "Skriver ut "
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Symboler"
 
@@ -206,7 +203,7 @@ msgstr "&Föregående"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Fönster"
 
@@ -768,11 +765,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "ObehandladCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "visa detta hjälpmeddelande"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "skapa mångordiga loggmeddelanden"
 
@@ -794,84 +791,84 @@ msgstr "Temat \"%s\" stöds inte."
 msgid "Invalid display mode specification '%s'."
 msgstr "Ogiltig bildskärmslägesspecifikation \"%s\"."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Flagga \"%s\" kan inte negeras"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Okänd lång flagga \"%s\""
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Okänd flagga \"%s\""
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Oväntat tecken efter flagga \"%s\"."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Flagga \"%s\" kräver ett värde."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Avgränsare förväntad efter flaggan \"%s\"."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "\"%s\" är inte ett korrekt numeriskt värde för flagga \"%s\"."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Flagga \"%s\": \"%s\" kan inte konverteras till ett datum."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Oväntad parameter \"%s\""
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (eller %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Värdet för flaggan \"%s\" måste anges."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Den obligatoriska parametern \"%s\" angavs inte."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Användning: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "flyttal"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "datum"
 
@@ -889,7 +886,7 @@ msgid "Can't &Undo "
 msgstr "Kan inte &ångra "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Ångra"
@@ -899,7 +896,7 @@ msgid "&Redo "
 msgstr "&Upprepa "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Upprepa"
@@ -927,12 +924,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "\"%s\" har extra \"..\", ignoreras."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -942,103 +939,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "understruken"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "idag"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "igår"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "i morgon"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "första"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "andra"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "tredje"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "fjärde"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "femte"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "sjätte"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "sjunde"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "åttonde"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "nionde"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "tionde"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "elfte"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "tolfte"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "trettonde"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "fjortonde"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "femtonde"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "sextonde"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "sjuttonde"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "artonde"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "nittonde"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "tjugonde"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "middag"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "midnatt"
 
@@ -1078,8 +1075,8 @@ msgstr "Skapande av debugrapport har misslyckats."
 msgid ""
 "Processing debug report has failed, leaving the files in \"%s\" directory."
 msgstr ""
-"Behandling av debugrapport har misslyckats, lämnar filerna i katalogen \"%s"
-"\"."
+"Behandling av debugrapport har misslyckats, lämnar filerna i katalogen "
+"\"%s\"."
 
 #: ../src/common/debugrpt.cpp:574
 msgid "A debug report has been generated. It can be found in"
@@ -1106,44 +1103,81 @@ msgstr "Kunde inte köra curl, installera den i PATH."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Kunde inte ladda upp debugrapport (felkod %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Spara som"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Bortse från ändringar och ladda om den senast sparade versionen?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "namnlös"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Vill du spara ändringar i %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Spara"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Spara inte"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Vill du spara ändringar i %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Texten kunde inte sparas."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Filen \"%s\" kunde inte öppnas för skrivning."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Kunde inte spara dokument till filen \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Fil \"%s\" kunde inte öppnas för läsning."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Kunde inte läsa dokument från filen \"%s\"."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1152,57 +1186,57 @@ msgstr ""
 "Filen \"%s\" finns inte och kunde inte öppnas.\n"
 "Den har tagits bort från senast använda filer-listan."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Förhandsgranskning kunde inte skapas."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Förhandsgranska"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Formatet för filen \"%s\" kunde inte avgöras."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "namnlös%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Öppna Fil"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Filfel"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Kunde inte öppna denna fil."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Filformatet för denna fil är okänt."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Välj en dokumentmall"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Mallar"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Välj en dokumentvy"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Vyer"
 
@@ -1236,41 +1270,41 @@ msgstr "Läsfel på fil \"%s\""
 msgid "Write error on file '%s'"
 msgstr "Skrivfel på fil \"%s\""
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "misslyckades att spola filen \"%s\""
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Sökfel på fil \"%s\" (stora filer stöds inte av stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Sökfel på fil \"%s\""
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Kan inte hitta aktuell position i fil \"%s\""
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Kunde inte sätta behörigheter på  temporär fil"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "kan inte ta bort fil \"%s\""
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "kan inte skriva ändringar till fil \"%s\""
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "kan inte ta bort temporär fil \"%s\""
@@ -1295,27 +1329,27 @@ msgstr "kan inte läsa från filidentifierare %d"
 msgid "can't write to file descriptor %d"
 msgstr "kan inte skriva till filidentifierare %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "kan inte spola filidentifierare %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "kan inte söka på filidentifierare %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "kan inte hitta sökposition på filidentifierare %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "kan inte hitta filens längd på filidentifierare %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "kan inte avgöra om slutet på filen är uppnått på identifierare %d"
@@ -1341,107 +1375,107 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Fel vid läsning av konfigureringsalternativ."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Kunde inte läsa konfigurationsalternativ."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "fil \"%s\": Oväntat tecken %c på rad %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "fil \"%s\", rad %d: \"%s\" ignorerad efter grupphuvud."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "fil \"%s\", rad %d: \"=\" förväntat."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "fil \"%s\", rad %d: Värde för ej skrivbar nyckel \"%s\" ignoreras."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "fil \"%s\", rad %d: Nyckel \"%s\" hittades först på rad %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Konfigurationspost kan inte starta med \"%c\"."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "kan inte öppna användarkonfigurationsfil."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "kan inte skriva användarkonfigurationsfil."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Kunde inte uppdatera användarkonfigurationsfil."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Fel vid sparande av användarkonfigurationsdata."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "kan inte ta bort användarkonfigurationsfil \"%s\""
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "post \"%s\" förekommer mer än en gång i grupp \"%s\""
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "försök att ändra ej skrivbar nyckel \"%s\" ignorerad."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "avslutande omvänt snedsträck ignorerades i \"%s\""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "oväntat \" på position %d i \"%s\"."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Kunde inte kopiera filen \"%s\" till \"%s\""
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Omöjligt att hämta behörigheter för fil \"%s\""
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Omöjligt att skriva över fil \"%s\""
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Kunde inte kopiera filen \"%s\" till \"%s\""
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Omöjligt att sätta behörigheter för filen \"%s\""
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1449,40 +1483,40 @@ msgid ""
 msgstr ""
 "Kunde inte döpa om filen \"%s\" till \"%s\" eftersom målfilen redan finns."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Filen \"%s\" kunde inte byta namn till \"%s\""
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Filen \"%s\" kunde inte tas bort"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Katalogen \"%s\" kunde inte skapas"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Katalogen \"%s\" kunde inte tas bort"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Kan inte räkna upp filerna \"%s\""
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Kunde inte hämta aktuell katalog"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Kunde inte ange aktuell katalog"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Filer (%s)"
@@ -1509,17 +1543,17 @@ msgstr "Kunde inte skapa ett namn för temporär fil"
 msgid "Failed to open temporary file."
 msgstr "Kunde inte öppna temporär fil."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Kunde inte ändra filtider för \"%s\""
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Kunde inte röra (touch) filen \"%s\""
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Kunde inte hämta filtider för \"%s\""
@@ -1528,22 +1562,22 @@ msgstr "Kunde inte hämta filtider för \"%s\""
 msgid "Browse"
 msgstr "Bläddra"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Alla filer (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s filer (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Läs in %s fil"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Spara %s fil"
@@ -1906,105 +1940,105 @@ msgstr "förvald"
 msgid "unknown-%d"
 msgstr "okänd-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "understruken"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " genomstruken"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " tunn"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " tunn"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " fet"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " fet"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " fet"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " kursiv"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "genomstruken"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "tunn"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "tunn"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "fet"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "kursiv"
 
@@ -2085,7 +2119,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Kunde inte sätta FTP-överföringsläge till %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2106,7 +2140,7 @@ msgstr "FTP-servern stöder inte passivt läge."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Inkorrekt GIF-ramstorlek (%u, %d) för ruta #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Kunde inte allokera färg för OpenGL"
 
@@ -2122,7 +2156,7 @@ msgstr "Anpassa kolumner"
 msgid "&Customize..."
 msgstr "&Anpassa..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Kunde inte öppna URL \"%s\" i standardwebbläsare."
@@ -2142,155 +2176,154 @@ msgstr "Kunde inte läsa in bild %d från ström."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Kunde inte läsa in ikon \"%s\" från resurser."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Kunde inte spara ogiltig bild."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage saknar egen wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Kunde inte skriva filhuvudet (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Kunde inte skriva filhuvudet (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Kunde inte skriva RGB-färgkarta."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Kunde inte skriva data."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Kunde inte allokera minne."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB-huvud: Bildbredd > 32767 pixlar för fil."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB-huvud: Bildhöjd > 32767 pixlar för fil."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB-huvud: Okänt bitdjup i fil."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB-huvud: Okänd kodning i fil."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB-huvud: Kodning matchar inte bitdjup."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Kunde inte allokera minne."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB-huvud: Bildbredd > 32767 pixlar för fil."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB-huvud: Bildhöjd > 32767 pixlar för fil."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB-huvud: Okänt bitdjup i fil."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB-huvud: Okänd kodning i fil."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB-huvud: Kodning matchar inte bitdjup."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Fel vid läsning av DIB-bild."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Fel vid läsning av mask DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Bilden är för hög för en ikon."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Bilden är för bred för en ikon."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Fel vid skrivning till bildfilen!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Ogiltigt ikonindex."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Bild och mask har olika storlekar."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Ingen oanvänd färg i bilden är maskad."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Kunde inte läsa in bild \"%s\" från resurser."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Kunde inte läsa in ikon \"%s\" från resurser."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Kunde inte läsa in bild från fil \"%s\"."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Kan inte spara bild till fil \"%s\": Okänd filändelse."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Ingen hanterare hittades för bildtyp."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Ingen bildhanterare är definierad för typ %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Bildfilen är inte av typen %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Kan inte automatiskt avgöra bildformat för icke-sökbar indata."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Okänt bilddataformat."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Detta är inte en %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Ingen bildhanterare är definierad för typ %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Bild är inte av typen %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Kunde kontrollera bildformat för fil \"%s\"."
@@ -2391,41 +2424,41 @@ msgstr "PNM: Filen tycks vara trunkerad."
 msgid " (in module \"%s\")"
 msgstr " (i modul \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Fel vid inläsning av bild."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Ogiltigt TIFF-bildindex."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Bildstorlek är onormalt stor."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Kunde inte allokera minne."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Fel vid läsning av bild."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Okänd TIFF-upplösningsenhet %d ignoreras"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Fel vid sparande av bild."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Fel vid skrivande till bild."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2434,11 +2467,11 @@ msgstr ""
 "Kommandoradsargument %d kunde inte bli konverterad till Unicode och kommer "
 "att ignoreras."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Initiering misslyckades i post init, avbryter."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Kan inte ange lokal för språk \"%s\"."
@@ -2536,7 +2569,7 @@ msgstr "kompressionsfel"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Omatchad \"{\" i en post för mime-typ %s."
@@ -2556,7 +2589,7 @@ msgstr "Beroende \"%s\" av modul \"%s\" finns inte."
 msgid "Module \"%s\" initialization failed"
 msgstr "Modul \"%s\" initiering misslyckades"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Meddelande"
 
@@ -3058,7 +3091,7 @@ msgstr "Utskriftsfel"
 msgid "Print"
 msgstr "Skriv ut"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Sidinställning"
 
@@ -3093,19 +3126,15 @@ msgstr "Skriver sida %d av %d"
 msgid " (copy %d of %d)"
 msgstr " (kopia %d av %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Skriver ut "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Första sida"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Föregående sida"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Nästa sida"
 
@@ -3149,16 +3178,16 @@ msgstr "Sida %d av %d"
 msgid "Page %d"
 msgstr "Sida %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "okänt fel"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Ogiltigt reguljärt uttryck \"%s\": %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Kunde inte hitta träff för reguljärt uttryck: %s"
@@ -3169,21 +3198,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Rendrerare \"%s\" har inkompatibel version %d.%d och kunde inte läsas in."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
@@ -3192,11 +3221,11 @@ msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 msgid "Failed to monitor I/O channels"
 msgstr "Kunde inte bevaka I/O-kanaler"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Spara"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Spara inte"
 
@@ -3280,10 +3309,10 @@ msgid "Clear"
 msgstr "Töm"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Stäng"
 
@@ -3295,7 +3324,7 @@ msgstr "&Konvertera"
 msgid "Convert"
 msgstr "Konvertera"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "K&opiera"
@@ -3304,7 +3333,7 @@ msgstr "K&opiera"
 msgid "Copy"
 msgstr "Kopiera"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Klipp ut"
@@ -3313,13 +3342,13 @@ msgstr "&Klipp ut"
 msgid "Cut"
 msgstr "Klipp ut"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Ta bort"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Ta bort"
@@ -3408,7 +3437,7 @@ msgstr "Hårddisk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Hjälp"
 
@@ -3428,7 +3457,7 @@ msgstr "Indentera"
 msgid "&Index"
 msgstr "&Index"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Index"
 
@@ -3497,7 +3526,7 @@ msgstr "&Ny"
 msgid "New"
 msgstr "Ny"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Nej"
 
@@ -3514,12 +3543,12 @@ msgstr "&Öppna..."
 msgid "Open..."
 msgstr "Öppna..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "K&listra in"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Klistra in"
@@ -3549,7 +3578,7 @@ msgid "Print..."
 msgstr "Skriv ut..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Egenskaper"
 
@@ -3583,10 +3612,6 @@ msgstr "Ersätt"
 msgid "Revert to Saved"
 msgstr "Återgå till sparad"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Spara"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Spara so&m..."
@@ -3596,7 +3621,7 @@ msgstr "Spara so&m..."
 msgid "Save As..."
 msgstr "Spara so&m..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Markera &allt"
@@ -3703,7 +3728,7 @@ msgstr "&Upp"
 msgid "Up"
 msgstr "Upp"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Ja"
 
@@ -3794,43 +3819,43 @@ msgstr "Spara aktuellt dokument"
 msgid "Save current document with a different filename"
 msgstr "Spara aktuellt dokument med ett annat filnamn"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Konvertering till teckenuppsättning \"%s\" fungerar inte."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "okänd"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "ofullständigt huvudblock i tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "checksumma misslyckades när tar-huvudblock lästes"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "felaktigt data i utökat tar-huvud"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar-post är inte öppen"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "oväntat slut på filen"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s passade inte tar-huvudet för post \"%s\""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "felaktig storlek angiven för tar-post"
 
@@ -3839,7 +3864,7 @@ msgstr "felaktig storlek angiven för tar-post"
 msgid "'%s' is probably a binary buffer."
 msgstr "\"%s\" är troligen en binär buffer."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Filen kunde inte läsas in."
 
@@ -3853,47 +3878,47 @@ msgstr "Kunde inte läsa dokument från filen \"%s\"."
 msgid "can't write buffer '%s' to disk."
 msgstr "kan inte skriva buffer \"%s\" till disk."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Kunde inte hämta den lokala systemtiden"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay misslyckades."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "\"%s\" är inte en giltig meddelandekatalog."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Ogiltig meddelandekatalog."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Kunde inte tolka pluralformer: \"%s\""
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "använder katalog \"%s\" från \"%s\"."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Resursen \"%s\" är inte en giltig meddelandekatalog."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Kunde inte räkna upp översättningar"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Inget standardprogram för HTML-filer är konfigurerat."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Kunde inte öppna URL \"%s\" i standardwebbläsare."
@@ -3926,7 +3951,7 @@ msgstr "\"%s\" får bara innehålla alfabetiska tecken."
 msgid "Error: %s (%d)"
 msgstr "Fel: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3935,21 +3960,21 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Kolumnbeskrivning kunde inte initieras."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 #, fuzzy
 msgid "RunScriptAsync not supported"
 msgstr "Strängomvandlingar stöds inte"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Denna plattform stöder inte bakgrundsgenomskinlighet."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Kunde inte föra över data till fönstret"
 
@@ -4001,8 +4026,8 @@ msgstr "Skapa-parameter %s hittades inte i deklarerade RTTI-parametrar"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Otillåten objektklass (icke-wxEvtHandler) som händelsekälla"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Typen måste ha enum - long omvandling"
 
@@ -4052,79 +4077,79 @@ msgstr "Objekt måste ha ett id-attribut"
 msgid "Doubly used id : %d"
 msgstr "Dubbelt använt id: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Okänd egenskap %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "En icke tom samling måste bestå av \"element\"-noder"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "felaktig händelsehanterarsträng, punkt saknas"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "kan inte återinitiera zlib deflate-ström"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "kan inte återinitiera zlib inflate-ström"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "antar att detta är en multi-part zip konkatenerad"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "ogiltig zip-fil"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "kan inte hitta central katalog i zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "fel vid läsning av central katalog i zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "fel vid läsning av lokalt ziphuvud"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "felaktig zipfil offset mot ingång"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "lagrad fillängd finns inte i Zip-huvud"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "komprimeringsmetod i Zip stöds inte"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "läser zip-ström (post %s): Felaktig längd"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "läser zip-ström (post %s): Felaktig crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "fel vid skrivning av zip-post \"%s\": Felaktig crc eller längd"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "fel vid skrivning av zip-post \"%s\": Felaktig crc eller längd"
@@ -4208,32 +4233,32 @@ msgstr "Grafik av "
 msgid "Translations by "
 msgstr "Översättningar av "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Version "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Om %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Licens"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Utvecklare"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Dokumentationssförfattare"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Konstnärer"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Översättare"
 
@@ -4285,44 +4310,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Falskt"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (eller %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Lägg till kolumn"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4333,8 +4357,7 @@ msgid "Left"
 msgstr "Vänster"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4429,7 +4452,7 @@ msgid "Home directory"
 msgstr "Hemkatalog"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Skrivbord"
 
@@ -4442,8 +4465,7 @@ msgstr "Ogiltigt katalognamn."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Fel"
 
@@ -4627,16 +4649,16 @@ msgstr "Visa filer som detaljerad lista"
 msgid "Go to parent directory"
 msgstr "Gå till föräldrakatalog"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Filen \"%s\" finns redan, vill du verkligen skriva över den?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Bekräfta"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Välj en existerande fil."
 
@@ -4730,7 +4752,7 @@ msgstr "Typsnittets punktstorlek"
 msgid "Whether the font is underlined."
 msgstr "Om typsnittet är understruket."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Förhandsgranska:"
@@ -4748,48 +4770,47 @@ msgstr "Klicka för att avbryta typsnittsvalet."
 msgid "Click to confirm the font selection."
 msgstr "Klicka för att bekräfta typsnittsvalet."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Välj typsnitt"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Hjälpkatalog \"%s\" hittades inte."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Hjälpfil \"%s\" hittades inte."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Rad %lu i map-fil \"%s\" har felaktig syntax, hoppar över."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Ingen giltig mappning hittad i fil \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Inga poster funna."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Hjälpindex"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Relevanta poster:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Poster funna"
 
@@ -4893,59 +4914,59 @@ msgstr "Kunde inte påbörja utskrift."
 msgid "Printing page %d..."
 msgstr "Skriver sida %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Skrivaralternativ"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Skriv ut till fil"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Inställningar..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Skrivare:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Status:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Alla"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Sidor"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Sidintervall"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Från:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Till:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopior:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript-fil"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Utskriftsinställningar"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Skrivare"
 
@@ -4953,25 +4974,25 @@ msgstr "Skrivare"
 msgid "Default printer"
 msgstr "Standardskrivare"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Pappersstorlek"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Stående"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Liggande"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Orientering"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Alternativ"
 
@@ -4983,52 +5004,52 @@ msgstr "Skriv ut med färg"
 msgid "Print spooling"
 msgstr "Utskrift-spooling"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Skrivarkommando:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Skrivaralternativ:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Vänster marginal (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Övre marginal (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Höger marginal (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Undre marginal (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Skrivare..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "&Hoppa över"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Okänd"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Färdigt."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Sök"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Kunde inte hitta flik för id"
 
@@ -5064,22 +5085,22 @@ msgstr "&Avsluta"
 msgid "< &Back"
 msgstr "< &Bakåt"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "Jonas Rydberg"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "Kunde inte initiera GTK+, är DISPLAY inställt korrekt?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Kunde inte skapa katalog \"%s\""
@@ -5105,12 +5126,12 @@ msgstr "Kunde inte läsa dokument från filen \"%s\"."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Kunde inte uppdatera användarkonfigurationsfil."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Ödesdigert fel"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5118,7 +5139,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5126,7 +5147,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI-barn"
 
@@ -5142,15 +5163,11 @@ msgstr "Fel vid utskrift: "
 msgid "Page Setup"
 msgstr "Sidinställningar"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Kunde inte sätta in text i kontrollen."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5158,24 +5175,20 @@ msgstr ""
 "Den installerade GTK+ på den här maskinen är för gammal för att stöda "
 "skärmkompositering, installera GTK+ 2.12 eller senare."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 "Kompositering stöds inte på detta system, slå på det i din fönsterhanterare."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Det här programmet kompilerades med en för gammal version av GTK+, bygg om "
 "det med GTK+ 2.12 eller senare"
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Välj ett giltigt typsnitt."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5274,45 +5287,45 @@ msgstr "Kan inte öppna innehållsfil: %s"
 msgid "Cannot open index file: %s"
 msgstr "Kan inte öppna indexfil: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "namnlös"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Kan inte öppna HTML-hjälpbok: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Visar hjälp medan du bläddrar i böckerna till vänster."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(bokmärken)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Lägg till aktuell sida till bokmärken"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Ta bort aktuell sida från bokmärken"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Innehåll"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Sök"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Visa alla"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5320,19 +5333,19 @@ msgstr ""
 "Visa alla indexposter som innehåller given delsträng. Sökningen är "
 "skiftlägesokänslig."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Visa alla poster i index"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Skiftlägeskänslig"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Endast hela ord"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5340,147 +5353,147 @@ msgstr ""
 "Sök i hjälpboken/böckernas innehåll efter alla förekomster av texten du "
 "skrev in ovan"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Visa/dölj navigeringspanel"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Gå tillbaka"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Gå framåt"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Gå upp en nivå i dokumenthierarki"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Öppna HTML-dokument"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Skriv ut denna sida"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Visa alternativdialog"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Välj vilken sida som skall visas:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Hjälpavsnitt"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Söker..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Ingen matchande sida hittad ännu"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Hittade %i träffar"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Hjälp)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d av %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu av %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Sök i alla böcker"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Hjälpbläddraralternativ"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normalt typsnitt:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Fastbreddstypsnitt:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Typsnittsstorlek:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "typsnittsstorlek"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normalt typsnitt<br>och <u>understruket</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Kursiv.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Fet.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Fet kursiv.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Fastbreddtypsnitt.<br> <b>fet</b> <i>kursiv</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>fet kursiv <u>understruket</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Hjälputskrift"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Kan inte skriva ut tom sida."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML-filer (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Hjälpböcker (*.htb)|*.htb|Hjälpböcker (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML-hjälpprojekt (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Komprimerad HTML-hjälpfil (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i av %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu av %lu"
@@ -5560,32 +5573,6 @@ msgstr ""
 "Det var problem när sidan ställdes in: Du måste kanske ange en "
 "standardskrivare."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Kunde inte visa HTML-dokument i %s-kodning"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets kunde inte öppna skärm för \"%s\": Avslutar."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Filter"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Kataloger"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Filer"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Markering"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Kunde inte öppna urklippsbordet."
@@ -5627,59 +5614,59 @@ msgstr "Färgväljningsdialogrutan misslyckades med fel %0lx."
 msgid "Failed to create cursor."
 msgstr "Kunde inte skapa markör."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Kunde inte registrera DDE-server \"%s\""
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Kunde inte avregistrera DDE-server \"%s\""
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Kunde inte skapa en anslutning till server \"%s\" med ämne \"%s\""
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE poke-förfrågan misslyckades"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Kunde inte starta en meddelandeslinga med DDE-server"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Kunde inte avsluta meddelandeslinga med DDE-servern"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Kunde inte skicka DDE-meddelandeanmälan"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Kunde inte skapa DDE-sträng"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "inget DDE-fel."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 "tiden för en förfrågan för en synkron meddelandetransaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "svaret på transaktionen gjorde att DDE_FBUSY-biten sattes."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "tiden för en förfrågan för en synkron datatransaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5690,7 +5677,7 @@ msgstr ""
 "eller en ogiltig instansidentifierare\n"
 "sändes till en DDEML-funktion."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5702,43 +5689,43 @@ msgstr ""
 "eller en applikation initierad som en APPCMD_CLIENTONLY har \n"
 "försökt genomföra servertransaktioner."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "tiden för en förfrågan för en synkron körningstransaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "en parameter kunde inte bekräftas av DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "en DDEML-applikation har skapat ett långvarigt race-tillstånd."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "en minnesallokering misslyckades."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "en klients försök att etablera en konversation har misslyckats."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "en transaktion misslyckades."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "tiden för en förfrågan för en synkron poke-transaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "ett internt anrop till PostMessage-funktionen har misslyckats. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "återinträdesproblem."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5748,16 +5735,16 @@ msgstr ""
 "som avslutades av klienten, eller servern\n"
 "avslutades före transaktionen var genomförd."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "ett internt fel har uppstått i DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 "tiden för en förfrågan att avsluta en meddelandetransaktion har gått ut."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5767,12 +5754,12 @@ msgstr ""
 "När applikationen har återvänt från ett XTYP_XACT_COMPLETE anrop,\n"
 "är transaktionsidentifieraren för det anropet inte längre giltig."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Okänt DDE-fel %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5781,7 +5768,7 @@ msgstr ""
 "fjärråtkomstservice (RAS) inte är installerad på denna maskin. Installera "
 "den."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5790,64 +5777,64 @@ msgstr ""
 "Versionen av fjärråtkomsttjänsten (RAS) som är installerad på denna maskin "
 "är för gammal, uppgradera (följande nödvändig funktion saknas: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Kunde inte hämta text från RAS-felmeddelande"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "okänt fel (felkod %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Kan inte hitta aktiv uppringningsanslutning: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Flera aktiva uppringningsanslutningar hittades, väljer en slumpvis."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Kunde inte etablera uppringningsanslutning: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Kunde inte hämta Internetleverantörers namn: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Kunde inte ansluta: Ingen Internetleverantör att ringa upp."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Välj Internetleverantör att ringa upp"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Välj vilken Internetleverantör du vill ansluta till"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Kunde inte ansluta: Användarnamn/lösenord saknas."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Kan inte hitta platsen för adressboksfil"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Kunde inte initiera den uppringda anslutningen: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kan inte lägga på - ingen aktiv uppringningsanslutning."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Kunde inte avsluta den uppringda anslutningen: %s"
@@ -5867,18 +5854,17 @@ msgstr "Kunde inte allokera %luKb minne för bilddata."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Kan inte räkna upp filerna i katalogen \"%s\""
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Kunde inte erhålla katalognamn"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (fel %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Kunde inte lägga till en bild till bildlistan."
 
@@ -5892,7 +5878,7 @@ msgstr "Kunde inte läsa in metafil från fil \"%s\"."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Kunde inte skapa standard sök/ersättdialogrutan (felkod %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Fildialogruta misslyckades med felkod %0lx."
@@ -5934,17 +5920,17 @@ msgstr "Kunde inte starta en bevakning för \"%s\""
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Kan inte bevaka icke existerande katalog \"%s\" för ändringar."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Kunde inte skapa en timer"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Kunde inte initiera OpenGL"
 
@@ -5952,7 +5938,7 @@ msgstr "Kunde inte initiera OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5960,7 +5946,7 @@ msgstr ""
 "MS HTML hjälpfunktioner är inte tillgängliga på grund av att MS HTML "
 "hjälpbiblioteket inte är installerat på den här maskinen. Installera det."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Kunde inte initiera MS HTML-hjälp."
 
@@ -5969,7 +5955,7 @@ msgstr "Kunde inte initiera MS HTML-hjälp."
 msgid "Can't delete the INI file '%s'"
 msgstr "Kan inte ta bort INI-filen \"%s\""
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Kunde inte hämta information om listkontrollpost %d."
@@ -6089,7 +6075,7 @@ msgstr "Kunde inte registrera urklippsformat \"%s\"."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Urklippsformatet \"%d\" finns inte."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Hoppa över"
 
@@ -6174,59 +6160,59 @@ msgstr ""
 "om du tar bort den kommer systemet bli instabilt:\n"
 "Operationen avbruten."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Kan inte ta bort nyckel \"%s\""
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Kan inte ta bort värde \"%s\" från nyckel \"%s\""
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Kan inte läsa värdet av nyckel \"%s\""
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Kan inte sätta värdet på \"%s\""
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Kan inte läsa värdet av \"%s\""
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Kan inte räkna upp värden för nyckel \"%s\""
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Kan inte räkna upp undernycklar för nyckel \"%s\""
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6234,17 +6220,17 @@ msgstr ""
 "Exporterar registernyckel: Filen \"%s\" finns redan och kommer inte att "
 "skrivas över."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Kan inte exportera värde av ej stödd typ %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Ignorerar värde \"%s\" i nyckeln \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6252,41 +6238,41 @@ msgstr ""
 "Omöjligt att skapa en rich edit control, använder enkel text control "
 "istället. Installera om riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Kan inte starta tråden: Fel vid skrivning av TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Kan inte sätta trådprioritet"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Kan inte skapa tråd"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Kunde inte avsluta tråd"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Kan inte vänta på att tråden avslutas"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Kan inte hålla inne tråd %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Kan inte återuppta tråden %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Kunde inte hämta den aktuella trådpekaren"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6294,7 +6280,7 @@ msgstr ""
 "Trådmodulinitialisering misslyckades: Omöjligt att allokera index i trådens "
 "lokala lagring"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6325,12 +6311,12 @@ msgstr "Kunde ladda resurs \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Kunde inte låsa resursen \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "bygge %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bitarsutgåva"
 
@@ -6342,47 +6328,47 @@ msgstr "Kunde inte skapa ett anonymt rör (pipe)"
 msgid "Failed to redirect the child process IO"
 msgstr "Kunde inte omdirigera barnprocessens IO"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Utförande av kommando \"%s\" misslyckades"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Kunde inte läsa in mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Kan inte läsa typnamn från \"%s\"!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Kan inte läsa in ikon från \"%s\"."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Kan inte sätta trådprioritet"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Kunde inte utföra \"%s\"\n"
@@ -6416,7 +6402,7 @@ msgid "Check to make the font italic."
 msgstr "Kryssa i för att göra typsnittet kursiv."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Understruken"
@@ -6484,17 +6470,32 @@ msgstr "<Någon teletyp>"
 msgid "File type:"
 msgstr "Teletyp"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Fönster"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Hjälp"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "&Minimera"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Zooma in"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6511,486 +6512,486 @@ msgstr "Filen %s finns inte."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Om %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Om..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Inställningar..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Tjänster"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Dölj %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "program"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Dölj övriga"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Visa alla"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Avsluta %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "program"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip stöds inte av den här versionen av zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Kolumnbeskrivning kunde inte initieras."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Punktstorlek"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Typsnittsnamn"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Stil"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Vikt"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Familj"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Ram"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "tunn"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Högerjustera text."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Ram"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Meny"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Fönster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Fönster"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Fönster"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Valfri storlek"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "MacGrekiska"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "Bläddra"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "Gör om"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "förvald"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "i morgon"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Höger"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Punktliststil"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "&Teckenkod:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Punktstorlek"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Högerjustera"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Fråga"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Höger"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Höger"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Skapa en markering:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Egenskap"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Värde"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategoriserat läge"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alfabetiskt läge"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Falskt"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Sant"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Ospecificerad"
 
@@ -7004,50 +7005,50 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Du har angett ett ogiltigt värde. Tryck ESC för att avbryta redigering."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Fel i resurs: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
-"Typoperation \"%s\" misslyckades: Egenskap med etikett \"%s\" är av typ \"%s"
-"\", INTE \"%s\"."
+"Typoperation \"%s\" misslyckades: Egenskap med etikett \"%s\" är av typ "
+"\"%s\", INTE \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Värde måste vara %s eller högre."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Värde måste vara mellan %s och %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Värde måste vara %s eller mindre."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Inte %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Välj en katalog:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Välj en fil"
 
@@ -7526,117 +7527,117 @@ msgstr "Infällning"
 msgid "Outset"
 msgstr "Utfällning"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Ändra stil"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Ändra objektstil"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Ändra egenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Byt liststil"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Omnumrera lista"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Infoga text"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Infoga bild"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Infoga objekt"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Infoga fält"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "För många EndStyle-anrop!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "filer"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standard/cirkel"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standard/cirkelram"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standard/kvadrat"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standard/diamant"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standard/triangel"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Egenskaper för låda"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Egenskaper för flera celler"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Egenskaper för cell"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Ange cellstil"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Ta bort rad"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Ta bort kolumn"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Lägg till rad"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Lägg till kolumn"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Tabellegenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Bildgenskaper"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "bild"
 
@@ -7844,24 +7845,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Dra"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Ta bort text"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Ta bort listpunkttecken"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Texten kunde inte sparas."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Ersätt"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Typsnitt:"
 
@@ -8831,53 +8832,53 @@ msgstr "Liststilar"
 msgid "Box styles"
 msgstr "Lådstilar"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Typsnitt att hämta symbolen från."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Delmängd:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Visar en Unicode-delmängd"
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Teckenkod:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Teckenkoden."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Från:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Räckvidden att visa."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Sätt in"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normal text)"
 
@@ -9062,7 +9063,7 @@ msgstr "Kunde inte hämta händelser från kqueue"
 msgid "Media playback error: %s"
 msgstr "Medieuppspelningsfel: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Misslyckades att förbereda uppspelning \"%s\"."
@@ -9162,78 +9163,78 @@ msgstr "Formatet på ljuddata stöds inte."
 msgid "Couldn't open audio: %s"
 msgstr "Kunde inte öppna ljud: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Kan inte hämta trådschemaläggningsregler."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Kan inte hämta prioritetsräckvidden för schemaläggningsregler %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Trådprioritetsinställningar ignoreras."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 "Kunde inte slå ihop en tråd, möjlig minnesläcka hittad - starta om programmet"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Kunde inte ange trådkonkurrensnivå till %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Kunde inte sätta trådprioritet %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Kunde inte avsluta en tråd."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Trådmodulinitialisering misslyckades: Kunde inte skapa trådnyckel"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Omöjligt att hämta barnprocessindata"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Kan inte skriva till stdin för barnprocess"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Kunde inte utföra \"%s\"\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Gren misslyckades"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Kunde inte ange processprioritet"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Kunde inte omdirigera barnprocess-in/utdata"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Kunde inte ställa in ickeblockerande rör, programet kan hänga sig."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Kan inte hämta värdnamnet"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Kan inte hämta det officiella värdnamnet"
 
@@ -9249,12 +9250,12 @@ msgstr "Misslyckades att växla wake up-rör till ickeblockerande läge"
 msgid "Failed to read from wake-up pipe"
 msgstr "Kunde inte läsa från wake up-rör"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Ogiltig geometrispecifikation \"%s\""
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets kunde inte öppna display. Avslutar."
 
@@ -9268,30 +9269,59 @@ msgstr "Kunde inte stänga display \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "Kunde inte öppna display \"%s\"."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML tolkningsfel: \"%s\" på rad %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kan inte läsa in resurser från \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Kan inte öppna resursfil \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kan inte läsa in resurser från fil \"%s\"."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
+
+#~ msgid "Printing "
+#~ msgstr "Skriver ut "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Kunde inte sätta in text i kontrollen."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Välj ett giltigt typsnitt."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Kunde inte visa HTML-dokument i %s-kodning"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets kunde inte öppna skärm för \"%s\": Avslutar."
+
+#~ msgid "Filter"
+#~ msgstr "Filter"
+
+#~ msgid "Directories"
+#~ msgstr "Kataloger"
+
+#~ msgid "Files"
+#~ msgstr "Filer"
+
+#~ msgid "Selection"
+#~ msgstr "Markering"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "omvandling till 8-bitskodning misslyckades"
@@ -9456,8 +9486,8 @@ msgstr "Uppackning av \"%s\" till \"%s\" misslyckades."
 #~ msgstr "Datumrendrerare kan inte rendrera värde; värdetyp:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/ta.po
+++ b/locale/ta.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-04-14 12:56+0530\n"
 "Last-Translator: DINAKAR T.D. <td.dinkar@gmail.com>\n"
 "Language-Team: DINAKAR T.D. <td.dinkar@gmail.com>\n"
@@ -13,11 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "எல்லாக் கோப்புகளும் (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "எல்லாக் கோப்புகளும் (*)|*"
 
@@ -34,24 +34,21 @@ msgid "Remaining time:"
 msgstr "எஞ்சியுள்ள நேரம்"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "ஆம்"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "இல்லை"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "சரி"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "விலக்குக"
@@ -102,7 +99,7 @@ msgid "Unable to create I/O completion port"
 msgstr "உள்ளீடு/வெளியீடு முழுமையடைதலின் நுழைவாயிலை உருவாக்க இயலவில்லை"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "அச்செடுப்பு"
 
@@ -139,7 +136,7 @@ msgstr "பொருள் பண்புகள்"
 msgid "Printing"
 msgstr "அச்சிடப்படுகிறது"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "குறியெழுத்துகள்"
 
@@ -208,7 +205,7 @@ msgstr "முந்தையது (&P)"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "சாளரம் (&W)"
 
@@ -737,11 +734,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "இவ்வுதவித் தகவலைக் காட்டுக"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "தேவைக்கு மிகுதியானவைகளின் செயற்குறிப்பேட்டுத் தகவல்களை உருவாக்குக"
 
@@ -764,84 +761,84 @@ msgstr "ஆதரவளிக்கப்படாத கருத்தோற�
 msgid "Invalid display mode specification '%s'."
 msgstr "ஏற்கமுடியாத காட்சியமைவு நிலை அளவுக் குறியீடு '%s'."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' விருப்பத் தேர்வினை இல்லாதாக்க முடியாது"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "அறியப்படாத நீள்விருப்பத்தேர்வு '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "அறியப்படாத விருப்பத்தேர்வு '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "'%s' விருப்பத் தேர்வுற்கு பின் எதிர்பாராத வரியுருக்கள்."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "'%s' விருப்பத் தேர்விற்கு ஒரு மதிப்பு தேவைப்படுகிறது."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "'%s' விருப்பத் தேர்விற்குப் பிறகு பிரிப்பான் எதிர்பார்க்கப்படுகிறது"
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' எண் மதிப்பு, '%s' விருப்பத் தேர்விற்கு சரியானது அல்ல."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "'%s' விருப்பத் தேர்வு: '%s'-யினை ஒரு தேதியாக மாற்ற இயலாது."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "எதிர்பாராத அளவுக் குறியீடு '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (அல்லது %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' விருப்பத் தேர்விற்கான மதிப்பைக் குறிப்பிட வேண்டும்."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "தேவைப்படும் '%s' அளவுக் குறியீடு குறிப்பிடப்படவில்லை."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "பயன்பாடு: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "எண்"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "இரட்டை"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "தேதி"
 
@@ -859,7 +856,7 @@ msgid "Can't &Undo "
 msgstr "செயலைநீக்க இயலவில்லை (&U)"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "செயல் நீக்கம் (&U)"
@@ -869,7 +866,7 @@ msgid "&Redo "
 msgstr "மீள்செயல் (&R)"
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "மீள்செயல் (&R)"
@@ -897,12 +894,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' மிகையாகவுள்ளது '..', புறந்தள்ளப்பட்டது."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "தேர்வானது"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "தேர்வாகாதது"
 
@@ -911,103 +908,103 @@ msgstr "தேர்வாகாதது"
 msgid "undetermined"
 msgstr "தீர்மானிக்கப்படாதது"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "இன்று"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "நேற்று"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "நாளை"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "முதல்"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "இரண்டாம்"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "மூன்றாம்"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "நான்காம்"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "ஐந்தாம்"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "ஆறாம்"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "ஏழாம்"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "எட்டாம்"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "ஒன்பதாம்"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "பத்தாம்"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "பதினொன்றாம்"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "பன்னிரண்டாம்"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "பதிமூன்றாம்"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "பதினான்காம்"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "பதினைந்தாம்"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "பதினாறாம்"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "பதினேழாம்"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "பதினெட்டாம்"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "பத்தொன்பதாம்"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "இருபதாம்"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "நண்பகல்"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "நள்ளிரவு"
 
@@ -1074,45 +1071,82 @@ msgstr "curl-இனை செயலாக்குவதில் தோல்�
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "வழுநீக்க அறிக்கையை தரவேற்றுவதில் தோல்வி (பிழைக் குறி: %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "இவ்வாறு சேமித்திடுக"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 "மாற்றங்களை நிராகரித்துவிட்டு இறுதியாக சேமிக்கப்பட்டுள்ள பதிப்பை மறுஏற்றம் செய்ய வேண்டுமா?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "பெயரிடப்படாதது"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "%s-இல் ஏற்பட்டுள்ள மாற்றங்களை தாங்கள் சேமிக்க வேண்டுமா?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "சேமித்திடுக (&S)"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "சேமிக்க வேண்டாம்"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "%s-இல் ஏற்பட்டுள்ள மாற்றங்களை தாங்கள் சேமிக்க வேண்டுமா?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "உரையை சேமிக்க இயலவில்லை."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "\"%s\" கோப்பினை எழுதுவதற்கு திறக்க இயலவில்லை."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "ஆவணத்தை \"%s\" கோப்பில் சேமிப்பதில் தோல்வி."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "\"%s\" கோப்பினை படிப்பதற்கு திறக்க இயலவில்லை."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "\"%s\" கோப்பிலிருந்து ஆவணத்தைப் படிப்பதில் தோல்வி."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1121,57 +1155,57 @@ msgstr ""
 "கோப்பு '%s' கிடைப்பிலில்லையென்பதால், அதைத் திறக்க இயலாது.\n"
 "மிக அண்மையில் பயன்படுத்தப்பட்ட கோப்புகளின் பட்டியலிலிருந்து அது நீக்கப்பட்டுள்ளது."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "அச்சு முன்தோற்ற உருவாக்கம் தோல்வியடைந்தது."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "அச்சு முன்தோற்றம்"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "'%s' கோப்பின் வடிவூட்டத்தை வரையறுக்க இயலவில்லை."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "பெயரிடப்படாதது %d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "கோப்பினைத் திறவுக"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "கோப்புப் பிழை"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "பொறுத்தருள்க, இந்தக் கோப்பினைத் திறக்க இயலவில்லை."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "பொறுத்தருள்க, இந்தக் கோப்பிற்கான வடிவூட்டம் அறியப்படாததாக உள்ளது."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "ஒரு ஆவண வார்ப்புருவைத் தேர்ந்தெடுத்திடுக"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "வார்ப்புருக்கள்"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "ஒரு ஆவணத் தோற்றத்தை தெரிவுச் செய்க"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "தோற்றங்கள்"
 
@@ -1205,41 +1239,41 @@ msgstr "'%s' கோப்பிலுள்ள பிழையைப் பட�
 msgid "Write error on file '%s'"
 msgstr "'%s' கோப்பில் பிழையை எழுதிடுக"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "'%s' கோப்பினை வெளித்தள்ளுவதில் தோல்வி"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "'%s' கோப்பில் பிழையை நாடுக (பெரிய கோப்புகளுக்கு ஆதரவு இல்லை)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' கோப்பிலிருக்கும் பிழையை நாடுக"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "'%s' கோப்பில் தற்போதைய நிலையைக் காண இயலவில்லை"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "தற்காலிக கோப்பு அனுமதிகளை அமைப்பதில் தோல்வி"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "'%s' கோப்பினை நீக்க இயலாது"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "'%s' கோப்புக்கு மாற்றங்களை ஒப்படைக்க இயலாது"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "'%s' தற்காலிக கோப்பினை நீக்க இயலாது"
@@ -1264,27 +1298,27 @@ msgstr "%d கோப்பு விளக்கியிலிருந்த�
 msgid "can't write to file descriptor %d"
 msgstr "%d கோப்பு விளக்கியில் எழுத இயலாது"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "%d கோப்பு விளக்கியை வெளித்தள்ள இயலாது"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "%d கோப்பு விளக்கியில் நாட இயலாது"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "%d கோப்பு விளக்கியில் நாடு நிலையை கண்டுபிடிக்க இயலாது"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "%d கோப்பு விளக்கியில் கோப்பின் நீளத்தை கண்டறிய இயலாது."
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "%d விளக்கியில் கோப்பின் இறுதியை அடைந்துவிட்டதா என்று தீர்மானிக்க இயலாது"
@@ -1308,108 +1342,108 @@ msgstr "\"%s\" கோப்பினை அழித்தெழுதாமல�
 msgid "Error reading config options."
 msgstr "அமைவடிவ விருப்பத் தேர்வுகளைப் படிப்பதில் பிழை."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "அமைவடிவ விருப்பத் தேர்வுகளைப் படிப்பதில் தோல்வி."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "கோப்பு '%s': %zu வரியில் எதிர்பாராத வரியுரு %c."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "கோப்பு '%s', வரி %zu: குழுத் தலைப்புரைக்குப் பிறகான '%s' புறந்தள்ளப்பட்டது."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "கோப்பு '%s', வரி %zu: '=' எதிர்பார்க்கப்படுகிறது."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 "கோப்பு '%s', வரி %zu: '%s' மாறுமியல்பிலா விசையின் மதிப்பு புறந்தள்ளப்படுகிறது."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "கோப்பு '%s', வரி %zu: '%s' விசை, %d வரியில் முதலாவதாக கண்டறியப்பட்டது."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "அமைவடிவ உள்ளிடின் பெயர் '%c' என்று துவங்க இயலாது."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "பயனர் அமைவடிவக் கோப்பினை திறக்க இயலாது"
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "பயனர் அமைவடிவக் கோப்பில் எழுத இயலாது."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "பயனர் அமைவடிவக் கோப்பினை இற்றைப்படுத்துவதில் தோல்வி."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "பயனர் அமைவடிவத் தரவினை சேமிப்பதில் பிழை."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "'%s' பயனர் அமைவடிவ கோப்பினை அழிக்க இயலாது"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "'%s' உள்ளிடு '%s' குழுவில் ஒரு முறைக்கும் மேல் தோன்றுகிறது"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "மாறுமியல்பிலா '%s' விசையை மாற்ற மேற்கொள்ளப்பட்ட முயற்சி புறந்தள்ளப்பட்டது."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s'-ல் பின்சாய்வுச் சுவடு புறந்தள்ளப்படுகிறது"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, fuzzy, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "'%s'ல் எதிர்பாராத \" நிலை %d."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "'%s' கோப்பினை '%s'-க்கு படியெடுப்பதில் தோல்வி."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "'%s' கோப்பிற்கு அனுமதிகளைப் பெற இயலவில்லை."
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "'%s' கோப்பினை அழித்தெழுத இயலவில்லை."
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "'%s' கோப்பினை '%s'-க்கு படியெடுப்பதில் தோல்வி."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "'%s' கோப்பிற்கு அனுமதிகளை அமைக்க இயலவில்லை."
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1417,40 +1451,40 @@ msgid ""
 msgstr ""
 "இலக்கில் கோப்பு ஏற்கனவே இருப்பதால், '%s' கோப்பினை '%s' என்றுப் பெயர் மாற்றுவதில் தோல்வி."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' கோப்பு '%s' என்று மறுபெயரிடப்பட இயலவில்லை"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' கோப்பு நீக்கப்பட இயலவில்லை"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' அடைவினை உருவாக்க இயலவில்லை"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' அடைவினை அழிக்க இயலவில்லை"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "'%s' கோப்புகளை கணக்கிட இயலாது"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "செயலிலிருக்கும் அடைவினைப் பெறுவதில் தோல்வி"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "தற்போதைய செயல் அடைவினை அமைக்க இயலவில்லை."
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "கோப்புகள் (%s)"
@@ -1477,17 +1511,17 @@ msgstr "தற்காலிக கோப்புப் பெயரை உர
 msgid "Failed to open temporary file."
 msgstr "தற்காலிக கோப்பினைத் திறப்பதில் தோல்வி."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "'%s'-ற்கான கோப்பு டைம்ஸை மாற்றுவதில் தோல்வி"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "'%s' கோப்பினைத் தொடுவதில் தோல்வி"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s'-ற்கான கோப்பு டைம்ஸை மீட்டெடுப்பதில் தோல்வி"
@@ -1496,22 +1530,22 @@ msgstr "'%s'-ற்கான கோப்பு டைம்ஸை மீட்�
 msgid "Browse"
 msgstr "உலாவுக"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "எல்லாக் கோப்புகளும் (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s கோப்புகள் (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "%s கோப்பினை ஏற்றிடுக"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "%s கோப்பினை சேமித்திடுக"
@@ -1874,99 +1908,99 @@ msgstr "இயல்பிருப்பு"
 msgid "unknown-%d"
 msgstr "அறியப்படாத %d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "அடிக்கோடிடப்பட்டது"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " ஊடாகக் கோடிடப்பட்டது"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr "சன்னமானது"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr "கூடுதல் இலகு"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr "இலகு"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr "ஊடகம்"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr "பாதி அடர்த்தி"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr "அடர்த்தி"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr "கூடுதல் அடர்த்தி"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr "கனமானது"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr "கூடுதல் கனமானது"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr "வலப்பக்க சாய்வு"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "ஊடாகக் கோடிடப்பட்டது"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "சன்னமானது"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "கூடுதல் இலகு"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "இலகுவானது"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "இயல்பான"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "ஊடகம்"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "பாதி அடர்த்தி"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "அடர்த்தி"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "கூடுதல் அடர்த்தி"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "கனமானது"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "கூடுதல் கனமானது"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "வலப்பக்க சாய்வு"
 
@@ -2050,7 +2084,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP மாற்று நிலையை %s என்று அமைப்பதில் தோல்வி."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2071,7 +2105,7 @@ msgstr "FTP வழங்கி முடக்க நிலையை ஆதர�
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "தவறான GIF சட்டக அளவு (%u, %d) - #%u சட்டகத்திற்கானது"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL-க்கு நிறத்தை ஒதுக்குவதில் தோல்வி. "
 
@@ -2087,7 +2121,7 @@ msgstr "நெடுவரிசைகளை தனிப் பயனாக்�
 msgid "&Customize..."
 msgstr "தனிப் பயனாக்குக... (&C)"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "\"%s\" இணைய முகவரியை இயல்புலாவியில் திறப்பதில் தோல்வி."
@@ -2107,155 +2141,154 @@ msgstr "ஓடையிலிருந்து %d படிமத்தை ஏ�
 msgid "Failed to load icons from resource '%s'."
 msgstr "படவுருக்களை '%s' வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: ஏற்கமுடியாத படிமத்தை சேமிக்க இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage சொந்த wxPalette-ஐ கொண்டிருக்கவில்லை."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: நுண்படத் தலைப்பினை எழுத இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: நுண்படத் தகவல் தலைப்பினை எழுத இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB நிற வரைபடத்தை எழுத இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: தரவினை எழுத இயலவில்லை."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: நினைவகத்தை ஒதுக்க இயலவில்லை."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB மேலுரை: கோப்பிற்கான பட உயரம் > 32767 படவணுக்கள்."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB மேலுரை: கோப்பிற்கான பட உயரம் > 32767 படவணுக்கள். "
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB மேலுரை: கோப்பில் அறியப்படாத bitdepth."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB மேலுரை: கோப்பில் அறியப்படாத குறியாக்கம்."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB மேலுரை: குறியாக்கம் bitdepth-உடன் பொருந்தவில்லை."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: நினைவகத்தை ஒதுக்க இயலவில்லை."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB மேலுரை: கோப்பிற்கான பட உயரம் > 32767 படவணுக்கள்."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB மேலுரை: கோப்பிற்கான பட உயரம் > 32767 படவணுக்கள். "
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB மேலுரை: கோப்பில் அறியப்படாத bitdepth."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB மேலுரை: கோப்பில் அறியப்படாத குறியாக்கம்."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB மேலுரை: குறியாக்கம் bitdepth-உடன் பொருந்தவில்லை."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "DIB படிமத்தை படிப்பதில் பிழை"
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: மறைப்பு DIB படிப்பதில் பிழை."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: படவுருவிற்கு இது மிக உயரமானப் படிமம்."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: படவுருவிற்கு இது மிக அகலமான படிமம்."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: படிமக் கோப்பினை எழுதுவதில் பிழை!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: ஏற்கமுடியாத படவுரு சுட்டெண்."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "படிமமும் மறைப்பும் வெவ்வேறு அளவுகளைக் கொண்டிருக்கின்றன."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "படிமத்தில் பயன்படுத்தப்படாத நிறம் ஏதும் மறைக்கப்படவில்லை."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "\"%s\" நுண்படத்தினை வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "\"%s\" படவுருவை வளத்திலிருந்து ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "\"%s\" கோப்பிலிருந்து படிமத்தை ஏற்றுவதில் தோல்வி."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "படிமத்தை '%s'- கோப்பில் சேமிக்க இயலாது: அறியப்படாத நீட்சி."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "படிம வகைக்கான கையாளு நிரல் காணப்படவில்லை."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d வகைக்கான படிம கையாளு நிரல் வரையறுக்கப்படவில்லை."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "படிமக் கோப்பின் வகை %d-ஆக இல்லை."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "நாடிச் செல்ல இயலாத உள்ளீட்டிற்கு படிம வடிவூட்டத்தைத் தானாக வரையறுக்க இயலாது."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "அறியப்படாத படிமத் தரவு வடிவூட்டம்"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "இது %s அல்ல."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s வகைக்கான படிம கையாளு நிரல் வரையறுக்கப்படவில்லை."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "படிமத்தின் வகை %s-ஆக இல்லை."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "\"%s\" படிமக் கோப்பின் வடிவூட்டத்தை சரிபார்ப்பதில் தோல்வி."
@@ -2358,52 +2391,52 @@ msgstr "PNM: கோப்பு அறுபட்டிருப்பதாக
 msgid " (in module \"%s\")"
 msgstr " (\"%s\" நிரற்கூறில் உள்ளது)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIF: படிமத்தை ஏற்றுவதில் பிழை."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "ஏற்கமுடியாத TIFF படிம சுட்டெண்."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIF: படிமம் இயல்பிற்கு புறம்பாக பெரிய அளவில் உள்ளது."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIF: நினைவகத்தை ஒதுக்கீடு செய்ய இயலவில்லை."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIF: படிமத்தை படிப்பதில் பிழை."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "அறியப்படாத TIF பிரிதிறன் தொகுதி %d தவிர்க்கப்பட்டது"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIF: படிமத்தை சேமிப்பதில் பிழை."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIF: படிமத்தை எழுதுவதில் பிழை."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "%d கட்டளை வரி தர்க்கத்தை ஒருங்குறியாக மாற்ற இயலாததால், அது தவிர்க்கப்படும்."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Post init-ல் துவக்க நிலையாக்கம் தோல்வி, செயல் இடைமறிக்கப்படுகிறது."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "\"%s\" மொழிக்கு வட்டார மொழியை அமைக்க இயலவில்லை"
@@ -2497,7 +2530,7 @@ msgstr "LZMA குறுக்கல் பிழை: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "வெளியீட்டினை வெளித்தள்ளும்பொழுது LZMA விரிவாக்கப் பிழை: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "%s மைம் வகைக்கான உள்ளீட்டில் பொருந்தாத '{' "
@@ -2517,7 +2550,7 @@ msgstr "\"%s\" சார்பு இல்லை. (\"%s\" நிரற்கூ
 msgid "Module \"%s\" initialization failed"
 msgstr "\"%s\" நிரற்கூறை துவக்க நிலையாக்குவதில் தோல்வி"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "தகவல்"
 
@@ -3019,7 +3052,7 @@ msgstr "அச்சீட்டில் பிழை"
 msgid "Print"
 msgstr "அச்சிடு"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "பக்க அமைவு"
 
@@ -3054,19 +3087,15 @@ msgstr "%d பக்கம் அச்சிடப்படுகிறது; 
 msgid " (copy %d of %d)"
 msgstr "%d-யின் படி; மொத்தம் %d"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "அச்சிடப்படுகிறது"
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "முதல் பக்கம்"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "முந்தைய பக்கம்"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "அடுத்தப் பக்கம்"
 
@@ -3110,16 +3139,16 @@ msgstr "பக்கம் %d, மொத்தம் %d"
 msgid "Page %d"
 msgstr "பக்கம் %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "தெரியாதப் பிழை"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "ஏற்கமுடியாத வழக்கமான வெளிப்பாடு '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "வழக்கமான வெளிப்பாட்டிற்கு பொருத்தத்தை காண்பதில் தோல்வி: %s "
@@ -3129,21 +3158,21 @@ msgstr "வழக்கமான வெளிப்பாட்டிற்க�
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "\"%s\" வழங்கி ஒவ்வாத %d.%d பதிப்பைக் கொண்டுள்ளது, அதை ஏற்ற இயலவில்லை."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "இந்த இயங்குதளத்திற்கு கிடைப்பிலில்லை"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "\"%s\"க்கு கடவுச்சொல்லினைச் சேமிப்பதில் தோல்வி: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "\"%s\"க்கு கடவுச்சொல்லினைப் படிப்பதில் தோல்வி: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "\"%s\"க்கான கடவுச்சொல்லினை அழிப்பதில் தோல்வி: %s."
@@ -3152,11 +3181,11 @@ msgstr "\"%s\"க்கான கடவுச்சொல்லினை அழ�
 msgid "Failed to monitor I/O channels"
 msgstr "உள்ளிடு/வெளியிடு அலைத்தடத்தை கவனிப்பதில் தோல்வி"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "சேமித்திடுக"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "சேமிக்க வேண்டாம்"
 
@@ -3237,10 +3266,10 @@ msgid "Clear"
 msgstr "துடை"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "மூடுக"
 
@@ -3252,7 +3281,7 @@ msgstr "மாற்றுக (&C)"
 msgid "Convert"
 msgstr "மாற்று"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "படியெடுத்திடுக (&C)"
@@ -3261,7 +3290,7 @@ msgstr "படியெடுத்திடுக (&C)"
 msgid "Copy"
 msgstr "படி"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "வெட்டுக (&T)"
@@ -3270,13 +3299,13 @@ msgstr "வெட்டுக (&T)"
 msgid "Cut"
 msgstr "வெட்டுக"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "அழி (&D)"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "அழி"
@@ -3363,7 +3392,7 @@ msgstr "வன்தட்டு"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "உதவி (&H)"
 
@@ -3383,7 +3412,7 @@ msgstr "வரித் துவக்க ஒழுங்கு"
 msgid "&Index"
 msgstr "சுட்டெண் (&I)"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "சுட்டெண்"
 
@@ -3452,7 +3481,7 @@ msgstr "புதிது (&N)"
 msgid "New"
 msgstr "புதிது"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "இல்லை (&N)"
 
@@ -3469,12 +3498,12 @@ msgstr "திறவுக... (&O)"
 msgid "Open..."
 msgstr "திறவுக..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "ஒட்டுக (&P)"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "ஒட்டுக"
@@ -3504,7 +3533,7 @@ msgid "Print..."
 msgstr "அச்சிடுக..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "பண்புகள் (&P)"
 
@@ -3536,10 +3565,6 @@ msgstr "மாற்றமர்வு..."
 msgid "Revert to Saved"
 msgstr "சேமிக்கப்பட்டதற்கு திரும்பிச் செல்"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "சேமித்திடுக (&S)"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "இவ்வாறு சேமித்திடுக... (&A)"
@@ -3548,7 +3573,7 @@ msgstr "இவ்வாறு சேமித்திடுக... (&A)"
 msgid "Save As..."
 msgstr "இவ்வாறு சேமித்திடுக..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "அனைத்தையும் தெரிவுச் செய்க (&A)"
@@ -3655,7 +3680,7 @@ msgstr "மேல் (&U)"
 msgid "Up"
 msgstr "மேல்"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "ஆம் (&Y)"
 
@@ -3743,43 +3768,43 @@ msgstr "தற்போதைய ஆவணத்தை சேமித்தி�
 msgid "Save current document with a different filename"
 msgstr "தற்போதைய ஆவணத்தை மாற்றுப் பெயர் கொண்டு சேமித்திடுக"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Charset '%s'-க்கான மாற்றம் செயல்படுவதில்லை."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "தெரியாதது"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "tar-ல் முழுமையடையாத மேலுரைத் தொகுதி"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "tar மேலுரை தொகுதியை படிப்பதில் checksum தோல்வி"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "நீட்டிக்கப்பட்ட tar மேலுரையில் ஏற்கமுடியாத தரவு"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar உள்ளிடு திறந்த நிலையில் இல்லை"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "எதிர்பாராத கோப்பு முடிவு"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s, '%s' உள்ளீட்டின் tar மேலுரைக்குள் பொருந்தவில்லை"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tar உள்ளீட்டிற்கு தவறான அளவு கொடுக்கப்பட்டுள்ளது"
 
@@ -3788,7 +3813,7 @@ msgstr "tar உள்ளீட்டிற்கு தவறான அளவு
 msgid "'%s' is probably a binary buffer."
 msgstr "%s ஒரு இருமக்கூறு இடையகமாக இருக்கலாம்."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "கோப்பு ஏற்றப்பட இயலவில்லை."
 
@@ -3802,47 +3827,47 @@ msgstr "\"%s\" உரைக் கோப்பினைப் படிப்ப
 msgid "can't write buffer '%s' to disk."
 msgstr "வட்டில் '%s' இடையகத்தை எழுத இயலாது."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "கணினி நேரத்தைப் பெறுவதில் தோல்வி"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay தோல்வியடைந்தது."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ஏற்க முடியாத தகவல் பட்டியலாகும்"
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "ஏற்கமுடியாத தகவல் பட்டியல்."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "பன்மை வடிவங்களை parse செய்வதில் தோல்வி: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' பட்டியல், '%s'-இடமிருந்துப் பயன்படுத்தப்படுகிறது."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' வளம் ஏற்கக்கூடிய தகவல் பட்டியல் அல்ல."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "மொழிபெயர்ப்புகளை கணக்கிட இயலவில்லை"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "HTML கோப்புகளுக்கு இயல்பான பயன்பாடு அமைவடிவமாக்கப்படவில்லை."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "\"%s\" இணைய முகவரியை இயல்புலாவியில் திறப்பதில் தோல்வி."
@@ -3875,7 +3900,7 @@ msgstr "'%s' ஏற்க முடியாதவரியுருக்கள
 msgid "Error: %s (%d)"
 msgstr "பிழை: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "தரவிறக்குவதற்கு வட்டில் போதிய இடமில்லை."
 
@@ -3883,20 +3908,20 @@ msgstr "தரவிறக்குவதற்கு வட்டில் ப�
 msgid "libcurl could not be initialized"
 msgstr "Libcurl-ஐ துவக்கநிலையாக்க இயலவில்லை"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "ஜாவா குறுநிரலை இயக்குவதில் பிழை: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "இத்தளம் பின்புலத் தெளிவினை ஆதரிப்பதில்லை."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "சாளரத்திற்கு தரவினை மாற்ற இயலவில்லை."
 
@@ -3949,8 +3974,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "சட்டப்புரம்பான பொருள் உட்பிரிவு நிலை (Non-wxEvtHandler) நிகழ்வு மூலமாக உள்ளது"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "வகை enm - நீள மாற்றியைக் கொண்டிருக்க வேண்டும். "
 
@@ -4001,81 +4026,81 @@ msgstr "பொருட்கள், அடையாள பண்புகளை
 msgid "Doubly used id : %d"
 msgstr "இருமுறை பயன்படுத்தப்பட்டுள்ள அடையாளம்: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "அறியப்படாத பண்பு %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "ஒரு வெறுமையான திரட்டு, அங்கங்களின் கணுக்களைக் கொண்டிருக்க வேண்டும்"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "தவறான நிகழ்வுக் கையாளுச் சரம், தவறவிடப்பட்டுள்ள புள்ளி"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib அமிழோடையை மறுதுவக்க நிலையாக்க இயலாது"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib விரியோடையை மறுதுவக்க நிலையாக்க இயலாது"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "தோற்றக்குறைகொண்ட கூடுதல் தரவுத் திரட்டினை புறந்தள்ளுகிறது. ZIP கோப்பு "
 "பழுதடைந்திருக்கலாம்."
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "இது பல பகுதிகள் ஒன்றிணைக்கப்பட்ட ஜிப் என்று அனுமானிக்கப்படுகிறது "
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "ஏற்கமுடியாத ஜிப் கோப்பு"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "zip-ல் நடுவன் அடைவினை காண இயலாது"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "ஜிப் நடுவன் அடைவினைப் படிப்பதில் பிழை"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "ஜிப் உள்ளக மேலுரையைப் படிப்பதில் பிழை"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "உள்ளீட்டில் பழுதடைந்த ஜிப் கோப்பு எதிரிடை"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "சேமிக்கப்பட்ட கோப்பின் நீளம் ஜிப் மேலுரையில் இல்லை"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "ஆதரவளிக்கப்படாத ஜிப் நெறுக்கு வழிமுறை"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "ஜிப் ஓடை படிக்கப்படுகிறது (உள்ளிடு %s): பழுதடைந்த நீளம்"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "ஜிப் ஓடை படிக்கப்படுகிறது (உள்ளிடு %s): பழுதடைந்த crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "'%s' ஜிப் உள்ளீட்டை எழுதுவதில் பிழை: ZIP64 இல்லாத மிகப் பெரிய கோப்பு."
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "'%s' ஜிப் உள்ளீட்டை எழுதுவதில் பிழை: பழுதான crc அல்லது நீளம்"
@@ -4160,32 +4185,32 @@ msgstr "வரைகலை ஓவியம்:"
 msgid "Translations by "
 msgstr "மொழிபெயர்ப்பாளர்"
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "பதிப்பு"
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "%s குறித்து"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "உரிமம்"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "மேம்படுத்துநர்கள்"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "ஆவணத்தை எழுதியோர்"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "கலைஞர்கள்"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "மொழிபெயர்ப்பாளர்கள்"
 
@@ -4236,43 +4261,42 @@ msgid "Password:"
 msgstr "கடவுச்சொல்:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "மெய்யானது"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "பொய்யான மதிப்பு"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "கிடைவரிசை %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "குறுக்குக"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "விரிவாக்குக"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d உருப்படிகள்)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "நெடுவரிசை %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4283,8 +4307,7 @@ msgid "Left"
 msgstr "இடது"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4381,7 +4404,7 @@ msgid "Home directory"
 msgstr "முகப்பு அடைவு"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "மேசைத்தளம்"
 
@@ -4394,8 +4417,7 @@ msgstr "சட்டப்புரம்பான அடைவுப் பெ�
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "பிழை"
 
@@ -4579,16 +4601,16 @@ msgstr "கோப்புகளை விளக்கங்களுடனா�
 msgid "Go to parent directory"
 msgstr "தாய் அடைவிற்குச் செல்க"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' கோப்பு ஏற்கனவே உள்ளது, அதை கட்டாயம் அழித்தெழுத வேண்டுமா?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "உறுதிச் செய்க"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "இருக்கும் கோப்பு ஒன்றினைத் தேர்ந்தெடுத்திடுக."
 
@@ -4682,7 +4704,7 @@ msgstr "எழுத்துரு அளவு."
 msgid "Whether the font is underlined."
 msgstr "எழுத்துரு அடிக்கோடிடப்பட்டதா? "
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "முன்தோற்றம்:"
@@ -4700,48 +4722,47 @@ msgstr "எழுத்துரு தெரிவினை விலக்க�
 msgid "Click to confirm the font selection."
 msgstr "எழுத்துரு தெரிவினை உறுதி செய்ய சொடுக்கிடுக."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "எழுத்துருவைத் தேர்ந்தெடுத்திடுக"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "ஒன்றுக்கும் மேற்பட்ட தெரிவான தொகுதியை பிடிப்புப்பலகைக்கு படியெடுக்க ஆதரவில்லை."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "\"%s\" உதவி அடைவு காணப்படவில்லை."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "\"%s\" உதவிக் கோப்பு காணப்படவில்லை."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "%lu வரியில் (\"%s\" வரைவுக் கோப்பு) ஏற்கமுடியாத நிரல்தொடர், தவிர்க்கப்படுகிறது."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "\"%s\" கோப்பில் ஏற்கக் கூடிய வரைப்படங்கள் காணப்படவில்லை."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "உள்ளீடுகள் காணப்படவில்லை."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "உதவிச் சுட்டெண்"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "பொருத்தமான உள்ளீடுகள்:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "உள்ளீடுகள் காணப்படுகின்றன"
 
@@ -4847,59 +4868,59 @@ msgstr "அச்சிடுதலை துவக்க இயலவில்�
 msgid "Printing page %d..."
 msgstr "%d பக்கம் அச்சிடப்படுகிறது..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "அச்சுப் பொறி விருப்பத் தேர்வுகள்"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "கோப்பிற்கு அச்சிடவும்"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "அமைவு..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "அச்சுப் பொறி:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "நிலைமை:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "அனைத்தும்"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "பக்கங்கள்"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "அச்சு வீச்சு"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "அனுப்புநர்:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "பெறுநர்:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "படிகள்:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript கோப்பு"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "அச்சு அமைவு"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "அச்சுப் பொறி"
 
@@ -4907,25 +4928,25 @@ msgstr "அச்சுப் பொறி"
 msgid "Default printer"
 msgstr "இயல்பு அச்சுப் பொறி"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "பக்க அளவு"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "நெடு தோற்றம்"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "கிடநீளம்"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "திசையமைவு"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "விருப்பத் தேர்வுகள்"
 
@@ -4937,52 +4958,52 @@ msgstr "நிறங்களைக் கொண்டு அச்சிடு"
 msgid "Print spooling"
 msgstr "அச்சு சுழலி"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "அச்சுக் கட்டளை:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "அச்சுப் பொறி விருப்பத் தேர்வுகள்"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "இடதுக் கரை (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "மேற்கரை (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "வலக் கரை  (mm): "
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "அடித்தளக் கரை (MM)"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "அச்சுப் பொறி..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "தவிர்த்திடுக (&S)"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "தெரியாதது"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "முடிவுற்றது"
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "தேடுக"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "அடையாளத்திற்கான தத்தலை காண இயலவில்லை"
 
@@ -5018,11 +5039,11 @@ msgstr "நிறைவுச் செய்க (&F)"
 msgid "< &Back"
 msgstr "< பின் (&B)"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "மொழிபெயர்ப்பாளர் அங்கீகாரம்"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5031,11 +5052,11 @@ msgstr ""
 "எச்சரிக்கை: XIM உள்ளீட்டு முறை ஆதரிக்கப்படுவதில்லை. ஆகவே, உள்ளீட்டைக் கையாள்வதில் சிக்கலும், "
 "ஊசலாட்டமும் ஏற்படும். GTK_IM நிரற்கூறின் அமைப்பை நீக்கவும், அல்லது \"ibus\"க்கு அமைக்கவும்."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+ துவக்க நிலையாக்க இயலவில்லை, காட்சியமைவு சரியாக அமைந்துள்ளதா?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "\"%s\"க்கு அடைவினை மாற்றுவதில் தோல்வி."
@@ -5061,11 +5082,11 @@ msgstr "\"%s\" தனிப்பயனாக்கப்பட்ட எழு�
 msgid "Failed to register font configuration using private fonts."
 msgstr "தனிப்பட்ட எழுத்துருக்களைப் பயன்படுத்தி எழுத்துரு அமைவடிவத்தைப் பதிவதில் தோல்வி."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "முறிவுப் பிழை"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5076,7 +5097,7 @@ msgstr ""
 " EGL நூலகங்களை நிறுவி மீண்டும் கட்டமைக்கவும், அல்லது நிரலைத் துவக்குவதற்கு முன்,\n"
 " GDK_BACKEND=x11 சூழல் மாற்றியை அமைத்து, X11 பின்னிலையில் இயக்கவும். "
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5087,7 +5108,7 @@ msgstr ""
 " தீர்வில்லாத இக்குறைபாட்டினைத் தவிர்க்க, தங்களின் நிரலைத் துவக்குவதற்கு முன்,\n"
 " GDK_BACKEND=x11 சூழல் மாற்றியை அமைக்கவும்."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI சேய்"
 
@@ -5103,15 +5124,11 @@ msgstr "அச்சிடுகையில் பிழை:"
 msgid "Page Setup"
 msgstr "பக்க அமைவு"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "கட்டுப்பாட்டில் உரையை செருகுவதில் தோல்வி."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "JavaScript குறுநிரல் வெளியீட்டின் மீட்டமைவை WebKit v1 ஆதரிப்பதில்லை"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5119,7 +5136,7 @@ msgstr ""
 "இந்த கணினியில் நிறுவப்பட்டிருக்கும் GTK+, திரைக் கலவையை ஆதரிக்க இயலாத அளவிற்கு "
 "பழமையாய் உள்ளது. GTK+ 2.12 அல்லது அதற்கும் பின்னரான பதிப்பினை அருள்கூர்ந்து நிறுவவும்."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5127,17 +5144,13 @@ msgstr ""
 "தங்கள் கணினி கலக்குதலை ஆதரிப்பதில்லை. அருள்கூர்ந்து தங்களின் சாளர மேலாளரில் இதை "
 "முடுக்கவும்."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "இந்த நிரல், மிகப் பழைய GTK+ பதிப்பைக் கொண்டு உருவாக்கப்பட்டது. GTK+ 2.12 அல்லது அதைவிட "
 "புதிய பதிப்பைக் கொண்டு மறுகட்டமைப்புச் செய்யவும்."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "ஏற்கக்கூடிய எழுத்துருவைத் தேர்ந்தெடுக்கவும்."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5236,45 +5249,45 @@ msgstr "உள்ளடக்கக் கோப்பினை திறக்�
 msgid "Cannot open index file: %s"
 msgstr "சுட்டெண் கோப்பினை திறக்க இயலாது: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "பெயரில்லை"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "HTML உதவி ஏட்டினை திறக்க இயலாது: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "இடப்பக்கமாக உலாவி, ஏடுகளைத் தேடுகின்றபொழுது, உதவியைக் காட்டும்."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(ஏட்டுக் குறிகள்)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "தற்போதைய பக்கத்தை ஏட்டுக்குறிகளில் ஏற்றிடுக"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "ஏட்டுக் குறிகளிலிருந்து தற்போதைய பக்கத்தை நீக்குக"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "உள்ளடக்கங்கள்"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "கண்டுபிடி"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "எல்லாம் காட்டுக"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5282,166 +5295,166 @@ msgstr ""
 "கொடுக்கப்பட்ட உட்சரத்தை கொண்டுள்ள சுட்டெண் உருப்படிகளை காட்டுக. ஒரு எழுத்து முகப்பெழுத்தா "
 "இல்லையா என்றுக் தேடல் கண்டுணராது."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "சுட்டெண்ணில் உள்ள எல்லா உருப்படிகளையும் காட்டுக"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "எழுத்து வகை உணரி"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "முழுச் சொற்கள் மட்டும்"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 "தாங்கள் மேலே தட்டச்சிய உரையின் எல்லா தோன்றுதல்களையும் உதவி ஏட்டின் உள்ளடக்கங்களில் தேடவும்"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "வழிநடத்து பொருத்துப் பலகையை காட்டுக/மறை"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "பின் செல்"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "முன் செல்"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "ஆவண அடுக்கில் ஒரு மேல் நிலைக்குச் செல்"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "HTML ஆவணத்தைத் திறவுக"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "இப்பக்கத்தை அச்சிடவும்"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "காட்சியமைவு விருப்பத் தேர்வுகள் உரையாடல்"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "காட்டப்பட வேண்டிய பக்கத்தை தேர்ந்தெடுக்கவும்."
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "உதவித் தலைப்புகள்"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "தேடப்படுகிறது..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "பொருத்தமான பக்கம் இதுவரைக் காணப்படவில்லை"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i பொருத்தங்கள் காணப்பட்டன"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(உதவி)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d, மொத்தம் %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu, மொத்தம் %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "எல்லா ஏடுகளிளும் தேடுக"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "உலாவி விருப்பத் தேர்வுகள் உதவி"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "இயல்பெழுத்துரு:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "நிலையான எழுத்துரு:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "எழுத்துரு அளவு:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "எழுத்துரு அளவு"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "இயல்முகப்பு <br>மற்றும் <u>அடிக்கோடிடப்பட்டது</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>வலப்பக்க சாய்வு </i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>அடர்த்தி.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>அடர்த்தி வலப்பக்க சாய்வு முகம்.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "நிலையான அளவு முகம். <br> <b>அடர்த்தி</b> <i>வலப்பக்க சாய்வு</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>அடர்த்தி வலப்பக்க சாய்வு <u>அடிக்கோடிடப்பட்டது</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "அச்சிடுதல் உதவி"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "வெற்றுப் பக்கத்தை அச்சிட இயலாது"
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML கோப்புகள் (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "உதவி ஏடுகள் (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML உதவிப் பணித் திட்டம் (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "குறுக்கப்பட்ட HTML உதவிக் கோப்பு (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%uல் %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u, மொத்தம் %u"
@@ -5516,32 +5529,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "பக்க அமைவில் இடையூறு ஏற்பட்டுள்ளது. இயல்பான அச்சுப் பொறியை தாங்கள் அமைக்கலாம்."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "%s குறியாக்கத்தில் HtML ஆவணத்தை காட்டுவதில் தோல்வி"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets, '%s'-ற்கான காட்சியளிப்பைத் திறக்க இயலவில்லை: வெளியேறுகிறது."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "வடிகட்டி"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "அடைவுகள்"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "கோப்புகள்"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "தெரிவு"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "பிடிப்புப் பலகையை திறப்பதில் தோல்வி."
@@ -5583,58 +5570,58 @@ msgstr "நிறத் தெரிவு உரையாடல் தோல்
 msgid "Failed to create cursor."
 msgstr "சுட்டியை உருவாக்குவதில் தோல்வி."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "'%s' DDE வழங்கியைப் பதிவு செய்வதில் தோல்வி"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "'%s' DDE வழங்கியைப் பதிவுநீக்கம் செய்வதில் தோல்வி"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "'%s' வழங்கியுடன் '%s' தலைப்பில் இணைவதில் தோல்வி."
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE poke வேண்டுகோள் தோல்வியடைந்தது"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE வழங்கியுடன் அறிவுரை முழுச்சுற்றினை நிலைநாட்டுவதில் தோல்வி"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE வழங்கியுடனான அறிவுரை சுழற்சியை முடிவிற்குக் கொண்டுவருவதில் தோல்வி"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "DDE அறிவுரை அறிவிக்கையை அனுப்புவதில் தோல்வி"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "DDE சரத்தை உருவாக்குவதில் தோல்வி."
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "DDE பிழை இல்லை."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "ஒத்திசைவு அறிவுரை பரிமாற்றத்திற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "பரிமாற்றத்திற்கான மறுமொழி, DDE_FBUSY நுண்மியை  அமைக்கச் செய்தது."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "ஒத்திசைவுத் தரவு பரிமாற்றத்திற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5645,7 +5632,7 @@ msgstr ""
 "அள்ளது ஒரு ஏற்கமுடியாத நிகழ்வு இநங்காட்டி\n"
 "ஒரு DDEML செயலுக்கு அனுப்பி வைக்கப்பட்டது."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5657,43 +5644,43 @@ msgstr ""
 "அல்லது APPCMD_CLIENTONLY என்று துவக்க நிலையாக்கப்பட்ட ஒரு செயலி\n"
 "வழங்கியின் பரிமாற்றங்களை மேற்கொள்ள முயற்சித்துள்ளது."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "ஒத்திசைவு செயற்படுத்து பரிமாற்றத்திற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "DDEML, ஒரு அளவுக் குறியீட்டை சரிபார்க்க தவறியது."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "ஒரு DDEML செயலி நீட்டிக்கப்பட்ட போட்டி நிலையை உருவாக்கியுள்ளது."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "நினைவக ஒதுக்கீடு தோல்வியடைந்தது"
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "ஒரு உரையாடலை நிலைநாட்டும் வாங்கியின் முயற்சி தோல்வியடைந்துள்ளது."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "ஒரு பரிமாற்றம் தோல்வியடைந்தது."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "ஒத்திசைவு poke பரிமாற்றத்திற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage செயற்பாட்டிற்கான உள் அழைப்பு தோல்வியடைந்துள்ளது."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "மறுநுழைவில் இடைஞ்சல்"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5703,15 +5690,15 @@ msgstr ""
 "ஆனால், அதை வழங்கியோ, வாங்கியோ முடிவிற்கு கொண்டு வந்துவிட்டது\n"
 "பரிமாற்றம் நிறைவடையும் முன் முடிக்கப்பட்டது."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML-ல் ஒரு உட்பிழை ஏற்பட்டுள்ளது."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "ஒரு அறிவுரை பரிமாற்றத்தை முடிப்பதற்கான வேண்டுகோள் காலாவதியாகிவிட்டது"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5721,12 +5708,12 @@ msgstr ""
 "XTYP_XACT_COMPLETE திரும்ப அழைத்தலிலிருந்து செயலி திரும்பிய பின்,\n"
 "அந்த திரும்ப அழைத்தலுக்கான பரிமாற்ற இனங்காட்டி, இனிமேல் ஏற்கக்கூடியதாக இருக்காது."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "அறியப்படாத DDE பிழை %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5734,7 +5721,7 @@ msgstr ""
 "தொலை அணுகுப் பணி (RAS) இக்கணினியில் நிறுவப்படவில்லையென்பதால், சுழல் செயல்கள் இல்லாமல் "
 "உள்ளது. அருள்கூர்ந்து RAS-ஐ நிறுவவும்."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5743,64 +5730,64 @@ msgstr ""
 "இந்தக் கணினியில் நிறுவப்பட்டுள்ள தொலை அணுகுப் பணி (RAS) பதிப்பு மிகப் பழையது, "
 "அருள்கூர்ந்துமேம்படுத்தவும்  (பின்வரும் தேவையான செயல் தவறவிடப்பட்டுள்ளது: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS பிழையின் உரையை மீட்டெடுப்பதில் தோல்வி."
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "தெரியாதப் பிழை (பிழைக் குறி %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "செயலில் இருக்கும் சுழல் இணைப்பை காண இயலவில்லை: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "பல சுழல் இணைப்புகள் செயலில் உள்ளன, குறிப்பின்றி ஒன்று தேர்ந்தெடுக்கப்படுகிறது."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "சுழல் இணைப்பினை நிலைநாட்டுவதில் தோல்வி: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "இணையப் பணி வழங்குவோர் (ISP) பெயர்களை பெறுவதில் தோல்வி: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "இணைப்பதில் தோல்வி: சுழற்ற ISP ஏதுமில்லை."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "சுழற்றுவதற்கு ISP-யினை தேர்ந்தெடுக்கவும்"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "எந்த ISP-யுடன் இணைப்பை உருவாக்க வேண்டுமென்றுத் தேர்ந்தெடுக்கவும்"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "இணைப்பதில் தோல்வி: பயனர் பெயர்/கடவுச்சொல் தவற விடப்பட்டுள்ளது"
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "முகவரி ஏட்டுக் கோப்பின் இருப்பிடத்தை காண இயலவில்லை"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "சுழல் இணைப்பினைத் துவக்குவதில் தோல்வி: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "துண்டிக்க இயலாது - செயலில் இருக்கும் சுழல் இணைப்பு ஏதுமில்லை"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "சுழல் இணைப்பினை துண்டிப்பதில் தோல்வி: %s"
@@ -5820,18 +5807,17 @@ msgstr "நுண்பட தரவிற்கு நினைவுத் த
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' அடைவில் இருக்கும் கோப்புகளை கணக்கிட இயலாது"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "கோப்புறையின் பெயரை பெற இயலவில்லை"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(பிழை %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "படிமங்களின் வரிசைப் பட்டியலில் ஒரு படிமத்தை சேர்க்க இயலவில்லை."
 
@@ -5845,7 +5831,7 @@ msgstr "\"%s\" கோப்பிலிருந்து meta கோப்ப�
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "நிலையான கண்டுபிடி/மாற்றமர்வு உரையாடலை உருவாக்குவதில் தோல்வி. (பிழைக் குறி %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "கோப்பு உரையாடல் தோல்வியடைந்தது. பிழைக் குறி %0lx."
@@ -5886,16 +5872,16 @@ msgstr "'%s'-ற்கான கவனிப்பை அமைக்க இய�
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "இல்லாத \"%s\" அடைவினை மாற்றங்களுக்காக கவனிக்க இயலாது"
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 3.0, அல்லது அதற்கும் பிறகான பதிப்புகளை OpenGL இயக்கி ஆதரிப்பதில்லை."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "OpenGL சூழலமைவை உருவாக்க இயலவில்லை"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL துவக்க நிலையாக்குவதில் தோல்வி"
 
@@ -5903,7 +5889,7 @@ msgstr "OpenGL துவக்க நிலையாக்குவதில் 
 msgid "Could not register custom DirectWrite font loader."
 msgstr "தனிப்பயனாக்கப்பட்ட DirectWrite எழுத்துரு ஏற்றியைப் பதிவிட இயலவில்லை."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5911,7 +5897,7 @@ msgstr ""
 "இந்தக் கணினியில் MS HTML உதவி நூலகம்  நிறுவப்படாததால், MS HTML உதவி செயல்கள் "
 "பயன்பாட்டில் இல்லை. அருள்கூர்ந்து அதை நிறுவவும்."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML உதவியை துவக்க நிலையாக்குவதில் தோல்வி."
 
@@ -5920,7 +5906,7 @@ msgstr "MS HTML உதவியை துவக்க நிலையாக்�
 msgid "Can't delete the INI file '%s'"
 msgstr "'%s' INI கோப்பினை அழிக்க இயலவில்லை"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "%d வரிசைப்பட்டியல் கட்டுப்பாடு உருப்படியின் தகவலை மீட்க இயலவில்லை."
@@ -6040,7 +6026,7 @@ msgstr "'%s' பிடிப்புப் பலகை வடிவூட்�
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "பிடிப்புப் பலகை வடிவூட்டம் '%d' இல்லை."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "தவிர்"
 
@@ -6125,59 +6111,59 @@ msgstr ""
 "இதை அழித்துவிட்டால், தங்களின் கணினி பயன்படுத்தப்பட இயலாத நிலைக்கு தள்ளப்படும்:\n"
 "நடவடிக்கை இடைமறிக்கப்படுகிறது."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "'%s' விசையினை அழிக்க இயலவில்லை"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "மதிப்பு '%s\" விசை '%s' இடமிருந்து அழிக்க இயலவில்லை"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "விசை '%s'-இன் மதிப்பை படிக்க இயலாது"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s'-இன் மதிப்பை அமைக்க இயலாது"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "பதிப்பக மதிப்பு \"%s\" எண்ணாக இல்லை (ஆனால், %s வகையாக உள்ளது)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "பதிப்பக மதிப்பு \"%s\" இருமமாக இல்லை (ஆனால், %s வகையாக உள்ளது)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "பதிப்பக மதிப்பு \"%s\" உரையாக இல்லை (ஆனால், %s வகையாக உள்ளது)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s'-இன் மதிப்பை படிக்க இயலாது"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "விசை '%s'-ன் மதிப்புகளை கணக்கிட இயலவில்லை"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "விசை '%s'-ன் உட்விசைகளை கணக்கிட இயலவில்லை"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
@@ -6185,17 +6171,17 @@ msgstr ""
 "பதிப்பக விசை ஏற்றம் செய்யப்படுகிறது: \"%s\" கோப்பு ஏற்கனவே உள்ளது; அது அழித்தெழுதப்பட "
 "மாட்டாது."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "%d ஆதரவளிக்கப்படாத வகை என்பதால், அதன் மதிப்பை ஏற்றம் செய்ய இயலவில்லை."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "மதிப்பு \"%s\" (\"%s\" விசையினுடையது) தவிர்க்கப்படுகிறது."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6203,41 +6189,41 @@ msgstr ""
 "செரிவூட்டப்பட்ட தொகு கட்டுப்பாட்டை உருவாக்க இயலாமையால், எளிய உரைக் கட்டுப்பாடு "
 "பயன்படுத்தப்படுகிறது. riched32.dll நிரலை மறுநிறுவு செய்யவும்."
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "இழையைத் துவக்க இயலவில்லை: TLS எழுதுவதில் பிழை "
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "இழையின் முன்னுரிமையை அமைக்க இயலாது"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "இழையினை உருவாக்க இயலவில்லை"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "இழையை முடிக்க இயலவில்லை."
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "இழை முடித்தலுக்கு காத்திருக்க இயலாது"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "%lx இழையை இடைநிறுத்த இயலாது"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "%lx இழையை மீண்டும் தொடர இயலாது"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "தற்போதைய இழைக்குறியை பெற இயலவில்லை."
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6245,7 +6231,7 @@ msgstr ""
 "இழை நிரற்கூறை துவக்க நிலையாக்குவதில் தோல்வி: இழையின் உள்ளக சேமிப்பகத்தில் சுட்டெண்ணை "
 "ஒதுக்கீடு செய்ய இயலாது."
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6276,12 +6262,12 @@ msgstr "\"%s\" வளத்தை ஏற்றுவதில் தோல்வ
 msgid "Failed to lock resource \"%s\"."
 msgstr "\"%s\" வளத்தை பூட்டுவதில் தோல்வி."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "கட்டு %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr "64 நுண்மி பதிப்பு"
 
@@ -6293,46 +6279,46 @@ msgstr "அனாமதேய குழாயை உருவாக்குவ�
 msgid "Failed to redirect the child process IO"
 msgstr "உள்ளிடு/வெளிடு சேய் செயல்முறையை வழிமாற்றுவதில் தோல்வி"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' கட்டளையின் செயலாக்கம் தோல்வியடைந்தது"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll ஏற்றுவதில் தோல்வி."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s'-இருந்து வகைப் பெயரை படிக்க இயலவில்லை"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s'-இருந்து படவுருக்களை ஏற்ற இயலவில்லை."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "வலையத் தோற்றத்தின் நிகர்நிலை மட்டத்தை பதிவகத்தில் காண இயலவில்லை"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "வலைத் தோற்றத்தை நவீன நிகர்நிலை மட்டத்திற்கு அமைக்க இயலவில்லை"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "வலைத் தோற்றத்தை தகுதர நிகர்நிலை மட்டத்திற்கு அமைக்க இயலவில்லை"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "ஏற்புடைய HTML ஆவணமில்லாமல் JavaScript குறுநிரலை இயக்க இயலாது"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "JavaScript பொருளைப் பெற இயலவில்லை"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "மதிப்பிடுவதில் தோல்வி"
 
@@ -6365,7 +6351,7 @@ msgid "Check to make the font italic."
 msgstr "எழுத்துரு வலப்பக்க சாய்வினை உறுதி செய்க."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "அடிக்கோடிடப்பட்டது"
@@ -6432,15 +6418,33 @@ msgstr "<ஏதேனுமொரு தொலைத் தட்டெழுத
 msgid "File type:"
 msgstr "கோப்பு வகை:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "சாளரம்"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "உதவி"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "சிறிதாக்கிடுக"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "பெரிதாக்கிடுக"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "அனைத்தையும் முன்னால் கொண்டுவருக"
 
@@ -6457,492 +6461,492 @@ msgstr "\"%s\" எழுத்துருக் கோப்பு கிடை
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "\"%s\" எழுத்துரு அடைவில் இல்லாததால், \"%s\" எழுத்துரு கோப்பினைப் பயன்படுத்த இயலாது."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "%s குறித்து"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "குறித்து..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "முன்னுரிமை விருப்பங்கள்..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "பணிகள்"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "%s-யினை மறை"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "பயன்பாடு"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "பிறவற்றை மறை"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "எல்லாம் காட்டுக"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "%s-ஐ விட்டு வெளியேறுக"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "பயன்பாடு"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "அச்சிடுவதை கணினி வலைக் கட்டுப்பாடு ஆதரிப்பதில்லை"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "அச்சிடும் செயலைத் துவக்கநிலையாக்க இயலவில்லை."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "குறியளவு"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "முகப் பெயர்"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "பாங்கு"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "எடை"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "குடும்பம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "பயன்பாட்டுப் பணிவெளி"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "இயக்கத்த்ிலிருக்கும் எல்லை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "இயக்கத்திலுள்ள தலைப்பு"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "பொத்தான் முகப்பு"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "பொத்தான் முன்னிலையாக்கம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "பொத்தான் நிழல்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "பொத்தான் உரை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "தலைப்புரை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "கட்டுப்பாட்டு இருள்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "கட்டுப்பாட்டு வெளிச்சம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "சாம்பலுரை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "துலக்கம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "உரையைத் துலக்கமாக்கிடுக"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "இயக்கம் முடங்கிய எல்லை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "முடங்கிய தலைப்பு"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "முடங்கிய தலைப்புரை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "பட்டியல்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "உருள்பட்டை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "கருவிக்குறிப்பு"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "கருவிக்குறிப்புரை"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "சாளரம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "சாளரச் சட்டகம்"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "சாளரவுரை"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "தனிப்பயனாக்கப்பட்டது "
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "கருப்பு"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "அரக்கு"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "கடற்படை நீலம்"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "ஊதா"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "இளம்பச்சை"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "சாம்பல்"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "பச்சை"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "ஆலிவ்"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "பிரௌன்"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "நீலம்"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "ஃப்யூஷியா சிவப்பு"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "சிவப்பு"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "செம்மஞ்சள்"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "வெள்ளி"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "எலுமிச்சை"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "நீலப்பச்சை"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "மஞ்சள்"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "வெள்ளை"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "இயல்பிருப்பு"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "அம்பு"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "வலதம்பு"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "வெற்று"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Bullseye"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "வரியுரு"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "சிலுவை "
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "கை"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 #, fuzzy
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "ஐபீம்"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "இடது பொத்தான்"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "உருப்பெருக்கி"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "நடு பொத்தான்"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 #, fuzzy
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "உள்ளீடு ஏதுமில்லை"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "வண்ணத் தூரிகை"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "பெண்சில்"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "இடமுனை"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "வலமுனை"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "கேள்வியம்பு"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "வலது பொத்தான்"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "சைசிங் NE-SW"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "சைசிங் N-S"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "சைசிங் NW-SE"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "சைசிங் W-E"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "சைசிங்"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "தெளிக்குவளை"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "காத்திரு"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "கவனி"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "காத்திரு அம்பு"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "தெரிவுச் செய்க:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "பண்பு"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "மதிப்பு"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "வகைப்படுத்தப்பட்ட நிலை"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "அகர நிலை"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "பொய்யானது"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "மெய்"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "குறிப்பிடப்படாதது"
 
@@ -6957,12 +6961,12 @@ msgstr ""
 "ஏற்கமுடியாத மதிப்பை உள்ளிடு செய்துள்ளீர்கள், தொகுத்தலை விலக்கிட, 'விடுபடு' விசையை "
 "அழுத்திடுக."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "வளத்தில் பிழை: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6971,36 +6975,36 @@ msgstr ""
 "நடவடிக்கை \"%s\" வகை தோல்வியடைந்தது: பண்புகள் \"%s\" சீட்டு, \"%s\" வகையை "
 "சார்ந்ததாகும், ஆனால், அது \"%s\" என்றுள்ளது."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "அறியப்படாத அடிப்படை %d. அடிப்படை 10 பயன்படுத்தப்படும்."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "மதிப்பு %s அல்லது அதற்கும் மேல் இருக்க வேண்டும்."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "மதிப்பு இதற்கிடையே இருக்க வேண்டும்: %s & %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "மதிப்பு %s அல்லது அதற்கும் குறைவாக இருக்க வேண்டும்."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "%s இல்லை"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "ஒரு அடைவைத் தேர்ந்தெடுக்கவும்:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "ஒரு கோப்பினைத் தேர்ந்தெடுக்கவும்"
 
@@ -7468,117 +7472,117 @@ msgstr "செருகு"
 msgid "Outset"
 msgstr "துவக்கம்"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "பாங்கினை மாற்றுக"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "பொருளின் பாங்கினை மாற்றுக"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "பண்புகளை மாற்றுக"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "வரிசைப் பட்டியலின் பாங்கினை மாற்றுக"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "பட்டியலை மறுஎண்ணிடுக"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "உரையை செருகு"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "படிமத்தை செருகு"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "பொருளை செருகு"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "களத்தை செருகு"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "மிகுதியான End Style அழைப்புகள்!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "கோப்புகள்"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "செந்தர வட்டம்"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "செந்தர வட்டம் வெளிவரைவு"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "செந்தரச் சதுரம்"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "செந்தர வைரம்"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "செந்தர முக்கோணம்"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "பெட்டிப் பண்புகள்"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "பல சிறுகட்டங்களின் பண்புகள்"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "சிறுகட்ட பண்புகள்"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "சிறுகட்டத்தின் பாங்கினை அமை"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "கிடை வரிசையை அழிக்கவும்"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "நெடுவரிசையை அழிக்கவும்"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "கிடை வரிசையை சேர்க்கவும்"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "நெடுவரிசையை சேர்க்கவும்"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "அட்டவணைப் பண்புகள்"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "படப் பண்புகள்"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "படிமம்"
 
@@ -7786,24 +7790,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "இழு"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "உரையை அழி"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "தோட்டாவை நீக்குக"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "உரையை சேமிக்க இயலவில்லை."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "மாற்றமர்வு"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "எழுத்துரு (&F)"
 
@@ -8772,53 +8776,53 @@ msgstr "வரிசைப் பட்டியல் பாங்குகள�
 msgid "Box styles"
 msgstr "பெட்டிப் பாங்குகள்"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "குறியெழுத்தை எடுக்க வேண்டிய எழுத்துரு."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "உட்கணம் (&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "ஒருங்குறி உட்கணத்தை காட்டுகிறது."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "வரியுருக்குறி (&C)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "வரியுருக் குறி."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "அனுப்புநர் (&F):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "ஒருங்குறி"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "காட்டப்பட வேண்டிய வீச்சு."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "செருகு"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(இயல்புரை)"
 
@@ -9002,7 +9006,7 @@ msgstr "kqueue-விடமிருந்து நிகழ்வுகளை 
 msgid "Media playback error: %s"
 msgstr "ஊடக மீட்பொலிப்பில் பிழை: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "\"%s\" ஓட்டுதலை ஆயத்தம் செய்வதில் தோல்வி."
@@ -9102,20 +9106,20 @@ msgstr "ஒலித் தரவுகள் ஆதரிக்கப்பட�
 msgid "Couldn't open audio: %s"
 msgstr "ஒலியத்தை திறக்க இயலவில்லை: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "இழை காலவரையீட்டுக் கொள்கையை மீட்க இயலாது"
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "%d கொள்கையை காலவரையீடுச் செய்ய, முன்னுரிமை வீச்சை பெற இயலவில்லை"
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "இழை முன்னுரிமை அமைப்பு தவிர்க்கப்படுகிறது."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9123,59 +9127,59 @@ msgstr ""
 "ஒரு இழையுடன் சேர்வதில் தோல்வி, நினைவுக் கசிவாக இருக்கக்கூடும் - அருள்கூர்ந்து நிரலை "
 "மறுதுவக்கிடுக "
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "இழையின் உடன்நிகழ் %lu மட்டத்திற்கு அமைப்பதில் தோல்வி."
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "%d இழை முன்னுரிமையை அமைப்பதில் தோல்வி."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "ஒரு இழையை முடிப்பதில் தோல்வி."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "இழை நிரல் செயலியை துவக்க நிலையாக்குவதில் தோல்வி: இழை விசையை உருவாக்குவதில் தோல்வி."
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "சேய் செயல்முறை உள்ளீட்டினை பெற இயலவில்லை."
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "சேய் செயல்முறை stdin-ல் எழுத இயலாது"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s'-இனை செயலாக்குவதில் தோல்வி. \n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "பிளவு தோல்வியடைந்தது"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "செயலி முன்னுரிமையை அமைப்பதில் தோல்வி"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "உள்ளிடு/வெளிடு சேய் செயல்முறையை வழிமாற்றுவதில் தோல்வி"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "அடைப்பில்லா குழாயை அமைப்பதில் தோல்வி, நிரல் இயக்கம் முடிவிற்கு வரலாம்."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "வழங்கியின் பெயரை பெற இயலவில்லை"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "வழங்கியின் அதிகாரப் பூர்வப் பெயரை பெற இயலவில்லை"
 
@@ -9191,12 +9195,12 @@ msgstr "விழிநிலை குழாயினை அடைப்பி�
 msgid "Failed to read from wake-up pipe"
 msgstr "விழிநிலை குழாயிலிருந்து படிப்பதில் தோல்வி"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "ஏற்கமுடியாத வடிவியல் அளவுக் குறியீடு '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "காட்சியமைவை wxWidgets திறக்க இயலவில்லை. வெளியேறுகிறது."
 
@@ -9210,30 +9214,59 @@ msgstr "\"%s\" காட்சியமைவை மூடுவதில் த
 msgid "Failed to open display \"%s\"."
 msgstr "\"%s\" காட்சியமைவை திறப்பதில் தோல்வி"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML parsing பிழை: '%s', %d வரியில்"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "'%s'-இருந்து வளங்களை ஏற்ற இயலவில்லை."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "'%s' வளங்கள் கோப்பினை திறக்க இயலாது"
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "'%s' கோப்பிலிருந்து வளங்களை ஏற்ற இயலவில்லை."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "%s உருவாக்கப்படுகிறது. \"%s\" தோல்வியடைந்தது."
+
+#~ msgid "Printing "
+#~ msgstr "அச்சிடப்படுகிறது"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "கட்டுப்பாட்டில் உரையை செருகுவதில் தோல்வி."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "ஏற்கக்கூடிய எழுத்துருவைத் தேர்ந்தெடுக்கவும்."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "%s குறியாக்கத்தில் HtML ஆவணத்தை காட்டுவதில் தோல்வி"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets, '%s'-ற்கான காட்சியளிப்பைத் திறக்க இயலவில்லை: வெளியேறுகிறது."
+
+#~ msgid "Filter"
+#~ msgstr "வடிகட்டி"
+
+#~ msgid "Directories"
+#~ msgstr "அடைவுகள்"
+
+#~ msgid "Files"
+#~ msgstr "கோப்புகள்"
+
+#~ msgid "Selection"
+#~ msgstr "தெரிவு"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "8-நுண்மி குறியாக்கத்திற்கு மாற்றுவதில் பிழை."
@@ -9397,8 +9430,8 @@ msgstr "%s உருவாக்கப்படுகிறது. \"%s\" தோ
 #~ msgstr "தேதி வழங்கி மதிப்பை வழங்க இயலாது; மதிப்பு வகை:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-06-28 03:37+0300\n"
 "Last-Translator: Kaya Zeren <translator@zeron.net>\n"
 "Language-Team: Turkish (Turkey) (http://www.transifex.com/klyok/wxwidgets/"
@@ -20,11 +20,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Tüm dosyalar (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Tüm dosyalar (*)|*"
 
@@ -41,24 +41,21 @@ msgid "Remaining time:"
 msgstr "Kalan süre:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Evet"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Hayır"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Tamam"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "İptal"
@@ -108,7 +105,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Giriş/çıkış tamamlanma kapısı oluşturulamadı"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Çıktı"
 
@@ -145,7 +142,7 @@ msgstr "Nesne özellikleri"
 msgid "Printing"
 msgstr "Yazdırılıyor"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Simgeler"
 
@@ -216,7 +213,7 @@ msgstr "Ö&nceki"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Pencere"
 
@@ -745,11 +742,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "HamCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "bu yardım iletisi görüntülensin"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "ayrıntılı günlük iletileri oluşturulsun"
 
@@ -771,84 +768,84 @@ msgstr "'%s' teması desteklenmiyor."
 msgid "Invalid display mode specification '%s'."
 msgstr "'%s' görünüm kipi özelliği geçersiz."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "'%s' seçeneği yok sayılamaz"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "'%s' long seçeneği bilinmiyor"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "'%s' seçeneği bilinmiyor"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "'%s' seçeneğinden sonra beklenmeyen karakterler var."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "'%s' seçeneğinin bir değeri olması gerekli."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "'%s' seçeneğinden sonra ayraç bekleniyor."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' '%s' seçeneği için doğru bir sayısal değer değil."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "'%s' seçeneği: '%s' tarihe dönüştürülemedi."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Beklenmeyen parametre '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (ya da %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "'%s' seçeneği için değer belirtilmelidir."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Gerekli '%s' parametresi belirtilmemiş."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Kullanım: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "çift"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "tarih"
 
@@ -866,7 +863,7 @@ msgid "Can't &Undo "
 msgstr "&Geri alınamıyor "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Geri al"
@@ -876,7 +873,7 @@ msgid "&Redo "
 msgstr "&Yinele "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Yinele"
@@ -903,12 +900,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' içindeki fazladan '..' yok sayıldı."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "işaretlenmiş"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "işaretlenmemiş"
 
@@ -917,103 +914,103 @@ msgstr "işaretlenmemiş"
 msgid "undetermined"
 msgstr "belirlenmemiş"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "bugün"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "dün"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "yarın"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "birinci"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "ikinci"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "üçüncü"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "dördüncü"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "beşinci"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "altıncı"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "yedinci"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "sekizinci"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "dokuzuncu"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "onuncu"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "onbirinci"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "yirminci"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "onüçüncü"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "ondördüncü"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "onbeşinci"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "onaltıncı"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "onyedinci"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "onsekizinci"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "ondokuzuncu"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "onikinci"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "öğlen"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "gece yarısı"
 
@@ -1080,44 +1077,81 @@ msgstr "cURL yürütülemedi, lütfen PATH içine yükleyin."
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Hata ayıklama raporu yüklenemedi (hata kodu %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Farklı kaydet"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Değişiklikler iptal edilip son kaydedilmiş sürüme dönülsün mü?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "adsız"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "%s üzerinde yapılan değişiklikleri kaydetmek istiyor musunuz?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "Kay&det"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Kaydedilmesin"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "%s üzerinde yapılan değişiklikleri kaydetmek istiyor musunuz?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Metin kaydedilemedi."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "\"%s\" dosyası yazılmak üzere açılamadı."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Belge \"%s\" dosyasına kaydedilemedi."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "\"%s\" dosyası okunmak üzere açılamadı."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "\"%s\" dosyasından belge okunamadı."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1126,57 +1160,57 @@ msgstr ""
 "'%s' dosyası yok ve açılamadı.\n"
 "Son kullanılan dosyalar listesinden kaldırıldı."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Yazdırma ön izlemesi oluşturulamadı."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Yazdırma ön izlemesi"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "'%s' dosyasının biçimi belirlenemedi."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "adsız%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Dosya aç"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Dosya hatası"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Ne yazık ki bu dosya açılamıyor."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Ne yazık ki bu dosyanın biçimi bilinmiyor."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Bir belge kalıbı seçin"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Kalıplar"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Bir belge görünümü seçin"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Görünümler"
 
@@ -1210,43 +1244,43 @@ msgstr "'%s' dosyasını okurken sorun çıktı"
 msgid "Write error on file '%s'"
 msgstr "'%s' dosyasına yazılırken sorun çıktı"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "'%s' dosyası temizlenemedi"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "'%s' dosyasında arama hatası (büyük dosyalar 'stdio' tarafından "
 "desteklenmiyor)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' dosyasında arama sorunu"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "'%s' dosyasındaki geçerli konum bulunamadı"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Geçici dosya izinleri ayarlanamadı"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "'%s' dosyası silinemedi"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "'%s' dosyasındaki değişiklikler işlenemedi"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "'%s' geçici dosyası silinemedi"
@@ -1271,27 +1305,27 @@ msgstr "%d dosya tanımlayıcısından okunamadı"
 msgid "can't write to file descriptor %d"
 msgstr "%d dosya tanımlayıcısına yazılamadı"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "%d dosya tanımlayıcısı temizlenemedi"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "%d dosya tanımlayıcısı üzerinde arama yapılamadı"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "%d dosya tanımlayıcısı üstündeki arama konumu alınamadı"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "%d tanımlayıcısı üstündeki dosyanın uzunluğu bulunamadı"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1319,107 +1353,107 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Ayarlar okunurken sorun çıktı."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Ayarlar okunamadı."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "dosya '%s': beklenmedik karakter %c,  satır: %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "dosya '%s', satır %zu: '%s' grup başlığından sonra yok sayıldı."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "dosya '%s', satır %zu: '=' bekleniyor."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "dosya '%s', satır %zu: '%s' değişmez anahtarı için değer yok sayıldı."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "dosya '%s', satır %zu: anahtar '%s' ilk olarak %d satırında bulundu."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Ayar kaydının adı '%c' ile başlayamaz."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "kullanıcı ayar dosyası açılamadı."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "kullanıcı ayar dosyası yazılamadı."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Kullanıcı ayarları dosyası kaydedilemedi."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Kullanıcı ayarları kaydedilirken sorun çıktı."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "kullanıcı yapılandırma dosyası '%s' silinemedi"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "'%s' kaydı '%s' grubunda birden çok kez geçiyor"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "'%s' değişmez anahtarını değiştirme denemesi yok sayıldı."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' sonundaki ters eğik çizgi yok sayıldı"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "%d konumunda, '%s' içinde beklenmeyen \"."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "'%s' dosyası '%s' içine kopyalanamadı"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "'%s' dosyasının izinleri okunamadı"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "'%s' dosyasının üzerine yazılamadı"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "'%s' dosyası '%s' içine kopyalanırken sorun çıktı."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "'%s' dosyasının izinleri değiştirilemedi"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1428,40 +1462,40 @@ msgstr ""
 "'%s' dosyası aynı adlı bir dosya olduğundan '%s' olarak yeniden "
 "adlandırılamadı."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "'%s' dosyası '%s' olarak yeniden adlandırılamadı"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "'%s' dosyası silinemedi"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "'%s' klasörü oluşturulamadı"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "'%s' klasörü silinemedi"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "'%s' dosyaları sayılamadı"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Çalışma klasörü alınamadı"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Geçerli çalışma klasörü ayarlanamadı"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Dosyalar (%s)"
@@ -1488,17 +1522,17 @@ msgstr "Geçici dosya adı oluşturulamadı"
 msgid "Failed to open temporary file."
 msgstr "Geçici dosya açılamadı."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "'%s' için dosya zamanları değiştirilemedi"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "'%s' dosyasına dokunulamadı"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "'%s' için dosya zamanları alınamadı"
@@ -1507,22 +1541,22 @@ msgstr "'%s' için dosya zamanları alınamadı"
 msgid "Browse"
 msgstr "Göz at"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Tüm dosyalar (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s dosya (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "%s dosyasını yükle"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "%s dosyasını kaydet"
@@ -1885,99 +1919,99 @@ msgstr "varsayılan"
 msgid "unknown-%d"
 msgstr "bilinmiyor-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "altı çizili"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " üstü çizili"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " ince"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " çok hafif"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " açık"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " orta"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " yarı koyu"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " koyu"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " çok koyu"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " ağır"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " çok ağır"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " yatık"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "üstüçizili"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "ince"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "çokhafif"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "açık"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "normal"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "orta"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "yarıkoyu"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "koyu"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "çokkoyu"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "ağır"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "çokağır"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "yatık"
 
@@ -2059,7 +2093,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "FTP aktarım kipi %s olarak ayarlanamadı."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2080,7 +2114,7 @@ msgstr "FTP sunucusu pasif kipi desteklemiyor."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF kare sayısı yanlış (%u, %d) #%u karesi"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "OpenGL için renk ayarlanamadı"
 
@@ -2096,7 +2130,7 @@ msgstr "Sütunları özelleştir"
 msgid "&Customize..."
 msgstr "Ö&zelleştir..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "\"%s\" adresi varsayılan tarayıcıda açılamadı"
@@ -2116,155 +2150,154 @@ msgstr "%d görseli akıştan yüklenemedi."
 msgid "Failed to load icons from resource '%s'."
 msgstr "'%s' kaynağından simgeler yüklenemedi."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Geçersiz görüntü kaydedilemedi."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage için wxPalette yok."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Dosya (Bitmap) başlık bilgisi yazılamadı."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Dosya (BitmapInfo) başlık bilgisi yazılamadı."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: RGB renk haritası yazılamadı."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Veri yazılamadı."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: bellek ayrılamadı."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB başlık bilgisi: Dosya için görsel genişliği > 32767 piksel."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB başlık bilgisi: Dosya için görsel yüksekliği > 32767 piksel."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB başlık bilgisi: Dosyada bilinmeyen bit derinliği."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB başlık bilgisi: Dosyada bilinmeyen kodlama."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB başlık bilgisi: Kodlama, bit derinliğine uymuyor."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: biBitCount=%d iken üst bilgide biClrUsed=%d."
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: bellek ayrılamadı."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB başlık bilgisi: Dosya için görsel genişliği > 32767 piksel."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB başlık bilgisi: Dosya için görsel yüksekliği > 32767 piksel."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB başlık bilgisi: Dosyada bilinmeyen bit derinliği."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB başlık bilgisi: Dosyada bilinmeyen kodlama."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB başlık bilgisi: Kodlama, bit derinliğine uymuyor."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "DIB görüntüsü okunurken sorun çıktı."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: DIB maskesi okuma hatası."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Görsel simge için çok uzun."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Görsel simge için çok geniş."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Görsel dosyasına yazılırken sorun çıktı!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Simge dizini geçersiz."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Görsel ve maske farklı boyutlarda."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Maskelenen görselde kullanılmamış renk yok."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Kaynaklardan \"%s\" bit eşlemi yüklenemedi."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Kaynaklardan \"%s\" simgesi yüklenemedi."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "\"%s\" dosyasından görsel yüklenemedi."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Görüntü '%s' dosyasına kaydedilemedi: bilinmeyen uzantı."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Görüntü türünün işleyicisi bulunamadı."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "%d türünün görüntü işleyicisi tanımlanmamış."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Görsel dosyası %d türünde değil."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "Aranamayan giriş için görsel biçimi kendiliğinden belirlenemiyor."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Görsel veri biçimi bilinmiyor."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Bu bir %s değil."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "%s türünün görüntü işleyicisi tanımlanmamış."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Görsel dosyası %s türünde değil."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "\"%s\" görsel dosyasının biçimi denetlenemedi."
@@ -2365,52 +2398,52 @@ msgstr "PNM: Dosya budanmış görünüyor."
 msgid " (in module \"%s\")"
 msgstr " (\"%s\" modülünde)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Görsel yüklenirken sorun çıktı."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "TIFF görsel dizini geçersiz."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Görsel boyutu anormal büyük."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Bellek ayrılamadı."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Görsel okunurken sorun çıktı."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Bilinmeyen TIFF %d çözünürlük birimi yok sayıldı"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Görsel kaydedilirken sorun çıktı."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Görsel yazılırken sorun çıktı."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "%d komut satırı değişkeni Unikoda çevrilemediğinden yok sayılacak."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Hazırlığın ardından başlatılamadı, vazgeçiliyor."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Yerel ayarlar \"%s\" diline çevrilemedi."
@@ -2504,7 +2537,7 @@ msgstr "LZMA sıkıştırma sorunu: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Çıktı temizlenirken LZMA sıkıştırma sorunu: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "%s MIME türü kaydına uymayan '{'."
@@ -2524,7 +2557,7 @@ msgstr "\"%s\" bağlılığı \"%s\" modülü için bulunamadı."
 msgid "Module \"%s\" initialization failed"
 msgstr "\"%s\" modülü başlatılamadı"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "İleti"
 
@@ -3026,7 +3059,7 @@ msgstr "Yazdırma hatası"
 msgid "Print"
 msgstr "Yazdır"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Sayfa düzeni"
 
@@ -3061,19 +3094,15 @@ msgstr "Yazdırılan sayfa %d / %d"
 msgid " (copy %d of %d)"
 msgstr " (kopya %d / %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Yazdırılıyor "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "İlk sayfa"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Önceki sayfa"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Sonraki sayfa"
 
@@ -3117,16 +3146,16 @@ msgstr "Sayfa %d / %d"
 msgid "Page %d"
 msgstr "%d. sayfa"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "bilinmeyen sorun"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Kurallı ifade geçersiz '%s': %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Kurallı ifadeye uygun veri bulunamadı: %s"
@@ -3136,21 +3165,21 @@ msgstr "Kurallı ifadeye uygun veri bulunamadı: %s"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "\"%s\" görüntüleyicisinin %d.%d sürümü uyumsuz olduğundan yüklenemedi."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Bu platform için kullanılamaz"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "\"%s\" parolası kaydedilirken sorun çıktı: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "\"%s\" için parola okunurken sorun çıktı: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "\"%s\" parolası silinemedi: %s."
@@ -3159,11 +3188,11 @@ msgstr "\"%s\" parolası silinemedi: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Giriş/çıkış kanalları izlenemedi"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Kaydedilmesin"
 
@@ -3244,10 +3273,10 @@ msgid "Clear"
 msgstr "Temizle"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Kapat"
 
@@ -3259,7 +3288,7 @@ msgstr "&Dönüştür"
 msgid "Convert"
 msgstr "Dönüştür"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "K&opyala"
@@ -3268,7 +3297,7 @@ msgstr "K&opyala"
 msgid "Copy"
 msgstr "Kopyala"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "&Kes"
@@ -3277,13 +3306,13 @@ msgstr "&Kes"
 msgid "Cut"
 msgstr "Kes"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Sil"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Delete"
@@ -3370,7 +3399,7 @@ msgstr "Sabit disk"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Yardım"
 
@@ -3390,7 +3419,7 @@ msgstr "Girinti"
 msgid "&Index"
 msgstr "D&izin"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Dizin"
 
@@ -3459,7 +3488,7 @@ msgstr "Ye&ni"
 msgid "New"
 msgstr "Yeni"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Hayır"
 
@@ -3476,12 +3505,12 @@ msgstr "&Aç..."
 msgid "Open..."
 msgstr "Aç..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "Ya&pıştır"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Yapıştır"
@@ -3511,7 +3540,7 @@ msgid "Print..."
 msgstr "Yazdır..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "Ö&zellikler"
 
@@ -3543,10 +3572,6 @@ msgstr "Değiştir..."
 msgid "Revert to Saved"
 msgstr "Kaydedilmiş olana geri dön"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "Kay&det"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Farklı kaydet..."
@@ -3555,7 +3580,7 @@ msgstr "&Farklı kaydet..."
 msgid "Save As..."
 msgstr "Farklı kaydet..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "&Tümünü seç"
@@ -3662,7 +3687,7 @@ msgstr "Y&ukarı"
 msgid "Up"
 msgstr "Yukarı"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Evet"
 
@@ -3750,43 +3775,43 @@ msgstr "Geçerli belgeyi kaydet"
 msgid "Save current document with a different filename"
 msgstr "Geçerli belgeyi farklı bir adla kaydet"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "'%s' karakter kümesine dönüşüm çalışmıyor."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "bilinmiyor"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "tar üst bilgi bloğu eksik"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "tar üst bilgi bloğu okunurken sağlama toplamı hatası"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "ek tar üst bilgisindeki veriler geçersiz"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar kaydı açık değil"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "beklenmeyen dosya sonu"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s '%s' kaydının tar başlığına sığmadı"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tar kaydının boyutu hatalı verilmiş"
 
@@ -3795,7 +3820,7 @@ msgstr "tar kaydının boyutu hatalı verilmiş"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' muhtemelen ikili ara bellek."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Dosya yüklenemedi."
 
@@ -3809,47 +3834,47 @@ msgstr "\"%s\" metin dosyası okunamadı."
 msgid "can't write buffer '%s' to disk."
 msgstr "'%s' ara belleği diske yazılamadı."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Yerel sistem zamanı alınamadı"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay başarısız."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' ileti kataloğu geçersiz."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "İleti kataloğu geçersiz."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Çoğul formlar işlenemedi: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "'%s' kataloğu '%s' üzerinden kullanılıyor."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' kaynağı geçerli bir ileti kataloğu değil."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Çeviriler sayılamadı"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "HTML dosyaları için varsayılan uygulama ayarlanmamış."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "'%s' adresi varsayılan tarayıcıyla açılamadı."
@@ -3882,7 +3907,7 @@ msgstr "'%s' içinde geçersiz karakterler var"
 msgid "Error: %s (%d)"
 msgstr "Hata: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "İndirme için yeterli boş disk alanı yok."
 
@@ -3890,20 +3915,20 @@ msgstr "İndirme için yeterli boş disk alanı yok."
 msgid "libcurl could not be initialized"
 msgstr "libcurl başlatılamadı"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync desteklenmiyor"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "JavaScript çalıştırılırken sorun çıktı: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Bu platformda arka plan saydamlığı desteklenmiyor."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Veri pencereye aktarılamadı"
 
@@ -3955,8 +3980,8 @@ msgstr "'Create Parameter' %s bildirilen RTTI parametreleri içinde bulunamadı"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Olay kaynağı nesne sınıfı geçersiz (Non-wxEvtHandler)"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Tür enum - long çevrimini desteklemelidir"
 
@@ -4006,81 +4031,81 @@ msgstr "Nesnelerin bir kod özniteliği olmalıdır"
 msgid "Doubly used id : %d"
 msgstr "Kod iki kez kullanılmış: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Özellik bilinmiyor %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Boş olmayan bir yığın 'element' düğümlerinden oluşmalıdır"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "hatalı olay işleyici dizgesi, nokta eksik"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "zlib ayıklama akışı yeniden başlatılamadı"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "zlib sıkıştırma akışı yeniden başlatılamadı"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 "Hatalı biçimlendirilmiş ek veri kaydı yok sayılıyor. ZIP dosyası bozulmuş "
 "olabilir"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "bunun çok parçalı birleştirilmiş bir zip olduğu varsayılıyor"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "zip dosyası geçersiz"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "zip içinde merkez klasör bulunamadı"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "zip merkez klasörü okunurken sorun çıktı"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "zip yerel başlığı okunurken sorun çıktı"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "kayıt için zip dosyası konumu hatalı"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "kayıtlı dosya uzunluğu Zip başlığında yok"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "zip sıkıştırma yöntemi desteklenmiyor"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "zip akışı okuma (kayıt %s): Uzunluk hatalı"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "zip akışı okuma (kayıt %s): CRC hatalı"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "'%s' zip kaydı yazılırken sorun çıktı: Dosya ZIP64 olmadan çok uzun"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "'%s' zip kaydı yazılırken sorun çıktı: CRC ya da uzunluk hatalı"
@@ -4164,32 +4189,32 @@ msgstr "Görselleri hazırlayan "
 msgid "Translations by "
 msgstr "Çeviren "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Sürüm "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "%s Hakkında"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Lisans"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Geliştiriciler"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Belge yazarları"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Sanatçılar"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Çevirmenler"
 
@@ -4240,42 +4265,42 @@ msgid "Password:"
 msgstr "Parola:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "doğru"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "yanlış"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "%i. Satır"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Daralt"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Genişlet"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d öge)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "%u. sütun"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4286,7 +4311,7 @@ msgid "Left"
 msgstr "Sol"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4381,7 +4406,7 @@ msgid "Home directory"
 msgstr "Açılış klasörü"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Masaüstü"
 
@@ -4394,8 +4419,7 @@ msgstr "Klasör adı geçersiz."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Hata"
 
@@ -4579,16 +4603,16 @@ msgstr "Dosyalar ayrıntı görünümünde görüntülensin"
 msgid "Go to parent directory"
 msgstr "Üst klasöre git"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "'%s' dosyası zaten var, üzerine yazılsın mı?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Onayla"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Lütfen var olan bir dosya seçin."
 
@@ -4682,7 +4706,7 @@ msgstr "Yazı türü punto boyutu."
 msgid "Whether the font is underlined."
 msgstr "Yazı türünün altı çizili olup olmadığı."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Ön izleme:"
@@ -4700,49 +4724,48 @@ msgstr "Yazı türü seçiminden vazgeçmek için tıklayın."
 msgid "Click to confirm the font selection."
 msgstr "Yazı türü seçimini onaylamak için tıklayın."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Yazı türü seçin"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "Seçilmiş bir bloktan fazlasının panoya kopyalanması desteklenmiyor."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "\"%s\" yardım klasörü bulunamadı."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "\"%s\" yardım dosyası bulunamadı."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 "%lu satırında \"%s\" eşleştirme dosyası içinde sözdizimi hatası var, atlandı."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "\"%s\" dosyasında geçerli eşleme bulunamadı."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Herhangi bir kayıt bulunamadı."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Yardım dizini"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "İlgili kayıtlar:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Bulunan kayıt"
 
@@ -4847,59 +4870,59 @@ msgstr "Yazdırma başlatılamadı."
 msgid "Printing page %d..."
 msgstr "Yazdırılan sayfa %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Yazıcı ayarları"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Dosyaya yazdır"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Kurulum..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Yazıcı:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Durum:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tümü"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Sayfalar"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Yazdırma aralığı"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Kaynak:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Kime:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Kopya sayısı:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript dosyası"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Yazdırma ayarları"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Yazıcı"
 
@@ -4907,25 +4930,25 @@ msgstr "Yazıcı"
 msgid "Default printer"
 msgstr "Varsayılan yazıcı"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Kağıt boyutu"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Dikey"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Yatay"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Yön"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Ayarlar"
 
@@ -4937,52 +4960,52 @@ msgstr "Renkli yazdır"
 msgid "Print spooling"
 msgstr "Yazdırma kuyruğu"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Yazıcı komutu:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Yazıcı ayarları:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Sol kenar boşluğu (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Üst kenar boşluğu (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Sağ kenar boşluğu (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Alt kenar boşluğu (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Yazıcı..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "A&tla"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Tamamlandı."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Arama"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Kodun sekmesi bulunamadı"
 
@@ -5018,11 +5041,11 @@ msgstr "&Bitti"
 msgid "< &Back"
 msgstr "< &Geri"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "çevirmenler"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5032,11 +5055,11 @@ msgstr ""
 "ve titremeyle ilgili sorunlara neden olabilir. GTK_IM_MODULE ayarını "
 "kaldırmayı ya da \"ibus\" olarak ayarlamayı düşünün."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "GTK+ başlatılamadı, DISPLAY düzgün ayarlanmış mı?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Geçerli klasör \"%s\" olarak değiştirilemedi"
@@ -5062,11 +5085,11 @@ msgstr "\"%s\" özel yazı türü eklenemedi."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Özel yazı türleri kullanılarak yazı türü yapılandırması kaydedilemedi."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Ciddi sorun"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5078,7 +5101,7 @@ msgstr ""
 "ve yeniden oluşturun ya da uygulamayı başlatmadan önce GDK_BACKEND=x11 \n"
 "ortam değişkenini ayarlayıp, uygulamayı X11 arka yüzü üzerinde çalıştırın."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5089,7 +5112,7 @@ msgstr ""
 "başlatmadan önce GDK_BACKEND=x11 ortam değişkenini ayarlayıp, uygulamayı \n"
 "X11 arka yüzü üzerinde çalıştırarak bu sorunu çözebilirsiniz."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "MDI alt"
 
@@ -5105,15 +5128,11 @@ msgstr "Yazdırma sorunu: "
 msgid "Page Setup"
 msgstr "Sayfa düzeni"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Metin denetime eklenemedi."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "WebKit v1 üzerinde JavaScript çıktısının alınması desteklenmiyor"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5121,7 +5140,7 @@ msgstr ""
 "Yüklü GTK+ çok eski ve ekran karmayı desteklemiyor. Lütfen GTK+ 2.12 ya da "
 "üzeri bir sürüm yükleyin."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5129,17 +5148,13 @@ msgstr ""
 "Sistemin birleştirme (compositing) desteği etkin değil. Lütfen Pencere "
 "Yöneticinizden etkinleştirin."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Bu program çok eski bir GTK+ sürümüyle derlenmiş. Lütfen GTK+ 2.12 ya da "
 "üzeri bir sürümle yeniden derleyin."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Lütfen geçerli bir yazı türü seçin."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5238,45 +5253,45 @@ msgstr "%s içerik dosyası açılamadı"
 msgid "Cannot open index file: %s"
 msgstr "%s dizin dosyası açılamadı"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "adsız"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "%s HTML yardım kitabı açılamadı"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Soldaki kitapları gezilirken yardım görüntülenir."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(yer imleri)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Geçerli sayfayı yer imlerine ekle"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Geçerli sayfayı yer imlerinden sil"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "İçerik"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Bul"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Tümünü görüntüle"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5284,165 +5299,165 @@ msgstr ""
 "Verilen alt dizgeyi içeren tüm dizin elemanları görüntülensin. Arama küçük-"
 "büyük harfe duyarlıdır."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Dizindeki tüm ögeleri görüntüle"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Büyük küçük harfe duyarlı"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Yalnız tam sözcükler"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Yukarıya yazılan metin yardım kitapları içinde her şekilde aranır"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Gezinti panosunu görüntüle/gizle"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Geri git"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "İleri git"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Belge hiyerarşisinde bir düzey yukarı git"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "HTML belgesi aç"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Bu sayfayı yazdır"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Ayarlar penceresi görüntülensin"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Lütfen görüntülenecek sayfayı seçin:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Yardım konuları"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Aranıyor..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Henüz eşleşen bir sayfa bulunamadı"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "%i sonuç bulundu"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Yardım)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d / %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu / %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Tüm kitaplarda arama"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Yardım tarayıcısı ayarları"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Normal yazı türü:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Sabit yazı türü:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Yazı boyutu:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "yazı türü boyutu"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Normal yazı türü <br>ve <u>altı çizili</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Yatık şekil.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Koyu şekil.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Koyu yatık şekil.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Sabit boyutlu tür.<br> <b>koyu</b> <i>eğik</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>koyu yatık <u>altı çizili</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Yardım yazdırma"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Boş sayfa yazdırılamaz."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML dosyaları (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Yardım kitapları (*.htb)|*.htb|Yardım kitapları (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML yardım projesi (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Sıkıştırılmış HTML yardım dosyası (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i / %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u / %u"
@@ -5519,32 +5534,6 @@ msgstr ""
 "Sayfa ayarlanırken bir sorun çıktı: Varsayılan bir yazıcı belirlemeniz "
 "gerekebilir."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "HTML belgesi %s kodlamasıyla görüntülenemedi"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets '%s' için görünümü açamadı: Çıkılıyor."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Süzgeç"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Klasörler"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Dosyalar"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Seçim"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Pano açılamadı."
@@ -5586,58 +5575,58 @@ msgstr "Renk seçimi penceresi %0lx hatasıyla kapandı."
 msgid "Failed to create cursor."
 msgstr "İmleç oluşturulamadı."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "'%s' DDE sunucusuna kayıt olunamadı"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "'%s' DDE sunucusundan kayıt iptali yapılamadı"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "'%s' sunucusuna '%s' konusundan bağlantı kurulamadı"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE itme isteği yapılamadı"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "DDE sunucusuyla danışma döngüsü sağlanamadı"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "DDE sunucusuyla danışma döngüsü sonlandırılamadı"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "DDE danışma uyarısı gönderilemedi"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "DDE dizgesi oluşturulamadı"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "DDE bulunamadı hatası."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "eşzamanlı danışma hareketi isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "harekete yanıt DDE_FBUSY bayrak bitinin kaldırılmasına yol açtı."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "eşzamanlı veri hareketi isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5648,7 +5637,7 @@ msgstr ""
 "ya da DDEML işlevine geçersiz bir \n"
 "örnek tanımlayıcısı gönderildi."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5660,43 +5649,43 @@ msgstr ""
 "ya da APPCMD_CLIENTONLY olarak başlatılmış bir uygulama\n"
 "sunucu hareketi gerçekleştirmeyi denedi."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "eşzamanlı çalıştırma hareketi isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "parametre DDEML tarafından doğrulanamadı."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "bir DDEML uygulaması uzun koşu durumu oluşturdu."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "bellek ayrılamadı."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "bir istemcinin konuşma başlatma denemesi başarısız oldu."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "bir hareket tamamlanamadı."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "eşzamanlı itme hareketi isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "PostMessage işlevine içsel çağrı yapılamadı. "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "yeniden giriş sorunu."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5706,15 +5695,15 @@ msgstr ""
 "sunucu tarafında bir hareket denendi, ya da sunucu\n"
 "hareket tamamlanmadan sonlandırıldı."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "DDEML içinde bir sorun çıktı."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "danışma hareketi bitirme isteği zaman aşımına uğradı."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5724,12 +5713,12 @@ msgstr ""
 "Uygulama XTYP_XACT_COMPLETE çağrısından döndüğünde\n"
 "bu çağrının hareket kimliği geçersiz olacak."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Bilinmeyen DDE hatası %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5737,7 +5726,7 @@ msgstr ""
 "Uzaktan erişim hizmeti (RAS) kurulu olmadığı için arama işlevleri "
 "kullanılamıyor. Lütfen kurun."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5746,64 +5735,64 @@ msgstr ""
 "Bu bilgisayarda kurulu uzak erişim hizmetinin (RAS) sürümü çok eski, lütfen "
 "yükseltin (gereken şu işlev eksik: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "RAS hata iletisi metni alınamadı"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "bilinmeyen sorun (hata kodu %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Etkin çevirmeli bağlantı bulunamadı: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "Birkaç etkin çevirmeli bağlantı bulundu, rastgele biri seçiliyor."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Çevirmeli bağlantı kurulamadı: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "ISS adları alınamadı: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Bağlantı kurulamadı: Aranacak hizmet sağlayıcı yok."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Aranacak hizmet sağlayıcıyı seçin"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Lütfen bağlanmak istediğiniz hizmet sağlayıcıyı seçin"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Bağlantı kurulamadı: Kullanıcı adı/parola eksik."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Adres defteri dosyasının yeri bulunamadı"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Çevirmeli bağlantı başlatılamadı: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Kapatılamadı - etkin çevirmeli bağlantı yok."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Çevirmeli bağlantı sonlandırılamadı: %s"
@@ -5823,18 +5812,17 @@ msgstr "Bit eşlem verisi için %luKb bellek ayrılamadı."
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "'%s' klasöründeki dosyalar sayılamadı"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Klasör adı alınamadı"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(hata %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Görsel listesine bir görsel eklenemedi."
 
@@ -5848,7 +5836,7 @@ msgstr "\"%s\" dosyasından metafile yüklenemedi."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Standart bul/değiştir penceresi oluşturulamadı (hata kodu %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Dosya penceresi %0lx hata koduyla kapandı."
@@ -5889,16 +5877,16 @@ msgstr "'%s' izlemesi kurulamadı"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "\"%s\" klasörü bulunamadığından değişiklikleri izlenemiyor."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL sürücüsü OpenGl 3.0 ve üzerini desteklemez."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "OpenGL içeriği oluşturulamadı"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "OpenGL başlatılamadı"
 
@@ -5906,7 +5894,7 @@ msgstr "OpenGL başlatılamadı"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "Özel DirectWrite yazı türü yükleyicisi kayıt edilemedi."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5914,7 +5902,7 @@ msgstr ""
 "MS HTML Yardım kitaplığı yüklü olmadığından yardım işlevleri kullanılamıyor. "
 "Lütfen yükleyin."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "MS HTML Yardım başlatılamadı."
 
@@ -5923,7 +5911,7 @@ msgstr "MS HTML Yardım başlatılamadı."
 msgid "Can't delete the INI file '%s'"
 msgstr "'%s' INI dosyası silinemedi"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "%d liste denetimi ögesi hakkında bilgi alınamadı."
@@ -6043,7 +6031,7 @@ msgstr "'%s' pano biçimi kaydedilemedi."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "'%d' pano biçimi bulunamıyor."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Atla"
 
@@ -6128,75 +6116,75 @@ msgstr ""
 "silinmesi sistemi kararsız bir hale getirir:\n"
 "işlem iptal edildi."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "'%s' anahtarı silinemedi"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "'%s' değeri '%s' anahtarından silinemiyor"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "'%s' anahtarının değeri okunamadı"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "'%s' değeri değiştirilemedi"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "\"%s\" kayıt değeri sayısal değil (ancak %s türünde)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "\"%s\" kayıt değeri ikili değil (ancak %s türünde)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "\"%s\" kayıt değeri metin değil (ancak %s türünde)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "'%s'' değeri okunamadı"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "'%s' anahtarının değerleri sayılamadı"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "'%s' anahtarının alt anahtarları sayılamadı"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "Kayıt anahtarı verme: \"%s\" dosyası zaten var, üstüne yazılmayacak."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Desteklenmeyen %d türünün değeri verilemedi."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "\"%s\" değeri \"%s\" anahtarı için yok sayılıyor."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6204,47 +6192,47 @@ msgstr ""
 "Zengin metin denetimi oluşturulamıyor. Onun yerine basit metin denetimi "
 "kullanılacak. Lütfen riched32.dll kitaplığını yeniden yükleyin"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "İş parçacığı başlatılamadı: TLS yazma hatası."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "İş parçacığının önceliği ayarlanamadı"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "İş parçacığı oluşturulamadı"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "İş parçacığı sonlandırılamadı"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "İş parçacığının sonlanması beklenemiyor"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "%lx iş parçacığı beklemeye alınamadı"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "%lx iş parçacığı sürdürülemiyor"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Geçerli iş parçacığı imleci alınamadı"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "İş parçacığı modülü başlatılamadı: Yerel depoda dizin oluşturulamıyor"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6273,12 +6261,12 @@ msgstr "\"%s\" kaynağı yüklenemedi."
 msgid "Failed to lock resource \"%s\"."
 msgstr "\"%s\" kaynağı kilitlenemedi."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "yapım %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-bit sürümü"
 
@@ -6290,46 +6278,46 @@ msgstr "Anonim bir tünel oluşturulamadı"
 msgid "Failed to redirect the child process IO"
 msgstr "Alt iş giriş/çıkışı yönlendirilemedi"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' komutu yürütülemedi"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "mpr.dll yüklenemedi."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "'%s' içinden tür adı okunamadı!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "'%s' içinden simge yüklenemedi."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "Kayıt defterinde web görünümü benzetimi düzeyi bulunamadı"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "Web görünümü modern benzetim düzeyine ayarlanamadı"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "Web görünümü standart benzetim düzeyine sıfırlanamadı"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Geçerli bir HTML belgesi olmadan JavaScript betiği çalıştırılamaz"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "JavaScript nesnesi alınamadı"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "değerlendirilemedi"
 
@@ -6362,7 +6350,7 @@ msgid "Check to make the font italic."
 msgstr "Yatık yazı türü için işaretleyin."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Altı çizili"
@@ -6429,15 +6417,33 @@ msgstr "<Any Teletype>"
 msgid "File type:"
 msgstr "Dosya türü:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Pencere"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Yardım"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Küçült"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Yakınlaştır"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Tümünü öne getir"
 
@@ -6454,463 +6460,463 @@ msgstr "\"%s\" yazı türü dosyası bulunamadı."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 "\"%s\" yazı türü dosyası, \"%s\" yazı türü klasöründe bulunamadığından "
 "kullanılamaz."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "%s Hakkında"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Hakkında..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Ayarlar..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Hizmetler"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "%s gizle"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Uygulamayı gizle"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Diğerlerini gizle"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Tümünü görüntüle"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "%s uygulamasından çıkın"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Uygulamadan çık"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Sistem web denetimi tarafından yazdırma desteklenmiyor"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Yazdırma işlemi başlatılamadı"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Punto boyutu"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Yazı türü adı"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Biçem"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Yoğunluk"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Aile"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "UygulamaAlanı"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "EtkinKenarlık"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "EtkinBaşlık"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "DüğmeÖnyüzü"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "DüğmeVurgusu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "DüğmeGölgesi"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "DüğmeMetni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "BaşlıkMetni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "DenetimKoyu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "DenetimAçık"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "GriMetin"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Vurgu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "VurguMetni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "DevreDışıKenarlık"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "DevreDışıBaşlık"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "DevreDışıBaşlıkMetni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Menü"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Kaydırma çubuğu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "İpucu"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "İpucuMetni"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Pencere"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "PencereÇerçevesi"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "PencereMetni"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "İsteğe göre uyarlanmış"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Siyah"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Kestane"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Lacivert"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Mor"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Yeşilimsi mavi"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Gri"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Yeşil"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Zeytin"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Kahverengi"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Mavi"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Fuşya"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Kırmızı"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Turuncu"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Gümüş"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Limon"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Deniz mavisi"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Sarı"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Beyaz"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Varsayılan"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Ok"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Sağ ok"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Boş"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Hedef"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Karakter"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Çarpı"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "El"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-Işını"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Sol düğme"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Büyüteç"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Orta düğme"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Kayıt yok"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Boya fırçası"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Kalem"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Sola ok"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Sağa ok"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Soru oku"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Sağ düğme"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Boyutlandırma KD-GB"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Boyutlandırma K-G"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Boyutlandırma KB-GD"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Boyutlandırma B-D"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Boyutlandırma"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Sprey"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Bekleme"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "İzleme"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Bekleme oku"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Bir seçim yapın:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Özellik"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Değer"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Kategorize kip"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Alfabetik kip"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Yanlış"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Doğru"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Belirtilmemiş"
 
@@ -6924,50 +6930,50 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Geçersiz bir değer yazdınız, düzenlemeyi iptal etmek için ESC tuşuna basın."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "%s kaynağında hata"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
-"\"%s\" tür işlemi yapılamadı: Etiketlenen özellik \"%s\" \"%s\" türünde, \"%s"
-"\" türünde DEĞİL."
+"\"%s\" tür işlemi yapılamadı: Etiketlenen özellik \"%s\" \"%s\" türünde, "
+"\"%s\" türünde DEĞİL."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "%d base bilinmiyor. Base 10 kullanılacak."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Değer %s ya da daha büyük olmalı."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Değer %s ile %s arasında olmalı."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Değer %s ya da daha küçük olmalı."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "%s değil"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Bir klasör seçin:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Bir dosya seçin"
 
@@ -7434,117 +7440,117 @@ msgstr "Gömme"
 msgid "Outset"
 msgstr "Kabartma"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Biçemi değiştir"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Nesne biçemini değiştir"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Özellikleri değiştir"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Liste biçemini değiştir"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Listeyi yeniden numarala"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Metin ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Görsel ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Nesne ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Alan ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Çok fazla EndStyle çağrısı!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "dosyalar"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "standart/daire"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "standart/daire-çerçeve"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "standart/kare"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "standart/elmas"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "standart/üçgen"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Kutu Özellikleri"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Çoklu hücre özellikleri"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Hücre özellikleri"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Hücre biçemini ayarla"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Satırı sil"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Sütunu sil"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Satır ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Sütun ekle"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Tablo özellikleri"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Görsel özellikleri"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "görsel"
 
@@ -7752,24 +7758,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Sürükleyin"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Metni sil"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Madde imini kaldır"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Metin kaydedilemedi."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Değiştir"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Yazı türü:"
 
@@ -8738,53 +8744,53 @@ msgstr "Liste biçemleri"
 msgid "Box styles"
 msgstr "Kutu biçemleri"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Simgenin alınacağı yazı türü."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "A&lt küme:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Bir Unikod alt kümesini görüntüler."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Karakter kodu:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Karakter kodu."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Kaynak:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unikod"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Görüntülenecek aralık."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Insert"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Normal metin)"
 
@@ -8968,7 +8974,7 @@ msgstr "Olaylar kqueue üzerinden alınamadı"
 msgid "Media playback error: %s"
 msgstr "Ortam oynatma hatası: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "\"%s\" oynatmaya hazırlanamadı."
@@ -9068,20 +9074,20 @@ msgstr "Ses verisi desteklenmeyen bir biçimde."
 msgid "Couldn't open audio: %s"
 msgstr "Ses açılamadı: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "İş parçacığı zamanlama ilkesi alınamadı."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Zamanlama ilkesi %d için öncelik aralığı alınamadı."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "İş parçacığı öncelik ayarları yok sayıldı."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9089,59 +9095,59 @@ msgstr ""
 "İş parçacığına katılınamadı, olası bellek taşması bulundu - lütfen programı "
 "yeniden başlatın"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "%lu iş parçacığı öncelik düzeyi ayarlanamadı"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "%d iş parçacığı önceliği ayarlanamadı."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Bir iş parçacığı sonlandırılamadı."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 "İş parçacığı modülü başlatılamadı: İş parçacığı anahtarı oluşturulamadı"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Alt iş girdisi alınamıyor"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Alt işlem stdin yazılamadı"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "'%s' yürütülemedi\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Ayrılma başarısız"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "İşlem önceliği ayarlanamadı"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Alt iş giriş/çıkışı yönlendirilemedi"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "Engellemesiz tünel kurulamadı, program takılabilir."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Sunucu adı alınamadı"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Resmi sunucu adı alınamadı"
 
@@ -9157,12 +9163,12 @@ msgstr "Uyandırma tüneli engellemesiz kipe döndürülemedi"
 msgid "Failed to read from wake-up pipe"
 msgstr "Uyandırma tüneli okunamadı"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "'%s' geometri özelliği geçersiz."
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets görünümü açamadı. Çıkılıyor."
 
@@ -9176,30 +9182,59 @@ msgstr "\"%s\" görüntüsü kapatılamadı"
 msgid "Failed to open display \"%s\"."
 msgstr "\"%s\" görüntüsü açılamadı."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML işleme sorunu: '%s' %d satırında"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Kaynaklar '%s' dosyasından yüklenemedi."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "'%s' kaynak dosyası açılamadı."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Kaynaklar '%s' dosyasından yüklenemedi."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "%s \"%s\" oluşturulamadı."
+
+#~ msgid "Printing "
+#~ msgstr "Yazdırılıyor "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Metin denetime eklenemedi."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Lütfen geçerli bir yazı türü seçin."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "HTML belgesi %s kodlamasıyla görüntülenemedi"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets '%s' için görünümü açamadı: Çıkılıyor."
+
+#~ msgid "Filter"
+#~ msgstr "Süzgeç"
+
+#~ msgid "Directories"
+#~ msgstr "Klasörler"
+
+#~ msgid "Files"
+#~ msgstr "Dosyalar"
+
+#~ msgid "Selection"
+#~ msgstr "Seçim"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "8-bit kodlama dönüşümü yapılamadı"

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-06-23 21:03+0300\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
@@ -15,14 +15,14 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Lokalize 20.12.0\n"
-"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
-"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : "
+"n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Всі файли (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Всі файли (*)|*"
 
@@ -39,24 +39,21 @@ msgid "Remaining time:"
 msgstr "Час, що залишився:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Так"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Ні"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Гаразд"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Скасувати"
@@ -106,7 +103,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Не вдалося створити порт завершення введення-виведення"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Відбиток"
 
@@ -143,7 +140,7 @@ msgstr "Властивості об'єкта"
 msgid "Printing"
 msgstr "Друк"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Символи"
 
@@ -212,7 +209,7 @@ msgstr "Попереднє"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Вікно"
 
@@ -741,11 +738,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "показати цю підказку"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "генерувати багатослівні повідомлення"
 
@@ -767,84 +764,84 @@ msgstr "Непідтримувана тема «%s»."
 msgid "Invalid display mode specification '%s'."
 msgstr "Неправильна специфікація режиму дисплею «%s»."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Знак параметра «%s» не можна обертати"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Невідомий параметр long «%s»"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Невідомий параметр «%s»"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "За параметром «%s» слідують неочікувані символи."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Параметр «%s» потребує значення."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Після параметра «%s» слід використовувати роздільник."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "«%s» — помилкове числове значення для параметра «%s»."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Параметр «%s»: «%s» не може бути конвертована у дату."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Несподіваний параметр «%s»"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (або %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Значення параметра «%s» повинно бути задано."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Обов'язковий параметр «%s» не вказаний."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Використання: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "num"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "double"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "дата"
 
@@ -862,7 +859,7 @@ msgid "Can't &Undo "
 msgstr "Не можу В&ідновити "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "В&ідмінити"
@@ -872,7 +869,7 @@ msgid "&Redo "
 msgstr "&Переробити "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Переробити"
@@ -901,12 +898,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "«%s» містить додаткові «..», проігноровано."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "позначено"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "не позначено"
 
@@ -915,103 +912,103 @@ msgstr "не позначено"
 msgid "undetermined"
 msgstr "не визначено"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "сьогодні"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "вчора"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "завтра"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "перший"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "другий"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "третій"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "четвертий"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "п'ятий"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "шостий"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "сьомий"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "восьмий"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "дев'ятий"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "десятий"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "одинадцятий"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "дванадцятий"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "тринадцятий"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "чотирнадцятий"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "п'ятнадцятий"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "шістнадцятий"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "сімнадцятий"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "вісімнадцятий"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "дев'ятнадцятий"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "двадцятий"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "південь"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "північ"
 
@@ -1080,44 +1077,81 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Не вдалося відвантажити звіт про помилку (код помилки %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Зберегти як"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Відкинути зміни і перезавантажити останню збережену версію?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "безіменний"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Записати зміни до %s?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Зберегти"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Не зберігати"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Записати зміни до %s?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Текст не може бути записаний."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Не вдалося відкрити файл «%s» для запису."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Не вдалося зберегти документ до файла «%s»."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Не вдалося відкрити файл «%s» для читання."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Не вдалося прочитати документ з файла «%s»."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1126,57 +1160,57 @@ msgstr ""
 "Файла «%s» не існує, отже його неможливо відкрити.\n"
 "Його було вилучено зі списку нещодавно використаних."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Не вдалося створити зображення попереднього перегляду друку."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Передогляд друку"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Не вдалося визначити формат файла «%s»."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "безіменний%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " — "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Відкрити файл"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Помилка файла"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Вибачте, не вдалося відкрити цей файл."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Вибачте, формат цього файла не відомий."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Виберіть шаблон документа"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Шаблони"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Виберіть перегляд документа"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Перегляди"
 
@@ -1210,41 +1244,41 @@ msgstr "Помилка читання файла «%s»"
 msgid "Write error on file '%s'"
 msgstr "Помилка запису в файл «%s»"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "не вдалося скинути буфер файла «%s»."
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "Помилка пошуку на файлі «%s» (великі файли не підтримуються stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Помилка пошуку в файлі «%s»"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Не можу знайти теперішню позицію в файлі «%s»"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Не вдалося встановити дозволи на тимчасовий файл"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "помилка вилучення файла «%s»"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "Не вдалося записати зміни в файл «%s»"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "помилка вилучення тимчасового файла «%s»"
@@ -1269,27 +1303,27 @@ msgstr "помилка читання файла з дескриптором %d"
 msgid "can't write to file descriptor %d"
 msgstr "Не вдалося записати в файл з дескриптором %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "Не вдалося злити файл з дескриптором %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "Не вдалося пересунутись у файлі з дескриптором %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "неможливо отримати дану позицію файла з дескриптором %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "Не вдалося встановити довжину файла з дескриптором %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "Не вдалося встановити досягнення кінця файла з дескриптором %d"
@@ -1313,107 +1347,107 @@ msgstr "Зміни не буде збережено, щоб уникнути п�
 msgid "Error reading config options."
 msgstr "Помилка під час читання параметрів налаштування."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Не вдалося прочитати параметри налаштування."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "файл «%s»: несподіваний символ %c у рядку %zu."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "файл «%s», рядок %zu: «%s» проігноровано після заголовка групи."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "файл «%s», рядок %zu: мало бути «=»."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "файл «%s», рядок %zu: значення незмінного ключа «%s» проігноровано."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "файл «%s», рядок %zu: ключ «%s» уперше було знайдено у рядку %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Назва поля в файлі налаштування не може починатися з «%c»."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "Не вдалося відкрити файл налаштувань."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "Не вдалося записати файл налаштувань."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Не вдалося оновити файл налаштування."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Помилка під час збереження даних налаштування користувача."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "Не вдалося вилучити файл налаштувань користувача «%s»"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "поле «%s» з'являється більше одного разу в групі «%s»"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "спроба замінити незамінну клавішу «%s» проігнорована."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "у «%s» проігноровано кінцеву похилу риску"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "несподіваний \" в позиції %d в «%s»."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Помилка копіювання файла «%s» в «%s»."
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Не вдалося отримати дозволи на файл «%s»"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Не вдалося переписати файл «%s»"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Помилка копіювання файла з «%s» до «%s»."
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Не вдалося встановити доступ до файла «%s»"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1422,40 +1456,40 @@ msgstr ""
 "Помилка під час перейменування файла «%s» на «%s», файл з такою назвою вже "
 "існує."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Не вдалося перейменувати файл «%s» на «%s»"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Не вдалося вилучити файл «%s»"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Не вдалося створити каталог «%s»"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Не вдалося вилучити каталог «%s»"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Не можу перелічити файли «%s»"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Не вдалося отримати робочий каталог"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Не вдалося вказати поточний робочий каталог"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Файли (%s)"
@@ -1482,17 +1516,17 @@ msgstr "Помилка створення назви тимчасового фа
 msgid "Failed to open temporary file."
 msgstr "Не вдалося відкрити тимчасовий файл."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Не вдалося змінити час файла для «%s»"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Не вдалося відкрити файл «%s»"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Не вдалося отримати часи файла для «%s»"
@@ -1501,22 +1535,22 @@ msgstr "Не вдалося отримати часи файла для «%s»"
 msgid "Browse"
 msgstr "Навігація"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Всі файли (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s файлів (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Завантажити файл %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Зберегти файл %s"
@@ -1879,99 +1913,99 @@ msgstr "типовий"
 msgid "unknown-%d"
 msgstr "невідомий-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "підкреслене"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " перекреслення"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " тонкий"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " дуже світлий"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " світлий"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr "середній"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr "напівжирний"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " жирний"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " дуже жирний"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " щільний"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " дуже щільний"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " курсив"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "перекреслення"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "тонкий"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "надсвітлий"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "світлий"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "звичайний"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "середній"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "напівжирний"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "жирний"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "наджирний"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "щільний"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "надщільний"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "курсив"
 
@@ -2052,7 +2086,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Не вдалося встановити режим передачі FTP у значення %s."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2073,7 +2107,7 @@ msgstr "Сервер FTP не підтримує пасивний режим."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Некоректна розмірність кадру GIF (%u, %d), кадр з номером %u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Не вдалося виділити колір для OpenGL"
 
@@ -2089,7 +2123,7 @@ msgstr "Налаштувати стовпчики"
 msgid "&Customize..."
 msgstr "&Налаштувати…"
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Не вдалося відкрити адресу «%s» у типовому переглядачі"
@@ -2109,157 +2143,156 @@ msgstr "Не вдалося завантажити зображення %d з п
 msgid "Failed to load icons from resource '%s'."
 msgstr "Не вдалося завантажити піктограми з ресурсу «%s»."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Не можу записати помилкове зображення."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr " BMP: wxImage не має свого wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Не вдалося записати заголовок (Bitmap) файла."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Не вдалося записати заголовок (BitmapInfo) файла."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Не вдалося записати карту кольорів RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Не можу записати дані."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Не вдалося виділити пам'ять."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Заголовок DIB: ширина картинки у файлі > 32767 пікселів."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Заголовок DIB: Висота картинки у файлі > 32767 пікселів."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Заголовок DIB: невідома бітова глибина даних у файлі."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Заголовок DIB: невідоме кодування файла."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Заголовок DIB: Кодування не відповідає глибині бітів."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: у заголовку вказано biClrUsed=%d, а biBitCount=%d."
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Не вдалося виділити пам'ять."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Заголовок DIB: ширина картинки у файлі > 32767 пікселів."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Заголовок DIB: Висота картинки у файлі > 32767 пікселів."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Заголовок DIB: невідома бітова глибина даних у файлі."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Заголовок DIB: невідоме кодування файла."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Заголовок DIB: Кодування не відповідає глибині бітів."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Помилка під час читання картинки DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Помилка під час читання маски DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: зображення зависоке для піктограми"
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: зображення зашироке для піктограми"
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Помилка запису файла зображення!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Помилковий індекс піктограми."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Зображення і маска мають різні розміри."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Немає невикористаного кольору в зображенні, яке маскується."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Не вдалося завантажити растрове зображення «%s» з ресурсів."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Не вдалося завантажити піктограму «%s» з ресурсів."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Не вдалося завантажити зображення з файла «%s»."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Не вдалося записати зображення до файла «%s»: невідомий суфікс назви."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Не знайдено жодного інструменту обробки для зображення."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Не знайдено жодного обробника для зображення типу %d."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Файл зображення не належить до типу %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Неможливо визначити формат зображення у автоматичному режимі для вхідних "
 "даних без можливості позиціювання."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Невідомий формат даних зображення."
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Це не %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Не знайдено жодного обробника для зображення типу %s."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Зображення не належить до типу %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Не вдалося перевірити формат файла зображення «%s»."
@@ -2362,41 +2395,41 @@ msgstr "PNM: файл здається обірваним."
 msgid " (in module \"%s\")"
 msgstr " (у модулі «%s»)"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Помилка під час завантаження зображення."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Неможливий індекс зображення TIFF."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: розмір зображення є надзвичайно великим."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Не вдалося виділити пам'ять."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Помилка читання зображення."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Невідому одиницю роздільної здатності TIFF, %d, проігноровано"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Помилка запису зображення."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Помилка запису зображення."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2405,11 +2438,11 @@ msgstr ""
 "Не вдалося перетворити параметр командного рядка %d у Unicode, параметр буде "
 "проігноровано."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Помилка ініціалізації у процесі post init, зупинка."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Не вдалося встановити локаль у значення «%s»."
@@ -2456,8 +2489,7 @@ msgstr "Не вдалося отримати область пам'яті для
 #: ../src/common/lzmastream.cpp:125
 #, c-format
 msgid "Failed to initialize LZMA decompression: unexpected error %u."
-msgstr ""
-"Не вдалося ініціалізувати розпаковування LZMA: неочікувана помилка %u."
+msgstr "Не вдалося ініціалізувати розпаковування LZMA: неочікувана помилка %u."
 
 #: ../src/common/lzmastream.cpp:179
 msgid "input is not in XZ format"
@@ -2508,7 +2540,7 @@ msgstr "Помилка пакування LZMA: %s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "Помилка стискання LZMA при скиданні виведених даних: %s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Незакрита дужка '{' в запису для типу MIME %s."
@@ -2528,7 +2560,7 @@ msgstr "Необхідний компонент «%s» для модуля «%s�
 msgid "Module \"%s\" initialization failed"
 msgstr "Виклик модулі «%s» зазнав невдачі"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Повідомлення"
 
@@ -3030,7 +3062,7 @@ msgstr "Помилка друку"
 msgid "Print"
 msgstr "Друк"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Налаштування сторінки"
 
@@ -3065,19 +3097,15 @@ msgstr "Друкуємо сторінку %d з %d"
 msgid " (copy %d of %d)"
 msgstr " (копія %d з %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Друк"
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Перша сторінка"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Попередня сторінка"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Наступна сторінка"
 
@@ -3121,16 +3149,16 @@ msgstr "Сторінка %d з %d"
 msgid "Page %d"
 msgstr "Сторінка %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "Невідома помилка"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Неправильний регулярний вираз «%s»: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Не вдалося знайти відповідник для регулярного виразу: %s"
@@ -3141,21 +3169,21 @@ msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 "Візуалізатор «%s» має несумісну версію %d.%d, його неможливо завантажити."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "Є недоступним для цієї платформи"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Не вдалося зберегти пароль для «%s»: %s."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Не вдалося прочитати пароль для «%s»: %s."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Не вдалося вилучити пароль для «%s»: %s."
@@ -3164,11 +3192,11 @@ msgstr "Не вдалося вилучити пароль для «%s»: %s."
 msgid "Failed to monitor I/O channels"
 msgstr "Спроба спостереження за каналами вводу-виводу була невдалою"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Зберегти"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Не зберігати"
 
@@ -3249,10 +3277,10 @@ msgid "Clear"
 msgstr "Спорожнити"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Закрити"
 
@@ -3264,7 +3292,7 @@ msgstr "Пе&ретворити"
 msgid "Convert"
 msgstr "Перетворити"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Копія"
@@ -3273,7 +3301,7 @@ msgstr "&Копія"
 msgid "Copy"
 msgstr "Копіювати"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "В&ирізати"
@@ -3282,13 +3310,13 @@ msgstr "В&ирізати"
 msgid "Cut"
 msgstr "Вирізати"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Вилучити"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Вилучити"
@@ -3375,7 +3403,7 @@ msgstr "Жорсткий диск"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "&Довідка"
 
@@ -3395,7 +3423,7 @@ msgstr "Відступ"
 msgid "&Index"
 msgstr "&Індекс"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Індекс"
 
@@ -3464,7 +3492,7 @@ msgstr "&Створити"
 msgid "New"
 msgstr "Створити"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Ні"
 
@@ -3481,12 +3509,12 @@ msgstr "&Відкрити…"
 msgid "Open..."
 msgstr "Відкрити…"
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Вставити"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Вставити"
@@ -3516,7 +3544,7 @@ msgid "Print..."
 msgstr "Надрукувати…"
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Властивості"
 
@@ -3548,10 +3576,6 @@ msgstr "Замінити…"
 msgid "Revert to Saved"
 msgstr "Повернутися до збереженого"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Зберегти"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "Зберегти &як..."
@@ -3560,7 +3584,7 @@ msgstr "Зберегти &як..."
 msgid "Save As..."
 msgstr "Зберегти як…"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "В&ибрати все"
@@ -3667,7 +3691,7 @@ msgstr "До&гори"
 msgid "Up"
 msgstr "Вверх"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "&Так"
 
@@ -3755,43 +3779,43 @@ msgstr "Зберегти поточний документ"
 msgid "Save current document with a different filename"
 msgstr "Зберегти поточний документ з іншою назвою"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Перетворення до набору символів «%s» не працює."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "невідомий"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "блок заголовка у tar не повний"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "помилка під час перевірки контрольної суми у заголовку tar"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "некоректні дані у розширеному заголовку tar"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "елемент tar не відкрито"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "несподіваний кінець файла"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s не відповідало заголовку архіву tar для елемента «%s»"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "некоректно задано розмір для елемента tar"
 
@@ -3800,7 +3824,7 @@ msgstr "некоректно задано розмір для елемента t
 msgid "'%s' is probably a binary buffer."
 msgstr "«%s» — можливо бінарний файл."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Файл не можна завантажити."
 
@@ -3814,47 +3838,47 @@ msgstr "Не вдалося прочитати текстовий файл «%s�
 msgid "can't write buffer '%s' to disk."
 msgstr "неможливо записати буфер «%s» на диск."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Не вдалося отримати локальний системний час"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "помилка wxGetTimeOfDay."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "«%s» — помилковий каталог повідомлень."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Помилковий каталог повідомлень."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Не вдалося обробити форми множини: «%s»"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "використовується каталог «%s» з «%s»."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Ресурс «%s» не є коректним каталогом повідомлень."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Не вдалося пронумерувати переклади"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Для файлів HTML не вказано типової програми."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Не вдалося відкрити адресу «%s» у типовому переглядачі."
@@ -3887,7 +3911,7 @@ msgstr "«%s» містить некоректні символи"
 msgid "Error: %s (%d)"
 msgstr "Помилка: %s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "Недостатньо вільного місця для отримання даних."
 
@@ -3895,20 +3919,20 @@ msgstr "Недостатньо вільного місця для отриман
 msgid "libcurl could not be initialized"
 msgstr "Не вдалося ініціалізувати libcurl"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "Підтримки RunScriptAsync не передбачено"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "Помилка під час спроби запустити JavaScript: %s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "На цій платформі підтримки прозорості тла не передбачено."
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Не вдалося передати дані в вікно"
 
@@ -3962,8 +3986,8 @@ msgstr "Параметр Create %s не знайдено серед описан
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Некоректний клас об'єктів (Не-wxEvtHandler) як джерело подій"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Тип має містити перетворення enum — long"
 
@@ -4015,81 +4039,81 @@ msgstr "Об'єкти повинні мати атрибут id"
 msgid "Doubly used id : %d"
 msgstr "Двічі використаний id : %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Невідома властивість %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Непорожня колекція має складатися з вузлів-\"елементів\""
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "помилковий рядок обробника події, відсутня точка"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "неможливо переініціювати потік стискання zlib"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "неможливо переініціювати потік розпакування zlib"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
-"Ігноруємо помилково форматований зайвий запис даних, файл ZIP може бути"
-" пошкоджено"
+"Ігноруємо помилково форматований зайвий запис даних, файл ZIP може бути "
+"пошкоджено"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "припускається, що це ланцюговий zip з багатьох частин"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "некоректний файл zip"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "неможливо знайти центральну теку у zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "помилка під час читання центральної теки zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "помилка читання локального заголовка zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "некоректний відступ для входу у zip-файлі"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "довжина запакованого файла не у заголовку Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "непідтримуваний метод стиснення Zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "читання потоку zip (елемент %s): помилкова довжина"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "читання потоку zip (елемент %s): помилкова контрольна сума"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "помилка запису елемента zip «%s»: файл є надто великим без ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4176,32 +4200,32 @@ msgstr "Графічні елементи від "
 msgid "Translations by "
 msgstr "Переклад "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Версія "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Про %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Ліцензія"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Розробники"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Автори документації"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Художники"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Перекладачі"
 
@@ -4252,43 +4276,42 @@ msgid "Password:"
 msgstr "Пароль:"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "істина"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "хибність"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "Рядок %i"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "Згорнути"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "Розгорнути"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d елемент)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "Стовпчик %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4299,8 +4322,7 @@ msgid "Left"
 msgstr "Ліворуч"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4396,7 +4418,7 @@ msgid "Home directory"
 msgstr "Домашня тека"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Робочий стіл"
 
@@ -4409,8 +4431,7 @@ msgstr "Неправильне назва теки."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Помилка"
 
@@ -4596,16 +4617,16 @@ msgstr "Перегляд файлів з подробицями"
 msgid "Go to parent directory"
 msgstr "В батьківську теку"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Файл «%s» вже присутній, ви справді хочете його переписати?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Підтвердити"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Будь ласка, виберіть наявний файл."
 
@@ -4699,7 +4720,7 @@ msgstr "Розмір шрифту:"
 msgid "Whether the font is underlined."
 msgstr "Чи буде шрифт з підкресленням."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Передогляд:"
@@ -4717,50 +4738,49 @@ msgstr "Клацніть, щоб скасувати вибір шрифту."
 msgid "Click to confirm the font selection."
 msgstr "Клацніть, щоб підтвердити вибір шрифту."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Виберіть шрифт"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
-"Підтримки копіювання декількох позначених блоків до буфера обміну даними не"
-" передбачено."
+"Підтримки копіювання декількох позначених блоків до буфера обміну даними не "
+"передбачено."
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Теку довідки «%s» не знайдено."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Файл довідки «%s» не знайдено."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Рядок %lu файла карти «%s» має помилковий синтаксис, пропущено."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Не знайдено дійсних відповідників у файлі «%s»."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Запис не знайдений."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Індекс довідки"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Відповідні записи:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Знайдені записи"
 
@@ -4864,59 +4884,59 @@ msgstr "Не вдалося почати друк."
 msgid "Printing page %d..."
 msgstr "Друк сторінки %d…"
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Параметри принтера"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "Друк в файл"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Налаштування…"
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Друкарка:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Статус:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Всі"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Сторінки"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Друк інтервалу"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Від:"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "До:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Копії:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "Файл PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Налаштування друку"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Друкарка"
 
@@ -4924,25 +4944,25 @@ msgstr "Друкарка"
 msgid "Default printer"
 msgstr "Типова друкарка"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Розмір паперу"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Книжкова"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Альбомна"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Орієнтація"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Параметри"
 
@@ -4954,52 +4974,52 @@ msgstr "Друк в кольорі"
 msgid "Print spooling"
 msgstr "Спулінг друку"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Команда принтеру:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Параметри принтера:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Ліве поле (мм):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Верхня межа (мм):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Права межа (мм):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Нижнє поле (мм):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Принтер…"
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Проп&устити"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Невідомий"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Зроблено."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Пошук"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Не вдалося знайти вкладку для ідентифікатора"
 
@@ -5035,27 +5055,27 @@ msgstr "&Закінчити"
 msgid "< &Back"
 msgstr "< &Назад"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "подяки перекладачам"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
-"УВАГА! Підтримки використання способу введення XIM не передбачено."
-" Використання цього способу введення може призвести до проблем із обробкою"
-" вхідних даних і блимання. Спробуйте скасувати встановлення GTK_IM_MODULE"
-" або встановіть спосіб введення «ibus»."
+"УВАГА! Підтримки використання способу введення XIM не передбачено. "
+"Використання цього способу введення може призвести до проблем із обробкою "
+"вхідних даних і блимання. Спробуйте скасувати встановлення GTK_IM_MODULE або "
+"встановіть спосіб введення «ibus»."
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "Не вдалося ініціалізувати GTK+, чи правильно встановлено змінну DISPLAY?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Не вдалося змінити поточний каталог на «%s»"
@@ -5065,8 +5085,8 @@ msgid ""
 "Using private fonts is not supported on this system: Pango library is too "
 "old, 1.38 or later required."
 msgstr ""
-"У цій системі не можна користуватися приватними шрифтами: бібліотека Pango є"
-" надто старою, потрібна версія 1.38 або новіша."
+"У цій системі не можна користуватися приватними шрифтами: бібліотека Pango є "
+"надто старою, потрібна версія 1.38 або новіша."
 
 #: ../src/gtk/font.cpp:562
 msgid "Failed to create font configuration object."
@@ -5080,14 +5100,14 @@ msgstr "Не вдалося додати нетиповий шрифт «%s»."
 #: ../src/gtk/font.cpp:580
 msgid "Failed to register font configuration using private fonts."
 msgstr ""
-"Не вдалося зареєструвати налаштування шрифтів з використанням приватних"
-" шрифтів."
+"Не вдалося зареєструвати налаштування шрифтів з використанням приватних "
+"шрифтів."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "Критична помилка"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5095,24 +5115,24 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 "Цю програму не було зібрано з підтримкою EGL, яка потрібна у Wayland; або\n"
-"встановіть бібліотеки EGL і повторно зберіть пакунок, або запустіть програму"
-" під керуванням модуля X11,\n"
-"встановивши значення змінної середовища GDK_BACKEND=x11 перед запуском вашої"
-" програми."
+"встановіть бібліотеки EGL і повторно зберіть пакунок, або запустіть програму "
+"під керуванням модуля X11,\n"
+"встановивши значення змінної середовища GDK_BACKEND=x11 перед запуском вашої "
+"програми."
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
 "work around this by setting environment variable GDK_BACKEND=x11 before\n"
 "starting your program."
 msgstr ""
-"Підтримку wxGLCanvas у поточній версії передбачено лише у Wayland та X11. Ви"
-" можете обійти цю проблему\n"
+"Підтримку wxGLCanvas у поточній версії передбачено лише у Wayland та X11. Ви "
+"можете обійти цю проблему\n"
 "встановленням значення змінної середовища GDK_BACKEND=x11 перед запуском\n"
 "вашої програми."
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "Нащадок MDI"
 
@@ -5128,17 +5148,13 @@ msgstr "Помилка під час друку: "
 msgid "Page Setup"
 msgstr "Налаштування сторінки"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Не вдалося додати текст до контрола."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
-"При використанні WebKit 1 не передбачено підтримки отримання виведених"
-" скриптом JavaScript даних"
+"При використанні WebKit 1 не передбачено підтримки отримання виведених "
+"скриптом JavaScript даних"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5147,7 +5163,7 @@ msgstr ""
 "композитне відтворення належним чином. Будь ласка, встановіть версію "
 "бібліотек GTK+ 2.12 або пізнішу."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5156,17 +5172,13 @@ msgstr ""
 "ласка, увімкніть композитне відтворення у вашій програмі для керування "
 "вікнами."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Цю програму було зібрано з надто старою версією GTK+. Будь ласка, виконайте "
 "повторне збирання з версією GTK+ 2.12 або новішою."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Будь ласка, виберіть коректний шрифт."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5265,45 +5277,45 @@ msgstr "Не вдалося відкрити файл змісту: %s"
 msgid "Cannot open index file: %s"
 msgstr "Не вдалося відкрити файл індексу: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "без назви"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Не вдалося відкрити книгу довідки HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Показує довідку у той час, коли ви гортаєте книжки ліворуч."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(закладки)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Додати цю сторінку до закладок"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Вилучити цю сторінку з закладок"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Зміст"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Знайти"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Показати всі"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5311,165 +5323,165 @@ msgstr ""
 "Вивести всі рядки індексу, що містять даний підрядок. Пошук без врахування \n"
 "регістру."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Показати всі рядки індексу"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "З врахуванням регістру"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Тільки цілі слова"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "Пошук в книгах довідки всіх згадок введеного вище тексту"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Показати/сховати навігаційну панель"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Іти назад"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Іти вперед"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Перейти на рівень вгору ієрархією документа"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Відкрити документ HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "Надрукувати цю сторінку"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Відкрити діалогове вікно параметрів"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Будь ласка, виберіть сторінку для показу:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Розділи довідки"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Пошук…"
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Відповідної сторінки ще не знайдено"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Знайдено %i відповідностей"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Довідка)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d з %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu з %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Пошук в усіх книгах"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Параметри перегляду довідки"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Звичайний шрифт:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Фіксований шрифт:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Розмір шрифту:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "Розмір шрифту:"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Звичайний шрифт<br>та <u>підкреслений</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Курсивний шрифт.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Жирний шрифт.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Жирний курсивний шрифт.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Шрифт з фіксованою шириною.<br> <b>жирний</b> <i>курсивний</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>жирний курсивний шрифт <u>з підкресленням</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Довідка друку"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Не вдалося надрукувати порожню сторінку."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Файли HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Книги довідки (*.htb)|*.htb|Книги довідки (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "Проект довідки HTML (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Стиснутий файл довідки HTML (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i з %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u з %u"
@@ -5549,32 +5561,6 @@ msgstr ""
 "Під час створення сторінки виникла проблема: можливо, вам слід встановити "
 "типовий принтер."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Не вдалося показати документ HTML у кодуванні %s"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets не зміг відкрити дисплей для «%s»: виходжу."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Фільтр"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Теки"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Файли"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Позначене"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Не вдалося відкрити clipboard."
@@ -5616,58 +5602,58 @@ msgstr "Діалогове вікно вибору кольору повідом
 msgid "Failed to create cursor."
 msgstr "Не вдалося створити курсор."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Не вдалося зареєструвати сервер DDE «%s»"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Не вдалося скасувати реєстрацію сервера DDE «%s»"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Не вдалося підключитись до серверу «%s» по темі «%s»"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Помилка читання DDE"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Не вдалося встановити зв'язок помочі з DDE сервером"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Не вдалося закінчити 'advise loop' з DDE сервером."
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Не вдалося надіслати повідомлення DDE"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Помилка створення рядка DDE"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "немає помилки"
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "запит на синхронну дію з надання поради перевищив границю часу"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "відповідь на дію викликала встановлення біта DDE_FBUSY."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "строк виконання запиту на синхронне передавання даних вичерпано."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5679,7 +5665,7 @@ msgstr ""
 "або неправильний ідентифікатор інстанції\n"
 "було передано до DDEML функції."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5691,44 +5677,44 @@ msgstr ""
 "або програма запущена як APPCMD_CLIENTONLY \n"
 "спробувала виконати серверні дії."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "строк виконання запиту на синхронну дію з виконання вичерпано."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "параметр не пройшов перевірку DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "застосування DDEML створило затяжні перегони."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "помилка виділення пам'яті."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "спроба клієнту встановити зв'язок не вдалася."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "помилкова дія."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 "строк виконання запиту на синхронну дію з запису елемента даних вичерпано."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "внутрішній виклик до PostMessage не пройшов"
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "проблема з повторним входом."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5738,16 +5724,15 @@ msgstr ""
 "її перервано клієнтом, або сервер було\n"
 "зупинено до завершення дії."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "внутрішня помилка у DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
-msgstr ""
-"строк виконання запиту щодо завершення дії з надання поради вичерпано."
+msgstr "строк виконання запиту щодо завершення дії з надання поради вичерпано."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5757,12 +5742,12 @@ msgstr ""
 "Тільки-но програма повернулася зі зворотного виклику XTYP_XACT_COMPLETE,\n"
 "ідентифікатор дії для цього виклику вже не є дійсним."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Невідома помилка DDE %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5770,7 +5755,7 @@ msgstr ""
 "Службу віддаленого з'єднання (RAS) на цьому комп’ютері не встановлено. Будь "
 "ласка, встановіть її."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5779,66 +5764,65 @@ msgstr ""
 "Версія служби віддаленого доступу (RAS), встановлена на цій машині "
 "застаріла, будь ласка, оновіть її (не вистачає функції %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Не вдалося прочитати повідомлення про помилку RAS"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "Невідома помилка (код помилки %08x)"
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Не вдалося знайти активне модемне з'єднання: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Знайдено декілька активних комутованих з'єднань, випадково вибираємо одне."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Не вдалося додзвонитись: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Не вдалося отримати номеру ISP: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Не вдалося додзвонитись: відсутній інтернет-провайдер."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Оберіть інтернет провайдера"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
-msgstr ""
-"Будь ласка, виберіть надавача послуг інтернету, з яким слід з’єднатися"
+msgstr "Будь ласка, виберіть надавача послуг інтернету, з яким слід з’єднатися"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Не вдалося підключитись: не вказано користувача/пароля."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Файл з адресною книгою не знайдений"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Не вдалося ініціалізувати комутоване з’єднання: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Не вдалося повісити трубку — немає з'єднання."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Не вдалося повісити трубку: %s"
@@ -5858,18 +5842,17 @@ msgstr "Не вдалося виділити %lu кБ пам'яті для да�
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Не можу перелічити файли в каталозі «%s»"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Не вдалося отримати назву теки"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(помилка %d: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Не вдалося додати зображення до списку зображень."
 
@@ -5884,7 +5867,7 @@ msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 "Не вдалося створити стандартний діалог знайти/замінити (код помилки %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Помилка діалогового вікна роботи з файлами з кодом %0lx."
@@ -5926,17 +5909,17 @@ msgstr "Не вдалося налаштувати спостереження з
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "Спостереження за змінами у каталозі «%s», якого не існує, неможливе."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 "У драйвері OpenGL  не передбачено підтримки OpenGL 3.0 або пізнішої версії."
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "Не вдалося створити контекст OpenGL"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Не вдалося ініціалізувати OpenGL"
 
@@ -5944,7 +5927,7 @@ msgstr "Не вдалося ініціалізувати OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "Не вдалося зареєструвати нетиповий завантажувач шрифтів DirectWrite."
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5952,7 +5935,7 @@ msgstr ""
 "Функції довідки MS HTML недоступні, оскільки на цій машині не встановлено "
 "бібліотеку довідки MS HTML. Будь ласка, встановіть її."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Не вдалося ініціалізувати MS HTML Help."
 
@@ -5961,7 +5944,7 @@ msgstr "Не вдалося ініціалізувати MS HTML Help."
 msgid "Can't delete the INI file '%s'"
 msgstr "Не вдалося вилучити INI-файл «%s»"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Не вдалося встановити інформацію про елемент списку %d."
@@ -6081,7 +6064,7 @@ msgstr "Не вдалося зареєструвати формат «%s»"
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Формату буфера даних «%d» не існує."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Пропустити"
 
@@ -6166,76 +6149,75 @@ msgstr ""
 "його знищення приведе вашу систему в недієздатний стан:\n"
 "дію скасовано."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Не вдалося вилучити ключ «%s»"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Не вдалося вилучити значення «%s» ключа «%s»"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Не вдалося прочитати значення ключа «%s»"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Не вдалося встановити значення «%s»"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "Значення реєстру «%s» не є числовим (а належить до типу %s)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "Значення реєстру «%s» не є двійковим (а належить до типу %s)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "Значення реєстру «%s» не є текстовим (а належить до типу %s)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Не вдалося прочитати значення «%s»"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Не вдалося підрахувати значення ключа «%s»"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Не вдалося підрахувати підключі ключа «%s»"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
-msgstr ""
-"Експорт ключа реєстру: файл «%s» вже існує, його не буде перезаписано."
+msgstr "Експорт ключа реєстру: файл «%s» вже існує, його не буде перезаписано."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Не вдалося експортувати значення непідтримуваного типу %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Значенням «%s» ключа «%s» знехтувано."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6244,41 +6226,41 @@ msgstr ""
 "використовується звичайний модуль показу тексту. Будь ласка, перевстановіть "
 "riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Не вдалося запустити нитку: помилка запису TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Не вдалося встановити пріоритет нитки"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Не вдалося створити нитку"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Не вдалося закінчити нитку"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Не вдалося дочекатись закінчення нитки"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Не вдалося зупинити нитку %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Не вдалося відновити нитку %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Не вдалося отримати показник на дану нитку"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6286,7 +6268,7 @@ msgstr ""
 "Помилка ініціалізації модуля ниток: Не вдалося виділити індекс в локальному "
 "просторі нитки"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6318,12 +6300,12 @@ msgstr "Не вдалося завантажити ресурс «%s»."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Не вдалося заблокувати ресурс «%s»."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "збірка %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", 64-бітова версія"
 
@@ -6335,51 +6317,51 @@ msgstr "Не вдалося створити анонімну трубу"
 msgid "Failed to redirect the child process IO"
 msgstr "Не вдалося переспрямувати IO дочірнього процесу"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Помилка виконання команди «%s»"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Не вдалося завантажити mpr.dll."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Не вдалося прочитати назву типу з «%s»!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Не вдалося завантажити піктограму з «%s»."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 "Не вдалося знайти рівень емуляції для перегляду сторінок інтернету у регістрі"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
-"Не вдалося встановити для перегляду сторінок інтернету сучасний рівень"
-" емуляції"
+"Не вдалося встановити для перегляду сторінок інтернету сучасний рівень "
+"емуляції"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
-"Не вдалося відновити для перегляду сторінок інтернету стандартний рівень"
-" емуляції"
+"Не вдалося відновити для перегляду сторінок інтернету стандартний рівень "
+"емуляції"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "Неможливо запустити скрипт JavaScript без коректного документа HTML"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "Не вдалося отримати об'єкт JavaScript"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "не вдалося обчислити"
 
@@ -6412,7 +6394,7 @@ msgid "Check to make the font italic."
 msgstr "Позначте, щоб зробити шрифт курсивним."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Підкреслене"
@@ -6479,15 +6461,33 @@ msgstr "<Будь-який машинописний>"
 msgid "File type:"
 msgstr "Тип файлів:"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "Вікно"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Довідка"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "Мінімізувати"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Масштаб"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "Пересунути все на передній план"
 
@@ -6504,463 +6504,463 @@ msgstr "Файла шрифту «%s» не існує."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
-"Файлом шрифту «%s» неможливо скористатися, оскільки він не зберігається у"
-" каталозі шрифтів «%s»."
+"Файлом шрифту «%s» неможливо скористатися, оскільки він не зберігається у "
+"каталозі шрифтів «%s»."
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Про %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Про програму…"
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Налаштування…"
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Служби"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Сховати %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Приховати програму"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Сховати решту"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Показати всі"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Вийти з %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Вийти з програми"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "Загальносистемним вебкеруванням не передбачено підтримки друку"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "Не вдалося ініціалізувати дію з друку"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "Розмір точки"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Нарис"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Стиль"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Вага"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Гарнітура"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "РобочаОбластьДодатків"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "АктивнаРамка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "АктивнийЗаголовок"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "ВерхКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "ПідсвічуванняКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "ЗатінитиКнопку"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "ТекстКнопки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "ТекстЗаголовка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "КонтрольТемний"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "КонтрольСвітлий"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "СірийТекст"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "Підсвічування"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "ПідсвічуванняТексту"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "НеактивнаРамка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "НеактивнийЗаголовок"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "ТекстНеактивногоЗаголовка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Меню"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "СмужкаГортання"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "Підказка"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "ТекстПідказки"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "Вікно"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "РамкаВікна"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "ТекстВікна"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "Нетиповий"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "Чорний"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "Брунато-малиновий"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "Темно-синій"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "Пурпуровий"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "Зеленувато-блакитний"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "Сірий"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "Зелений"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "Оливковий"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "Коричневий"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "Синій"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "Фуксія"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "Червоний"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "Помаранчевий"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "Срібний"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "Лайм"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "Аква"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "Жовтий"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "Білий"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "Типовий"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "Стрілка"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Стрілка праворуч"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "Порожній"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Центр мішені"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "Символ"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "Хрест"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "Рука"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "I-подібний"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "Ліва кнопка"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "Лупа"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "Середня кнопка"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "Вхід заборонено"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "Кінчик пензля"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "Олівець"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "Вказівник ліворуч"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Вказівник праворуч"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Стрілка зі знаком питання"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Права кнопка"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "Розмірний ПнСх-ПдЗх"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "Розмірний Пн-Пд"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "Розмірний ПнЗх-ПдСх"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "Розмірний Зх-Сх"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "Зміна розміру"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "Пульверизатор"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "Очікування"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "Спостереження"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Стрілка очікування"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Зробіть вибір:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Властивість"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Значення"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Режим з категоризацією"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Абетковий режим"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Ні"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Так"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Не вказано"
 
@@ -6974,12 +6974,12 @@ msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 "Вами введено некоректне значення. Натисніть ESC, щоб скасувати редагування."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Помилка у ресурсі: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -6988,36 +6988,36 @@ msgstr ""
 "Помилка дії з типами «%s»: властивість з міткою «%s» належить до типу «%s», "
 "а не «%s»."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "Невідома основа числення %d. Буде використано основу числення 10."
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Значення має бути рівним або більшим за %s."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Значення має належати проміжку від %s до %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Значення має бути рівним або меншим за %s."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Не %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Виберіть каталог:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Виберіть файл"
 
@@ -7484,117 +7484,117 @@ msgstr "Вкладка"
 msgid "Outset"
 msgstr "Накладка"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Змінити стиль"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Змінити стиль об’єкта"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Змінити властивості"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Змінити стиль списку"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Перенумерувати список"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Вставити текст"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Вставити картинку"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Вставити об’єкт"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Вставити поле"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Забагато викликів EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "файли"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "стандартний/коло"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "стандартний/круговий контур"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "стандартний/квадрат"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "стандартний/ромб"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "стандартний/трикутник"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Властивості рамок"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Властивості декількох комірок"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Властивості комірки"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Встановити стиль комірки"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Вилучити рядок"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Вилучити стовпчик"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Додати рядок"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Додати стовпчик"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Властивості таблиці"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Властивості малюнка"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "картинка"
 
@@ -7802,24 +7802,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Перетягування"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Вилучити текст"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Вилучити позначку"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Текст не може бути записаний."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Замінити"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Шрифт:"
 
@@ -8789,53 +8789,53 @@ msgstr "Стилі списку"
 msgid "Box styles"
 msgstr "Стилі рамок"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Шрифт, з якого слід брати символ."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "&Підмножина:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Показує підмножину Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "Код &символу:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Код символу."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Від:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Діапазон показу."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Вставити"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Звичайний шрифт)"
 
@@ -9021,7 +9021,7 @@ msgstr "Не вдалося отримати список подій від kque
 msgid "Media playback error: %s"
 msgstr "Помилка відтворення мультимедійних даних: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Не вдалося приготувати «%s» до відтворення."
@@ -9121,20 +9121,20 @@ msgstr "Звукові дані знаходяться у непідтримув
 msgid "Couldn't open audio: %s"
 msgstr "Не вдалося відкрити аудіо: «%s»"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Не вдалося встановити порядок нитки."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Не вдалося отримати інтервал пріоритету для розпорядку %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Пріоритет нитки проігноровано."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9142,60 +9142,60 @@ msgstr ""
 "Не вдалося з'єднатися з ниткою, можливий виток пам'яті, будь ласка, "
 "перезапустіть програму"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Не вдалося встановити рівень пріоритетності нитки у значення %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Не вдалося встановити пріоритет нитки %d."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Не вдалося закінчити нитку."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Помилка ініціалізації модуля ниток: не вдалося створити ключ нитки"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Не вдалося отримати дані від зародженого процесу"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Запис до стандартного входу дочірнього процесу неможливий"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Не вдалося виконати «%s»\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Невдале розгалуження"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Не вдалося встановити пріоритет процесу"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Не вдалося переспрямувати ввід/вивід зародженого процесу"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Не вдалося налаштувати канал обробки без блокування, програма може "
 "«зависнути»."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Не вдалося отримати назву вузла"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Не вдалося отримати офіційне назву вузла"
 
@@ -9213,12 +9213,12 @@ msgstr "Не вдалося перемкнути канал повернення
 msgid "Failed to read from wake-up pipe"
 msgstr "Не вдалося прочитати дані з каналу повернення зі сну"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Неправильна специфікація геометрії «%s»"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets не вдалося відкрити дисплей. Завершення роботи."
 
@@ -9232,30 +9232,59 @@ msgstr "Не вдалося закрити дисплей «%s»"
 msgid "Failed to open display \"%s\"."
 msgstr "Не вдалося відкрити дисплей «%s»."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Помилка розбору XML: «%s» у рядку %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Не вдалося завантажити ресурси з «%s»."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Не вдалося відкрити файл ресурсів «%s»."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Не вдалося завантажити ресурси з файла «%s»."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Не вдалося створити %s «%s»."
+
+#~ msgid "Printing "
+#~ msgstr "Друк"
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Не вдалося додати текст до контрола."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Будь ласка, виберіть коректний шрифт."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Не вдалося показати документ HTML у кодуванні %s"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets не зміг відкрити дисплей для «%s»: виходжу."
+
+#~ msgid "Filter"
+#~ msgstr "Фільтр"
+
+#~ msgid "Directories"
+#~ msgstr "Теки"
+
+#~ msgid "Files"
+#~ msgstr "Файли"
+
+#~ msgid "Selection"
+#~ msgstr "Позначене"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "перетворення у 8-бітове кодування зазнало невдачі"
@@ -9423,8 +9452,8 @@ msgstr "Не вдалося створити %s «%s»."
 #~ "Інструменту обробки даних не вдалося обробити значення; тип значення: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/vi.po
+++ b/locale/vi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2014-03-30 09:14+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 1.5.5\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "Mọi tập tin (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "Mọi tập tin (*)|*"
 
@@ -39,24 +39,21 @@ msgid "Remaining time:"
 msgstr "Thời gian còn lại:"
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "Đồng ý"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "Không"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "Đồng ý"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "Hủy bỏ"
@@ -106,7 +103,7 @@ msgid "Unable to create I/O completion port"
 msgstr "Không thể tạo handle cổng Vào/Ra"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "Dữ liệu in"
 
@@ -143,7 +140,7 @@ msgstr "Thuộc tính Đối tượng"
 msgid "Printing"
 msgstr "In ấn"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "Ký tự đặc biệt"
 
@@ -212,7 +209,7 @@ msgstr "&Trước"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "&Cửa sổ"
 
@@ -774,11 +771,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "hiển thị thông tin trợ giúp này"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "tạo ra nhật ký thông tin đầy đủ"
 
@@ -800,84 +797,84 @@ msgstr "Theme '%s' không được hỗ trợ."
 msgid "Invalid display mode specification '%s'."
 msgstr "Chi tiết chế độ hiển thị '%s' không hợp lệ."
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "Tuỳ chọn '%s' không thể bị phủ định"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "Không rõ tùy chọn dài '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "Không biết tùy chọn %s"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "Không cần ký tự đi sau tùy chọn '%s'."
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "Tùy chọn '%s' yêu cầu một giá trị."
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "Cần dấu phân cách sau tùy chọn '%s'."
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' không phải là một giá trị bằng số đúng cho tùy chọn '%s'."
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "Tùy chọn '%s': '%s' không thể chuyển thành dạng ngày tháng."
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "Tham số không cần thiết '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (hoặc %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "Giá trị cho tùy chọn '%s' phải được định rõ."
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "Tham số yêu cầu '%s' đã không được định rõ."
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "Cách dùng: %s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "str"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "số"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "kép"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "ngày tháng"
 
@@ -895,7 +892,7 @@ msgid "Can't &Undo "
 msgstr "Không thể &Undo"
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "&Undo"
@@ -905,7 +902,7 @@ msgid "&Redo "
 msgstr "&Redo "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "&Redo"
@@ -935,12 +932,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' có thêm '..', bỏ qua."
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -950,103 +947,103 @@ msgstr ""
 msgid "undetermined"
 msgstr "gạch chân"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "hôm nay"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "hôm qua"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "ngày mai"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "đầu tiên"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "giây"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "thứ ba"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "thứ tư"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "thứ năm"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "thứ sáu"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "thứ bảy"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "thứ tám"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "thứ chín"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "thứ mười"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "thứ mười một"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "thứ mười hai"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "thứ mười ba"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "thứ mười bốn"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "thứ mười lăm"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "thứ mười sáu"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "thứ mười bảy"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "thứ mười tám"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "thứ mười chín"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "thứ hai mươi"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "buổi trưa"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "nửa đêm"
 
@@ -1112,44 +1109,81 @@ msgstr "Thực thi curl gặp lỗi, xin thiết đặt nó trong ĐƯỜNG DẪ
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "Tải lên báo cáo lỗi gặp lỗi (mã lỗi %d)."
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "Ghi Lại Bằng Tên Mới"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "Không dùng những thay đổi này và tải lại dữ liệu đã lưu lần trước?"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "không_tên"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "Bạn có muốn ghi lại các thay đổi với %s không?"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "&Ghi lại"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "Không Ghi Lại"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "Bạn có muốn ghi lại các thay đổi với %s không?"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "Dữ liệu dạng chữ không thể được ghi lại."
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "Tập tin  \"%s\" không thể mở để ghi."
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "Gặp lỗi khi ghi tài liệu vào tập tin \"%s\"."
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "Tập tin  \"%s\" không thể mở để đọc."
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1158,57 +1192,57 @@ msgstr ""
 "Tập tin '%s' không tồn tại và không thể mở được.\n"
 "Nó đã bị gỡ bỏ từ danh sách tập tin mới được dùng gần đây nhất."
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "Tạo bản xem thử khi in gặp lỗi."
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "Mô Phỏng Bản In"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "Định dạng của tập tin '%s' không phân tách đúng định dạng."
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "Không_tên%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "Mở tập tin"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "Lỗi tập tin"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "Xin lỗi, không thể mở tập tin này."
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "Rất tiếc, định dạng tập tin này không hiểu."
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "Chọn một tài liệu tạm thời"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "Biểu mẫu"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "Chọn một bộ hiển thị tài liệu"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "Trình bày"
 
@@ -1242,43 +1276,43 @@ msgstr "Lỗi đọc trong tập tin '%s'"
 msgid "Write error on file '%s'"
 msgstr "Lỗi ghi trên tập tin '%s'"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "làm phẳng tập tin '%s' gặp lỗi"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 "Lỗi khi di chuyển vị trí đọc trên tập tin '%s' (tập tin có kích thước lớn "
 "không được hỗ trợ bởi stdio)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "Lỗi khi di chuyển vị trí đọc trên tập tin '%s'"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "Không thể tìm được vị trí hiện hành trong tập tin '%s'"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "Đặt quyền cho tập tin tạm gặp lỗi"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "không thể gỡ bỏ tập tin '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "không thể chuyển các thay đổi tới tập tin '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "không thể gỡ bỏ tập tin tạm thời '%s'"
@@ -1303,27 +1337,27 @@ msgstr "không thể đọc từ phần mô tả tập tin %d"
 msgid "can't write to file descriptor %d"
 msgstr "không thể ghi dữ liệu vào phần mô tả tập tin %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "không thể vào thẳng phần mô tả tập tin %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "không thể tìm kiếm trên phần mô tả tập tin %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "không thể tìm thấy vị trí trên phần mô tả tập tin %d"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "không thể tìm thấy độ dài của tập tin trên phần mô tả tập tin %d"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "không thể kết thúc nếu kết thúc tập tin nằm trên phần mô tả %d"
@@ -1348,107 +1382,107 @@ msgstr ""
 msgid "Error reading config options."
 msgstr "Lỗi trong việc đọc các tùy chọn cấu hình."
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "Đọc cấu hình tùy chọn gặp lỗi."
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, fuzzy, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "tập tin '%s': không mong ký tự %c tại dòng %d."
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "tập tin '%s', dòng %d: '%s' được bỏ qua trước phần đầu nhóm."
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, fuzzy, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "tập tin '%s', dòng %d: cần '='."
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, fuzzy, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "tập tin '%s', dòng %d: giá trị khóa bất biến '%s' bị bỏ qua."
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, fuzzy, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "tập tin '%s', dòng %d: khóa '%s' được tìm thấy đầu tiên tại dòng %d."
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "Tên mục tin cấu hình không thể bắt đầu bằng '%c'."
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "không thể mở tập tin cấu hình của người dùng."
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "không thể ghi tập tin cấu hình của người dùng."
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "Cập nhật tập tin cấu hình gặp lỗi."
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "Lỗi ghi lại dữ liệu cấu hình người dùng."
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "không thể xóa tập tin cấu hình '%s' của người dùng"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "mục từ '%s' xuất hiện nhiều hơn một lần trong nhóm '%s'"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "cố gắng đổi khóa bất biến '%s' bị bỏ qua."
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "dấu gạch ngược bị bỏ qua trong '%s'"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "không cần \" tại vị trí %d trong '%s'."
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "Sao chép tập tin từ '%s' sang '%s' gặp lỗi"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "Không thể nào lấy được quyền cho tập tin '%s'"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "Không thể xảy ra việc ghi đè lên tập tin '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, fuzzy, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "Sao chép tập tin từ '%s' sang '%s' gặp lỗi"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "Không thể nào đặt được quyền cho tập tin '%s'"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
@@ -1456,40 +1490,40 @@ msgid ""
 msgstr ""
 "Đổi tên tập tin '%s' thành '%s' gặp lỗi bởi vì tập tin đích đã tồn tại rồi."
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "Tập tin '%s' không thể bị đổi tên '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "Tập tin  '%s' gỡ bỏ được"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "Thư mục '%s' không thể được tạo"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "Thư mục '%s' không thể xóa được"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "Không thể liệt kê các tập tin '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "Lấy thư mục đang làm việc gặp lỗi"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "Không thể đặt thư mục làm việc hiện hành"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "Tập tin (%s)"
@@ -1516,17 +1550,17 @@ msgstr "Tạo tên tập tin tạm gặp lỗi"
 msgid "Failed to open temporary file."
 msgstr "Mở tập tin tạm thời gặp lỗi."
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "Chỉnh sửa thời gian tập tin '%s' gặp lỗi"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "Mở tập tin '%s' gặp lỗi"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "Khôi phục thời gian tập tin cho '%s' gặp lỗi"
@@ -1535,22 +1569,22 @@ msgstr "Khôi phục thời gian tập tin cho '%s' gặp lỗi"
 msgid "Browse"
 msgstr "Tìm duyệt"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "Mọi tập tin (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s tập tin (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "Tải %s tập tin"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "Ghi lại %s tập tin"
@@ -1913,105 +1947,105 @@ msgstr "mặc định"
 msgid "unknown-%d"
 msgstr "không_hiểu-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "gạch chân"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " gạch giữa"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 #, fuzzy
 msgid " extra light"
 msgstr " sáng"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " sáng"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 #, fuzzy
 msgid " semi bold"
 msgstr " đậm"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " đậm"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 #, fuzzy
 msgid " extra bold"
 msgstr " đậm"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " nghiêng"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "Gạch giữa"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 #, fuzzy
 msgid "extralight"
 msgstr "ánh sáng"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "ánh sáng"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "thường"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 #, fuzzy
 msgid "semibold"
 msgstr "đậm"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "đậm"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 #, fuzzy
 msgid "extrabold"
 msgstr "đậm"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "nghiêng"
 
@@ -2092,7 +2126,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "Đặt chế độ truyền FTP thành %s gặp lỗi."
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2113,7 +2147,7 @@ msgstr "Máy chủ FTP không hỗ trợ chế độ tích cực."
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "Frame của ảnh  GIF (%u, %d) cho frame #%u không đúng"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "Cấp phát màu cho OpenGL gặp lỗi"
 
@@ -2129,7 +2163,7 @@ msgstr "Tùy Chỉnh Số Cột"
 msgid "&Customize..."
 msgstr "&Cá nhân..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, fuzzy, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "Mở URL \"%s\" trong trình duyệt mặc định gặp lỗi."
@@ -2149,157 +2183,156 @@ msgstr "Lỗi khi tải ảnh %d từ dòng dữ liệu."
 msgid "Failed to load icons from resource '%s'."
 msgstr "Tải biểu tượng \"%s\" từ nguồn tài nguyên gặp lỗi."
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: Không thể ghi ảnh không hợp lệ."
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage không có quyền sở hữu wxPalette."
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: Không thể ghi phần đầu tập tin (Bitmap)."
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: Không thể ghi phần đầu tập tin (BitmapInfo)."
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: Không thể ghi bản đồ màu RGB."
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: Không thể ghi dữ liệu."
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: Không thể cấp phát bộ nhớ."
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "Phần đầu DIB: Độ rộng ảnh > 32767 điểm ảnh cho tập tin."
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "Phần đầu DIB: Độ cao ảnh > 32767 điểm ảnh cho tập tin."
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "Phần đầu DIB: Không rõ độ sâu bit trong tập tin."
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "Phần Đầu DIB: Không hiểu bộ giải mã trong tập tin."
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "Phần đầu DIB: Bộ giải mã không khớp với độ sâu bit."
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: Không thể cấp phát bộ nhớ."
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "Phần đầu DIB: Độ rộng ảnh > 32767 điểm ảnh cho tập tin."
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "Phần đầu DIB: Độ cao ảnh > 32767 điểm ảnh cho tập tin."
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "Phần đầu DIB: Không rõ độ sâu bit trong tập tin."
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "Phần Đầu DIB: Không hiểu bộ giải mã trong tập tin."
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "Phần đầu DIB: Bộ giải mã không khớp với độ sâu bit."
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "Lỗi trong việc đọc ảnh DIB."
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO: Lỗi trong việc đọc mặt nạ DIB."
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO: Ảnh quá cao đối với biểu tượng."
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO: Ảnh quá rộng đối với biểu tượng."
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO: Lỗi khi đang ghi tập tin ảnh!"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO: Chỉ mục biểu tượng không hợp lệ."
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "Ảnh và mặt nạ có sự khác biệt kích thước."
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "Không có màu không dùng đến trong mặt nạ ảnh này."
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "Gặp lỗi tải ảnh \"%s\" từ nguồn tài nguyên."
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "Tải biểu tượng \"%s\" từ nguồn tài nguyên gặp lỗi."
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "Tải ảnh từ tập tin \"%s\" gặp lỗi."
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "Không thể ghi ảnh ra tập tin '%s': không hiểu phần mở rộng."
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "Không có phần điều khiển cho kiểu ảnh này."
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "Không có bộ điều khiển ảnh cho kiểu %d được định nghĩa."
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "Tập tin ảnh không thuộc kiểu %d."
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 "Không thể tự động dò tìm định dạng ảnh cho đầu vào không-di-chuyển-vị-trí-"
 "đọc-được."
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "Không hiểu định dạng dữ liệu ảnh"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "Cái này không phải là một %s."
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "Không có bộ điều khiển ảnh cho kiểu %s được định nghĩa."
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "Ảnh không thuộc kiểu %s."
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "Gặp lỗi khi kiểm tra định dạng của tập tin ảnh \"%s\"."
@@ -2400,41 +2433,41 @@ msgstr "PNM: Tập tin dường như đã bị cắt xén."
 msgid " (in module \"%s\")"
 msgstr " (trong mô-đun \"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF: Lỗi tải ảnh."
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "Chỉ mục ảnh TIFF không hợp lệ."
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF: Kích cỡ ảnh thường lớn."
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF: Không thể cấp phát bộ nhớ."
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF: Lỗi trong khi đọc tập tin ảnh."
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "Không hiểu đơn vị độ phân giải TIFF %d bỏ qua"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF: Gặp lỗi khi ghi tập tin ảnh."
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF: Gặp lỗi khi ghi tập tin ảnh."
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
@@ -2442,11 +2475,11 @@ msgid ""
 msgstr ""
 "Tham số dòng lệnh %d không thể chuyển đổi sang Unicode và sẽ bị bỏ qua."
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "Khởi tạo lỗi trong việc post init, đang bãi bỏ."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "Không thể đặt ngôn ngữ thành \"%s\"."
@@ -2542,7 +2575,7 @@ msgstr "lỗi nén"
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "Không khớp '{' trong một mục từ cho kiểu diễn tả %s."
@@ -2562,7 +2595,7 @@ msgstr "Phần phụ thuộc \"%s\" của mô đun \"%s\" chưa tồn tại."
 msgid "Module \"%s\" initialization failed"
 msgstr "Sự khởi tạo mô-đun \"%s\" gặp lỗi"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "Tin nhắn"
 
@@ -3064,7 +3097,7 @@ msgstr "Lỗi In"
 msgid "Print"
 msgstr "In"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "Cài đặt giấy"
 
@@ -3099,19 +3132,15 @@ msgstr "Đang in trang %d trong tổng số %d"
 msgid " (copy %d of %d)"
 msgstr " (chép %d trong số %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "Đang in "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "Trang đầu"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "Trang trước"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "Trang tiếp theo"
 
@@ -3155,16 +3184,16 @@ msgstr "Trang %d của %d"
 msgid "Page %d"
 msgstr "Trang %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "lỗi lạ"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "Biểu thức thông thường '%s' không hợp lệ: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "Việc tìm khớp với biểu thức thông thường gặp lỗi: %s"
@@ -3176,21 +3205,21 @@ msgstr ""
 "Renderer \"% s\" đã không tương thích với phiên bản% d.% d và không thể được "
 "nạp."
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, fuzzy, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, fuzzy, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, fuzzy, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
@@ -3199,11 +3228,11 @@ msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 msgid "Failed to monitor I/O channels"
 msgstr "Kênh vào ra màn hình gặp lỗi"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "Ghi lại"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "Không Ghi Lại"
 
@@ -3287,10 +3316,10 @@ msgid "Clear"
 msgstr "Xóa sạch"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "Đóng"
 
@@ -3302,7 +3331,7 @@ msgstr "&Chuyển đổi"
 msgid "Convert"
 msgstr "Chuyển đổi"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "&Sao chép"
@@ -3311,7 +3340,7 @@ msgstr "&Sao chép"
 msgid "Copy"
 msgstr "Chép"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "Cắ&t"
@@ -3320,13 +3349,13 @@ msgstr "Cắ&t"
 msgid "Cut"
 msgstr "Cắt"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "&Xóa"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "Xóa bỏ"
@@ -3415,7 +3444,7 @@ msgstr "Đĩa cứng"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "Trợ &giúp"
 
@@ -3435,7 +3464,7 @@ msgstr "Thụt lề"
 msgid "&Index"
 msgstr "&Chỉ mục"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "Chỉ mục"
 
@@ -3504,7 +3533,7 @@ msgstr "Tạo &mới"
 msgid "New"
 msgstr "Mới"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "&Không"
 
@@ -3521,12 +3550,12 @@ msgstr "&Mở..."
 msgid "Open..."
 msgstr "Mở..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "&Dán"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "Dán"
@@ -3556,7 +3585,7 @@ msgid "Print..."
 msgstr "In..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "&Thuộc tính"
 
@@ -3590,10 +3619,6 @@ msgstr "Thay thế"
 msgid "Revert to Saved"
 msgstr "Hoàn nguyên để Ghi Lại"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "&Ghi lại"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "&Ghi Lại Bằng Tên Mới..."
@@ -3603,7 +3628,7 @@ msgstr "&Ghi Lại Bằng Tên Mới..."
 msgid "Save As..."
 msgstr "&Ghi Lại Bằng Tên Mới..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "Chọn &Hết"
@@ -3710,7 +3735,7 @@ msgstr "&Lên"
 msgid "Up"
 msgstr "Lên"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "Đồn&g ý"
 
@@ -3801,43 +3826,43 @@ msgstr "Ghi lại tài liệu hiện tại"
 msgid "Save current document with a different filename"
 msgstr "Ghi lại tài liệu hiện hành với một cái tên khác"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "Việc chuyển đổi bộ ký tự thành '%s' không làm việc."
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "không rõ"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "không hoàn thành khối đầu trong gói tar"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "tổng kiểm tra việc đọc khối đầu gói tar bị thất bại"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "dữ liệu trong phần đầu mở rộng của gói tar không hợp lệ"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "mục tin tar không mở được"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "kết thúc tập tin đột xuất"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s không vừa khớp với phần đầu tar cho mục vào '%s'"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "kích thước định sẵn cho mục tin của gói tar không hợp lệ"
 
@@ -3846,7 +3871,7 @@ msgstr "kích thước định sẵn cho mục tin của gói tar không hợp l
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' chắc chắn là một bộ đệm nhị phân."
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "Không thể tải tập tin lên."
 
@@ -3860,47 +3885,47 @@ msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
 msgid "can't write buffer '%s' to disk."
 msgstr "không thể ghi dữ liệu đệm '%s' vào đĩa."
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "Lấy thời gian từ hệ thống gặp lỗi"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay bị lỗi."
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' không phải là catalog thông điệp hợp lệ."
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "Catalog không hợp lệ."
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "Lỗi khi phân tích dạng thức số nhiều: '%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "sử dụng catalog '%s' từ '%s'."
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "Tài nguyên '%s' không đúng định dạng."
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "Không thể liệt kê các bản dịch"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "Không có ứng dụng mặc định được cấu hình tập tin HTML."
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "Mở URL \"%s\" trong trình duyệt mặc định gặp lỗi."
@@ -3933,7 +3958,7 @@ msgstr "'%s' chứa các ký tự không hợp lệ"
 msgid "Error: %s (%d)"
 msgstr "Lỗi: "
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3942,20 +3967,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr "Phần miêu tả cột không thể được khởi tạo."
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "Hệ thống này không hỗ trợ làm trong suốt nền"
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "Không thể truyền dữ liệu tới cửa sổ"
 
@@ -4009,8 +4034,8 @@ msgstr "Tạo Tham Số %s không tìm thấy trong khai báo Tham Số RTTI"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "Kiểu phải ở dạng enum - long chuyển đổi"
 
@@ -4060,79 +4085,79 @@ msgstr "Đối tượng phải có giá trị thuộc tính id"
 msgid "Doubly used id : %d"
 msgstr "Chỉ số id người dùng kép: %d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "Không Rõ Thuộc Tính %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "Một tập hợp không trống rỗng phải gồm có những nút 'phần tử'"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "xâu chữ bộ điều khiển sự kiện không hợp lệ, thiếu dấu chấm"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "không thể khởi tạo lại zlib deflate stream"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "không thể khởi tạo lại zlib inflate stream"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "xác nhận rằng đây là các phần móc nối của tập tin zip"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "tập tin zip không hợp lệ"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "không thể tìm thấy thư mục trung tâm trong zip"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "lỗi đọc thư mục trung tâm zip"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "lỗi đọc phần đầu nội bộ của zip"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "đoạn offset tập tin zipfile hỏng được ghi vào"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "phần lưu giữ độ dài tập tin không ở trong phần đầu của Zip"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "không hỗ trợ phương thức nén Zip"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "đang đọc dòng dữ liệu zip (mục vào %s): chiều dài lỗi"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "đang đọc dòng dữ liệu zip (mục vào %s): kiểm tra độ dư vòng(crc) hỏng"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, fuzzy, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "lỗi ghi mục tin zip '%s': kiểm tra crc hay độ dài hỏng"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "lỗi ghi mục tin zip '%s': kiểm tra crc hay độ dài hỏng"
@@ -4219,32 +4244,32 @@ msgstr "Đồ họa bởi "
 msgid "Translations by "
 msgstr "Dịch bởi "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "Phiên bản "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "Giới thiệu %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "Giấy phép"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "Những người phát triển"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "Những người viết tài liệu"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "Nghệ sĩ"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "Người dịch"
 
@@ -4296,44 +4321,43 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 #, fuzzy
 msgid "false"
 msgstr "Sai"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, fuzzy, c-format
 msgid "%s (%d items)"
 msgstr "%s (hoặc %s)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, fuzzy, c-format
 msgid "Column %u"
 msgstr "Thêm cột"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4344,8 +4368,7 @@ msgid "Left"
 msgstr "Trái"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4443,7 +4466,7 @@ msgid "Home directory"
 msgstr "Thư mục Home"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "Thư mục Desktop"
 
@@ -4456,8 +4479,7 @@ msgstr "Tên thư mục không hợp lệ."
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "Lỗi"
 
@@ -4640,16 +4662,16 @@ msgstr "Hiển thị tập tin dạng chi tiết"
 msgid "Go to parent directory"
 msgstr "Chuyển sang thư mục cha"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "Tập tin '%s' đã tồn tại. Bạn có muốn ghi đè lên nó không?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "Xác nhận"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "Xin hãy chọn một tập tin đã tồn tại."
 
@@ -4743,7 +4765,7 @@ msgstr "Cỡ phông chữ theo đơn vị point."
 msgid "Whether the font is underlined."
 msgstr "Không biết phông chữ có gạch chân hay không."
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "Xem trước:"
@@ -4761,48 +4783,47 @@ msgstr "Bấm vào để hủy việc chọn phông chữ."
 msgid "Click to confirm the font selection."
 msgstr "Bấm vào để xác nhận việc chọn phông chữ."
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "Chọn phông chữ"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "Không tìm thấy thư mục trợ giúp \"%s\"."
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "Tập tin trợ giúp \"%s\" không tìm thấy."
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "Dòng %lu của tập tin ánh xạ \"%s\" có cú pháp không hợp lệ, đã bỏ qua."
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "Không có ánh xạ hợp lệ nào được tìm thấy trong tập tin \"%s\"."
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "Không tìm thấy đề mục nào."
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "Mục lục Trợ Giúp"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "Các đề mục tin hợp:"
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "Các mục tin tìm thấy"
 
@@ -4906,59 +4927,59 @@ msgstr "Không thể bắt đầu in."
 msgid "Printing page %d..."
 msgstr "Đang in trang %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "Tùy chọn về máy in"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "In ra Tập tin"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "Cài đặt..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "Máy in:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "Tình trạng:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "Tất cả"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "Giấy"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "Vùng cần in"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "Từ :"
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "Đến:"
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "Bản sao:"
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "tập tin PostScript"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "Cài Đặt In"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "Máy in"
 
@@ -4966,25 +4987,25 @@ msgstr "Máy in"
 msgid "Default printer"
 msgstr "Máy in mặc định"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "Cỡ giấy"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "Thẳng đứng"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "Nằm ngang"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "Hướng"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "Tùy chọn"
 
@@ -4996,52 +5017,52 @@ msgstr "In màu"
 msgid "Print spooling"
 msgstr "In vào bộ nhớ"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "Lệnh in:"
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "Tùy chọn về máy in:"
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "Lề trái (mm):"
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "Để lề trên (mm):"
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "Lề phải (mm):"
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "Lề dưới chân (mm):"
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "Máy in..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "Giữ &nguyên"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "Không hiểu"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "Hoàn tất."
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "Không thể tìm thấy tab cho id"
 
@@ -5077,23 +5098,23 @@ msgstr "&Hoàn tất"
 msgid "< &Back"
 msgstr "< &Quay lại"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "công-trạng-dịch-thuật"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 "Không thể khởi tạo GTK+, BỘ HIỂN THỊ đã cài đặt các thuộc tính hay chưa?"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, fuzzy, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "Tạo thư mục \"%s\" gặp lỗi"
@@ -5119,12 +5140,12 @@ msgstr "Lỗi đọc từ tập tin \"%s\" gặp lỗi."
 msgid "Failed to register font configuration using private fonts."
 msgstr "Cập nhật tập tin cấu hình gặp lỗi."
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 #, fuzzy
 msgid "Fatal Error"
 msgstr "Lỗi nghiêm trọng"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5132,7 +5153,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5140,7 +5161,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "cửa sổ MDI con"
 
@@ -5156,15 +5177,11 @@ msgstr "Lỗi trong khi in: "
 msgid "Page Setup"
 msgstr "Cài đặt giấy"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "Chèn chữ vào điều khiển gặp lỗi."
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
@@ -5172,7 +5189,7 @@ msgstr ""
 "GTK+ đã cài đặt trên máy này quá cũ để nó có thể hỗ trợ ghép màn hình, hãy "
 "cài GTK+ 2.12 hay mới hơn."
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
@@ -5180,17 +5197,13 @@ msgstr ""
 "Sự kết hợp không được hỗ trợ bởi hệ thống này, xin hãy bật nó lên trong "
 "Window Manager."
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr ""
 "Chương trình này được dịch với phiên bản cũ của GTK+, xin hãy dịch lại với "
 "GTK+ 2.12 hay mới hơn."
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "Hãy chọn một phông chữ hợp lệ."
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5289,45 +5302,45 @@ msgstr "Không thể mở tập tin nội dung: %s"
 msgid "Cannot open index file: %s"
 msgstr "Không thể mở tập tin chỉ mục: %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "không tên"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "Không thể mở sách trợ giúp dạng HTML: %s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "Hiện phần trợ giúp như là một trình duyệt sách trên phần bên trái."
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(Dấu trang)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "Thêm trang hiện thời vào dấu trang"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "Gỡ bỏ trang hiện hành từ dấu trang"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "Nội dung"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "Tìm"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "Hiện tất"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
@@ -5335,19 +5348,19 @@ msgstr ""
 "Hiện tất cả chỉ số mục tin mà có chứa chuỗi con định sẵn. Tìm kiếm phân biệt "
 "Hoa/thường."
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "Hiển thị tất cả các mục tin trong mục lục"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "Phân biệt chữ HOA/thường"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "Chỉ khi khớp cả từ"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
@@ -5355,147 +5368,147 @@ msgstr ""
 "Tìm kiếm nội dung của cuốn sách trợ giúp cho tất cả các lần xuất hiện của "
 "chữ bạn đã gõ ở trên"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "Hiện/ẩn bản điều hướng"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "Đi lùi"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "Đi tiếp"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "Tăng một cấp trong thứ bậc tài liệu"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "Mở tài liệu định dạng HTML"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "In ra trang này"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "Hiển thị hộp thoại tùy chọn"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "Xin hãy chọn trang bạn muốn hiển thị:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "Trợ Giúp Theo Chủ Đề..."
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "Đang tìm kiếm..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "Không tìm thấy trang phù hợp"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "Tìm thấy %i cái khớp"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(Trợ giúp)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d của %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu của %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "Tìm trong tất cả các sách"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "Các tùy chọn Duyệt Trợ Giúp"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "Phông chữ thường:"
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "Phông chữ cố định:"
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "Cỡ phông chữ:"
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "cỡ phông chữ"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "Bình thường<br>và <u>gạch chân</u>. "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>Chữ nghiêng.</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>Chữ đậm.</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>Chữ vừa đậm vừa nghiêng.</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "Kích thước bình thường.<br> <b>đậm</b> <i>nghiêng</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>đậm và nghiêng <u>có gạch chân</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "Trợ Giúp In Ấn"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "Không thể in một trang rỗng."
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "Tập tin HTML (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "Sách trợ giúp (*.htb)|*.htb|Sách trợ giúp (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML Đề án Trợ giúp (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "Nén tập tin Trợ Giúp dạng HTML (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, fuzzy, c-format
 msgid "%i of %u"
 msgstr "%i của %i"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, fuzzy, c-format
 msgid "%u of %u"
 msgstr "%lu của %lu"
@@ -5576,32 +5589,6 @@ msgstr ""
 "Có trục trặc xảy ra khi cài đặt kiểu giấy: có lẽ bạn cần phải đặt một máy in "
 "mặc định."
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "Hiển thị tài liệu HTML trong bộ mã %s gặp lỗi"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets không thể mở' %s' ra, đang thoát ra."
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "Bộ lọc"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "Thư mục"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "Tập tin"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "Vùng chọn"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "Mở clipboard gặp lỗi."
@@ -5643,58 +5630,58 @@ msgstr "Hộp thoại chọn màu gặp lỗi %0lx."
 msgid "Failed to create cursor."
 msgstr "Tạo con trỏ chuột gặp lỗi."
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "Đăng ký máy chủ DDE '%s' gặp lỗi."
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "Việc bỏ đăng ký máy chủ DDE '%s' gặp lỗi"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "Tạo kết nối tới máy chủ '%s' với chủ đề '%s' gặp lỗi"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "Yêu cầu poke DDE gặp lỗi"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "Thiết lập một vòng lặp advise máy chủ DDE gặp lỗi"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "Chấm dứt vòng lặp advise với máy chủ DDE gặp lỗi"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "Gửi thông báo DDE advise gặp lỗi"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "Tạo chuỗi DDE gặp lỗi"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "không có lỗi DDE."
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "yêu cầu cho chuyển tác advise đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "đáp ứng chuyển tác này là nguyên nhân bít DDE_FBUSY được đặt."
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "yêu cầu chuyển tác dữ liệu đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5705,7 +5692,7 @@ msgstr ""
 "hay bộ nhận dạng instance không hợp lệ\n"
 "đã được chuyển qua hàm DDEML."
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5717,43 +5704,43 @@ msgstr ""
 "hay một ứng dụng khởi tạo như APPCMD_CLIENTONLY đã\n"
 "cố gắng thi hành một chuyển tác phía máy chủ."
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "yêu cầu cho chuyển tác thi hành đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "một tham số gặp lỗi được công nhận bởi DDEML."
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "một ứng dụng DDEML đã tạo ra một loại điều kiện nối dài."
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "sự cấp phát bộ nhớ bị lỗi."
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "sự có gắng của máy khách để thiết lập một cuộc đàm thoại bị lỗi."
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "một chuyển tác bị lỗi."
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "yêu cầu cho chuyển tác poke đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "cuộc gọi nội tới hàm PostMessage gặp lỗi."
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "trục trặc reentrancy."
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5763,15 +5750,15 @@ msgstr ""
 "với chuyển tác đã chấm dứt phía máy khách, hay máy chủ\n"
 "chấm dứt trước khi hoàn tất chuyển tác."
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "một lỗi nội bộ phát sinh trong DDEML."
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "yêu cầu cho chuyển tác end và advise đồng bộ gặp lỗi quá lâu."
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5781,12 +5768,12 @@ msgstr ""
 "Một khi ứng dụng trả về từ một XTYP_XACT_COMPLETE callback,\n"
 "bộ nhận dạng chuyển tác cho callback đó sẽ không còn hợp lệ."
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "Không hiểu lỗi DDE %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
@@ -5794,7 +5781,7 @@ msgstr ""
 "Hàm quay số không sẵn sàng bởi vì dịch vụ truy cập từ xa (RAS) chưa được cài "
 "trong máy này. Xin hãy cài nó vào."
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5803,65 +5790,65 @@ msgstr ""
 "Phiên bản của chương trình truy cập dữ liệu từ xa (RAS) được cài đặt trong "
 "máy này đã quá cũ, xin hãy cập nhật (hàm yêu cầu sau đây bị thiếu: %s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "Khôi phục chữ của thông điệp lỗi RAS gặp lỗi"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "chưa biết lỗi (mã sai %08x)."
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "Không thể tìm thấy kết nối quay số đang hoạt động: %s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 "Tìm thấy nhiều kết nối quay số đang hoạt động, đang chọn một cái ngẫu nhiên."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "Thiết lập kết nối quay số gặp lỗi: %s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "Lấy tên của nhà cung cấp dịch vụ Internet ISP gặp lỗi: %s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "Kết nối lỗi: không có nhà cung cấp dịch vụ Internet ISP để quay số."
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "Chọn nhà cung cấp dịch vụ Internet ISP để quay số"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "Xin hãy chọn nhà cung cấp dịch vụ Internet ISP mà bạn muốn kết nối tới"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "Kết nối lỗi: không có tên người dùng/mật khẩu."
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "Không tìm thấy vị trí trong tập tin sổ địa chỉ"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "Khởi tạo kết nối quay số gặp lỗi: %s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "Không thể gác máy - không có kết nối quay số nào đang hoạt động."
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "Chấm dứt kết nối quay số gặp lỗi: %s"
@@ -5881,18 +5868,17 @@ msgstr "Việc cấp phát %luKb bộ nhớ cho dữ liệu ảnh bitmap gặp l
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "Không thể đếm các tập tin trong thư mục '%s'"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "Không thể lấy được tên thư mục"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, fuzzy, c-format
 msgid "(error %d: %s)"
 msgstr " (lỗi %ld: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "Không thể thêm ảnh vào trong danh sách ảnh."
 
@@ -5906,7 +5892,7 @@ msgstr "Tải metafile từ tập tin \"%s\" gặp lỗi."
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "Tạo hộp thoại tìm/thay thế tiêu chuẩn gặp lỗi (mã lỗi %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "Hộp thoại chọn tập tin bị lỗi %0lx."
@@ -5950,17 +5936,17 @@ msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 "Không thể theo dõi thư mục không-hiện-có \"%s\" để thấy được các thay đổi."
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 #, fuzzy
 msgid "Couldn't create OpenGL context"
 msgstr "Không tạo được một timer"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "Khởi tạo OpenGL gặp lỗi."
 
@@ -5968,7 +5954,7 @@ msgstr "Khởi tạo OpenGL gặp lỗi."
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
@@ -5976,7 +5962,7 @@ msgstr ""
 "Hàm MS HTML Help không sẵn sàng bởi vì thư viện MS HTML Help không được cài "
 "đặt trong máy này. Xin hãy cài nó vào."
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "Khởi tạo Trợ Giúp MS HTML gặp lỗi."
 
@@ -5985,7 +5971,7 @@ msgstr "Khởi tạo Trợ Giúp MS HTML gặp lỗi."
 msgid "Can't delete the INI file '%s'"
 msgstr "Không thể xóa tập tin INI '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "Không thể phục hồi thông tin về điều khiển danh sách mục tin %d."
@@ -6105,7 +6091,7 @@ msgstr "Không thể đăng ký định dạng clipboard '%s'."
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "Định dạng clipboard '%d' chưa tồn tại."
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "Bỏ qua"
 
@@ -6190,76 +6176,76 @@ msgstr ""
 "việc xóa nó sẽ làm cho hệ thống của bạn rơi vào trạng thái không ổn định:\n"
 "thao tác đã bị hủy bỏ."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "Không thể xóa khóa '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "Không thể xóa giá trị '%s' từ khóa '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "Không thể đọc giá trị của khóa '%s'"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "Không thể đặt giá trị của '%s'"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "Không thể đọc giá trị của '%s'"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "Không thể liệt kê các giá trị của khóa '%s'"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "Không thể liệt kê khóa phụ từ khóa '%s'"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 "Sự xuất khóa đăng ký: tập tin \"%s\" đã tồn tại và không thể ghi đè lên."
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "Không thể xuất ra giá trị của kiểu không được hỗ trợ %d."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "Bỏ qua giá trị \"%s\" của khóa \"%s\"."
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6267,41 +6253,41 @@ msgstr ""
 "Không thể nào khởi tạo điều khiển văn bản (rich edit), đang sử dụng điều "
 "khiển văn bản đơn giản để thay thế. Xin hãy cài lại riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "Không thể khởi động tuyến trình: lỗi ghi TLS."
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "Không thể đặt mức ưu tiên tuyến trình"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "Không thể tạo tuyến trình"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "Không thể chấm dứt tuyến trình"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "Không thể chờ tuyến trình thiết bị cuối"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "Không thể đình chỉ tuyến trình %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "Không thể phục hồi tuyến trình %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "Không thể lấy con trỏ tuyến trình hiện hành"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
@@ -6309,7 +6295,7 @@ msgstr ""
 "Khởi tạo mô đun tuyến trình gặp lỗi: không thể cấp phát chỉ số trong phần "
 "lưu trữ nội bộ tuyến trình"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6341,12 +6327,12 @@ msgstr "Lỗi khi tải tài nguyên \"%s\"."
 msgid "Failed to lock resource \"%s\"."
 msgstr "Lỗi khi khóa tài nguyên \"%s\"."
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "xây dựng %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ", bản 64-bit"
 
@@ -6358,47 +6344,47 @@ msgstr "Tạo anonymous pipe gặp lỗi"
 msgid "Failed to redirect the child process IO"
 msgstr "Chuyển hướng vào xử lý IO con gặp lỗi"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "Thi hành lệnh '%s' gặp lỗi"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "Tải thư viện mpr.dll gặp lỗi."
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "Không thể đọc kiểu tên từ '%s'!"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "Không thể tải biểu tượng từ '%s'."
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 #, fuzzy
 msgid "Can't get the JavaScript object"
 msgstr "Không thể đặt mức ưu tiên tuyến trình"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 #, fuzzy
 msgid "failed to evaluate"
 msgstr "Thực thi '%s' gặp lỗi\n"
@@ -6432,7 +6418,7 @@ msgid "Check to make the font italic."
 msgstr "Đánh đấu kiểm để làm cho phông chữ nghiêng."
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "Bị gạch dưới"
@@ -6500,17 +6486,32 @@ msgstr "<Dạng Teletype bất kỳ>"
 msgid "File type:"
 msgstr "Dạng Teletype"
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
 #, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "&Cửa sổ"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "Trợ giúp"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "&Nhỏ nhất"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
 #, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "Phóng to"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6527,486 +6528,486 @@ msgstr "Tập tin %s chưa tồn tại."
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "Giới thiệu %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "Giới thiệu..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "Cá nhân hóa..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "Dịch vụ"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "Ẩn %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "Ứng dụng"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "Các thứ khác ẩn"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "Hiện tất"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "Thoát %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 #, fuzzy
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "Ứng dụng"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 #, fuzzy
 msgid "Printing is not supported by the system web control"
 msgstr "Gzip không được hỗ trợ bởi phiên bản này của zlib"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 #, fuzzy
 msgid "Print operation could not be initialized"
 msgstr "Phần miêu tả cột không thể được khởi tạo."
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "&Kích thước Phông chữ:"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "Tên Mặt"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "Kiểu dáng"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "Độ rộng"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "Họ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 #, fuzzy
 msgid "ActiveBorder"
 msgstr "Viền"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 #, fuzzy
 msgid "Highlight"
 msgstr "ánh sáng"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 #, fuzzy
 msgid "HighlightText"
 msgstr "Canh lề chữ phải."
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 #, fuzzy
 msgid "InactiveBorder"
 msgstr "Viền"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "Trình đơn"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 #, fuzzy
 msgid "Window"
 msgstr "&Cửa sổ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 #, fuzzy
 msgid "WindowFrame"
 msgstr "&Cửa sổ"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 #, fuzzy
 msgid "WindowText"
 msgstr "&Cửa sổ"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 #, fuzzy
 msgid "Custom"
 msgstr "Cỡ riêng"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 #, fuzzy
 msgid "Green"
 msgstr "MacGreek"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 #, fuzzy
 msgid "Brown"
 msgstr "Tìm duyệt"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 #, fuzzy
 msgid "Red"
 msgstr "Redo"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "mặc định"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "ngày mai"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "Phải"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "Kiểu dáng bullet"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "&Mã ký tự:"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "&Kích thước Phông chữ:"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "Canh lề Phải"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "Câu hỏi"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "Phải"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 #, fuzzy
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "Phải"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "Làm với vùng chọn:"
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "Thuộc tính"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "Giá trị"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "Chế độ Cá nhân hóa"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "Chế độ Bảng chữ cái"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "Sai"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "Đúng"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "Chưa định danh"
 
@@ -7021,12 +7022,12 @@ msgstr ""
 "Bạn đã nhập vào giá trị không hợp lệ. Hãy bấm phím ESC để huỷ bỏ việc chỉnh "
 "sửa."
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "Lỗi trong tài nguyên: %s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
@@ -7035,36 +7036,36 @@ msgstr ""
 "Toán tử kiểu \"%s\" gặp lỗi: Tên thuộc tính \"%s\" là kiểu  \"%s\", KHÔNG "
 "PHẢI \"%s\"."
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "Giá trị phải là %s hay lớn hơn."
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "Giá trị phải nằm giữa %s và %s."
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "Giá trị phải là %s hay nhỏ hơn."
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "Không %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "Chọn thư mục:"
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "Chọn một tập tin"
 
@@ -7543,117 +7544,117 @@ msgstr "Chèn"
 msgid "Outset"
 msgstr "Bắt đầu"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "Thay đổi Kiểu Dáng"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "Thay đổi Kiểu dáng Đối tượng"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "Thay đổi các thuộc tính"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "Thay Đổi Kiểu Dáng List"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "Đánh số lại List"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "Chèn Chữ"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "Chèn Ảnh"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "Chèn Đối tượng"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "Chèn trường"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "Quá nhiều cú gọi EndStyle!"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "tập tin"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "Tiêu chuẩn/ hình tròn"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "tiêu-chuẩn/viền-tròn"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "Tiêu chuẩn/vuông"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "Tiêu chuẩn/Thoi"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "Tiêu chuẩn/chữ nhật"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "Các tính chất Hộp"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "Thuộc tính Đa Ô"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "Các thuộc tính của ô"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "Đặt Kiểu Dáng Ô"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "Xóa hàng"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "Xóa cột"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "Thêm hàng"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "Thêm cột"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "Các thuộc tính Bảng"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "Các thuộc tính Hình ảnh"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "hình ảnh"
 
@@ -7861,24 +7862,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "Kéo"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "Xóa Chữ"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "Gỡ bỏ Bullet"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "Dữ liệu dạng chữ không thể được ghi lại."
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "Thay thế"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "&Phông chữ:"
 
@@ -8849,53 +8850,53 @@ msgstr "Kiểu dáng của danh sách"
 msgid "Box styles"
 msgstr "Kiểu dáng Hộp"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "Phông chữ từ đó đã lấy ký tự đặc biệt."
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "Tập c&on:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "Hiển thị tập con của bộ mã Unicode."
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "&Mã ký tự:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "Mã ký tự."
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "&Từ:"
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "Unicode"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "Chọn vùng cần hiện."
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "Chèn"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(Chữ thường)"
 
@@ -9083,7 +9084,7 @@ msgstr "Không thể lấy các sự kiện từ kqueue"
 msgid "Media playback error: %s"
 msgstr "Lỗi phát đa phương tiện: %s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "Gặp lỗi khi chuẩn bị phát \"%s\"."
@@ -9183,20 +9184,20 @@ msgstr "Có vẻ như dữ liệu có định dạng không được hỗ trợ.
 msgid "Couldn't open audio: %s"
 msgstr "Không mở âm thanh: %s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "Không thể khôi phục chính sách tạo lập tác vụ tuyến trình."
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "Không thể nhận vùng ưu tiên cho việc tạo lập chính sách %d."
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "Cài đặt quyền ưu tiên tuyến trình bị bỏ qua."
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
@@ -9204,60 +9205,60 @@ msgstr ""
 "Gia nhập tuyến trình gặp lỗi, đã phát hiện lỗ thủng bộ nhớ tiềm tàng - xin "
 "hãy khởi động lại chương trình"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "Gặp lỗi khi đặt mức tuyến trình đồng thời thành %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "Đặt mức ưu tiên tuyến trình %d gặp lỗi."
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "Chấm dứt một tuyến trình gặp lỗi."
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "Khởi tạo mô đun tuyến trình gặp lỗi: lỗi tạo khóa tuyến trình"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "Không thể lấy đầu vào của tiến trình con"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "Không thể ghi ra đầu vào chuẩn của quá trình con"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "Thực thi '%s' gặp lỗi\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Gặp lỗi khi rẽ nhánh tiến trình"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "Gặp lỗi khi đặt mức ưu tiên tuyến trình"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "Chuyển hướng quá trình kết nhập/kết xuất của tiến trình con gặp lỗi"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 "Gặp lỗi khi cài đặt đường ống không-khối (non-blocking pipe), chương trình "
 "có lẽ bị treo."
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "Không thể lấy được tên máy chủ"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "Không lấy được tên máy chủ văn phòng"
 
@@ -9273,12 +9274,12 @@ msgstr "Chuyển sang chế độ từ wake up pipe sang non-blocking gặp lỗ
 msgid "Failed to read from wake-up pipe"
 msgstr "Đọc từ ống dẫn wake-up gặp lỗi"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "Chi tiết hình học '%s' không hợp lệ"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets không thể mở bộ hiển thị. Đang thoát ra."
 
@@ -9292,30 +9293,59 @@ msgstr "Đóng bộ hiển thị \"%s\" gặp lỗi"
 msgid "Failed to open display \"%s\"."
 msgstr "Mở bộ hiển thị \"%s\" gặp lỗi."
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "Gặp lỗi khi phân tách XML: '%s' trên dòng %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "Không thể tải tài nguyên từ  '%s'."
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "Không thể mở tập tin tài nguyên '%s'."
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "Không thể tải tài nguyên từ tập tin '%s'."
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, fuzzy, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "Rút trích '%s' vào '%s' gặp lỗi."
+
+#~ msgid "Printing "
+#~ msgstr "Đang in "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "Chèn chữ vào điều khiển gặp lỗi."
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "Hãy chọn một phông chữ hợp lệ."
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "Hiển thị tài liệu HTML trong bộ mã %s gặp lỗi"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets không thể mở' %s' ra, đang thoát ra."
+
+#~ msgid "Filter"
+#~ msgstr "Bộ lọc"
+
+#~ msgid "Directories"
+#~ msgstr "Thư mục"
+
+#~ msgid "Files"
+#~ msgstr "Tập tin"
+
+#~ msgid "Selection"
+#~ msgstr "Vùng chọn"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "chuyển đổi sang bộ mã 8-bit gặp lỗi"
@@ -9479,15 +9509,15 @@ msgstr "Rút trích '%s' vào '%s' gặp lỗi."
 #~ msgstr "Bộ đáp ứng Ngày tháng không trả về giá trị; giá trị kiểu: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"
 #~ "%s %1"
 #~ msgstr ""
-#~ "Bạn có muốn ghi đè lệnh thường dùng với tập tin %s với phần mở rộng \"%s"
-#~ "\" ?\n"
+#~ "Bạn có muốn ghi đè lệnh thường dùng với tập tin %s với phần mở rộng "
+#~ "\"%s\" ?\n"
 #~ "Giá trị hiện hành là \n"
 #~ "%s, \n"
 #~ "Giá trị mới là \n"

--- a/locale/wxstd.pot
+++ b/locale/wxstd.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr ""
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr ""
 
@@ -39,24 +39,21 @@ msgid "Remaining time:"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr ""
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr ""
@@ -106,7 +103,7 @@ msgid "Unable to create I/O completion port"
 msgstr ""
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr ""
 
@@ -143,7 +140,7 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr ""
 
@@ -212,7 +209,7 @@ msgstr ""
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr ""
 
@@ -741,11 +738,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr ""
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr ""
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr ""
 
@@ -767,84 +764,84 @@ msgstr ""
 msgid "Invalid display mode specification '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr ""
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr ""
 
@@ -862,7 +859,7 @@ msgid "Can't &Undo "
 msgstr ""
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr ""
@@ -872,7 +869,7 @@ msgid "&Redo "
 msgstr ""
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr ""
@@ -899,12 +896,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr ""
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr ""
 
@@ -913,103 +910,103 @@ msgstr ""
 msgid "undetermined"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr ""
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr ""
 
@@ -1073,101 +1070,136 @@ msgstr ""
 msgid "Failed to upload the debug report (error code %d)."
 msgstr ""
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr ""
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr ""
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr ""
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr ""
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr ""
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+msgid "Do&n't close"
+msgstr ""
+
+#: ../src/common/docview.cpp:554
+#, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr ""
+
+#: ../src/common/docview.cpp:560
+msgid "The document must be closed."
+msgstr ""
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr ""
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr ""
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr ""
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr ""
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
 "It has been removed from the most recently used files list."
 msgstr ""
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr ""
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr ""
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr ""
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr ""
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr ""
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr ""
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr ""
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr ""
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr ""
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr ""
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr ""
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr ""
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr ""
 
@@ -1201,41 +1233,41 @@ msgstr ""
 msgid "Write error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr ""
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr ""
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr ""
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr ""
@@ -1260,27 +1292,27 @@ msgstr ""
 msgid "can't write to file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr ""
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr ""
@@ -1304,147 +1336,147 @@ msgstr ""
 msgid "Error reading config options."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr ""
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr ""
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr ""
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr ""
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr ""
@@ -1471,17 +1503,17 @@ msgstr ""
 msgid "Failed to open temporary file."
 msgstr ""
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr ""
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr ""
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr ""
@@ -1490,22 +1522,22 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr ""
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr ""
@@ -1868,99 +1900,99 @@ msgstr ""
 msgid "unknown-%d"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr ""
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr ""
 
@@ -2030,7 +2062,7 @@ msgstr ""
 msgid "Failed to set FTP transfer mode to %s."
 msgstr ""
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr ""
 
@@ -2051,7 +2083,7 @@ msgstr ""
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr ""
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr ""
 
@@ -2067,7 +2099,7 @@ msgstr ""
 msgid "&Customize..."
 msgstr ""
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr ""
@@ -2087,155 +2119,154 @@ msgstr ""
 msgid "Failed to load icons from resource '%s'."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr ""
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr ""
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr ""
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr ""
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr ""
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr ""
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr ""
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr ""
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr ""
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr ""
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr ""
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr ""
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr ""
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr ""
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr ""
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr ""
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr ""
@@ -2336,52 +2367,52 @@ msgstr ""
 msgid " (in module \"%s\")"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr ""
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr ""
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr ""
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr ""
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr ""
@@ -2475,7 +2506,7 @@ msgstr ""
 msgid "LZMA compression error when flushing output: %s"
 msgstr ""
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr ""
@@ -2495,7 +2526,7 @@ msgstr ""
 msgid "Module \"%s\" initialization failed"
 msgstr ""
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr ""
 
@@ -2997,7 +3028,7 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr ""
 
@@ -3032,19 +3063,15 @@ msgstr ""
 msgid " (copy %d of %d)"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr ""
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr ""
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr ""
 
@@ -3088,16 +3115,16 @@ msgstr ""
 msgid "Page %d"
 msgstr ""
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr ""
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr ""
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr ""
@@ -3107,21 +3134,21 @@ msgstr ""
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr ""
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr ""
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr ""
@@ -3130,11 +3157,11 @@ msgstr ""
 msgid "Failed to monitor I/O channels"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr ""
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr ""
 
@@ -3215,10 +3242,10 @@ msgid "Clear"
 msgstr ""
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr ""
 
@@ -3230,7 +3257,7 @@ msgstr ""
 msgid "Convert"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr ""
@@ -3239,7 +3266,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr ""
@@ -3248,13 +3275,13 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr ""
@@ -3341,7 +3368,7 @@ msgstr ""
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr ""
 
@@ -3361,7 +3388,7 @@ msgstr ""
 msgid "&Index"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr ""
 
@@ -3430,7 +3457,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr ""
 
@@ -3447,12 +3474,12 @@ msgstr ""
 msgid "Open..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr ""
@@ -3482,7 +3509,7 @@ msgid "Print..."
 msgstr ""
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr ""
 
@@ -3514,10 +3541,6 @@ msgstr ""
 msgid "Revert to Saved"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr ""
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr ""
@@ -3526,7 +3549,7 @@ msgstr ""
 msgid "Save As..."
 msgstr ""
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr ""
@@ -3633,7 +3656,7 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr ""
 
@@ -3721,43 +3744,43 @@ msgstr ""
 msgid "Save current document with a different filename"
 msgstr ""
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr ""
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr ""
 
@@ -3766,7 +3789,7 @@ msgstr ""
 msgid "'%s' is probably a binary buffer."
 msgstr ""
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr ""
 
@@ -3780,47 +3803,47 @@ msgstr ""
 msgid "can't write buffer '%s' to disk."
 msgstr ""
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr ""
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr ""
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr ""
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr ""
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr ""
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr ""
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr ""
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "Error: %s (%d)"
 msgstr ""
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr ""
 
@@ -3861,20 +3884,20 @@ msgstr ""
 msgid "libcurl could not be initialized"
 msgstr ""
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr ""
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr ""
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr ""
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr ""
 
@@ -3926,8 +3949,8 @@ msgstr ""
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr ""
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr ""
 
@@ -3977,79 +4000,79 @@ msgstr ""
 msgid "Doubly used id : %d"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr ""
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr ""
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr ""
@@ -4133,32 +4156,32 @@ msgstr ""
 msgid "Translations by "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr ""
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr ""
 
@@ -4209,43 +4232,42 @@ msgid "Password:"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr ""
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr ""
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087
-#: ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4256,8 +4278,7 @@ msgid "Left"
 msgstr ""
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090
-#: ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4344,7 +4365,7 @@ msgid "Home directory"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr ""
 
@@ -4357,8 +4378,7 @@ msgstr ""
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr ""
 
@@ -4538,16 +4558,16 @@ msgstr ""
 msgid "Go to parent directory"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr ""
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr ""
 
@@ -4641,7 +4661,7 @@ msgstr ""
 msgid "Whether the font is underlined."
 msgstr ""
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr ""
@@ -4659,48 +4679,47 @@ msgstr ""
 msgid "Click to confirm the font selection."
 msgstr ""
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr ""
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr ""
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr ""
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr ""
 
@@ -4804,59 +4823,59 @@ msgstr ""
 msgid "Printing page %d..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr ""
 
@@ -4864,25 +4883,25 @@ msgstr ""
 msgid "Default printer"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr ""
 
@@ -4894,52 +4913,52 @@ msgstr ""
 msgid "Print spooling"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr ""
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr ""
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr ""
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr ""
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr ""
 
@@ -4975,22 +4994,22 @@ msgstr ""
 msgid "< &Back"
 msgstr ""
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
 "setting to \"ibus\"."
 msgstr ""
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr ""
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr ""
@@ -5014,11 +5033,11 @@ msgstr ""
 msgid "Failed to register font configuration using private fonts."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5026,7 +5045,7 @@ msgid ""
 "environment variable GDK_BACKEND=x11 before starting your program."
 msgstr ""
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5034,7 +5053,7 @@ msgid ""
 "starting your program."
 msgstr ""
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr ""
 
@@ -5050,34 +5069,26 @@ msgstr ""
 msgid "Page Setup"
 msgstr ""
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr ""
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr ""
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr ""
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
-msgstr ""
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
 msgstr ""
 
 #: ../src/html/chm.cpp:138
@@ -5177,209 +5188,209 @@ msgstr ""
 msgid "Cannot open index file: %s"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr ""
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr ""
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr ""
@@ -5450,32 +5461,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr ""
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr ""
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr ""
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr ""
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr ""
@@ -5517,58 +5502,58 @@ msgstr ""
 msgid "Failed to create cursor."
 msgstr ""
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr ""
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr ""
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr ""
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr ""
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5576,7 +5561,7 @@ msgid ""
 "was passed to a DDEML function."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5584,140 +5569,140 @@ msgid ""
 "attempted to perform server transactions."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr ""
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
 "terminated before completing a transaction."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
 "the transaction identifier for that callback is no longer valid."
 msgstr ""
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
 "old, please upgrade (the following required function is missing: %s)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr ""
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr ""
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr ""
@@ -5737,18 +5722,17 @@ msgstr ""
 msgid "Cannot enumerate files in directory '%s'"
 msgstr ""
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr ""
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr ""
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr ""
 
@@ -5762,7 +5746,7 @@ msgstr ""
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr ""
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr ""
@@ -5803,16 +5787,16 @@ msgstr ""
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr ""
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr ""
 
@@ -5820,13 +5804,13 @@ msgstr ""
 msgid "Could not register custom DirectWrite font loader."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr ""
 
@@ -5835,7 +5819,7 @@ msgstr ""
 msgid "Can't delete the INI file '%s'"
 msgstr ""
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr ""
@@ -5955,7 +5939,7 @@ msgstr ""
 msgid "The clipboard format '%d' doesn't exist."
 msgstr ""
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr ""
 
@@ -6037,121 +6021,121 @@ msgid ""
 "operation aborted."
 msgstr ""
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr ""
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr ""
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr ""
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr ""
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr ""
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr ""
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr ""
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr ""
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr ""
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr ""
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6180,12 +6164,12 @@ msgstr ""
 msgid "Failed to lock resource \"%s\"."
 msgstr ""
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr ""
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr ""
 
@@ -6197,46 +6181,46 @@ msgstr ""
 msgid "Failed to redirect the child process IO"
 msgstr ""
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr ""
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr ""
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr ""
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr ""
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr ""
 
@@ -6269,7 +6253,7 @@ msgid "Check to make the font italic."
 msgstr ""
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr ""
@@ -6336,15 +6320,28 @@ msgstr ""
 msgid "File type:"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:260
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr ""
+
+#: ../src/osx/cocoa/menu.mm:299
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr ""
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr ""
 
@@ -6361,461 +6358,461 @@ msgstr ""
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr ""
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr ""
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr ""
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr ""
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr ""
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr ""
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr ""
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr ""
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr ""
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr ""
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr ""
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr ""
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr ""
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr ""
 
@@ -6828,48 +6825,48 @@ msgstr ""
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr ""
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr ""
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr ""
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr ""
 
@@ -7336,117 +7333,117 @@ msgstr ""
 msgid "Outset"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr ""
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr ""
 
@@ -7654,24 +7651,24 @@ msgstr ""
 msgid "Drag"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr ""
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr ""
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr ""
 
@@ -8640,53 +8637,53 @@ msgstr ""
 msgid "Box styles"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr ""
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr ""
 
@@ -8870,7 +8867,7 @@ msgstr ""
 msgid "Media playback error: %s"
 msgstr ""
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr ""
@@ -8970,77 +8967,77 @@ msgstr ""
 msgid "Couldn't open audio: %s"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr ""
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr ""
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr ""
 
@@ -9056,12 +9053,12 @@ msgstr ""
 msgid "Failed to read from wake-up pipe"
 msgstr ""
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr ""
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr ""
 
@@ -9075,27 +9072,27 @@ msgstr ""
 msgid "Failed to open display \"%s\"."
 msgstr ""
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr ""
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr ""

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-07-11 10:47+0800\n"
 "Last-Translator: James Pan <bojaypan@mail.ru>\n"
 "Language-Team: wxWidgets tranlators <wx-translators@wxwidgets.org>\n"
@@ -20,11 +20,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "所有文件 (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "所有文件 (*)|*"
 
@@ -41,24 +41,21 @@ msgid "Remaining time:"
 msgstr "剩余时间："
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "是"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "否"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "确认"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "取消"
@@ -108,7 +105,7 @@ msgid "Unable to create I/O completion port"
 msgstr "无法创建 I/O 完成端口"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "打印"
 
@@ -145,7 +142,7 @@ msgstr "对象属性"
 msgid "Printing"
 msgstr "正在打印"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "符号"
 
@@ -214,7 +211,7 @@ msgstr "上一个(&P)"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "窗口(&W)"
 
@@ -743,11 +740,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "显示帮助信息"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "生成详细日志信息"
 
@@ -769,84 +766,84 @@ msgstr "不支持的视觉效果主题 '%s'。"
 msgid "Invalid display mode specification '%s'."
 msgstr "无效的显示模式 '%s'。"
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "選项’%s’无法取消"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "未知的长选项 '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "未知选项 '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "选项 '%s' 后有异常的字符。"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "选项 '%s' 须有一个值。"
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "期望在选项 '%s' 后存在分隔号。"
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "'%s' 不是匹配选项 '%s'的正确数字值。"
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "选项 '%s'：'%s' 无法转成日期。"
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "异常参数 '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (或 %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "必须指定 '%s' 选项的值。"
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "未指定必要的参数 '%s'。"
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "用法：%s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "字符串"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "数字"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "双倍"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "日期"
 
@@ -864,7 +861,7 @@ msgid "Can't &Undo "
 msgstr "无法撤销(&U) "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "撤销(&U)"
@@ -874,7 +871,7 @@ msgid "&Redo "
 msgstr "恢复(&R) "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "恢复(&R)"
@@ -901,12 +898,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' 有额外的 '..'，已忽略。"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "已勾选"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "未勾选"
 
@@ -915,103 +912,103 @@ msgstr "未勾选"
 msgid "undetermined"
 msgstr "未判定"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "今天"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "昨天"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "明天"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "第一"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "第二"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "第三"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "第四"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "第五"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "第六"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "第七"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "第八"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "第九"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "第十"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "第十一"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "第十二"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "第十三"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "第十四"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "第十五"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "第十六"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "第十七"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "第十八"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "第十九"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "第二十"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "中午"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "午夜"
 
@@ -1077,44 +1074,81 @@ msgstr "无法执行 curl，请在 PATH 变量所指的目录中安装 curl。"
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "无法上传调试报告 (错误号 %d)。"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "另存为"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "放弃更改，并重新加载最近保存的版本？"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "未命名"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "是否保存修改至 %s？"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "保存(&S)"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "不保存"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "是否保存修改至 %s？"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "文本无法保存。"
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "文件 \"%s\" 无法开启为写入模式。"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "无法将文档保存至 \"%s\" 文件。"
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "文件 \"%s\" 无法开启为读取模式。"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "无法从 \"%s\" 文件读取文档。"
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1123,57 +1157,57 @@ msgstr ""
 "'%s'文件不存在，无法打开。\n"
 "已从最近使用的文件列表中移去。"
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "创建打印预览失败。"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "预览打印"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "无法确定 '%s' 文件格式。"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "未命名%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "打开文件"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "文件错误"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "抱歉，无法打开文件。"
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "抱歉，此文件格式未知。"
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "选择文档模板"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "模板"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "选择文档视图"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "视图"
 
@@ -1207,41 +1241,41 @@ msgstr "读文件 '%s' 出错"
 msgid "Write error on file '%s'"
 msgstr "写文件 '%s' 出错"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "清空文件 '%s' 失败"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "'%s' 文件定位错误 (stdio 不支持大文件)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' 文件定位错误"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "无法在 '%s' 文件中找到当前位置"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "无法设置临时文件的许可权限"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "无法删除文件 '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "无法提交修改至文件 '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "无法删除临时文件 '%s'"
@@ -1266,27 +1300,27 @@ msgstr "无法读取文件描述符 %d"
 msgid "can't write to file descriptor %d"
 msgstr "无法写文件描述符 %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "无法清空文件描述符 %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "无法定位文件描述符 %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "无法获得文件描述符 %d 的指针位置"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "无法获得文件描述符 %d 的文件长度"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "无法确定文件是否已达描述符 %d 的尾部"
@@ -1310,147 +1344,147 @@ msgstr "为了防止重写已有的 \"%s\" 文件，不会保存更改。"
 msgid "Error reading config options."
 msgstr "读配置选项错误。"
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "无法读配置选项。"
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "文件 '%s'：异常字符 %c 存在于行 %zu。"
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "文件 ‘%s’，行%zu：忽略群组标头之后的 '%s'。"
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "文件 '%s'，行 %zu：应有 '='。"
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "文件 '%s'，行 %zu：已忽略不可变密钥 '%s' 的值。"
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "文件 '%s'，行 %zu：键 '%s' 第一次出现在 %d 行。"
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "配置条目名不能以 '%c' 开头。"
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "无法打开用户配置文件。"
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "无法写用户配置文件。"
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "无法更新用户配置文件。"
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "保存用户配置数据错误。"
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "无法删除用户配置文件 '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "条目 '%s' 在 '%s' 组中已出现一次以上"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "忽略对不可变表项 '%s' 的修改。"
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "'%s' 尾部的斜线将被忽略"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "异常的 \" 发现在 %d 位于 '%s'。"
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "无法复制 '%s' 文件至 '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "无法获得许可权限访问 '%s'文件"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "不可能重写文件 '%s'"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "无法复制文件 '%s' 至 ‘%s’。"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "不可能设置文件 '%s' 的许可权限"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr "无法将文件 '%s' 重命名为 '%s'，因为目标文件已存在。"
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "文件 '%s' 无法重命名为 '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "文件 '%s' 无法被移除"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "无法创建目录 '%s'"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "无法删除目录 '%s'"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "无法枚举文件 '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "无法获取工作目录"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "无法设置当前工作目录"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "文件 (%s)"
@@ -1477,17 +1511,17 @@ msgstr "无法创建临时文件名"
 msgid "Failed to open temporary file."
 msgstr "无法打开临时文件。"
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "无法为 '%s' 修改文件时间"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "无法设置 '%s' 文件的修改和访问时间"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "无法提取 '%s' 文件时间"
@@ -1496,22 +1530,22 @@ msgstr "无法提取 '%s' 文件时间"
 msgid "Browse"
 msgstr "浏览"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "所有文件 (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s 文件 (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "装入文件 %s"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "保存文件 %s"
@@ -1874,99 +1908,99 @@ msgstr "默认值"
 msgid "unknown-%d"
 msgstr "未知-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "下划线"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " 删除线"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " 浅"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " 超细体"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " 细体"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " 中"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " 半粗体"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " 粗体"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " 超粗体"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " 加重"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " 超重"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " 斜体"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "删除线"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "浅"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "超细体"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "细体"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "正常"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "中"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "半粗体"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "粗体"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "超粗体"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "加重"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "超重"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "斜体"
 
@@ -2045,7 +2079,7 @@ msgstr "等待 FTP 服务器连接时超时，请尝试用被动模式。"
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "无法设置 FTP 传输模式为 %s。"
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2066,7 +2100,7 @@ msgstr "FTP 服务器不支持被动模式。"
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "错误的 GIF 帧尺寸(%u，%d) 对于第 #%u 帧"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "无法为 OpenGL 分配颜色"
 
@@ -2082,7 +2116,7 @@ msgstr "自定义列"
 msgid "&Customize..."
 msgstr "自定义(&C)..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "无法在默认浏览器中打开 URL \"%s\""
@@ -2102,155 +2136,154 @@ msgstr "无法从数据流中加载图像 %d。"
 msgid "Failed to load icons from resource '%s'."
 msgstr "无法从资源 \"%s\" 中加载图标 。"
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP：无法保存无效图像。"
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP：wxImage 没有自己的 wxPalette。"
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP：无法写文件 (Bitmap) 表头。"
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP：无法写文件 (BitmapInfo) 表头。"
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP：无法写 RGB 色彩表。"
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP：无法写数据。"
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP：无法分配内存。"
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB 表头：对于文件，图像宽度 > 32767 象素。"
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB 表头：对于文件，图像高度 > 32767 象素。"
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB 表头：文件中颜色位数未知。"
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB 表头：文件编码未知。"
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB 表头：编码不匹配颜色位数。"
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP：当 biBitCount=%d 时，表头则为 biClrUsed=%d。"
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP：无法分配内存。"
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB 表头：对于文件，图像宽度 > 32767 象素。"
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB 表头：对于文件，图像高度 > 32767 象素。"
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB 表头：文件中颜色位数未知。"
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB 表头：文件编码未知。"
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB 表头：编码不匹配颜色位数。"
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "读取图像 DIB 错误。"
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO：读掩码 DIB 错误。"
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO：图像高度超出范围，不适合做图标。"
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO：图像宽度超出范围，不适合做图标。"
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO：写图像文件错误！"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO：无效的图标索引。"
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "图像和掩码的大小不一致。"
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "图像中没有被掩码的未用颜色。"
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "无法从资源中加载图像 \"%s\"。"
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "无法从资源中加载图标 \"%s\"。"
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "无法从文件 \"%s\" 中读取图像。"
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "无法从将图像保存至文件 '%s' 中：无法识别的扩展名。"
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "没有找到图像类型的句柄。"
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "没有定义 %d 类型的图像句柄。"
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "图像文件的不是 %d 类型。"
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "无法自动确定不可定位输入的图像格式。"
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "未知图像数据格式。"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "这不是 %s。"
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "没有类型 %s 的图像句柄定义。"
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "图像的类型不是 %s。"
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "无法确认图像文件 \"%s\" 的格式。"
@@ -2351,52 +2384,52 @@ msgstr "PNM：文件似乎已被截断。"
 msgid " (in module \"%s\")"
 msgstr " (于模块：\"%s\")"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF：加载图像错误。"
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "无效TIFF图像索引。"
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF：图像大小过大。"
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF：无法分配内存。"
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF：读图像错误。"
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "未知 TIFF 解析度单位 %d，忽略之"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF：保存图像错误。"
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF：写图像错误。"
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "命令行参数 %d 无法被转化成统一编码，其将被忽略。"
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "在后初始化阶段出错，退出..."
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "无法设定区域语言为 \"%s\"。"
@@ -2488,7 +2521,7 @@ msgstr "LZMA 压缩错误：%s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "刷新输出时出现 LZMA 压缩错误：%s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "类型 %s 中有不配套的 '{'。"
@@ -2508,7 +2541,7 @@ msgstr "依赖 \"%s\" 对模块 \"%s\" 不存在。"
 msgid "Module \"%s\" initialization failed"
 msgstr "模块 \"%s\" 初始化失败"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "消息"
 
@@ -3010,7 +3043,7 @@ msgstr "打印出错"
 msgid "Print"
 msgstr "打印"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "页面设置"
 
@@ -3045,19 +3078,15 @@ msgstr "正在打印 %d 页其中 %d"
 msgid " (copy %d of %d)"
 msgstr " (复制 %d / %d)"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "正在打印 "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "第一页"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "前页"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "下一页"
 
@@ -3101,16 +3130,16 @@ msgstr "页 %d / %d"
 msgid "Page %d"
 msgstr "页 %d"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "未知错误"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "无效的正则表达式 '%s'：%s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "无法找到匹配的正则表达式：%s"
@@ -3120,21 +3149,21 @@ msgstr "无法找到匹配的正则表达式：%s"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "渲染器 \"%s\" 的版本 %d.%d 不兼容，无法加载。"
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "不适用于此平台"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "保存 “%s” 的密码失败：%s。"
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "读取 “%s” 的密码失败：%s。"
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "删除 \"%s\" 的密码失败：%s。"
@@ -3143,11 +3172,11 @@ msgstr "删除 \"%s\" 的密码失败：%s。"
 msgid "Failed to monitor I/O channels"
 msgstr "无法监视 I/O 通道"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "保存"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "不保存"
 
@@ -3228,10 +3257,10 @@ msgid "Clear"
 msgstr "清除"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "关闭"
 
@@ -3243,7 +3272,7 @@ msgstr "转换(&C)"
 msgid "Convert"
 msgstr "转换"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "复制(&C)"
@@ -3252,7 +3281,7 @@ msgstr "复制(&C)"
 msgid "Copy"
 msgstr "复制"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "剪切(&t)"
@@ -3261,13 +3290,13 @@ msgstr "剪切(&t)"
 msgid "Cut"
 msgstr "剪切"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "删除(&D)"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "删除"
@@ -3354,7 +3383,7 @@ msgstr "磁盘"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "帮助(&H)"
 
@@ -3374,7 +3403,7 @@ msgstr "缩进"
 msgid "&Index"
 msgstr "索引(&I)"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "索引"
 
@@ -3443,7 +3472,7 @@ msgstr "新建(&N)"
 msgid "New"
 msgstr "新建"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "否(&N)"
 
@@ -3460,12 +3489,12 @@ msgstr "打开(&O)..."
 msgid "Open..."
 msgstr "打开..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "粘贴(&P)"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "粘贴"
@@ -3495,7 +3524,7 @@ msgid "Print..."
 msgstr "打印..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "属性(&P)"
 
@@ -3527,10 +3556,6 @@ msgstr "替换…"
 msgid "Revert to Saved"
 msgstr "还原为上次保存的文件"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "保存(&S)"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "另存为(&A)..."
@@ -3539,7 +3564,7 @@ msgstr "另存为(&A)..."
 msgid "Save As..."
 msgstr "另存为..."
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "全部选择(&A)"
@@ -3646,7 +3671,7 @@ msgstr "向上(&U)"
 msgid "Up"
 msgstr "向上"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "是(&Y)"
 
@@ -3734,43 +3759,43 @@ msgstr "保存当前文档"
 msgid "Save current document with a different filename"
 msgstr "保存当前文档至重命名"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "无法进行到字符集 '%s' 的转换。"
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "未知"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "tar 表头块不完整"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "读取 tar 表头块发生校验和错误"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "tar 扩展表头中有图小数据"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar 标头未打开"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "异常地到达文件结尾"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s 不符合 tar 项目 '%s' 的表头"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "tar 项目不正确的大小"
 
@@ -3779,7 +3804,7 @@ msgstr "tar 项目不正确的大小"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' 或许是一个二进制文件。"
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "文件无法加载。"
 
@@ -3793,47 +3818,47 @@ msgstr "无法读取文本文件 “%s”。"
 msgid "can't write buffer '%s' to disk."
 msgstr "无法把缓存区 '%s' 写到磁盘。"
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "无法获取本地系统时间"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay 失败。"
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' 不是有效的消息目录。"
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "无效的消息目录。"
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "无法解析复数形式：'%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "使用目录 '%s' 从 '%s'。"
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "资源 '%s' 不是有效的消息目录。"
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "无法枚举翻译"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "没有配置 HTML 文件的默认应用。"
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "无法在默认浏览器中打开 URL \"%s\"。"
@@ -3866,7 +3891,7 @@ msgstr "'%s' 包含无效字符。"
 msgid "Error: %s (%d)"
 msgstr "错误：%s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "没有足够的可用磁盘空间供下载。"
 
@@ -3874,20 +3899,20 @@ msgstr "没有足够的可用磁盘空间供下载。"
 msgid "libcurl could not be initialized"
 msgstr "libcurl 无法初始化"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "不支持 RunScriptAsync"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "运行 JavaScript 时出错：%s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "该平台不支持背景透明度。"
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "无法把数据转到窗口"
 
@@ -3939,8 +3964,8 @@ msgstr "在声明的 RTTI 参数里找不到创建参数 %s"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "非法的对象类 (非-wxEvtHandler) 作为事件源"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "必须进行 enum - long 的类型转换"
 
@@ -3990,79 +4015,79 @@ msgstr "对象必须有一个 id 属性"
 msgid "Doubly used id : %d"
 msgstr "重复使用的 id：%d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "未知属性 %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "非空集合必须包含 'element' 节点"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "错误的时间句柄字符串，缺少点号('.')"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "无法重新初始化 zlib 压缩流"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "无法重新初始化 zlib 解压流"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr "忽略格式错误的额外数据记录，ZIP 文件可能已损坏"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "假定这是一个分段 zip 文件的合并"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "无效的 zip 文件"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "无法在 zip 文件中找到中央目录"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "读 zip 中央目录时出错"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "读 zip 本地头时出错"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "zip 文件中到条目的偏移值错误"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "此 Zip 头没有已存文件的长度信息"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "不支持的 Zip 压缩方法"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "读入 zip 流 (条目 %s)：长度错误"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "读入 zip 流 (条目 %s)：crc 校验错误"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "写入 zip 条目 ‘%s’ 时出错：文件太大，没有 ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "写 zip 条目 '%s' 时出错：crc 校验或长度错误"
@@ -4146,32 +4171,32 @@ msgstr "图形艺术设计由 "
 msgid "Translations by "
 msgstr "翻译人员 "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "版本 "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "关于 %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "授权"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "开发者"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "文档作者"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "美术设计者"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "翻译人员"
 
@@ -4222,42 +4247,42 @@ msgid "Password:"
 msgstr "密码："
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "true"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "false"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "第 %i 行"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "折叠"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "扩展"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d 项)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "列 %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4268,7 +4293,7 @@ msgid "Left"
 msgstr "左"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4362,7 +4387,7 @@ msgid "Home directory"
 msgstr "主目录"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "桌面"
 
@@ -4375,8 +4400,7 @@ msgstr "不合规范的目录名。"
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "错误"
 
@@ -4559,16 +4583,16 @@ msgstr "按详细视图观看文件"
 msgid "Go to parent directory"
 msgstr "进入父目录"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "文件 '%s' 已存在，确实需要重写它?"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "确认"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "请选择一个已存在的文件."
 
@@ -4662,7 +4686,7 @@ msgstr "字体大小。"
 msgid "Whether the font is underlined."
 msgstr "字体是否为下划线。"
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "预览："
@@ -4680,48 +4704,47 @@ msgstr "点击取消字体选择。"
 msgid "Click to confirm the font selection."
 msgstr "点击确认字体选择。"
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "选择字体"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "不支持将多个选定块复制到剪贴板。"
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "找不到帮助目录 \"%s\"。"
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "找不到帮助文件 \"%s\"。"
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "行 %lu 的map文件 \"%s\" 有无效语法，跳过。"
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "文件 \"%s\" 中无有效映射。"
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "没找到条目。"
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "帮助索引"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "相关条目："
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "找到的条目"
 
@@ -4825,59 +4848,59 @@ msgstr "无法启动打印。"
 msgid "Printing page %d..."
 msgstr "正在打印页 %d..."
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "打印机选项"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "打印到文件"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "设置..."
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "打印机："
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "状态："
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "所有"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "页"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "打印范围"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "从："
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "到："
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "份数："
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript文件"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "打印设置"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "打印机"
 
@@ -4885,25 +4908,25 @@ msgstr "打印机"
 msgid "Default printer"
 msgstr "默认的打印机"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "纸张大小"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "纵向"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "横向"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "方向"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "选项"
 
@@ -4915,52 +4938,52 @@ msgstr "彩色打印"
 msgid "Print spooling"
 msgstr "打印假脱机"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "打印机命令："
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "打印机选项："
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "左边距 (毫米)："
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "上页边距 (毫米)："
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "右边距 (毫米)："
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "底边距 (毫米)："
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "打印机..."
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "跳过(&S)"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "未知"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "完成。"
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "搜索"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "找不到 id 的标签"
 
@@ -4996,11 +5019,11 @@ msgstr "完成(&F)"
 msgid "< &Back"
 msgstr "< 返回(&B)"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr "翻译人员"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5009,11 +5032,11 @@ msgstr ""
 "警告：不支持使用 XIM 输入法，可能会导致输入处理和闪烁问题。 考虑取消设置 "
 "GTK_IM_MODULE 或设置为 “ibus\"。"
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "无法初始化 GTK+，DISPLAY 是否已正确设置？"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "将当前目录更改为 \"%s\" 失败"
@@ -5037,11 +5060,11 @@ msgstr "添加自定义字体 \"%s\" 失败。"
 msgid "Failed to register font configuration using private fonts."
 msgstr "使用私有字体注册字体配置失败。"
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "严重错误"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5052,7 +5075,7 @@ msgstr ""
 "通过设置安装 EGL 库并在 X11 后端下重建或运行它\n"
 "启动程序之前的环境变量 GDK_BACKEND=x11。"
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5063,7 +5086,7 @@ msgstr ""
 "通过在之前设置环境变量 GDK_BACKEND=x11 来解决这个问题\n"
 "开始你的程序。"
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "多文档界面子窗口"
 
@@ -5079,36 +5102,28 @@ msgstr "打印时出错： "
 msgid "Page Setup"
 msgstr "页面设置"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "无法在控件中插入文字。"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "WebKit v1 不支持检索 JavaScript 脚本输出"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 "本机安装的 GTK+ 版本过低，不支持屏幕组合，请安装 GTK+2.12 或者更新版本。"
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr "当前系统不支持组合模式，请在窗口管理器中启用。"
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr "该应用由过早版本的 GTK+ 编译，请用 GTK+ 2.12 或以上版本重新构建。"
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "请选择一个有效的字体。"
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5207,209 +5222,209 @@ msgstr "无法打开目录文件：%s"
 msgid "Cannot open index file: %s"
 msgstr "无法打开索引文件：%s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "未名"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "无法打开 HTML 帮助：%s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "在您浏览左侧的书籍时显示帮助。"
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(书签)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "把当前页加到书签中"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "从书签中移去当前页"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "内容"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "查找"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "显示全部"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr "显示包含给定子串的所有索引项。搜索是大小写无关的。"
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "以索引方式显示所有项目"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "大小写敏感"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "仅为整字"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "从帮助内容中搜索符合你在上面输入的正文的所有条目"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "显示/隐藏 导航面板"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "返回"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "前进"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "到上一级文档目录"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "打开HTML文档"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "打印本页"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "显示选项对话框"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "请选择欲显示的页面："
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "帮助主题"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "搜索中..."
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "还没有找到匹配页"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "找到 %i 个匹配项"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(帮助)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d / %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu / %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "搜索所有的书籍"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "帮助浏览器选项"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "正常字体："
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "固定字体："
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "字体大小："
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "字体大小"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "正常字体<br>且<u>带下划线</u>。 "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>斜体</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>粗体</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>粗斜体</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "固定字体。<br> <b>粗体</b><i>斜体</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>粗斜体<u>加下划线</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "帮助打印"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "无法打印空白页面。"
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML文件 (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "帮助书 (*.htb)|*.htb|帮助书 (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML 帮助的工程文件 (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "压缩的HTML帮助文件 (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i / %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u / %u"
@@ -5483,32 +5498,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "在页面建立时发生问题：您可能需要设置一台默认的打印机。"
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "无法按编码 %s 显示 HTML 文档"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets 无法为 '%s' 打开显示设备：退出。"
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "过滤器"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "目录"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "文件"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "选区"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "无法打开剪贴板。"
@@ -5550,58 +5539,58 @@ msgstr "颜色选择对话框错误，错误码 %0lx。"
 msgid "Failed to create cursor."
 msgstr "无法创建游标。"
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "无法注册 DDE 服务器 '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "无法撤消 DDE 服务器 '%s' 的注册"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "无法创建到服务器 '%s' 关于主题 '%s' 的连接"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "DDE poke 请求失败"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "无法在 DDE 服务器建立 advise 循环"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "无法终止与 DDE 服务器的 advise 循环"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "无法发送 DDE advise 通知"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "无法创建 DDE 字符串"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "没有 DDE 错误。"
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "同步 advise 事务请求超时。"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "对事件的响应导致 DDE_FBUSY 位被设置。"
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "同步 data 事务请求超时。"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5612,7 +5601,7 @@ msgstr ""
 "或传给DDEML函数的是\n"
 "无效的实例标识。"
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5624,43 +5613,43 @@ msgstr ""
 "或初始化为 APPCMD_CLIENTONLY 的应用程序\n"
 "视图执行服务器事务。"
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "同步 execute 事务请求超时。"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "参数无法通过 DDEML 验证。"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "一 DDEML 应用程序已生成延时竞态条件。"
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "内存分配失败。"
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "客户试图建立的会话已失败。"
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "事务失败。"
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "同步 poke 事务请求超时。"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "内部调用 PostMessage 失败。 "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "重入问题。"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5670,15 +5659,15 @@ msgstr ""
 "已被客户端终止的会话，或服务器\n"
 "在完成事务前终止。"
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "在 DDEML 中发生内部错误。"
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "终止 advise 事务的请求超时。"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5688,82 +5677,82 @@ msgstr ""
 "一旦应用程序从 XTYP_XACT_COMPLETE 回调函数返回，\n"
 "回调函数事务标识符就不再有效。"
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "未知 DDE 错误 %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr "由于远程访问服务 (RAS) 没有安装在本机，拨号功能无法使用。请安装它。"
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
 "old, please upgrade (the following required function is missing: %s)."
 msgstr "安装在本机的远程访问服务(RAS)太旧，请更新它 (缺少下列必要的函数：%s)."
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "无法提取 RAS 错误消息正文"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "未知错误 (错误号 %08x)。"
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "无法找到活动的拨号连接：%s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "找到多个活动拨号连接，随机选择一个."
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "无法建立拨号连接：%s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "无法获取 ISP 名称：%s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "连接失败：没有可用的 ISP。"
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "选择 ISP 进行拨号"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "请选择你想连接的 ISP"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "连接失败：缺少用户名/密码。"
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "无法找到地址簿文件的位置"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "无法初始化拨号连接：%s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "无法挂断 - 没有活动的拨号连接。"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "无法终止拨号连接：%s"
@@ -5783,18 +5772,17 @@ msgstr "无法为位图数据分配 %luKb 内存。"
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "无法枚举目录 '%s' 中的文件"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "无法获取文件夹名称"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(错误 %d：%s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "无法把图像加到图象列表。"
 
@@ -5808,7 +5796,7 @@ msgstr "无法从文件 \"%s\" 读取元文件。"
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "无法创建标准 \"查找/替换\" 对话框 (错误号 %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "文件对话框错误，错误码：%0lx。"
@@ -5849,16 +5837,16 @@ msgstr "无法为 '%s' 设置 watch"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "无法监视不存在目录 \"%s\" 的更新。"
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "OpenGL 驱动程序不支持 OpenGL 3.0 或更高版本。"
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "无法创建 OpenGL 上下文"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "无法初始化 OpenGL"
 
@@ -5866,13 +5854,13 @@ msgstr "无法初始化 OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "无法注册自定义 DirectWrite 字体加载器。"
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr "MS HTML帮助功能不存在，因为此机器上没有安装 MS HTML 帮助库。请安装它。"
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "无法初始化 MS HTML 帮助。"
 
@@ -5881,7 +5869,7 @@ msgstr "无法初始化 MS HTML 帮助。"
 msgid "Can't delete the INI file '%s'"
 msgstr "无法删除 INI 文件 '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "无法获得列表控件的项 %d 信息。"
@@ -6001,7 +5989,7 @@ msgstr "无法注册剪贴板格式 '%s'。"
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "剪贴板格式 '%d' 不存在。"
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "跳过"
 
@@ -6086,122 +6074,122 @@ msgstr ""
 "删除它将使系统进入不可用状态：\n"
 "操作终止."
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "无法删除键 '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "无法删除值 '%s' 位于键 '%s'"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "无法读项 '%s' 的值"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "无法设置 '%s' 的值"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "注册表值 “%s\" 不是数字（但类型为 %s）"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "注册表值 “%s\" 不是二进制的（但类型为 %s）"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "注册表值 “%s\" 不是文本（但类型为 %s）"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "无法读 '%s' 的值"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "无法枚举键 '%s' 的值"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "无法枚举键 '%s' 的子键"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "导出注册表项：文件 \"%s\" 已经存在，无法覆盖。"
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "无法导出不支持的类型 %d 的值."
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "忽略值 \"%s\" (项 \"%s\")。"
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
 msgstr ""
 "无法创建富文本编辑器控件，使用简单文本编辑器控件代替。请重新安装 riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "无法启动线程：写 TLS 出错。"
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "无法设置线程优先级"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "无法创建线程"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "无法终止线程"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "无法等候线程终止"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "无法挂起线程 %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "无法恢复线程 %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "无法获得当前线程指针"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "线程模块初始化失败：无法在线程本地存储区中分配索引"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6230,12 +6218,12 @@ msgstr "无法加载资源 \"%s\"。"
 msgid "Failed to lock resource \"%s\"."
 msgstr "无法锁定资源 \"%s\"。"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "构建 %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr "，64位版"
 
@@ -6247,46 +6235,46 @@ msgstr "无法创建匿名管道"
 msgid "Failed to redirect the child process IO"
 msgstr "无法重定向子过程 IO"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "命令 '%s' 执行失败"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "无法加载 mpr.dll。"
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "无法从 '%s' 中读取类型名称！"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "无法从 '%s' 中读取图标。"
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "无法在注册表中找到 Web 视图仿真级别"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "无法将 Web 视图设置为现代仿真级别"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "无法将 Web 视图重置为标准仿真级别"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "没有有效的 HTML 文档就无法运行 JavaScript 脚本"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "无法获取 JavaScript 对象"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "未能评估"
 
@@ -6319,7 +6307,7 @@ msgid "Check to make the font italic."
 msgstr "勾选设置为斜体。"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "下划线"
@@ -6386,15 +6374,33 @@ msgstr "<任一 Teletype>"
 msgid "File type:"
 msgstr "文件类型："
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "视窗"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "帮助"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "最小化"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "放大缩小"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "最上层显示"
 
@@ -6411,461 +6417,461 @@ msgstr "字体文件“%s\"不存在。"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr "无法使用字体文件 “%s”，因为它不在字体目录 “%s” 内。"
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "关于 %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "关于..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "偏好设置..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "服务"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "隐藏 %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "隐藏应用程序"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "隐藏其他"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "显示全部"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "退出 %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "退出应用程序"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "系统网页控制不支持打印"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "无法初始化打印操作"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "字体大小(磅值)"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "字体名称"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "样式"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "字体粗细"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "系列"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "应用工作区"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "活动边框"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "主动字幕"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "按钮面"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "按钮反白"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "按钮阴影"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "按钮文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "标题文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "控制暗度"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "控制亮度"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "灰阶文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "反白"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "反白文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "待用边框"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "待用标题"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "待用标题文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "菜单"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "滚动条"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "工具提示"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "工具提示文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "视窗"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "窗框"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "视窗文字"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "自选"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "黑色"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "栗色"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "海军蓝"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "紫色"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "蓝绿色"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "灰色"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "绿色"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "橄榄色"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "咖啡色"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "蓝色"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "紫红色"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "红色"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "橘色"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "银色"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "莱姆色"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "海蓝色"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "黄色"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "白色"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "默认"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "箭头"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "右箭头"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "空"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "靶心"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "字符编码"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "交叉"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "手"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "工字梁"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "左键"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "放大镜"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "中间按钮"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "不可进入"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "油漆刷"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "铅笔"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "向左指"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "向右指"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "问题箭头"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "右键"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "缩放 (东北至西南)"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "缩放 (北至南)"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "缩放 (西北至东南)"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "缩放 (西至东)"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "缩放"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "喷雾罐"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "等待"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "监控"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "等待箭头"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "请选择："
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "属性"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "值"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "分类模式"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "字母顺序模式"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "False"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "True"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "未指定"
 
@@ -6878,48 +6884,48 @@ msgstr "属性错误"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "你输入了无效值。按 ESC 取消编辑。"
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "资源错误：%s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr "类型操作“%s\"失败：标记为“%s\"的属性属于“%s\"类型，而不是“%s\"类型。"
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "未知基数 %d。 将使用基数 10。"
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "数值必须大于或等于 %s。"
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "数值必须在 %s 和 %s 之间。"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "数值必须小于或等于 %s。"
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "非 %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "选择目录："
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "选择文件"
 
@@ -7386,117 +7392,117 @@ msgstr "插入"
 msgid "Outset"
 msgstr "抽离"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "更改样式"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "更改对象样式"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "更改属性"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "更改列表样式"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "重编号列表"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "插入文本"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "插入图片"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "插入对象"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "插入范围"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "调用 EndStyle 太多次！"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "文件"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "标准/圆形"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "标准/圆框"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "标准/方形"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "标准/菱形"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "标准/三角形"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "方块属性"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "多重单元属性"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "单元格属性"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "设置单元格样式"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "删除行"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "删除列"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "添加行"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "添加列"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "表格属性"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "图片属性"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "图片"
 
@@ -7704,24 +7710,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "移动"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "删除文字"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "移除项目符号"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "文本无法保存。"
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "替换"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "字体(&F)："
 
@@ -8690,53 +8696,53 @@ msgstr "列表样式"
 msgid "Box styles"
 msgstr "方块样式"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "符号使用该字体。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "子集(&S)："
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "显示统一编码子集。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "字符编码(&C)："
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "字符编码。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "从(&F)："
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "统一编码"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "显示的范围。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "插入"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(正常字体)"
 
@@ -8920,7 +8926,7 @@ msgstr "无法从 kqueue 中获取事件"
 msgid "Media playback error: %s"
 msgstr "媒体回放错误：%s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "无法准备播放 “%s”。"
@@ -9020,77 +9026,77 @@ msgstr "声音数据为不支持的格式。"
 msgid "Couldn't open audio: %s"
 msgstr "无法打开音频：%s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "无法找回线程调度策略。"
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "无法获得调度策略 %d 的优先级范围。"
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "线程优先级设置被忽略。"
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr "无法合并线程，检测到潜在地内存丢失 - 请重新启动系统"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "无法设置线程并发级别至 %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "无法设置线程优先级 %d。"
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "无法终止线程。"
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "线程模块初始化失败：创建线程键失败"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "不可能获得子过程的输入"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "无法写入子进程的标准输入"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "无法执行 '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "Fork 失败"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "无法设置线程优先级"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "无法重定向子过程输入/输出"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "无法设置非闭塞通道，程序可能挂起。"
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "无法获得主机名"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "无法获得正式的主机名"
 
@@ -9106,12 +9112,12 @@ msgstr "无法将唤醒管道切换至非闭塞模式"
 msgid "Failed to read from wake-up pipe"
 msgstr "无法读取唤醒管道"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "无效的几何规格 '%s'"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets 无法打开显示设备。退出。"
 
@@ -9125,30 +9131,59 @@ msgstr "无法关闭显示 \"%s\""
 msgid "Failed to open display \"%s\"."
 msgstr "无法打开显示设备 \"%s\"。"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML 解析错误：'%s'，位于行 %d"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "无法从文件 '%s' 中加载资源。"
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "无法打开资源文件 '%s'。"
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "无法从文件 '%s' 中加载资源。"
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "创建 %s \"%s\" 失败。"
+
+#~ msgid "Printing "
+#~ msgstr "正在打印 "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "无法在控件中插入文字。"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "请选择一个有效的字体。"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "无法按编码 %s 显示 HTML 文档"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets 无法为 '%s' 打开显示设备：退出。"
+
+#~ msgid "Filter"
+#~ msgstr "过滤器"
+
+#~ msgid "Directories"
+#~ msgstr "目录"
+
+#~ msgid "Files"
+#~ msgstr "文件"
+
+#~ msgid "Selection"
+#~ msgstr "选区"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "无法转换为 8 位编码"
@@ -9310,8 +9345,8 @@ msgstr "创建 %s \"%s\" 失败。"
 #~ msgstr "数据渲染器无法渲染该值；类型为:"
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxWidgets 3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-02 08:37+0200\n"
+"POT-Creation-Date: 2023-02-06 16:05+0100\n"
 "PO-Revision-Date: 2022-07-09 10:45+0800\n"
 "Last-Translator: James Pan <bojaypan@mail.ru>\n"
 "Language-Team: Chinese <zh-l10n@lists.linux.org.tw>\n"
@@ -22,11 +22,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.1.1\n"
 
-#: ../include/wx/defs.h:2705
+#: ../include/wx/defs.h:2592
 msgid "All files (*.*)|*.*"
 msgstr "所有檔案 (*.*)|*.*"
 
-#: ../include/wx/defs.h:2708
+#: ../include/wx/defs.h:2595
 msgid "All files (*)|*"
 msgstr "所有檔案 (*)|*"
 
@@ -43,24 +43,21 @@ msgid "Remaining time:"
 msgstr "剩餘時間："
 
 #: ../include/wx/msgdlg.h:278 ../src/common/stockitem.cpp:212
-#: ../src/motif/msgdlg.cpp:196
 msgid "Yes"
 msgstr "是"
 
 #: ../include/wx/msgdlg.h:279 ../src/common/stockitem.cpp:183
-#: ../src/motif/msgdlg.cpp:196
 msgid "No"
 msgstr "否"
 
 #: ../include/wx/msgdlg.h:280 ../src/common/stockitem.cpp:184
-#: ../src/gtk1/fontdlg.cpp:138 ../src/msw/msgdlg.cpp:449
-#: ../src/msw/msgdlg.cpp:744 ../src/richtext/richtextstyledlg.cpp:293
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/msgdlg.cpp:751
+#: ../src/richtext/richtextstyledlg.cpp:293
 msgid "OK"
 msgstr "確認"
 
 #: ../include/wx/msgdlg.h:281 ../src/common/stockitem.cpp:151
-#: ../src/gtk1/fontdlg.cpp:144 ../src/motif/msgdlg.cpp:196
-#: ../src/msw/msgdlg.cpp:449 ../src/msw/progdlg.cpp:940
+#: ../src/msw/msgdlg.cpp:447 ../src/msw/progdlg.cpp:884
 #: ../src/richtext/richtextstyledlg.cpp:296
 msgid "Cancel"
 msgstr "取消"
@@ -111,7 +108,7 @@ msgid "Unable to create I/O completion port"
 msgstr "無法創建 I/O 完成通訊埠"
 
 #: ../include/wx/prntbase.h:267 ../include/wx/richtext/richtextprint.h:109
-#: ../src/common/docview.cpp:2137
+#: ../src/common/docview.cpp:2166
 msgid "Printout"
 msgstr "列印"
 
@@ -148,7 +145,7 @@ msgstr "物件屬性"
 msgid "Printing"
 msgstr "列印"
 
-#: ../include/wx/richtext/richtextsymboldlg.h:47
+#: ../include/wx/richtext/richtextsymboldlg.h:40
 msgid "Symbols"
 msgstr "符號"
 
@@ -217,7 +214,7 @@ msgstr "上一個(&P)"
 #: ../src/aui/tabmdi.cpp:332 ../src/aui/tabmdi.cpp:348
 #: ../src/aui/tabmdi.cpp:350 ../src/generic/mdig.cpp:291
 #: ../src/generic/mdig.cpp:307 ../src/generic/mdig.cpp:311
-#: ../src/msw/mdi.cpp:337 ../src/osx/cocoa/menu.mm:243
+#: ../src/msw/mdi.cpp:337
 msgid "&Window"
 msgstr "視窗(&W)"
 
@@ -746,11 +743,11 @@ msgctxt "keyboard key"
 msgid "RawCtrl+"
 msgstr "RawCtrl+"
 
-#: ../src/common/appbase.cpp:774
+#: ../src/common/appbase.cpp:733
 msgid "show this help message"
 msgstr "顯示說明訊息"
 
-#: ../src/common/appbase.cpp:784
+#: ../src/common/appbase.cpp:743
 msgid "generate verbose log messages"
 msgstr "產生詳細日誌訊息"
 
@@ -772,84 +769,84 @@ msgstr "不支援的視覺主題 '%s'。"
 msgid "Invalid display mode specification '%s'."
 msgstr "無效的顯示模式規格 '%s'。"
 
-#: ../src/common/cmdline.cpp:896
+#: ../src/common/cmdline.cpp:885
 #, c-format
 msgid "Option '%s' can't be negated"
 msgstr "選項 '%s' 無法取消"
 
-#: ../src/common/cmdline.cpp:910
+#: ../src/common/cmdline.cpp:899
 #, c-format
 msgid "Unknown long option '%s'"
 msgstr "未知的長選項 '%s'"
 
-#: ../src/common/cmdline.cpp:925 ../src/common/cmdline.cpp:947
+#: ../src/common/cmdline.cpp:914 ../src/common/cmdline.cpp:936
 #, c-format
 msgid "Unknown option '%s'"
 msgstr "未知的選項 '%s'"
 
-#: ../src/common/cmdline.cpp:1025
+#: ../src/common/cmdline.cpp:1014
 #, c-format
 msgid "Unexpected characters following option '%s'."
 msgstr "'%s' 選項後出現異常的字元。"
 
-#: ../src/common/cmdline.cpp:1060
+#: ../src/common/cmdline.cpp:1049
 #, c-format
 msgid "Option '%s' requires a value."
 msgstr "選項 ’%s’ 須有一個值。"
 
-#: ../src/common/cmdline.cpp:1079
+#: ../src/common/cmdline.cpp:1068
 #, c-format
 msgid "Separator expected after the option '%s'."
 msgstr "在 '%s' 選項後應接著分隔字元。"
 
-#: ../src/common/cmdline.cpp:1109 ../src/common/cmdline.cpp:1127
+#: ../src/common/cmdline.cpp:1098 ../src/common/cmdline.cpp:1116
 #, c-format
 msgid "'%s' is not a correct numeric value for option '%s'."
 msgstr "‘%s’ 不是 ‘%s’ 選項的正確數值。"
 
-#: ../src/common/cmdline.cpp:1143
+#: ../src/common/cmdline.cpp:1132
 #, c-format
 msgid "Option '%s': '%s' cannot be converted to a date."
 msgstr "'%s' 選項：'%s' 無法轉換成日期。"
 
-#: ../src/common/cmdline.cpp:1191
+#: ../src/common/cmdline.cpp:1180
 #, c-format
 msgid "Unexpected parameter '%s'"
 msgstr "異常參數 '%s'"
 
-#: ../src/common/cmdline.cpp:1217
+#: ../src/common/cmdline.cpp:1206
 #, c-format
 msgid "%s (or %s)"
 msgstr "%s (或 %s)"
 
-#: ../src/common/cmdline.cpp:1228
+#: ../src/common/cmdline.cpp:1217
 #, c-format
 msgid "The value for the option '%s' must be specified."
 msgstr "必須指定 '%s' 選項的值。"
 
-#: ../src/common/cmdline.cpp:1250
+#: ../src/common/cmdline.cpp:1239
 #, c-format
 msgid "The required parameter '%s' was not specified."
 msgstr "未指定必要的參數 '%s'。"
 
-#: ../src/common/cmdline.cpp:1322
+#: ../src/common/cmdline.cpp:1311
 #, c-format
 msgid "Usage: %s"
 msgstr "用法：%s"
 
-#: ../src/common/cmdline.cpp:1483
+#: ../src/common/cmdline.cpp:1472
 msgid "str"
 msgstr "字串"
 
-#: ../src/common/cmdline.cpp:1487
+#: ../src/common/cmdline.cpp:1476
 msgid "num"
 msgstr "數字"
 
-#: ../src/common/cmdline.cpp:1491
+#: ../src/common/cmdline.cpp:1480
 msgid "double"
 msgstr "雙倍"
 
-#: ../src/common/cmdline.cpp:1495
+#: ../src/common/cmdline.cpp:1484
 msgid "date"
 msgstr "日期"
 
@@ -867,7 +864,7 @@ msgid "Can't &Undo "
 msgstr "不能復原(&U) "
 
 #: ../src/common/cmdproc.cpp:264 ../src/common/stockitem.cpp:209
-#: ../src/msw/textctrl.cpp:2932 ../src/osx/textctrl_osx.cpp:634
+#: ../src/msw/textctrl.cpp:2705 ../src/osx/textctrl_osx.cpp:634
 #: ../src/richtext/richtextctrl.cpp:328
 msgid "&Undo"
 msgstr "復原(&U)"
@@ -877,7 +874,7 @@ msgid "&Redo "
 msgstr "重做(&R) "
 
 #: ../src/common/cmdproc.cpp:286 ../src/common/cmdproc.cpp:293
-#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2933
+#: ../src/common/stockitem.cpp:191 ../src/msw/textctrl.cpp:2706
 #: ../src/osx/textctrl_osx.cpp:635 ../src/richtext/richtextctrl.cpp:329
 msgid "&Redo"
 msgstr "重做(&R)"
@@ -904,12 +901,12 @@ msgid "'%s' has extra '..', ignored."
 msgstr "'%s' 有額外的 '..'，已忽略。"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1416
+#: ../src/common/datavcmn.cpp:2165 ../src/generic/datavgen.cpp:1424
 msgid "checked"
 msgstr "已勾選"
 
 #. TRANSLATORS: Checkbox state name
-#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1418
+#: ../src/common/datavcmn.cpp:2169 ../src/generic/datavgen.cpp:1426
 msgid "unchecked"
 msgstr "未勾選"
 
@@ -918,103 +915,103 @@ msgstr "未勾選"
 msgid "undetermined"
 msgstr "未判定"
 
-#: ../src/common/datetimefmt.cpp:1845
+#: ../src/common/datetimefmt.cpp:1847
 msgid "today"
 msgstr "今天"
 
-#: ../src/common/datetimefmt.cpp:1846
+#: ../src/common/datetimefmt.cpp:1848
 msgid "yesterday"
 msgstr "昨天"
 
-#: ../src/common/datetimefmt.cpp:1847
+#: ../src/common/datetimefmt.cpp:1849
 msgid "tomorrow"
 msgstr "明天"
 
-#: ../src/common/datetimefmt.cpp:2041
+#: ../src/common/datetimefmt.cpp:2043
 msgid "first"
 msgstr "第一"
 
-#: ../src/common/datetimefmt.cpp:2042
+#: ../src/common/datetimefmt.cpp:2044
 msgid "second"
 msgstr "第二"
 
-#: ../src/common/datetimefmt.cpp:2043
+#: ../src/common/datetimefmt.cpp:2045
 msgid "third"
 msgstr "第三"
 
-#: ../src/common/datetimefmt.cpp:2044
+#: ../src/common/datetimefmt.cpp:2046
 msgid "fourth"
 msgstr "第四"
 
-#: ../src/common/datetimefmt.cpp:2045
+#: ../src/common/datetimefmt.cpp:2047
 msgid "fifth"
 msgstr "第五"
 
-#: ../src/common/datetimefmt.cpp:2046
+#: ../src/common/datetimefmt.cpp:2048
 msgid "sixth"
 msgstr "第六"
 
-#: ../src/common/datetimefmt.cpp:2047
+#: ../src/common/datetimefmt.cpp:2049
 msgid "seventh"
 msgstr "第七"
 
-#: ../src/common/datetimefmt.cpp:2048
+#: ../src/common/datetimefmt.cpp:2050
 msgid "eighth"
 msgstr "第八"
 
-#: ../src/common/datetimefmt.cpp:2049
+#: ../src/common/datetimefmt.cpp:2051
 msgid "ninth"
 msgstr "第九"
 
-#: ../src/common/datetimefmt.cpp:2050
+#: ../src/common/datetimefmt.cpp:2052
 msgid "tenth"
 msgstr "第十"
 
-#: ../src/common/datetimefmt.cpp:2051
+#: ../src/common/datetimefmt.cpp:2053
 msgid "eleventh"
 msgstr "第十一"
 
-#: ../src/common/datetimefmt.cpp:2052
+#: ../src/common/datetimefmt.cpp:2054
 msgid "twelfth"
 msgstr "第十二"
 
-#: ../src/common/datetimefmt.cpp:2053
+#: ../src/common/datetimefmt.cpp:2055
 msgid "thirteenth"
 msgstr "第十三"
 
-#: ../src/common/datetimefmt.cpp:2054
+#: ../src/common/datetimefmt.cpp:2056
 msgid "fourteenth"
 msgstr "第十四"
 
-#: ../src/common/datetimefmt.cpp:2055
+#: ../src/common/datetimefmt.cpp:2057
 msgid "fifteenth"
 msgstr "第十五"
 
-#: ../src/common/datetimefmt.cpp:2056
+#: ../src/common/datetimefmt.cpp:2058
 msgid "sixteenth"
 msgstr "第十六"
 
-#: ../src/common/datetimefmt.cpp:2057
+#: ../src/common/datetimefmt.cpp:2059
 msgid "seventeenth"
 msgstr "第十七"
 
-#: ../src/common/datetimefmt.cpp:2058
+#: ../src/common/datetimefmt.cpp:2060
 msgid "eighteenth"
 msgstr "第十八"
 
-#: ../src/common/datetimefmt.cpp:2059
+#: ../src/common/datetimefmt.cpp:2061
 msgid "nineteenth"
 msgstr "第十九"
 
-#: ../src/common/datetimefmt.cpp:2060
+#: ../src/common/datetimefmt.cpp:2062
 msgid "twentieth"
 msgstr "第廿十"
 
-#: ../src/common/datetimefmt.cpp:2218
+#: ../src/common/datetimefmt.cpp:2220
 msgid "noon"
 msgstr "中午"
 
-#: ../src/common/datetimefmt.cpp:2219
+#: ../src/common/datetimefmt.cpp:2221
 msgid "midnight"
 msgstr "午夜"
 
@@ -1080,44 +1077,81 @@ msgstr "無法執行 curl，請在 PATH 變數所指的目錄安裝 curl。"
 msgid "Failed to upload the debug report (error code %d)."
 msgstr "無法上載偵錯報告 (錯誤代號 %d)。"
 
-#: ../src/common/docview.cpp:359
+#: ../src/common/docview.cpp:367
 msgid "Save As"
 msgstr "另存新檔"
 
-#: ../src/common/docview.cpp:450
+#: ../src/common/docview.cpp:458
 msgid "Discard changes and reload the last saved version?"
 msgstr "是否捨棄變更，並重新載入上次儲存的版本？"
 
-#: ../src/common/docview.cpp:502
+#: ../src/common/docview.cpp:489
 msgid "unnamed"
 msgstr "未命名"
 
-#: ../src/common/docview.cpp:526
+#: ../src/common/docview.cpp:514
 #, c-format
 msgid "Do you want to save changes to %s?"
 msgstr "是否儲存變更至 %s？"
 
-#: ../src/common/docview.cpp:641
+#: ../src/common/docview.cpp:522 ../src/common/docview.cpp:561
+#: ../src/common/stockitem.cpp:196
+msgid "&Save"
+msgstr "儲存(&S)"
+
+#: ../src/common/docview.cpp:523 ../src/common/docview.cpp:561
+msgid "&Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:524
+#, fuzzy
+msgid "Do&n't close"
+msgstr "不儲存"
+
+#: ../src/common/docview.cpp:554
+#, fuzzy, c-format
+msgid "Do you want to save changes to %s before closing it?"
+msgstr "是否儲存變更至 %s？"
+
+#: ../src/common/docview.cpp:560
+#, fuzzy
+msgid "The document must be closed."
+msgstr "無法儲存文字。"
+
+#: ../src/common/docview.cpp:572
+#, c-format
+msgid "Saving %s failed, would you like to retry?"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Retry"
+msgstr ""
+
+#: ../src/common/docview.cpp:578
+msgid "Discard changes"
+msgstr ""
+
+#: ../src/common/docview.cpp:680
 #, c-format
 msgid "File \"%s\" could not be opened for writing."
 msgstr "檔案 “%s” 無法開啟為寫入模式。"
 
-#: ../src/common/docview.cpp:647
+#: ../src/common/docview.cpp:686
 #, c-format
 msgid "Failed to save document to the file \"%s\"."
 msgstr "無法將文件儲存至 \"'%s'\"檔案。"
 
-#: ../src/common/docview.cpp:664
+#: ../src/common/docview.cpp:703
 #, c-format
 msgid "File \"%s\" could not be opened for reading."
 msgstr "檔案 “%s” 無法開啟為讀取模式。"
 
-#: ../src/common/docview.cpp:676
+#: ../src/common/docview.cpp:715
 #, c-format
 msgid "Failed to read document from the file \"%s\"."
 msgstr "無法從 “%s” 檔案讀取文件。"
 
-#: ../src/common/docview.cpp:1196
+#: ../src/common/docview.cpp:1240
 #, c-format
 msgid ""
 "The file '%s' doesn't exist and couldn't be opened.\n"
@@ -1126,57 +1160,57 @@ msgstr ""
 "'%s' 檔案不存在，無法開啟。\n"
 "檔案已從最近使用的檔案清單中移除。"
 
-#: ../src/common/docview.cpp:1256
+#: ../src/common/docview.cpp:1300
 msgid "Print preview creation failed."
 msgstr "創建列印預覽失敗。"
 
-#: ../src/common/docview.cpp:1262
+#: ../src/common/docview.cpp:1306
 msgid "Print Preview"
 msgstr "預覽列印"
 
-#: ../src/common/docview.cpp:1477
+#: ../src/common/docview.cpp:1521
 #, c-format
 msgid "The format of file '%s' couldn't be determined."
 msgstr "無法確定 ’%s’ 檔案格式。"
 
-#: ../src/common/docview.cpp:1618
+#: ../src/common/docview.cpp:1648
 #, c-format
 msgid "unnamed%d"
 msgstr "未命名%d"
 
-#: ../src/common/docview.cpp:1636
+#: ../src/common/docview.cpp:1665
 msgid " - "
 msgstr " - "
 
-#: ../src/common/docview.cpp:1767 ../src/common/docview.cpp:1820
+#: ../src/common/docview.cpp:1796 ../src/common/docview.cpp:1849
 msgid "Open File"
 msgstr "開啟檔案"
 
-#: ../src/common/docview.cpp:1783
+#: ../src/common/docview.cpp:1812
 msgid "File error"
 msgstr "檔案錯誤"
 
-#: ../src/common/docview.cpp:1785
+#: ../src/common/docview.cpp:1814
 msgid "Sorry, could not open this file."
 msgstr "抱歉，無法開啟檔案。"
 
-#: ../src/common/docview.cpp:1819
+#: ../src/common/docview.cpp:1848
 msgid "Sorry, the format for this file is unknown."
 msgstr "抱歉，此檔案格式不明。"
 
-#: ../src/common/docview.cpp:1900
+#: ../src/common/docview.cpp:1929
 msgid "Select a document template"
 msgstr "選擇文件範本"
 
-#: ../src/common/docview.cpp:1901
+#: ../src/common/docview.cpp:1930
 msgid "Templates"
 msgstr "範本"
 
-#: ../src/common/docview.cpp:1974
+#: ../src/common/docview.cpp:2003
 msgid "Select a document view"
 msgstr "選擇文件檢視"
 
-#: ../src/common/docview.cpp:1975
+#: ../src/common/docview.cpp:2004
 msgid "Views"
 msgstr "檢視"
 
@@ -1210,41 +1244,41 @@ msgstr "讀取 '%s' 檔案時發生錯誤"
 msgid "Write error on file '%s'"
 msgstr "寫入 '%s' 檔案時發生錯誤"
 
-#: ../src/common/ffile.cpp:187
+#: ../src/common/ffile.cpp:183
 #, c-format
 msgid "failed to flush the file '%s'"
 msgstr "排清檔案 '%s' 失敗"
 
-#: ../src/common/ffile.cpp:227
+#: ../src/common/ffile.cpp:223
 #, c-format
 msgid "Seek error on file '%s' (large files not supported by stdio)"
 msgstr "'%s' 檔案定位錯誤 (stdio 不支援大檔案)"
 
-#: ../src/common/ffile.cpp:237
+#: ../src/common/ffile.cpp:233
 #, c-format
 msgid "Seek error on file '%s'"
 msgstr "'%s' 檔案定位錯誤"
 
-#: ../src/common/ffile.cpp:253
+#: ../src/common/ffile.cpp:249
 #, c-format
 msgid "Can't find current position in file '%s'"
 msgstr "無法在 '%s' 檔案中找到目前位置"
 
-#: ../src/common/ffile.cpp:354 ../src/common/file.cpp:574
+#: ../src/common/ffile.cpp:350 ../src/common/file.cpp:570
 msgid "Failed to set temporary file permissions"
 msgstr "無法設定暫存檔的存取權限"
 
-#: ../src/common/ffile.cpp:376 ../src/common/file.cpp:596
+#: ../src/common/ffile.cpp:372 ../src/common/file.cpp:592
 #, c-format
 msgid "can't remove file '%s'"
 msgstr "無法移除檔案 '%s'"
 
-#: ../src/common/ffile.cpp:381 ../src/common/file.cpp:601
+#: ../src/common/ffile.cpp:377 ../src/common/file.cpp:597
 #, c-format
 msgid "can't commit changes to file '%s'"
 msgstr "無法交付修改至檔案 '%s'"
 
-#: ../src/common/ffile.cpp:393 ../src/common/file.cpp:613
+#: ../src/common/ffile.cpp:389 ../src/common/file.cpp:609
 #, c-format
 msgid "can't remove temporary file '%s'"
 msgstr "無法移除暫存檔 '%s'"
@@ -1269,27 +1303,27 @@ msgstr "無法讀取檔案描述符 %d"
 msgid "can't write to file descriptor %d"
 msgstr "無法寫入檔案描述符 %d"
 
-#: ../src/common/file.cpp:395
+#: ../src/common/file.cpp:391
 #, c-format
 msgid "can't flush file descriptor %d"
 msgstr "無法排清檔案描述符 %d"
 
-#: ../src/common/file.cpp:437
+#: ../src/common/file.cpp:433
 #, c-format
 msgid "can't seek on file descriptor %d"
 msgstr "無法定位檔案描述符 %d"
 
-#: ../src/common/file.cpp:451
+#: ../src/common/file.cpp:447
 #, c-format
 msgid "can't get seek position on file descriptor %d"
 msgstr "無法獲得檔案描述符 %d 的定位位置"
 
-#: ../src/common/file.cpp:480
+#: ../src/common/file.cpp:476
 #, c-format
 msgid "can't find length of file on file descriptor %d"
 msgstr "無法獲得檔案描述符 %d 的檔案長度"
 
-#: ../src/common/file.cpp:510
+#: ../src/common/file.cpp:506
 #, c-format
 msgid "can't determine if the end of file is reached on descriptor %d"
 msgstr "無法確定檔案是否已達描述符 %d 的檔尾"
@@ -1313,147 +1347,147 @@ msgstr "為了避免覆寫已有的 '%s' 檔案，將不會儲存變更。"
 msgid "Error reading config options."
 msgstr "讀取組態選項時發生錯誤。"
 
-#: ../src/common/fileconf.cpp:432
+#: ../src/common/fileconf.cpp:431
 msgid "Failed to read config options."
 msgstr "無法讀取組態選項。"
 
-#: ../src/common/fileconf.cpp:543
+#: ../src/common/fileconf.cpp:538
 #, c-format
 msgid "file '%s': unexpected character %c at line %zu."
 msgstr "檔案 '%s'： 異常字元 %c 存在於第 %zu 列。"
 
-#: ../src/common/fileconf.cpp:579
+#: ../src/common/fileconf.cpp:574
 #, c-format
 msgid "file '%s', line %zu: '%s' ignored after group header."
 msgstr "檔案 '%s' 第 %zu 列：忽略位於群組表頭之後的 '%s' 。"
 
-#: ../src/common/fileconf.cpp:608
+#: ../src/common/fileconf.cpp:603
 #, c-format
 msgid "file '%s', line %zu: '=' expected."
 msgstr "檔案 '%s' 第 %zu 列：應有 '='。"
 
-#: ../src/common/fileconf.cpp:621
+#: ../src/common/fileconf.cpp:616
 #, c-format
 msgid "file '%s', line %zu: value for immutable key '%s' ignored."
 msgstr "檔案 '%s' 第 %zu 列：已忽略不可變金鑰 '%s' 的值。"
 
-#: ../src/common/fileconf.cpp:631
+#: ../src/common/fileconf.cpp:626
 #, c-format
 msgid "file '%s', line %zu: key '%s' was first found at line %d."
 msgstr "檔案 '%s', 第 %zu 列：機碼 '%s' 第一次出現在第 %d 列。"
 
-#: ../src/common/fileconf.cpp:934
+#: ../src/common/fileconf.cpp:929
 #, c-format
 msgid "Config entry name cannot start with '%c'."
 msgstr "組態項目名稱不能以 '%c' 開頭。"
 
-#: ../src/common/fileconf.cpp:986
+#: ../src/common/fileconf.cpp:981
 msgid "can't open user configuration file."
 msgstr "無法開啟使用者組態檔案。"
 
-#: ../src/common/fileconf.cpp:1000
+#: ../src/common/fileconf.cpp:995
 msgid "can't write user configuration file."
 msgstr "無法寫入使用者組態檔案。"
 
-#: ../src/common/fileconf.cpp:1006
+#: ../src/common/fileconf.cpp:1001
 msgid "Failed to update user configuration file."
 msgstr "無法更新使用者組態檔案。"
 
-#: ../src/common/fileconf.cpp:1029
+#: ../src/common/fileconf.cpp:1024
 msgid "Error saving user configuration data."
 msgstr "儲存使用者組態資料錯誤。"
 
-#: ../src/common/fileconf.cpp:1141
+#: ../src/common/fileconf.cpp:1136
 #, c-format
 msgid "can't delete user configuration file '%s'"
 msgstr "無法刪除使用者組態檔案 '%s'"
 
-#: ../src/common/fileconf.cpp:1835
+#: ../src/common/fileconf.cpp:1830
 #, c-format
 msgid "entry '%s' appears more than once in group '%s'"
 msgstr "項目 '%s' 在 '%s' 群中已出現一次以上"
 
-#: ../src/common/fileconf.cpp:1849
+#: ../src/common/fileconf.cpp:1844
 #, c-format
 msgid "attempt to change immutable key '%s' ignored."
 msgstr "嘗試變更不可變機碼 '%s' 已被忽略。"
 
-#: ../src/common/fileconf.cpp:1946
+#: ../src/common/fileconf.cpp:1941
 #, c-format
 msgid "trailing backslash ignored in '%s'"
 msgstr "忽略 %s’ 裡的結尾反斜線"
 
-#: ../src/common/fileconf.cpp:1981
+#: ../src/common/fileconf.cpp:1976
 #, c-format
 msgid "unexpected \" at position %d in '%s'."
 msgstr "異常 \" 出現在 %d 位於'%s'。"
 
-#: ../src/common/filefn.cpp:905
+#: ../src/common/filefn.cpp:474
 #, c-format
 msgid "Failed to copy the file '%s' to '%s'"
 msgstr "無法複製 '%s' 檔案到 '%s'"
 
-#: ../src/common/filefn.cpp:918
+#: ../src/common/filefn.cpp:487
 #, c-format
 msgid "Impossible to get permissions for file '%s'"
 msgstr "無法獲得權限以存取 '%s' 檔案"
 
-#: ../src/common/filefn.cpp:932
+#: ../src/common/filefn.cpp:501
 #, c-format
 msgid "Impossible to overwrite the file '%s'"
 msgstr "無法覆寫 '%s' 檔案"
 
-#: ../src/common/filefn.cpp:939
+#: ../src/common/filefn.cpp:508
 #, c-format
 msgid "Error copying the file '%s' to '%s'."
 msgstr "複製 %s 檔案至 %s 時發生錯誤。"
 
-#: ../src/common/filefn.cpp:987
+#: ../src/common/filefn.cpp:556
 #, c-format
 msgid "Impossible to set permissions for the file '%s'"
 msgstr "無法設定 '%s' 檔案的存取權限"
 
-#: ../src/common/filefn.cpp:1012
+#: ../src/common/filefn.cpp:581
 #, c-format
 msgid ""
 "Failed to rename the file '%s' to '%s' because the destination file already "
 "exists."
 msgstr "無法將檔案 ‘%s’ 重新命名為 ‘%s’，因目的檔案已存在。"
 
-#: ../src/common/filefn.cpp:1029
+#: ../src/common/filefn.cpp:598
 #, c-format
 msgid "File '%s' couldn't be renamed '%s'"
 msgstr "檔案 '%s' 無法重新命名為 '%s'"
 
-#: ../src/common/filefn.cpp:1045
+#: ../src/common/filefn.cpp:614
 #, c-format
 msgid "File '%s' couldn't be removed"
 msgstr "無法移除 '%s' 檔案"
 
-#: ../src/common/filefn.cpp:1072
+#: ../src/common/filefn.cpp:641
 #, c-format
 msgid "Directory '%s' couldn't be created"
 msgstr "無法創建 '%s' 目錄"
 
-#: ../src/common/filefn.cpp:1086
+#: ../src/common/filefn.cpp:655
 #, c-format
 msgid "Directory '%s' couldn't be deleted"
 msgstr "無法刪除 '%s' 目錄"
 
-#: ../src/common/filefn.cpp:1150
+#: ../src/common/filefn.cpp:687
 #, c-format
 msgid "Cannot enumerate files '%s'"
 msgstr "無法列舉檔案 '%s'"
 
-#: ../src/common/filefn.cpp:1234
+#: ../src/common/filefn.cpp:765
 msgid "Failed to get the working directory"
 msgstr "無法取得工作目錄"
 
-#: ../src/common/filefn.cpp:1292
+#: ../src/common/filefn.cpp:810
 msgid "Could not set current working directory"
 msgstr "無法設定目前工作目錄"
 
-#: ../src/common/filefn.cpp:1480
+#: ../src/common/filefn.cpp:941
 #, c-format
 msgid "Files (%s)"
 msgstr "檔案 (%s)"
@@ -1480,17 +1514,17 @@ msgstr "無法創建暫存檔的檔名"
 msgid "Failed to open temporary file."
 msgstr "無法開啟暫存檔。"
 
-#: ../src/common/filename.cpp:2768
+#: ../src/common/filename.cpp:2779
 #, c-format
 msgid "Failed to modify file times for '%s'"
 msgstr "無法在 '%s' 修改檔案時間"
 
-#: ../src/common/filename.cpp:2783
+#: ../src/common/filename.cpp:2794
 #, c-format
 msgid "Failed to touch the file '%s'"
 msgstr "無法設定 '%s' 檔案的修改與存取時間"
 
-#: ../src/common/filename.cpp:2864
+#: ../src/common/filename.cpp:2875
 #, c-format
 msgid "Failed to retrieve file times for '%s'"
 msgstr "無法擷取 '%s' 檔案的各項時間"
@@ -1499,22 +1533,22 @@ msgstr "無法擷取 '%s' 檔案的各項時間"
 msgid "Browse"
 msgstr "瀏覽"
 
-#: ../src/common/fldlgcmn.cpp:104 ../src/generic/filectrlg.cpp:1185
+#: ../src/common/fldlgcmn.cpp:785 ../src/generic/filectrlg.cpp:1185
 #, c-format
 msgid "All files (%s)|%s"
 msgstr "所有檔案 (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:121
+#: ../src/common/fldlgcmn.cpp:802
 #, c-format
 msgid "%s files (%s)|%s"
 msgstr "%s 個檔案 (%s)|%s"
 
-#: ../src/common/fldlgcmn.cpp:343
+#: ../src/common/fldlgcmn.cpp:1064
 #, c-format
 msgid "Load %s file"
 msgstr "載入 %s 檔案"
 
-#: ../src/common/fldlgcmn.cpp:345
+#: ../src/common/fldlgcmn.cpp:1066
 #, c-format
 msgid "Save %s file"
 msgstr "儲存 %s 檔案"
@@ -1877,99 +1911,99 @@ msgstr "預設值"
 msgid "unknown-%d"
 msgstr "未知-%d"
 
-#: ../src/common/fontcmn.cpp:935 ../src/common/fontcmn.cpp:1141
+#: ../src/common/fontcmn.cpp:930 ../src/common/fontcmn.cpp:1136
 msgid "underlined"
 msgstr "下底線"
 
-#: ../src/common/fontcmn.cpp:940
+#: ../src/common/fontcmn.cpp:935
 msgid " strikethrough"
 msgstr " 刪除線"
 
-#: ../src/common/fontcmn.cpp:953
+#: ../src/common/fontcmn.cpp:948
 msgid " thin"
 msgstr " 淡體"
 
-#: ../src/common/fontcmn.cpp:957
+#: ../src/common/fontcmn.cpp:952
 msgid " extra light"
 msgstr " 特細"
 
-#: ../src/common/fontcmn.cpp:961
+#: ../src/common/fontcmn.cpp:956
 msgid " light"
 msgstr " 細體"
 
-#: ../src/common/fontcmn.cpp:965
+#: ../src/common/fontcmn.cpp:960
 msgid " medium"
 msgstr " 適中"
 
-#: ../src/common/fontcmn.cpp:969
+#: ../src/common/fontcmn.cpp:964
 msgid " semi bold"
 msgstr " 次粗"
 
-#: ../src/common/fontcmn.cpp:973
+#: ../src/common/fontcmn.cpp:968
 msgid " bold"
 msgstr " 粗體"
 
-#: ../src/common/fontcmn.cpp:977
+#: ../src/common/fontcmn.cpp:972
 msgid " extra bold"
 msgstr " 特粗"
 
-#: ../src/common/fontcmn.cpp:981
+#: ../src/common/fontcmn.cpp:976
 msgid " heavy"
 msgstr " 濃體"
 
-#: ../src/common/fontcmn.cpp:985
+#: ../src/common/fontcmn.cpp:980
 msgid " extra heavy"
 msgstr " 特濃"
 
-#: ../src/common/fontcmn.cpp:1001
+#: ../src/common/fontcmn.cpp:996
 msgid " italic"
 msgstr " 斜體"
 
-#: ../src/common/fontcmn.cpp:1145
+#: ../src/common/fontcmn.cpp:1140
 msgid "strikethrough"
 msgstr "刪除線"
 
-#: ../src/common/fontcmn.cpp:1154
+#: ../src/common/fontcmn.cpp:1149
 msgid "thin"
 msgstr "淡體"
 
-#: ../src/common/fontcmn.cpp:1167
+#: ../src/common/fontcmn.cpp:1162
 msgid "extralight"
 msgstr "特細"
 
-#: ../src/common/fontcmn.cpp:1172
+#: ../src/common/fontcmn.cpp:1167
 msgid "light"
 msgstr "細體"
 
-#: ../src/common/fontcmn.cpp:1180 ../src/richtext/richtextstyles.cpp:776
+#: ../src/common/fontcmn.cpp:1175 ../src/richtext/richtextstyles.cpp:776
 msgid "normal"
 msgstr "標準"
 
-#: ../src/common/fontcmn.cpp:1185
+#: ../src/common/fontcmn.cpp:1180
 msgid "medium"
 msgstr "適中"
 
-#: ../src/common/fontcmn.cpp:1190 ../src/common/fontcmn.cpp:1210
+#: ../src/common/fontcmn.cpp:1185 ../src/common/fontcmn.cpp:1205
 msgid "semibold"
 msgstr "次粗"
 
-#: ../src/common/fontcmn.cpp:1195
+#: ../src/common/fontcmn.cpp:1190
 msgid "bold"
 msgstr "粗體"
 
-#: ../src/common/fontcmn.cpp:1205
+#: ../src/common/fontcmn.cpp:1200
 msgid "extrabold"
 msgstr "特粗"
 
-#: ../src/common/fontcmn.cpp:1215
+#: ../src/common/fontcmn.cpp:1210
 msgid "heavy"
 msgstr "濃體"
 
-#: ../src/common/fontcmn.cpp:1223
+#: ../src/common/fontcmn.cpp:1218
 msgid "extraheavy"
 msgstr "特濃"
 
-#: ../src/common/fontcmn.cpp:1228
+#: ../src/common/fontcmn.cpp:1223
 msgid "italic"
 msgstr "斜體"
 
@@ -2048,7 +2082,7 @@ msgstr "等待 FTP 伺服器連線時逾時，請嘗試用被動模式。"
 msgid "Failed to set FTP transfer mode to %s."
 msgstr "無法設定檔案傳輸 FTP 模式為 %s。"
 
-#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:455
+#: ../src/common/ftp.cpp:400 ../src/richtext/richtextsymboldlg.cpp:433
 msgid "ASCII"
 msgstr "ASCII"
 
@@ -2069,7 +2103,7 @@ msgstr "檔案傳輸 FTP 伺服器不支援被動模式。"
 msgid "Incorrect GIF frame size (%u, %d) for the frame #%u"
 msgstr "GIF 影格大小 (%u, %d) 不正確，無法用於影格 #%u"
 
-#: ../src/common/glcmn.cpp:112
+#: ../src/common/glcmn.cpp:108
 msgid "Failed to allocate colour for OpenGL"
 msgstr "無法為 OpenGL 分配顏色"
 
@@ -2085,7 +2119,7 @@ msgstr "自訂欄位"
 msgid "&Customize..."
 msgstr "自訂(&C)..."
 
-#: ../src/common/hyperlnkcmn.cpp:133
+#: ../src/common/hyperlnkcmn.cpp:132
 #, c-format
 msgid "Failed to open URL \"%s\" in the default browser"
 msgstr "無法在預設瀏覽器中開啟網址 \"'%s\""
@@ -2105,155 +2139,154 @@ msgstr "無法從串流載入 %d 影像。"
 msgid "Failed to load icons from resource '%s'."
 msgstr "無法從 '%s' 資源載入圖示。"
 
-#: ../src/common/imagbmp.cpp:97
+#: ../src/common/imagbmp.cpp:96
 msgid "BMP: Couldn't save invalid image."
 msgstr "BMP: 不能儲存無效的影像。"
 
-#: ../src/common/imagbmp.cpp:137
+#: ../src/common/imagbmp.cpp:136
 msgid "BMP: wxImage doesn't have own wxPalette."
 msgstr "BMP: wxImage 沒有原生的 wxPalette。"
 
-#: ../src/common/imagbmp.cpp:243
+#: ../src/common/imagbmp.cpp:242
 msgid "BMP: Couldn't write the file (Bitmap) header."
 msgstr "BMP: 無法寫入檔案表頭 (Bitmap)。"
 
-#: ../src/common/imagbmp.cpp:266
+#: ../src/common/imagbmp.cpp:265
 msgid "BMP: Couldn't write the file (BitmapInfo) header."
 msgstr "BMP: 無法寫入檔案表頭 (BitmapInfo)。"
 
-#: ../src/common/imagbmp.cpp:353
+#: ../src/common/imagbmp.cpp:352
 msgid "BMP: Couldn't write RGB color map."
 msgstr "BMP: 無法寫入 RGB 顏色對應表。"
 
-#: ../src/common/imagbmp.cpp:487
+#: ../src/common/imagbmp.cpp:486
 msgid "BMP: Couldn't write data."
 msgstr "BMP: 無法寫入資料。"
 
-#: ../src/common/imagbmp.cpp:533
+#: ../src/common/imagbmp.cpp:556 ../src/common/imagbmp.cpp:571
+msgid "BMP: Couldn't allocate memory."
+msgstr "BMP: 無法分配記憶體。"
+
+#: ../src/common/imagbmp.cpp:1055
+msgid "DIB Header: Image width > 32767 pixels for file."
+msgstr "DIB 表頭：影像寬度大於 32767 個像素。"
+
+#: ../src/common/imagbmp.cpp:1063
+msgid "DIB Header: Image height > 32767 pixels for file."
+msgstr "DIB 表頭：影像高度大於 32767 個像素。"
+
+#: ../src/common/imagbmp.cpp:1093
+msgid "DIB Header: Unknown bitdepth in file."
+msgstr "DIB 表頭：未知的顏色位元數。"
+
+#: ../src/common/imagbmp.cpp:1167
+msgid "DIB Header: Unknown encoding in file."
+msgstr "DIB 表頭：未知的檔案編碼。"
+
+#: ../src/common/imagbmp.cpp:1176
+msgid "DIB Header: Encoding doesn't match bitdepth."
+msgstr "DIB 表頭：編碼與顏色位元數不符合。"
+
+#: ../src/common/imagbmp.cpp:1192
 #, c-format
 msgid "BMP: header has biClrUsed=%d when biBitCount=%d."
 msgstr "BMP: 當 biBitCount=%d 時，表頭則為 biClrUsed=%d。"
 
-#: ../src/common/imagbmp.cpp:544 ../src/common/imagbmp.cpp:574
-#: ../src/common/imagbmp.cpp:589
-msgid "BMP: Couldn't allocate memory."
-msgstr "BMP: 無法分配記憶體。"
-
-#: ../src/common/imagbmp.cpp:1094
-msgid "DIB Header: Image width > 32767 pixels for file."
-msgstr "DIB 表頭：影像寬度大於 32767 個像素。"
-
-#: ../src/common/imagbmp.cpp:1102
-msgid "DIB Header: Image height > 32767 pixels for file."
-msgstr "DIB 表頭：影像高度大於 32767 個像素。"
-
-#: ../src/common/imagbmp.cpp:1122
-msgid "DIB Header: Unknown bitdepth in file."
-msgstr "DIB 表頭：未知的顏色位元數。"
-
-#: ../src/common/imagbmp.cpp:1177
-msgid "DIB Header: Unknown encoding in file."
-msgstr "DIB 表頭：未知的檔案編碼。"
-
-#: ../src/common/imagbmp.cpp:1209
-msgid "DIB Header: Encoding doesn't match bitdepth."
-msgstr "DIB 表頭：編碼與顏色位元數不符合。"
-
-#: ../src/common/imagbmp.cpp:1221
+#: ../src/common/imagbmp.cpp:1279
 msgid "Error in reading image DIB."
 msgstr "讀取影像 DIB 時發生錯誤。"
 
-#: ../src/common/imagbmp.cpp:1236
+#: ../src/common/imagbmp.cpp:1300
 msgid "ICO: Error in reading mask DIB."
 msgstr "ICO：讀取遮罩式 DIB 時發生錯誤。"
 
-#: ../src/common/imagbmp.cpp:1295
+#: ../src/common/imagbmp.cpp:1359
 msgid "ICO: Image too tall for an icon."
 msgstr "ICO：影像太高，不合於圖示。"
 
-#: ../src/common/imagbmp.cpp:1303
+#: ../src/common/imagbmp.cpp:1367
 msgid "ICO: Image too wide for an icon."
 msgstr "ICO：影像太寬，不合於圖示。"
 
-#: ../src/common/imagbmp.cpp:1330 ../src/common/imagbmp.cpp:1430
-#: ../src/common/imagbmp.cpp:1445 ../src/common/imagbmp.cpp:1456
-#: ../src/common/imagbmp.cpp:1470 ../src/common/imagbmp.cpp:1518
-#: ../src/common/imagbmp.cpp:1533 ../src/common/imagbmp.cpp:1547
-#: ../src/common/imagbmp.cpp:1558
+#: ../src/common/imagbmp.cpp:1394 ../src/common/imagbmp.cpp:1494
+#: ../src/common/imagbmp.cpp:1509 ../src/common/imagbmp.cpp:1520
+#: ../src/common/imagbmp.cpp:1534 ../src/common/imagbmp.cpp:1582
+#: ../src/common/imagbmp.cpp:1597 ../src/common/imagbmp.cpp:1611
+#: ../src/common/imagbmp.cpp:1622
 msgid "ICO: Error writing the image file!"
 msgstr "ICO：寫入影像檔時發生錯誤！"
 
-#: ../src/common/imagbmp.cpp:1643
+#: ../src/common/imagbmp.cpp:1707
 msgid "ICO: Invalid icon index."
 msgstr "ICO：無效的圖示索引。"
 
-#: ../src/common/image.cpp:2360
+#: ../src/common/image.cpp:2330
 msgid "Image and mask have different sizes."
 msgstr "影像和遮罩的大小不一致。"
 
-#: ../src/common/image.cpp:2368 ../src/common/image.cpp:2409
+#: ../src/common/image.cpp:2338 ../src/common/image.cpp:2379
 msgid "No unused colour in image being masked."
 msgstr "影像裡沒有被遮罩的未用顏色。"
 
-#: ../src/common/image.cpp:2592
+#: ../src/common/image.cpp:2562
 #, c-format
 msgid "Failed to load bitmap \"%s\" from resources."
 msgstr "無法從資源載入 ”%s” 位元圖。"
 
-#: ../src/common/image.cpp:2601
+#: ../src/common/image.cpp:2571
 #, c-format
 msgid "Failed to load icon \"%s\" from resources."
 msgstr "無法從資源載入 ”%s” 圖示。"
 
-#: ../src/common/image.cpp:2679 ../src/common/image.cpp:2698
+#: ../src/common/image.cpp:2649 ../src/common/image.cpp:2668
 #, c-format
 msgid "Failed to load image from file \"%s\"."
 msgstr "無法從 '%s' 檔案載入影像。"
 
-#: ../src/common/image.cpp:2712
+#: ../src/common/image.cpp:2682
 #, c-format
 msgid "Can't save image to file '%s': unknown extension."
 msgstr "無法儲存影像到 '%s' 檔案：未知的副檔名。"
 
-#: ../src/common/image.cpp:2820
+#: ../src/common/image.cpp:2790
 msgid "No handler found for image type."
 msgstr "沒有找到影像類型處理常式。"
 
-#: ../src/common/image.cpp:2828 ../src/common/image.cpp:2951
-#: ../src/common/image.cpp:3017
+#: ../src/common/image.cpp:2798 ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2987
 #, c-format
 msgid "No image handler for type %d defined."
 msgstr "沒有定義 %d 類型的影像處理常式。"
 
-#: ../src/common/image.cpp:2838
+#: ../src/common/image.cpp:2808
 #, c-format
 msgid "Image file is not of type %d."
 msgstr "影像檔不是 %d 類型。"
 
-#: ../src/common/image.cpp:2921
+#: ../src/common/image.cpp:2891
 msgid "Can't automatically determine the image format for non-seekable input."
 msgstr "無法自動判定用於不可定位輸入的影像格式。"
 
-#: ../src/common/image.cpp:2939
+#: ../src/common/image.cpp:2909
 msgid "Unknown image data format."
 msgstr "未知的影像資料格式。"
 
-#: ../src/common/image.cpp:2960
+#: ../src/common/image.cpp:2930
 #, c-format
 msgid "This is not a %s."
 msgstr "這不是 %s。"
 
-#: ../src/common/image.cpp:2983 ../src/common/image.cpp:3031
+#: ../src/common/image.cpp:2953 ../src/common/image.cpp:3001
 #, c-format
 msgid "No image handler for type %s defined."
 msgstr "沒有定義 %s 類型的影像處理常式。"
 
-#: ../src/common/image.cpp:2992
+#: ../src/common/image.cpp:2962
 #, c-format
 msgid "Image is not of type %s."
 msgstr "影像不是 %s 類型。"
 
-#: ../src/common/image.cpp:3457
+#: ../src/common/image.cpp:3430
 #, c-format
 msgid "Failed to check format of image file \"%s\"."
 msgstr "無法確認圖片檔 “%s” 的格式。"
@@ -2354,52 +2387,52 @@ msgstr "PNM：檔案似乎被截斷。"
 msgid " (in module \"%s\")"
 msgstr " (在 ‘%s’ 模組中）"
 
-#: ../src/common/imagtiff.cpp:298
+#: ../src/common/imagtiff.cpp:304
 msgid "TIFF: Error loading image."
 msgstr "TIFF：載入影像錯誤。"
 
-#: ../src/common/imagtiff.cpp:308
+#: ../src/common/imagtiff.cpp:314
 msgid "Invalid TIFF image index."
 msgstr "無效的 TIFF 影像索引。"
 
-#: ../src/common/imagtiff.cpp:352
+#: ../src/common/imagtiff.cpp:358
 msgid "TIFF: Image size is abnormally big."
 msgstr "TIFF：影像太大。"
 
-#: ../src/common/imagtiff.cpp:366 ../src/common/imagtiff.cpp:379
-#: ../src/common/imagtiff.cpp:738
+#: ../src/common/imagtiff.cpp:372 ../src/common/imagtiff.cpp:385
+#: ../src/common/imagtiff.cpp:744
 msgid "TIFF: Couldn't allocate memory."
 msgstr "TIFF：無法分配記憶體。"
 
-#: ../src/common/imagtiff.cpp:465
+#: ../src/common/imagtiff.cpp:471
 msgid "TIFF: Error reading image."
 msgstr "TIFF：讀取影像錯誤。"
 
-#: ../src/common/imagtiff.cpp:526
+#: ../src/common/imagtiff.cpp:532
 #, c-format
 msgid "Unknown TIFF resolution unit %d ignored"
 msgstr "未知 TIFF 解析度單位 %d，已忽略"
 
-#: ../src/common/imagtiff.cpp:605
+#: ../src/common/imagtiff.cpp:611
 msgid "TIFF: Error saving image."
 msgstr "TIFF：儲存影像錯誤。"
 
-#: ../src/common/imagtiff.cpp:843
+#: ../src/common/imagtiff.cpp:849
 msgid "TIFF: Error writing image."
 msgstr "TIFF：寫入影像錯誤。"
 
-#: ../src/common/init.cpp:192
+#: ../src/common/init.cpp:186
 #, c-format
 msgid ""
 "Command line argument %d couldn't be converted to Unicode and will be "
 "ignored."
 msgstr "由於指令列引數 %d 無法轉換為 Unicode 編碼，其將被忽略。"
 
-#: ../src/common/init.cpp:283
+#: ../src/common/init.cpp:275
 msgid "Initialization failed in post init, aborting."
 msgstr "安裝後續的啟始失敗，正在中斷。"
 
-#: ../src/common/intl.cpp:393
+#: ../src/common/intl.cpp:379
 #, c-format
 msgid "Cannot set locale to language \"%s\"."
 msgstr "無法將地區語言設定為 '%s'。"
@@ -2491,7 +2524,7 @@ msgstr "LZMA 壓縮錯誤：%s"
 msgid "LZMA compression error when flushing output: %s"
 msgstr "排清輸出時發生 LZMA 壓縮錯誤：%s"
 
-#: ../src/common/mimecmn.cpp:221
+#: ../src/common/mimecmn.cpp:172
 #, c-format
 msgid "Unmatched '{' in an entry for mime type %s."
 msgstr "%s mime 類型中，有不成對的{ 項目。"
@@ -2512,7 +2545,7 @@ msgstr "“%s” 模組的 “%s” 不存在。"
 msgid "Module \"%s\" initialization failed"
 msgstr "'%s' 模組初始化失敗"
 
-#: ../src/common/msgout.cpp:121
+#: ../src/common/msgout.cpp:93
 msgid "Message"
 msgstr "郵件"
 
@@ -3014,7 +3047,7 @@ msgstr "列印時發生錯誤"
 msgid "Print"
 msgstr "列印"
 
-#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:819
+#: ../src/common/prntbase.cpp:481 ../src/generic/prntdlgg.cpp:810
 msgid "Page setup"
 msgstr "頁面設定"
 
@@ -3049,19 +3082,15 @@ msgstr "正在列印第 %d 頁 (共 %d 頁)"
 msgid " (copy %d of %d)"
 msgstr " (複製 %d / %d )"
 
-#: ../src/common/prntbase.cpp:609
-msgid "Printing "
-msgstr "正在列印 "
-
 #: ../src/common/prntbase.cpp:1582
 msgid "First page"
 msgstr "第一頁"
 
-#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:661
+#: ../src/common/prntbase.cpp:1587 ../src/html/helpwnd.cpp:656
 msgid "Previous page"
 msgstr "上一頁"
 
-#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:662
+#: ../src/common/prntbase.cpp:1601 ../src/html/helpwnd.cpp:657
 msgid "Next page"
 msgstr "下一頁"
 
@@ -3105,16 +3134,16 @@ msgstr "第 %d / %d 頁"
 msgid "Page %d"
 msgstr "第 %d 頁"
 
-#: ../src/common/regex.cpp:456 ../src/html/chm.cpp:348
+#: ../src/common/regex.cpp:383 ../src/html/chm.cpp:348
 msgid "unknown error"
 msgstr "未知的錯誤"
 
-#: ../src/common/regex.cpp:1095
+#: ../src/common/regex.cpp:996
 #, c-format
 msgid "Invalid regular expression '%s': %s"
 msgstr "無效的正則表達式 ‘%s’: %s"
 
-#: ../src/common/regex.cpp:1224
+#: ../src/common/regex.cpp:1088
 #, c-format
 msgid "Failed to find match for regular expression: %s"
 msgstr "找不到與正規運算式 %s 相符的字串"
@@ -3124,21 +3153,21 @@ msgstr "找不到與正規運算式 %s 相符的字串"
 msgid "Renderer \"%s\" has incompatible version %d.%d and couldn't be loaded."
 msgstr "模擬描繪器 “%s” 的 %d.%d 版本有相容性問題，無法載入。"
 
-#: ../src/common/secretstore.cpp:168
+#: ../src/common/secretstore.cpp:162
 msgid "Not available for this platform"
 msgstr "不適用於此平台"
 
-#: ../src/common/secretstore.cpp:189
+#: ../src/common/secretstore.cpp:183
 #, c-format
 msgid "Saving password for \"%s\" failed: %s."
 msgstr "無法儲存 “%s” 的密碼：%s。"
 
-#: ../src/common/secretstore.cpp:211
+#: ../src/common/secretstore.cpp:205
 #, c-format
 msgid "Reading password for \"%s\" failed: %s."
 msgstr "讀取 “%s” 的密碼失敗：%s。"
 
-#: ../src/common/secretstore.cpp:234
+#: ../src/common/secretstore.cpp:228
 #, c-format
 msgid "Deleting password for \"%s\" failed: %s."
 msgstr "刪除 “%s” 密碼失敗：%s。"
@@ -3147,11 +3176,11 @@ msgstr "刪除 “%s” 密碼失敗：%s。"
 msgid "Failed to monitor I/O channels"
 msgstr "無法監控輸入輸出通道"
 
-#: ../src/common/sizer.cpp:3023 ../src/common/stockitem.cpp:196
+#: ../src/common/sizer.cpp:3016 ../src/common/stockitem.cpp:196
 msgid "Save"
 msgstr "儲存"
 
-#: ../src/common/sizer.cpp:3025
+#: ../src/common/sizer.cpp:3018
 msgid "Don't Save"
 msgstr "不儲存"
 
@@ -3232,10 +3261,10 @@ msgid "Clear"
 msgstr "清除"
 
 #: ../src/common/stockitem.cpp:154 ../src/generic/dbgrptg.cpp:94
-#: ../src/generic/progdlgg.cpp:781 ../src/html/helpdlg.cpp:86
-#: ../src/msw/progdlg.cpp:211 ../src/msw/progdlg.cpp:946
+#: ../src/generic/progdlgg.cpp:772 ../src/html/helpdlg.cpp:86
+#: ../src/msw/progdlg.cpp:209 ../src/msw/progdlg.cpp:890
 #: ../src/richtext/richtextstyledlg.cpp:273
-#: ../src/richtext/richtextsymboldlg.cpp:473
+#: ../src/richtext/richtextsymboldlg.cpp:449
 msgid "Close"
 msgstr "關閉"
 
@@ -3247,7 +3276,7 @@ msgstr "轉換(&C)"
 msgid "Convert"
 msgstr "轉換"
 
-#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2936
+#: ../src/common/stockitem.cpp:156 ../src/msw/textctrl.cpp:2709
 #: ../src/osx/textctrl_osx.cpp:638 ../src/richtext/richtextctrl.cpp:332
 msgid "&Copy"
 msgstr "複製(&C)"
@@ -3256,7 +3285,7 @@ msgstr "複製(&C)"
 msgid "Copy"
 msgstr "複製"
 
-#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2935
+#: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331
 msgid "Cu&t"
 msgstr "剪下(&T)"
@@ -3265,13 +3294,13 @@ msgstr "剪下(&T)"
 msgid "Cut"
 msgstr "剪下"
 
-#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2938
+#: ../src/common/stockitem.cpp:158 ../src/msw/textctrl.cpp:2711
 #: ../src/osx/textctrl_osx.cpp:640 ../src/richtext/richtextctrl.cpp:334
 #: ../src/richtext/richtexttabspage.cpp:138
 msgid "&Delete"
 msgstr "刪除(&D)"
 
-#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8266
+#: ../src/common/stockitem.cpp:158 ../src/richtext/richtextbuffer.cpp:8267
 #: ../src/stc/stc_i18n.cpp:20
 msgid "Delete"
 msgstr "刪除"
@@ -3358,7 +3387,7 @@ msgstr "硬碟"
 
 #: ../src/common/stockitem.cpp:169 ../src/generic/wizard.cpp:438
 #: ../src/osx/cocoa/menu.mm:226 ../src/richtext/richtextstyledlg.cpp:299
-#: ../src/richtext/richtextsymboldlg.cpp:476
+#: ../src/richtext/richtextsymboldlg.cpp:452
 msgid "&Help"
 msgstr "說明(&H)"
 
@@ -3378,7 +3407,7 @@ msgstr "縮排"
 msgid "&Index"
 msgstr "索引(&I)"
 
-#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:512
+#: ../src/common/stockitem.cpp:172 ../src/html/helpwnd.cpp:507
 msgid "Index"
 msgstr "索引"
 
@@ -3447,7 +3476,7 @@ msgstr "新增(&N)"
 msgid "New"
 msgstr "新增"
 
-#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:183 ../src/msw/msgdlg.cpp:434
 msgid "&No"
 msgstr "否(&N)"
 
@@ -3464,12 +3493,12 @@ msgstr "開啟(&O)…"
 msgid "Open..."
 msgstr "開啟..."
 
-#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2937
+#: ../src/common/stockitem.cpp:186 ../src/msw/textctrl.cpp:2710
 #: ../src/osx/textctrl_osx.cpp:639 ../src/richtext/richtextctrl.cpp:333
 msgid "&Paste"
 msgstr "貼上(&P)"
 
-#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3514
+#: ../src/common/stockitem.cpp:186 ../src/richtext/richtextctrl.cpp:3490
 #: ../src/stc/stc_i18n.cpp:19
 msgid "Paste"
 msgstr "貼上"
@@ -3499,7 +3528,7 @@ msgid "Print..."
 msgstr "列印..."
 
 #: ../src/common/stockitem.cpp:190 ../src/richtext/richtextctrl.cpp:338
-#: ../src/richtext/richtextctrl.cpp:5512
+#: ../src/richtext/richtextctrl.cpp:5488
 msgid "&Properties"
 msgstr "屬性(&P)"
 
@@ -3531,10 +3560,6 @@ msgstr "更換…"
 msgid "Revert to Saved"
 msgstr "恢復為上次儲存的檔案"
 
-#: ../src/common/stockitem.cpp:196
-msgid "&Save"
-msgstr "儲存(&S)"
-
 #: ../src/common/stockitem.cpp:197 ../src/generic/logg.cpp:509
 msgid "Save &As..."
 msgstr "另存新檔(&A)…"
@@ -3543,7 +3568,7 @@ msgstr "另存新檔(&A)…"
 msgid "Save As..."
 msgstr "另存新檔(&A)…"
 
-#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2940
+#: ../src/common/stockitem.cpp:198 ../src/msw/textctrl.cpp:2713
 #: ../src/osx/textctrl_osx.cpp:642 ../src/richtext/richtextctrl.cpp:336
 msgid "Select &All"
 msgstr "全部選擇(&A)"
@@ -3650,7 +3675,7 @@ msgstr "向上(&U)"
 msgid "Up"
 msgstr "上"
 
-#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:436
+#: ../src/common/stockitem.cpp:212 ../src/msw/msgdlg.cpp:434
 msgid "&Yes"
 msgstr "是(&Y)"
 
@@ -3738,43 +3763,43 @@ msgstr "儲存目前文件"
 msgid "Save current document with a different filename"
 msgstr "儲存目前文件並使用不同檔名"
 
-#: ../src/common/strconv.cpp:2208
+#: ../src/common/strconv.cpp:2209
 #, c-format
 msgid "Conversion to charset '%s' doesn't work."
 msgstr "無法轉換到 '%s' 字集。"
 
-#: ../src/common/tarstrm.cpp:364 ../src/common/tarstrm.cpp:387
-#: ../src/common/tarstrm.cpp:418 ../src/generic/progdlgg.cpp:376
+#: ../src/common/tarstrm.cpp:359 ../src/common/tarstrm.cpp:382
+#: ../src/common/tarstrm.cpp:413 ../src/generic/progdlgg.cpp:367
 msgid "unknown"
 msgstr "未知"
 
-#: ../src/common/tarstrm.cpp:788
+#: ../src/common/tarstrm.cpp:783
 msgid "incomplete header block in tar"
 msgstr "tar 的表頭區塊不完整"
 
-#: ../src/common/tarstrm.cpp:812
+#: ../src/common/tarstrm.cpp:807
 msgid "checksum failure reading tar header block"
 msgstr "讀取 tar 表頭區塊時發生檢查碼錯誤"
 
-#: ../src/common/tarstrm.cpp:985
+#: ../src/common/tarstrm.cpp:980
 msgid "invalid data in extended tar header"
 msgstr "tar 擴充表頭中有無效的資料"
 
-#: ../src/common/tarstrm.cpp:995 ../src/common/tarstrm.cpp:1017
-#: ../src/common/tarstrm.cpp:1499 ../src/common/tarstrm.cpp:1521
+#: ../src/common/tarstrm.cpp:990 ../src/common/tarstrm.cpp:1012
+#: ../src/common/tarstrm.cpp:1486 ../src/common/tarstrm.cpp:1508
 msgid "tar entry not open"
 msgstr "tar 項目未開啟"
 
-#: ../src/common/tarstrm.cpp:1037
+#: ../src/common/tarstrm.cpp:1032
 msgid "unexpected end of file"
 msgstr "異常的檔案結尾"
 
-#: ../src/common/tarstrm.cpp:1311
+#: ../src/common/tarstrm.cpp:1306
 #, c-format
 msgid "%s did not fit the tar header for entry '%s'"
 msgstr "%s 不適用於 ‘%s’ 項目的 tar 表頭"
 
-#: ../src/common/tarstrm.cpp:1373
+#: ../src/common/tarstrm.cpp:1368
 msgid "incorrect size given for tar entry"
 msgstr "指定的 tar 項目大小不正確"
 
@@ -3783,7 +3808,7 @@ msgstr "指定的 tar 項目大小不正確"
 msgid "'%s' is probably a binary buffer."
 msgstr "'%s' 或許是個二進位緩衝區。"
 
-#: ../src/common/textcmn.cpp:957 ../src/richtext/richtextctrl.cpp:3082
+#: ../src/common/textcmn.cpp:956 ../src/richtext/richtextctrl.cpp:3058
 msgid "File couldn't be loaded."
 msgstr "無法載入檔案。"
 
@@ -3797,47 +3822,47 @@ msgstr "無法讀取 “%s” 文字檔案。"
 msgid "can't write buffer '%s' to disk."
 msgstr "無法將緩衝區 '%s' 寫到磁碟。"
 
-#: ../src/common/time.cpp:216
+#: ../src/common/time.cpp:209
 msgid "Failed to get the local system time"
 msgstr "無法取得本機系統的時間"
 
-#: ../src/common/time.cpp:285
+#: ../src/common/time.cpp:278
 msgid "wxGetTimeOfDay failed."
 msgstr "wxGetTimeOfDay 失敗。"
 
-#: ../src/common/translation.cpp:1025
+#: ../src/common/translation.cpp:1018
 #, c-format
 msgid "'%s' is not a valid message catalog."
 msgstr "'%s' 不是有效的訊息記錄。"
 
-#: ../src/common/translation.cpp:1050
+#: ../src/common/translation.cpp:1043
 msgid "Invalid message catalog."
 msgstr "無效的訊息記錄。"
 
-#: ../src/common/translation.cpp:1109
+#: ../src/common/translation.cpp:1102
 #, c-format
 msgid "Failed to parse Plural-Forms: '%s'"
 msgstr "無法解析眾數型式(Plural-Forms)：'%s'"
 
-#: ../src/common/translation.cpp:1823
+#: ../src/common/translation.cpp:1753
 #, c-format
 msgid "using catalog '%s' from '%s'."
 msgstr "使用記錄 '%s' — '%s'。"
 
-#: ../src/common/translation.cpp:1906
+#: ../src/common/translation.cpp:1846
 #, c-format
 msgid "Resource '%s' is not a valid message catalog."
 msgstr "'%s' 資源不是有效的訊息記錄。"
 
-#: ../src/common/translation.cpp:1955
+#: ../src/common/translation.cpp:1895
 msgid "Couldn't enumerate translations"
 msgstr "無法列舉翻譯"
 
-#: ../src/common/utilscmn.cpp:1095
+#: ../src/common/utilscmn.cpp:1088
 msgid "No default application configured for HTML files."
 msgstr "沒有專為 HTML 檔案而架構的預設程式。"
 
-#: ../src/common/utilscmn.cpp:1140
+#: ../src/common/utilscmn.cpp:1133
 #, c-format
 msgid "Failed to open URL \"%s\" in default browser."
 msgstr "無法在預設瀏覽器中開啟網址 ”%s”。"
@@ -3870,7 +3895,7 @@ msgstr "'%s' 含有無效字元"
 msgid "Error: %s (%d)"
 msgstr "錯誤：%s (%d)"
 
-#: ../src/common/webrequest.cpp:647
+#: ../src/common/webrequest.cpp:628
 msgid "Not enough free disk space for download."
 msgstr "沒有足夠磁碟空間可供下載。"
 
@@ -3878,20 +3903,20 @@ msgstr "沒有足夠磁碟空間可供下載。"
 msgid "libcurl could not be initialized"
 msgstr "無法初始化 libcurl"
 
-#: ../src/common/webview.cpp:246
+#: ../src/common/webview.cpp:334
 msgid "RunScriptAsync not supported"
 msgstr "RunScriptAsync 仍未支援"
 
-#: ../src/common/webview.cpp:257 ../src/msw/webview_ie.cpp:1061
+#: ../src/common/webview.cpp:345 ../src/msw/webview_ie.cpp:1063
 #, c-format
 msgid "Error running JavaScript: %s"
 msgstr "執行 JavaScript 時發生錯誤：%s"
 
-#: ../src/common/wincmn.cpp:1671
+#: ../src/common/wincmn.cpp:1657
 msgid "This platform does not support background transparency."
 msgstr "這個平臺不支援透明背景。"
 
-#: ../src/common/wincmn.cpp:2144
+#: ../src/common/wincmn.cpp:2111
 msgid "Could not transfer data to window"
 msgstr "無法傳輸資料到視窗中"
 
@@ -3943,8 +3968,8 @@ msgstr "宣告的 RTTI 參數中找不到創建的參數 %s"
 msgid "Illegal Object Class (Non-wxEvtHandler) as Event Source"
 msgstr "作為事件來源的物件類別 (非-wxEvtHandler) 不合規範"
 
-#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:352
-#: ../src/common/xtixml.cpp:505
+#: ../src/common/xtistrm.cpp:315 ../src/common/xtixml.cpp:347
+#: ../src/common/xtixml.cpp:500
 msgid "Type must have enum - long conversion"
 msgstr "必須進行 enum - long 的類型轉換"
 
@@ -3994,79 +4019,79 @@ msgstr "物件必須有 id 屬性"
 msgid "Doubly used id : %d"
 msgstr "雙重使用 id ：%d"
 
-#: ../src/common/xtixml.cpp:323
+#: ../src/common/xtixml.cpp:318
 #, c-format
 msgid "Unknown Property %s"
 msgstr "未知屬性 %s"
 
-#: ../src/common/xtixml.cpp:414
+#: ../src/common/xtixml.cpp:409
 msgid "A non empty collection must consist of 'element' nodes"
 msgstr "非空集合必須包含 'element' 節點"
 
-#: ../src/common/xtixml.cpp:485
+#: ../src/common/xtixml.cpp:480
 msgid "incorrect event handler string, missing dot"
 msgstr "不正確的事件處理常式字串，缺少小點"
 
-#: ../src/common/zipstrm.cpp:572
+#: ../src/common/zipstrm.cpp:558
 msgid "can't re-initialize zlib deflate stream"
 msgstr "無法重新初始化 zlib 壓縮串流"
 
-#: ../src/common/zipstrm.cpp:597
+#: ../src/common/zipstrm.cpp:583
 msgid "can't re-initialize zlib inflate stream"
 msgstr "無法重新初始化 zlib 解壓串流"
 
-#: ../src/common/zipstrm.cpp:1043
+#: ../src/common/zipstrm.cpp:1029
 msgid "Ignoring malformed extra data record, ZIP file may be corrupted"
 msgstr "忽略格式錯誤的延伸資料記錄，ZIP 檔案可能已損壞"
 
-#: ../src/common/zipstrm.cpp:1522
+#: ../src/common/zipstrm.cpp:1508
 msgid "assuming this is a multi-part zip concatenated"
 msgstr "假設這是一個多重部分 zip 的結合"
 
-#: ../src/common/zipstrm.cpp:1688
+#: ../src/common/zipstrm.cpp:1674
 msgid "invalid zip file"
 msgstr "無效的 zip 檔案"
 
-#: ../src/common/zipstrm.cpp:1747
+#: ../src/common/zipstrm.cpp:1733
 msgid "can't find central directory in zip"
 msgstr "無法在 zip 檔中找到中心目錄"
 
-#: ../src/common/zipstrm.cpp:1836
+#: ../src/common/zipstrm.cpp:1822
 msgid "error reading zip central directory"
 msgstr "讀取 zip 中心目錄發生錯誤"
 
-#: ../src/common/zipstrm.cpp:1940
+#: ../src/common/zipstrm.cpp:1926
 msgid "error reading zip local header"
 msgstr "讀取 zip 本地表頭時發生錯誤"
 
-#: ../src/common/zipstrm.cpp:1988
+#: ../src/common/zipstrm.cpp:1974
 msgid "bad zipfile offset to entry"
 msgstr "損壞的 zip 檔案移動至項目"
 
-#: ../src/common/zipstrm.cpp:2055
+#: ../src/common/zipstrm.cpp:2041
 msgid "stored file length not in Zip header"
 msgstr "儲存的檔案長度不在 Zip 表頭中"
 
-#: ../src/common/zipstrm.cpp:2069 ../src/common/zipstrm.cpp:2390
+#: ../src/common/zipstrm.cpp:2055 ../src/common/zipstrm.cpp:2376
 msgid "unsupported Zip compression method"
 msgstr "不支援的 Zip 壓縮方法"
 
-#: ../src/common/zipstrm.cpp:2150
+#: ../src/common/zipstrm.cpp:2136
 #, c-format
 msgid "reading zip stream (entry %s): bad length"
 msgstr "讀取 zip 串流 (條目 %s): 不良的長度"
 
-#: ../src/common/zipstrm.cpp:2155
+#: ../src/common/zipstrm.cpp:2141
 #, c-format
 msgid "reading zip stream (entry %s): bad crc"
 msgstr "讀取 zip 串流 (條目 %s): 不良的 crc"
 
-#: ../src/common/zipstrm.cpp:2608
+#: ../src/common/zipstrm.cpp:2594
 #, c-format
 msgid "error writing zip entry '%s': file too large without ZIP64"
 msgstr "寫入 zip 條目 '%s' 時發生錯誤：檔案過大，且沒有 ZIP64"
 
-#: ../src/common/zipstrm.cpp:2615
+#: ../src/common/zipstrm.cpp:2601
 #, c-format
 msgid "error writing zip entry '%s': bad crc or length"
 msgstr "寫入 zip 條目 '%s' 時發生錯誤：不當的 crc 或長度"
@@ -4150,32 +4175,32 @@ msgstr "美術設計： "
 msgid "Translations by "
 msgstr "翻譯團隊： "
 
-#: ../src/generic/aboutdlgg.cpp:125 ../src/osx/cocoa/aboutdlg.mm:83
+#: ../src/generic/aboutdlgg.cpp:123 ../src/osx/cocoa/aboutdlg.mm:83
 msgid "Version "
 msgstr "版本 "
 
-#: ../src/generic/aboutdlgg.cpp:137 ../src/msw/aboutdlg.cpp:61
+#: ../src/generic/aboutdlgg.cpp:135 ../src/msw/aboutdlg.cpp:58
 #, c-format
 msgid "About %s"
 msgstr "關於 %s"
 
-#: ../src/generic/aboutdlgg.cpp:170
+#: ../src/generic/aboutdlgg.cpp:167
 msgid "License"
 msgstr "授權"
 
-#: ../src/generic/aboutdlgg.cpp:173
+#: ../src/generic/aboutdlgg.cpp:170
 msgid "Developers"
 msgstr "開發者"
 
-#: ../src/generic/aboutdlgg.cpp:177
+#: ../src/generic/aboutdlgg.cpp:174
 msgid "Documentation writers"
 msgstr "文件撰寫者"
 
-#: ../src/generic/aboutdlgg.cpp:181
+#: ../src/generic/aboutdlgg.cpp:178
 msgid "Artists"
 msgstr "藝術家"
 
-#: ../src/generic/aboutdlgg.cpp:185
+#: ../src/generic/aboutdlgg.cpp:182
 msgid "Translators"
 msgstr "翻譯者"
 
@@ -4226,42 +4251,42 @@ msgid "Password:"
 msgstr "密碼："
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/generic/datavgen.cpp:1164
+#: ../src/generic/datavgen.cpp:1172
 msgid "true"
 msgstr "真"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/generic/datavgen.cpp:1166
+#: ../src/generic/datavgen.cpp:1174
 msgid "false"
 msgstr "假"
 
-#: ../src/generic/datavgen.cpp:6855
+#: ../src/generic/datavgen.cpp:6892
 #, c-format
 msgid "Row %i"
 msgstr "第 %i 行"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6945
+#: ../src/generic/datavgen.cpp:6982
 msgid "Collapse"
 msgstr "摺疊"
 
 #. TRANSLATORS: Action for manipulating a tree control
-#: ../src/generic/datavgen.cpp:6948
+#: ../src/generic/datavgen.cpp:6985
 msgid "Expand"
 msgstr "展開"
 
-#: ../src/generic/datavgen.cpp:6967
+#: ../src/generic/datavgen.cpp:7004
 #, c-format
 msgid "%s (%d items)"
 msgstr "%s (%d 個項目)"
 
-#: ../src/generic/datavgen.cpp:7018
+#: ../src/generic/datavgen.cpp:7055
 #, c-format
 msgid "Column %u"
 msgstr "欄位 %u"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7087 ../src/richtext/richtextbulletspage.cpp:186
+#: ../src/generic/datavgen.cpp:7124 ../src/richtext/richtextbulletspage.cpp:186
 #: ../src/richtext/richtextbulletspage.cpp:189
 #: ../src/richtext/richtextbulletspage.cpp:190
 #: ../src/richtext/richtextliststylepage.cpp:249
@@ -4272,7 +4297,7 @@ msgid "Left"
 msgstr "左"
 
 #. TRANSLATORS: Keystroke for manipulating a tree control
-#: ../src/generic/datavgen.cpp:7090 ../src/richtext/richtextbulletspage.cpp:188
+#: ../src/generic/datavgen.cpp:7127 ../src/richtext/richtextbulletspage.cpp:188
 #: ../src/richtext/richtextliststylepage.cpp:251
 #: ../src/richtext/richtextsizepage.cpp:250
 msgid "Right"
@@ -4366,7 +4391,7 @@ msgid "Home directory"
 msgstr "主目錄"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:784
+#: ../src/generic/dirctrlg.cpp:490 ../src/propgrid/advprops.cpp:780
 msgid "Desktop"
 msgstr "桌面"
 
@@ -4379,8 +4404,7 @@ msgstr "目錄名稱不合規範。"
 #: ../src/generic/filectrlg.cpp:638 ../src/generic/filectrlg.cpp:752
 #: ../src/generic/filectrlg.cpp:766 ../src/generic/filectrlg.cpp:782
 #: ../src/generic/filectrlg.cpp:1356 ../src/generic/filectrlg.cpp:1387
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:74
-#: ../src/gtk1/fontdlg.cpp:74
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:75
 msgid "Error"
 msgstr "錯誤"
 
@@ -4563,16 +4587,16 @@ msgstr "按詳細資料檢視檔案"
 msgid "Go to parent directory"
 msgstr "前往父系目錄"
 
-#: ../src/generic/filedlgg.cpp:343 ../src/gtk/filedlg.cpp:57
+#: ../src/generic/filedlgg.cpp:353 ../src/gtk/filedlg.cpp:58
 #, c-format
 msgid "File '%s' already exists, do you really want to overwrite it?"
 msgstr "檔案 '%s' 已存在，是否要覆寫？"
 
-#: ../src/generic/filedlgg.cpp:346 ../src/gtk/filedlg.cpp:60
+#: ../src/generic/filedlgg.cpp:356 ../src/gtk/filedlg.cpp:61
 msgid "Confirm"
 msgstr "確認"
 
-#: ../src/generic/filedlgg.cpp:354 ../src/gtk/filedlg.cpp:73
+#: ../src/generic/filedlgg.cpp:364 ../src/gtk/filedlg.cpp:74
 msgid "Please choose an existing file."
 msgstr "請選擇現存的檔案。"
 
@@ -4666,7 +4690,7 @@ msgstr "字點大小。"
 msgid "Whether the font is underlined."
 msgstr "字型是否加底線。"
 
-#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1219
+#: ../src/generic/fontdlgg.cpp:451 ../src/html/helpwnd.cpp:1214
 #: ../src/osx/carbon/fontdlg.cpp:386
 msgid "Preview:"
 msgstr "預覽："
@@ -4684,48 +4708,47 @@ msgstr "點擊取消字型選擇。"
 msgid "Click to confirm the font selection."
 msgstr "點擊確認字型選擇。"
 
-#: ../src/generic/fontpickerg.cpp:47 ../src/gtk/fontdlg.cpp:77
-#: ../src/gtk1/fontdlg.cpp:125
+#: ../src/generic/fontpickerg.cpp:51 ../src/gtk/fontdlg.cpp:77
 msgid "Choose font"
 msgstr "選擇字型"
 
-#: ../src/generic/grid.cpp:6222
+#: ../src/generic/grid.cpp:6170
 msgid "Copying more than one selected block to clipboard is not supported."
 msgstr "不支援將多個選定區塊複製至剪貼簿。"
 
-#: ../src/generic/helpext.cpp:266
+#: ../src/generic/helpext.cpp:258
 #, c-format
 msgid "Help directory \"%s\" not found."
 msgstr "找不到說明目錄 '%s'。"
 
-#: ../src/generic/helpext.cpp:274
+#: ../src/generic/helpext.cpp:266
 #, c-format
 msgid "Help file \"%s\" not found."
 msgstr "找不到 '%s' 檔案。"
 
-#: ../src/generic/helpext.cpp:293
+#: ../src/generic/helpext.cpp:285
 #, c-format
 msgid "Line %lu of map file \"%s\" has invalid syntax, skipped."
 msgstr "對應檔案「%2$s」的第 %1$lu 列語法無效，已略過。"
 
-#: ../src/generic/helpext.cpp:301
+#: ../src/generic/helpext.cpp:293
 #, c-format
 msgid "No valid mappings found in the file \"%s\"."
 msgstr "在 '%s' 檔案找不到有效對應。"
 
-#: ../src/generic/helpext.cpp:444
+#: ../src/generic/helpext.cpp:436
 msgid "No entries found."
 msgstr "找不到項目。"
 
-#: ../src/generic/helpext.cpp:453 ../src/generic/helpext.cpp:454
+#: ../src/generic/helpext.cpp:445 ../src/generic/helpext.cpp:446
 msgid "Help Index"
 msgstr "說明索引"
 
-#: ../src/generic/helpext.cpp:457
+#: ../src/generic/helpext.cpp:449
 msgid "Relevant entries:"
 msgstr "相關項目："
 
-#: ../src/generic/helpext.cpp:458
+#: ../src/generic/helpext.cpp:450
 msgid "Entries found"
 msgstr "找到的項目"
 
@@ -4829,59 +4852,59 @@ msgstr "無法啟動列印。"
 msgid "Printing page %d..."
 msgstr "正在列印第 %d 頁…"
 
-#: ../src/generic/prntdlgg.cpp:173
+#: ../src/generic/prntdlgg.cpp:172
 msgid "Printer options"
 msgstr "印表機選項"
 
-#: ../src/generic/prntdlgg.cpp:178
+#: ../src/generic/prntdlgg.cpp:177
 msgid "Print to File"
 msgstr "輸出成檔案"
 
-#: ../src/generic/prntdlgg.cpp:181
+#: ../src/generic/prntdlgg.cpp:180
 msgid "Setup..."
 msgstr "設定…"
 
-#: ../src/generic/prntdlgg.cpp:189
+#: ../src/generic/prntdlgg.cpp:188
 msgid "Printer:"
 msgstr "印表機:"
 
-#: ../src/generic/prntdlgg.cpp:197
+#: ../src/generic/prntdlgg.cpp:196
 msgid "Status:"
 msgstr "狀態:"
 
-#: ../src/generic/prntdlgg.cpp:208
+#: ../src/generic/prntdlgg.cpp:207
 msgid "All"
 msgstr "所有"
 
-#: ../src/generic/prntdlgg.cpp:209
+#: ../src/generic/prntdlgg.cpp:208
 msgid "Pages"
 msgstr "頁"
 
-#: ../src/generic/prntdlgg.cpp:217
+#: ../src/generic/prntdlgg.cpp:216
 msgid "Print Range"
 msgstr "列印範圍"
 
-#: ../src/generic/prntdlgg.cpp:231
+#: ../src/generic/prntdlgg.cpp:230
 msgid "From:"
 msgstr "從："
 
-#: ../src/generic/prntdlgg.cpp:235
+#: ../src/generic/prntdlgg.cpp:234
 msgid "To:"
 msgstr "到："
 
-#: ../src/generic/prntdlgg.cpp:240
+#: ../src/generic/prntdlgg.cpp:239
 msgid "Copies:"
 msgstr "副本數："
 
-#: ../src/generic/prntdlgg.cpp:290
+#: ../src/generic/prntdlgg.cpp:289
 msgid "PostScript file"
 msgstr "PostScript 文件"
 
-#: ../src/generic/prntdlgg.cpp:441
+#: ../src/generic/prntdlgg.cpp:440
 msgid "Print Setup"
 msgstr "列印設定"
 
-#: ../src/generic/prntdlgg.cpp:485
+#: ../src/generic/prntdlgg.cpp:484
 msgid "Printer"
 msgstr "印表機"
 
@@ -4889,25 +4912,25 @@ msgstr "印表機"
 msgid "Default printer"
 msgstr "預設印表機"
 
-#: ../src/generic/prntdlgg.cpp:594 ../src/generic/prntdlgg.cpp:792
-#: ../src/generic/prntdlgg.cpp:833 ../src/generic/prntdlgg.cpp:846
-#: ../src/generic/prntdlgg.cpp:1042 ../src/generic/prntdlgg.cpp:1047
+#: ../src/generic/prntdlgg.cpp:596 ../src/generic/prntdlgg.cpp:783
+#: ../src/generic/prntdlgg.cpp:823 ../src/generic/prntdlgg.cpp:836
+#: ../src/generic/prntdlgg.cpp:1032 ../src/generic/prntdlgg.cpp:1037
 msgid "Paper size"
 msgstr "紙張大小"
 
-#: ../src/generic/prntdlgg.cpp:604 ../src/generic/prntdlgg.cpp:858
+#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:848
 msgid "Portrait"
 msgstr "直向列印"
 
-#: ../src/generic/prntdlgg.cpp:605 ../src/generic/prntdlgg.cpp:859
+#: ../src/generic/prntdlgg.cpp:606 ../src/generic/prntdlgg.cpp:849
 msgid "Landscape"
 msgstr "橫向列印"
 
-#: ../src/generic/prntdlgg.cpp:607 ../src/generic/prntdlgg.cpp:860
+#: ../src/generic/prntdlgg.cpp:608 ../src/generic/prntdlgg.cpp:850
 msgid "Orientation"
 msgstr "方向"
 
-#: ../src/generic/prntdlgg.cpp:610
+#: ../src/generic/prntdlgg.cpp:611
 msgid "Options"
 msgstr "選項"
 
@@ -4919,52 +4942,52 @@ msgstr "彩色列印"
 msgid "Print spooling"
 msgstr "列印佇列中"
 
-#: ../src/generic/prntdlgg.cpp:625
+#: ../src/generic/prntdlgg.cpp:624
 msgid "Printer command:"
 msgstr "印表機指令："
 
-#: ../src/generic/prntdlgg.cpp:637
+#: ../src/generic/prntdlgg.cpp:632
 msgid "Printer options:"
 msgstr "印表機選項："
 
-#: ../src/generic/prntdlgg.cpp:871
+#: ../src/generic/prntdlgg.cpp:861
 msgid "Left margin (mm):"
 msgstr "左邊距(公釐[mm])："
 
-#: ../src/generic/prntdlgg.cpp:872
+#: ../src/generic/prntdlgg.cpp:862
 msgid "Top margin (mm):"
 msgstr "頂邊距(公釐)："
 
-#: ../src/generic/prntdlgg.cpp:883
+#: ../src/generic/prntdlgg.cpp:873
 msgid "Right margin (mm):"
 msgstr "右邊距(公釐)："
 
-#: ../src/generic/prntdlgg.cpp:884
+#: ../src/generic/prntdlgg.cpp:874
 msgid "Bottom margin (mm):"
 msgstr "底邊距(公釐[mm])："
 
-#: ../src/generic/prntdlgg.cpp:907
+#: ../src/generic/prntdlgg.cpp:897
 msgid "Printer..."
 msgstr "印表機…"
 
-#: ../src/generic/progdlgg.cpp:249
+#: ../src/generic/progdlgg.cpp:240
 msgid "&Skip"
 msgstr "略過(&S)"
 
-#: ../src/generic/progdlgg.cpp:350 ../src/generic/progdlgg.cpp:629
+#: ../src/generic/progdlgg.cpp:341 ../src/generic/progdlgg.cpp:620
 msgid "Unknown"
 msgstr "未知"
 
-#: ../src/generic/progdlgg.cpp:454 ../src/msw/progdlg.cpp:535
+#: ../src/generic/progdlgg.cpp:445 ../src/msw/progdlg.cpp:526
 msgid "Done."
 msgstr "完成。"
 
 #: ../src/generic/srchctlg.cpp:55 ../src/gtk/srchctrl.cpp:182
-#: ../src/html/helpwnd.cpp:532 ../src/html/helpwnd.cpp:547
+#: ../src/html/helpwnd.cpp:527 ../src/html/helpwnd.cpp:542
 msgid "Search"
 msgstr "搜尋"
 
-#: ../src/generic/tabg.cpp:1045
+#: ../src/generic/tabg.cpp:1027
 msgid "Could not find tab for id"
 msgstr "找不到識別碼標籤"
 
@@ -5000,7 +5023,7 @@ msgstr "完成(&F)"
 msgid "< &Back"
 msgstr "《 返回(&B)"
 
-#: ../src/gtk/aboutdlg.cpp:216
+#: ../src/gtk/aboutdlg.cpp:204
 msgid "translator-credits"
 msgstr ""
 "譯者名單：\n"
@@ -5010,7 +5033,7 @@ msgstr ""
 "Walter Cheuk <wwycheuk@gmail.com>, 2019.\n"
 "James Pan <gag247@mail.ru>"
 
-#: ../src/gtk/app.cpp:456
+#: ../src/gtk/app.cpp:468
 msgid ""
 "WARNING: using XIM input method is unsupported and may result in problems "
 "with input handling and flickering. Consider unsetting GTK_IM_MODULE or "
@@ -5019,11 +5042,11 @@ msgstr ""
 "警告：不支援使用 XIM 輸入方法，可能會導致輸入處理和閃爍的問題。 可考慮不設定 "
 "gtk_im_module 或設定為 “ibus”。"
 
-#: ../src/gtk/app.cpp:539
+#: ../src/gtk/app.cpp:538
 msgid "Unable to initialize GTK+, is DISPLAY set properly?"
 msgstr "無法初始化 gtk+，DISPLAY 是否已經正確設定？"
 
-#: ../src/gtk/filedlg.cpp:87 ../src/gtk/filepicker.cpp:192
+#: ../src/gtk/filedlg.cpp:88 ../src/gtk/filepicker.cpp:192
 #, c-format
 msgid "Changing current directory to \"%s\" failed"
 msgstr "無法將目前目錄變更為 '%s'"
@@ -5047,11 +5070,11 @@ msgstr "無法加入 ”%s” 自訂字型。"
 msgid "Failed to register font configuration using private fonts."
 msgstr "無法使用私用字型註冊字型組態。"
 
-#: ../src/gtk/glcanvas.cpp:181 ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:124 ../src/gtk/glcanvas.cpp:139
 msgid "Fatal Error"
 msgstr "嚴重錯誤"
 
-#: ../src/gtk/glcanvas.cpp:181
+#: ../src/gtk/glcanvas.cpp:124
 msgid ""
 "This program wasn't compiled with EGL support required under Wayland, "
 "either\n"
@@ -5062,7 +5085,7 @@ msgstr ""
 "安裝 EGL 函式庫，並透過設定在 X11 後端進行重建或運行\n"
 "啟動此程式之前的環境變數為 GDK_BACKEND=x11。"
 
-#: ../src/gtk/glcanvas.cpp:196
+#: ../src/gtk/glcanvas.cpp:139
 msgid ""
 "wxGLCanvas is only supported on Wayland and X11 currently.  You may be able "
 "to\n"
@@ -5073,7 +5096,7 @@ msgstr ""
 "在啟動程式之前透過設定環境變數 GDK_BACKEND×x11 \n"
 "來解決這個問題。"
 
-#: ../src/gtk/mdi.cpp:433 ../src/gtk1/mdi.cpp:431
+#: ../src/gtk/mdi.cpp:433
 msgid "MDI child"
 msgstr "媒體相依介面子表單"
 
@@ -5089,36 +5112,28 @@ msgstr "列印時發生錯誤: "
 msgid "Page Setup"
 msgstr "頁面設定"
 
-#: ../src/gtk/textctrl.cpp:1273
-msgid "Failed to insert text in the control."
-msgstr "無法於控制元件插入文字。"
-
 #: ../src/gtk/webview_webkit.cpp:930
 msgid "Retrieving JavaScript script output is not supported with WebKit v1"
 msgstr "WebKit v1 不支援擷取 JavaScript 程序檔輸出"
 
-#: ../src/gtk/window.cpp:5781
+#: ../src/gtk/window.cpp:5807
 msgid ""
 "GTK+ installed on this machine is too old to support screen compositing, "
 "please install GTK+ 2.12 or later."
 msgstr ""
 "安裝於這臺機器的 GTK+ 太舊而不支援螢幕組合，請安裝 GTK+2.12 或後續版本。"
 
-#: ../src/gtk/window.cpp:5799
+#: ../src/gtk/window.cpp:5825
 msgid ""
 "Compositing not supported by this system, please enable it in your Window "
 "Manager."
 msgstr "這個系統不支援組合介面，請在視窗管理員啟用之。"
 
-#: ../src/gtk/window.cpp:5810
+#: ../src/gtk/window.cpp:5836
 msgid ""
 "This program was compiled with a too old version of GTK+, please rebuild "
 "with GTK+ 2.12 or newer."
 msgstr "這個程式是以很舊版本的 GTK+ 所編譯，請以 GTK+2.12 或更新版本重新組建。"
-
-#: ../src/gtk1/fontdlg.cpp:74
-msgid "Please choose a valid font."
-msgstr "請選擇有效字型。"
 
 #: ../src/html/chm.cpp:138
 #, c-format
@@ -5217,209 +5232,209 @@ msgstr "無法開啟目錄檔案： %s"
 msgid "Cannot open index file: %s"
 msgstr "無法開啟索引檔： %s"
 
-#: ../src/html/helpdata.cpp:650
+#: ../src/html/helpdata.cpp:644
 msgid "noname"
 msgstr "未命名"
 
-#: ../src/html/helpdata.cpp:660
+#: ../src/html/helpdata.cpp:654
 #, c-format
 msgid "Cannot open HTML help book: %s"
 msgstr "無法開啟 HTML 說明書：%s"
 
-#: ../src/html/helpwnd.cpp:320
+#: ../src/html/helpwnd.cpp:315
 msgid "Displays help as you browse the books on the left."
 msgstr "當瀏覽書籍時，於左側顯示說明。"
 
-#: ../src/html/helpwnd.cpp:416 ../src/html/helpwnd.cpp:1103
-#: ../src/html/helpwnd.cpp:1739
+#: ../src/html/helpwnd.cpp:411 ../src/html/helpwnd.cpp:1098
+#: ../src/html/helpwnd.cpp:1734
 msgid "(bookmarks)"
 msgstr "(書籤)"
 
-#: ../src/html/helpwnd.cpp:429
+#: ../src/html/helpwnd.cpp:424
 msgid "Add current page to bookmarks"
 msgstr "把目前頁面加到書籤"
 
-#: ../src/html/helpwnd.cpp:430
+#: ../src/html/helpwnd.cpp:425
 msgid "Remove current page from bookmarks"
 msgstr "從書籤移除目前頁面"
 
-#: ../src/html/helpwnd.cpp:472
+#: ../src/html/helpwnd.cpp:467
 msgid "Contents"
 msgstr "內容表格"
 
-#: ../src/html/helpwnd.cpp:487
+#: ../src/html/helpwnd.cpp:482
 msgid "Find"
 msgstr "尋找"
 
-#: ../src/html/helpwnd.cpp:489
+#: ../src/html/helpwnd.cpp:484
 msgid "Show all"
 msgstr "全部顯示"
 
-#: ../src/html/helpwnd.cpp:499
+#: ../src/html/helpwnd.cpp:494
 msgid ""
 "Display all index items that contain given substring. Search is case "
 "insensitive."
 msgstr "顯示包含該字串的所有索引項目。搜尋不區分大小寫。"
 
-#: ../src/html/helpwnd.cpp:500
+#: ../src/html/helpwnd.cpp:495
 msgid "Show all items in index"
 msgstr "以索引的方式顯示所有項目"
 
-#: ../src/html/helpwnd.cpp:530
+#: ../src/html/helpwnd.cpp:525
 msgid "Case sensitive"
 msgstr "區分大小寫"
 
-#: ../src/html/helpwnd.cpp:531
+#: ../src/html/helpwnd.cpp:526
 msgid "Whole words only"
 msgstr "只限整個字"
 
-#: ../src/html/helpwnd.cpp:534
+#: ../src/html/helpwnd.cpp:529
 msgid ""
 "Search contents of help book(s) for all occurrences of the text you typed "
 "above"
 msgstr "搜尋說明文件內容中，您所輸入文字的所有出現過的地方"
 
-#: ../src/html/helpwnd.cpp:655
+#: ../src/html/helpwnd.cpp:650
 msgid "Show/hide navigation panel"
 msgstr "顯示/隱藏導覽面板"
 
-#: ../src/html/helpwnd.cpp:657
+#: ../src/html/helpwnd.cpp:652
 msgid "Go back"
 msgstr "返回"
 
-#: ../src/html/helpwnd.cpp:658
+#: ../src/html/helpwnd.cpp:653
 msgid "Go forward"
 msgstr "進行轉送"
 
-#: ../src/html/helpwnd.cpp:660
+#: ../src/html/helpwnd.cpp:655
 msgid "Go one level up in document hierarchy"
 msgstr "到上一階文件層級"
 
-#: ../src/html/helpwnd.cpp:668 ../src/html/helpwnd.cpp:1551
+#: ../src/html/helpwnd.cpp:663 ../src/html/helpwnd.cpp:1546
 msgid "Open HTML document"
 msgstr "開啟 HTML 文件"
 
-#: ../src/html/helpwnd.cpp:672
+#: ../src/html/helpwnd.cpp:667
 msgid "Print this page"
 msgstr "列印本頁"
 
-#: ../src/html/helpwnd.cpp:676
+#: ../src/html/helpwnd.cpp:671
 msgid "Display options dialog"
 msgstr "顯示選項對話方塊"
 
-#: ../src/html/helpwnd.cpp:797
+#: ../src/html/helpwnd.cpp:792
 msgid "Please choose the page to display:"
 msgstr "請選擇要顯示的頁面:"
 
-#: ../src/html/helpwnd.cpp:798
+#: ../src/html/helpwnd.cpp:793
 msgid "Help Topics"
 msgstr "說明主題"
 
-#: ../src/html/helpwnd.cpp:854
+#: ../src/html/helpwnd.cpp:849
 msgid "Searching..."
 msgstr "搜尋中…"
 
-#: ../src/html/helpwnd.cpp:855
+#: ../src/html/helpwnd.cpp:850
 msgid "No matching page found yet"
 msgstr "未找到符合的頁面"
 
-#: ../src/html/helpwnd.cpp:872
+#: ../src/html/helpwnd.cpp:867
 #, c-format
 msgid "Found %i matches"
 msgstr "找到 %i 個符合項"
 
-#: ../src/html/helpwnd.cpp:960
+#: ../src/html/helpwnd.cpp:955
 msgid "(Help)"
 msgstr "(說明)"
 
-#: ../src/html/helpwnd.cpp:1028
+#: ../src/html/helpwnd.cpp:1023
 #, c-format
 msgid "%d of %lu"
 msgstr "%d / %lu"
 
-#: ../src/html/helpwnd.cpp:1030
+#: ../src/html/helpwnd.cpp:1025
 #, c-format
 msgid "%lu of %lu"
 msgstr "%lu / %lu"
 
-#: ../src/html/helpwnd.cpp:1049
+#: ../src/html/helpwnd.cpp:1044
 msgid "Search in all books"
 msgstr "搜尋所有說明書"
 
-#: ../src/html/helpwnd.cpp:1197
+#: ../src/html/helpwnd.cpp:1192
 msgid "Help Browser Options"
 msgstr "說明瀏覽器選項"
 
-#: ../src/html/helpwnd.cpp:1202
+#: ../src/html/helpwnd.cpp:1197
 msgid "Normal font:"
 msgstr "正常字型："
 
-#: ../src/html/helpwnd.cpp:1203
+#: ../src/html/helpwnd.cpp:1198
 msgid "Fixed font:"
 msgstr "固定字型："
 
-#: ../src/html/helpwnd.cpp:1204
+#: ../src/html/helpwnd.cpp:1199
 msgid "Font size:"
 msgstr "字型大小："
 
-#: ../src/html/helpwnd.cpp:1249
+#: ../src/html/helpwnd.cpp:1244
 msgid "font size"
 msgstr "字型大小"
 
-#: ../src/html/helpwnd.cpp:1260
+#: ../src/html/helpwnd.cpp:1255
 msgid "Normal face<br>and <u>underlined</u>. "
 msgstr "正常字體<br>且<u>加底線</u>。 "
 
-#: ../src/html/helpwnd.cpp:1261
+#: ../src/html/helpwnd.cpp:1256
 msgid "<i>Italic face.</i> "
 msgstr "<i>斜體</i> "
 
-#: ../src/html/helpwnd.cpp:1262
+#: ../src/html/helpwnd.cpp:1257
 msgid "<b>Bold face.</b> "
 msgstr "<b>粗體</b> "
 
-#: ../src/html/helpwnd.cpp:1263
+#: ../src/html/helpwnd.cpp:1258
 msgid "<b><i>Bold italic face.</i></b><br>"
 msgstr "<b><i>粗斜體</i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1266
+#: ../src/html/helpwnd.cpp:1261
 msgid "Fixed size face.<br> <b>bold</b> <i>italic</i> "
 msgstr "固定大小字體<br> <b>粗體</b> <i>斜體</i> "
 
-#: ../src/html/helpwnd.cpp:1267
+#: ../src/html/helpwnd.cpp:1262
 msgid "<b><i>bold italic <u>underlined</u></i></b><br>"
 msgstr "<b><i>粗斜<u>加底線</u></i></b><br>"
 
-#: ../src/html/helpwnd.cpp:1528
+#: ../src/html/helpwnd.cpp:1523
 msgid "Help Printing"
 msgstr "說明列印"
 
-#: ../src/html/helpwnd.cpp:1531
+#: ../src/html/helpwnd.cpp:1526
 msgid "Cannot print empty page."
 msgstr "無法列印空頁面。"
 
-#: ../src/html/helpwnd.cpp:1544
+#: ../src/html/helpwnd.cpp:1539
 msgid "HTML files (*.html;*.htm)|*.html;*.htm|"
 msgstr "HTML 檔 (*.html;*.htm)|*.html;*.htm|"
 
-#: ../src/html/helpwnd.cpp:1545
+#: ../src/html/helpwnd.cpp:1540
 msgid "Help books (*.htb)|*.htb|Help books (*.zip)|*.zip|"
 msgstr "說明書 (*.htb)|*.htb|說明書 (*.zip)|*.zip|"
 
-#: ../src/html/helpwnd.cpp:1546
+#: ../src/html/helpwnd.cpp:1541
 msgid "HTML Help Project (*.hhp)|*.hhp|"
 msgstr "HTML 說明檔專案 (*.hhp)|*.hhp|"
 
-#: ../src/html/helpwnd.cpp:1548
+#: ../src/html/helpwnd.cpp:1543
 msgid "Compressed HTML Help file (*.chm)|*.chm|"
 msgstr "壓縮超文件說明檔 (*.chm)|*.chm|"
 
-#: ../src/html/helpwnd.cpp:1675
+#: ../src/html/helpwnd.cpp:1670
 #, c-format
 msgid "%i of %u"
 msgstr "%i / %u"
 
-#: ../src/html/helpwnd.cpp:1713
+#: ../src/html/helpwnd.cpp:1708
 #, c-format
 msgid "%u of %u"
 msgstr "%u / %u"
@@ -5493,32 +5508,6 @@ msgid ""
 "There was a problem during page setup: you may need to set a default printer."
 msgstr "頁面設定時有問題：必須設定預設印表機。"
 
-#: ../src/html/winpars.cpp:727
-#, c-format
-msgid "Failed to display HTML document in %s encoding"
-msgstr "無法以 %s 編碼顯示 HTML 文件"
-
-#: ../src/motif/app.cpp:242
-#, c-format
-msgid "wxWidgets could not open display for '%s': exiting."
-msgstr "wxWidgets 無法開啟 ‘%s’ 顯示設備：已經存在。"
-
-#: ../src/motif/filedlg.cpp:218
-msgid "Filter"
-msgstr "篩選器"
-
-#: ../src/motif/filedlg.cpp:219
-msgid "Directories"
-msgstr "目錄"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Files"
-msgstr "檔案"
-
-#: ../src/motif/filedlg.cpp:220
-msgid "Selection"
-msgstr "選擇"
-
 #: ../src/msw/clipbrd.cpp:89
 msgid "Failed to open the clipboard."
 msgstr "無法開啟剪貼簿。"
@@ -5560,58 +5549,58 @@ msgstr "顏色選擇對話框無效，錯誤碼：%0lx。"
 msgid "Failed to create cursor."
 msgstr "無法創建游標。"
 
-#: ../src/msw/dde.cpp:283
+#: ../src/msw/dde.cpp:279
 #, c-format
 msgid "Failed to register DDE server '%s'"
 msgstr "無法註冊動態資料交換 (DDE) 伺服器 '%s'"
 
-#: ../src/msw/dde.cpp:304
+#: ../src/msw/dde.cpp:300
 #, c-format
 msgid "Failed to unregister DDE server '%s'"
 msgstr "無法取消註冊’%s’ DDE 伺服器"
 
-#: ../src/msw/dde.cpp:432
+#: ../src/msw/dde.cpp:428
 #, c-format
 msgid "Failed to create connection to server '%s' on topic '%s'"
 msgstr "無法創建連線到 '%s' 伺服器的主題 '%s'"
 
-#: ../src/msw/dde.cpp:698
+#: ../src/msw/dde.cpp:655
 msgid "DDE poke request failed"
 msgstr "動態資料交換 (DDE) 存數指令要求失敗"
 
-#: ../src/msw/dde.cpp:717
+#: ../src/msw/dde.cpp:674
 msgid "Failed to establish an advise loop with DDE server"
 msgstr "無法建立與動態資料交換 (DDE) 伺服器溝通的連結"
 
-#: ../src/msw/dde.cpp:736
+#: ../src/msw/dde.cpp:693
 msgid "Failed to terminate the advise loop with DDE server"
 msgstr "無法終止與動態資料交換 (DDE) 伺服器溝通的連結"
 
-#: ../src/msw/dde.cpp:811
+#: ../src/msw/dde.cpp:768
 msgid "Failed to send DDE advise notification"
 msgstr "無法傳送動態資料交換 (DDE) 連結通知訊息"
 
-#: ../src/msw/dde.cpp:1134
+#: ../src/msw/dde.cpp:1085
 msgid "Failed to create DDE string"
 msgstr "無法創建動態資料交換 (DDE) 字串"
 
-#: ../src/msw/dde.cpp:1180
+#: ../src/msw/dde.cpp:1131
 msgid "no DDE error."
 msgstr "未發現動態資料交換 (DDE) 錯誤。"
 
-#: ../src/msw/dde.cpp:1184
+#: ../src/msw/dde.cpp:1135
 msgid "a request for a synchronous advise transaction has timed out."
 msgstr "同步「連結交易」請求已逾時。"
 
-#: ../src/msw/dde.cpp:1187
+#: ../src/msw/dde.cpp:1138
 msgid "the response to the transaction caused the DDE_FBUSY bit to be set."
 msgstr "交易的回應，設定了 DDE_FBUSY 位元。"
 
-#: ../src/msw/dde.cpp:1190
+#: ../src/msw/dde.cpp:1141
 msgid "a request for a synchronous data transaction has timed out."
 msgstr "同步「資料交易」請求已逾時。"
 
-#: ../src/msw/dde.cpp:1193
+#: ../src/msw/dde.cpp:1144
 msgid ""
 "a DDEML function was called without first calling the DdeInitialize "
 "function,\n"
@@ -5622,7 +5611,7 @@ msgstr ""
 "或傳給 DDEML 函式的是\n"
 "無效的執行個體物件識別。"
 
-#: ../src/msw/dde.cpp:1196
+#: ../src/msw/dde.cpp:1147
 msgid ""
 "an application initialized as APPCLASS_MONITOR has\n"
 "attempted to perform a DDE transaction,\n"
@@ -5634,43 +5623,43 @@ msgstr ""
 "或初始化為 APPCMD_CLIENTONLY 的應用程式\n"
 "試圖執行伺服器的交易。"
 
-#: ../src/msw/dde.cpp:1199
+#: ../src/msw/dde.cpp:1150
 msgid "a request for a synchronous execute transaction has timed out."
 msgstr "同步「執行交易」請求已逾時。"
 
-#: ../src/msw/dde.cpp:1202
+#: ../src/msw/dde.cpp:1153
 msgid "a parameter failed to be validated by the DDEML."
 msgstr "此參數無法通過 DDEML 驗證。"
 
-#: ../src/msw/dde.cpp:1205
+#: ../src/msw/dde.cpp:1156
 msgid "a DDEML application has created a prolonged race condition."
 msgstr "在 DDEML 應用程式產生了拖延的競態情況。"
 
-#: ../src/msw/dde.cpp:1208
+#: ../src/msw/dde.cpp:1159
 msgid "a memory allocation failed."
 msgstr "記憶體分配失敗。"
 
-#: ../src/msw/dde.cpp:1211
+#: ../src/msw/dde.cpp:1162
 msgid "a client's attempt to establish a conversation has failed."
 msgstr "用戶端的嘗試創建通訊失敗。"
 
-#: ../src/msw/dde.cpp:1214
+#: ../src/msw/dde.cpp:1165
 msgid "a transaction failed."
 msgstr "交易失敗。"
 
-#: ../src/msw/dde.cpp:1217
+#: ../src/msw/dde.cpp:1168
 msgid "a request for a synchronous poke transaction has timed out."
 msgstr "同步「資料存數指令交易」請求已逾時。"
 
-#: ../src/msw/dde.cpp:1220
+#: ../src/msw/dde.cpp:1171
 msgid "an internal call to the PostMessage function has failed. "
 msgstr "一例內部調用 PostMessage 函式已失效。 "
 
-#: ../src/msw/dde.cpp:1223
+#: ../src/msw/dde.cpp:1174
 msgid "reentrancy problem."
 msgstr "重複進入問題。"
 
-#: ../src/msw/dde.cpp:1226
+#: ../src/msw/dde.cpp:1177
 msgid ""
 "a server-side transaction was attempted on a conversation\n"
 "that was terminated by the client, or the server\n"
@@ -5680,15 +5669,15 @@ msgstr ""
 "被用戶端終止，或伺服器\n"
 "在完成交易前終止。"
 
-#: ../src/msw/dde.cpp:1229
+#: ../src/msw/dde.cpp:1180
 msgid "an internal error has occurred in the DDEML."
 msgstr "在 DDEML 發生內部錯誤。"
 
-#: ../src/msw/dde.cpp:1232
+#: ../src/msw/dde.cpp:1183
 msgid "a request to end an advise transaction has timed out."
 msgstr "終止「連結交易」的請求已逾時。"
 
-#: ../src/msw/dde.cpp:1235
+#: ../src/msw/dde.cpp:1186
 msgid ""
 "an invalid transaction identifier was passed to a DDEML function.\n"
 "Once the application has returned from an XTYP_XACT_COMPLETE callback,\n"
@@ -5698,18 +5687,18 @@ msgstr ""
 "一旦應用程式從 XTYP_XACT_COMPLETE 回調函式返回，\n"
 "該回調函式的交易識別碼就不再有效。"
 
-#: ../src/msw/dde.cpp:1238
+#: ../src/msw/dde.cpp:1189
 #, c-format
 msgid "Unknown DDE error %08x"
 msgstr "未知的動態資料交換 (DDE) 錯誤 %08x"
 
-#: ../src/msw/dialup.cpp:368
+#: ../src/msw/dialup.cpp:344
 msgid ""
 "Dial up functions are unavailable because the remote access service (RAS) is "
 "not installed on this machine. Please install it."
 msgstr "由於沒有安裝遠端存取服務 (RAS)，撥號功能無法使用。請先安裝。"
 
-#: ../src/msw/dialup.cpp:427
+#: ../src/msw/dialup.cpp:403
 #, c-format
 msgid ""
 "The version of remote access service (RAS) installed on this machine is too "
@@ -5718,64 +5707,64 @@ msgstr ""
 "於此電腦安裝的遠端存取服務 (RAS) 版本太舊， (缺少以下必要函式：%s ) 請進行升"
 "級。"
 
-#: ../src/msw/dialup.cpp:462
+#: ../src/msw/dialup.cpp:438
 msgid "Failed to retrieve text of RAS error message"
 msgstr "無法擷取 RAS 錯誤訊息的對應文字"
 
-#: ../src/msw/dialup.cpp:465
+#: ../src/msw/dialup.cpp:441
 #, c-format
 msgid "unknown error (error code %08x)."
 msgstr "未知的錯誤 (錯誤碼 %08x)。"
 
-#: ../src/msw/dialup.cpp:517
+#: ../src/msw/dialup.cpp:493
 #, c-format
 msgid "Cannot find active dialup connection: %s"
 msgstr "找不到可用的撥號連線：%s"
 
-#: ../src/msw/dialup.cpp:538
+#: ../src/msw/dialup.cpp:514
 msgid "Several active dialup connections found, choosing one randomly."
 msgstr "找到多個可用的撥號連線，隨機選擇一個。"
 
-#: ../src/msw/dialup.cpp:623 ../src/msw/dialup.cpp:857
+#: ../src/msw/dialup.cpp:599 ../src/msw/dialup.cpp:833
 #, c-format
 msgid "Failed to establish dialup connection: %s"
 msgstr "無法建立撥號連線：%s"
 
-#: ../src/msw/dialup.cpp:689
+#: ../src/msw/dialup.cpp:665
 #, c-format
 msgid "Failed to get ISP names: %s"
 msgstr "無法取得 ISP 名稱：%s"
 
-#: ../src/msw/dialup.cpp:737
+#: ../src/msw/dialup.cpp:713
 msgid "Failed to connect: no ISP to dial."
 msgstr "連線失敗：無可用的 ISP 供撥號。"
 
-#: ../src/msw/dialup.cpp:757
+#: ../src/msw/dialup.cpp:733
 msgid "Choose ISP to dial"
 msgstr "選擇 ISP 進行撥號"
 
-#: ../src/msw/dialup.cpp:758
+#: ../src/msw/dialup.cpp:734
 msgid "Please choose which ISP do you want to connect to"
 msgstr "請選擇要連線的 ISP"
 
-#: ../src/msw/dialup.cpp:791
+#: ../src/msw/dialup.cpp:767
 msgid "Failed to connect: missing username/password."
 msgstr "連線失敗：缺少使用者名稱或密碼。"
 
-#: ../src/msw/dialup.cpp:821
+#: ../src/msw/dialup.cpp:797
 msgid "Cannot find the location of address book file"
 msgstr "找不到通訊錄檔案的位置"
 
-#: ../src/msw/dialup.cpp:852
+#: ../src/msw/dialup.cpp:828
 #, c-format
 msgid "Failed to initiate dialup connection: %s"
 msgstr "無法初始撥號連線：%s"
 
-#: ../src/msw/dialup.cpp:922
+#: ../src/msw/dialup.cpp:898
 msgid "Cannot hang up - no active dialup connection."
 msgstr "無法掛斷—沒有可用的撥號連線。"
 
-#: ../src/msw/dialup.cpp:932
+#: ../src/msw/dialup.cpp:908
 #, c-format
 msgid "Failed to terminate the dialup connection: %s"
 msgstr "無法終止撥號連線：%s"
@@ -5795,18 +5784,17 @@ msgstr "無法分配點陣圖資料 %luKb 的記憶體。"
 msgid "Cannot enumerate files in directory '%s'"
 msgstr "無法列舉 '%s' 資料夾的檔案"
 
-#: ../src/msw/dirdlg.cpp:289
+#: ../src/msw/dirdlg.cpp:328
 msgid "Couldn't obtain folder name"
 msgstr "無法取得資料夾名稱"
 
-#: ../src/msw/dlmsw.cpp:167
+#: ../src/msw/dlmsw.cpp:164
 #, c-format
 msgid "(error %d: %s)"
 msgstr "(錯誤 %id: %s)"
 
-#: ../src/msw/dragimag.cpp:182 ../src/msw/dragimag.cpp:217
-#: ../src/msw/imaglist.cpp:302 ../src/msw/imaglist.cpp:322
-#: ../src/msw/imaglist.cpp:347
+#: ../src/msw/dragimag.cpp:144 ../src/msw/dragimag.cpp:179
+#: ../src/msw/imaglist.cpp:304 ../src/msw/imaglist.cpp:326
 msgid "Couldn't add an image to the image list."
 msgstr "無法把影像加到影像清單。"
 
@@ -5820,7 +5808,7 @@ msgstr "從 '%s' 檔案讀取中繼檔案失敗。"
 msgid "Failed to create the standard find/replace dialog (error code %d)"
 msgstr "無法創建標準的「尋找/更改」對話窗 (錯誤碼 %d)"
 
-#: ../src/msw/filedlg.cpp:412
+#: ../src/msw/filedlg.cpp:1481
 #, c-format
 msgid "File dialog failed with error code %0lx."
 msgstr "檔案對話視窗錯誤，錯誤碼 %0lx。"
@@ -5861,16 +5849,16 @@ msgstr "無法設定監看至 '%s'"
 msgid "Can't monitor non-existent directory \"%s\" for changes."
 msgstr "無法監控不存在的 “%s” 目錄是否有變更。"
 
-#: ../src/msw/glcanvas.cpp:592 ../src/unix/glx11.cpp:513
+#: ../src/msw/glcanvas.cpp:586 ../src/unix/glx11.cpp:504
 msgid "OpenGL 3.0 or later is not supported by the OpenGL driver."
 msgstr "此 OpenGL 驅動程式不支援 OpenGL 3.0 或更新版本。"
 
-#: ../src/msw/glcanvas.cpp:616 ../src/osx/glcanvas_osx.cpp:411
-#: ../src/unix/glegl.cpp:318 ../src/unix/glx11.cpp:559
+#: ../src/msw/glcanvas.cpp:610 ../src/osx/glcanvas_osx.cpp:403
+#: ../src/unix/glegl.cpp:312 ../src/unix/glx11.cpp:550
 msgid "Couldn't create OpenGL context"
 msgstr "無法創建 OpenGL 內容"
 
-#: ../src/msw/glcanvas.cpp:1376
+#: ../src/msw/glcanvas.cpp:1312
 msgid "Failed to initialize OpenGL"
 msgstr "無法初始化 OpenGL"
 
@@ -5878,14 +5866,14 @@ msgstr "無法初始化 OpenGL"
 msgid "Could not register custom DirectWrite font loader."
 msgstr "無法註冊自訂 DirectWrite 字型載入器。"
 
-#: ../src/msw/helpchm.cpp:53
+#: ../src/msw/helpchm.cpp:48
 msgid ""
 "MS HTML Help functions are unavailable because the MS HTML Help library is "
 "not installed on this machine. Please install it."
 msgstr ""
 "MS HTML Help 函式目前不可用，起因於未安裝 MS HTML Help 函式庫，請先安裝。"
 
-#: ../src/msw/helpchm.cpp:60
+#: ../src/msw/helpchm.cpp:55
 msgid "Failed to initialize MS HTML Help."
 msgstr "無法初始化 MS HTML Help。"
 
@@ -5894,7 +5882,7 @@ msgstr "無法初始化 MS HTML Help。"
 msgid "Can't delete the INI file '%s'"
 msgstr "無法刪除 INI 檔 '%s'"
 
-#: ../src/msw/listctrl.cpp:945
+#: ../src/msw/listctrl.cpp:1003
 #, c-format
 msgid "Couldn't retrieve information about list control item %d."
 msgstr "無法擷取控管項目清單中細項 %d 的資訊。"
@@ -6014,7 +6002,7 @@ msgstr "無法註冊剪貼簿格式 '%s'。"
 msgid "The clipboard format '%d' doesn't exist."
 msgstr "剪貼簿格式「%d」不存在。"
 
-#: ../src/msw/progdlg.cpp:1088
+#: ../src/msw/progdlg.cpp:1025
 msgid "Skip"
 msgstr "略過"
 
@@ -6099,75 +6087,75 @@ msgstr ""
 "刪除它會使系統處於無法使用的狀態：\n"
 "操作中斷。"
 
-#: ../src/msw/registry.cpp:765
+#: ../src/msw/registry.cpp:752
 #, c-format
 msgid "Can't delete key '%s'"
 msgstr "無法刪除機碼 '%s'"
 
-#: ../src/msw/registry.cpp:793
+#: ../src/msw/registry.cpp:780
 #, c-format
 msgid "Can't delete value '%s' from key '%s'"
 msgstr "無法從 ‘%s’ 機碼刪除 '%s' 值"
 
-#: ../src/msw/registry.cpp:866 ../src/msw/registry.cpp:898
-#: ../src/msw/registry.cpp:940 ../src/msw/registry.cpp:1011
+#: ../src/msw/registry.cpp:853 ../src/msw/registry.cpp:885
+#: ../src/msw/registry.cpp:927 ../src/msw/registry.cpp:998
 #, c-format
 msgid "Can't read value of key '%s'"
 msgstr "無法讀取機碼 '%s' 的值"
 
-#: ../src/msw/registry.cpp:884 ../src/msw/registry.cpp:926
-#: ../src/msw/registry.cpp:974 ../src/msw/registry.cpp:1117
+#: ../src/msw/registry.cpp:871 ../src/msw/registry.cpp:913
+#: ../src/msw/registry.cpp:961 ../src/msw/registry.cpp:1104
 #, c-format
 msgid "Can't set value of '%s'"
 msgstr "無法設定 '%s' 的值"
 
-#: ../src/msw/registry.cpp:905 ../src/msw/registry.cpp:954
+#: ../src/msw/registry.cpp:892 ../src/msw/registry.cpp:941
 #, c-format
 msgid "Registry value \"%s\" is not numeric (but of type %s)"
 msgstr "登錄機碼 “%s” 不是數字 (但卻是 %s 類型)"
 
-#: ../src/msw/registry.cpp:990
+#: ../src/msw/registry.cpp:977
 #, c-format
 msgid "Registry value \"%s\" is not binary (but of type %s)"
 msgstr "登錄機碼 “%s” 不是二進位 (但卻是 %s 類型)"
 
-#: ../src/msw/registry.cpp:1039
+#: ../src/msw/registry.cpp:1026
 #, c-format
 msgid "Registry value \"%s\" is not text (but of type %s)"
 msgstr "登錄機碼 “%s” 不是文字 (但卻是 %s 類型)"
 
-#: ../src/msw/registry.cpp:1100
+#: ../src/msw/registry.cpp:1087
 #, c-format
 msgid "Can't read value of '%s'"
 msgstr "無法讀取 '%s' 的值"
 
-#: ../src/msw/registry.cpp:1168
+#: ../src/msw/registry.cpp:1155
 #, c-format
 msgid "Can't enumerate values of key '%s'"
 msgstr "無法列舉機碼 '%s' 的值"
 
-#: ../src/msw/registry.cpp:1207
+#: ../src/msw/registry.cpp:1194
 #, c-format
 msgid "Can't enumerate subkeys of key '%s'"
 msgstr "無法列舉機碼 '%s' 的子機碼"
 
-#: ../src/msw/registry.cpp:1277
+#: ../src/msw/registry.cpp:1260
 #, c-format
 msgid ""
 "Exporting registry key: file \"%s\" already exists and won't be overwritten."
 msgstr "匯出登錄機碼 已有 “%s” 檔案，無法覆寫。"
 
-#: ../src/msw/registry.cpp:1426
+#: ../src/msw/registry.cpp:1409
 #, c-format
 msgid "Can't export value of unsupported type %d."
 msgstr "無法匯出不支援類型 %d 的值。"
 
-#: ../src/msw/registry.cpp:1442
+#: ../src/msw/registry.cpp:1425
 #, c-format
 msgid "Ignoring value \"%s\" of the key \"%s\"."
 msgstr "忽略 “%s” 機碼的 “%s” 值。"
 
-#: ../src/msw/textctrl.cpp:554
+#: ../src/msw/textctrl.cpp:564
 msgid ""
 "Impossible to create a rich edit control, using simple text control instead. "
 "Please reinstall riched32.dll"
@@ -6175,47 +6163,47 @@ msgstr ""
 "無法創建 rich edit 控制元件，使用 simple text 控制元件代替。請重新安裝 "
 "riched32.dll"
 
-#: ../src/msw/thread.cpp:530 ../src/unix/threadpsx.cpp:855
+#: ../src/msw/thread.cpp:532 ../src/unix/threadpsx.cpp:856
 msgid "Cannot start thread: error writing TLS."
 msgstr "無法啟動執行緒：寫入「執行緒內部儲存區」時發生錯誤。"
 
-#: ../src/msw/thread.cpp:621
+#: ../src/msw/thread.cpp:627
 msgid "Can't set thread priority"
 msgstr "無法設定執行緒的優先等級"
 
-#: ../src/msw/thread.cpp:657
+#: ../src/msw/thread.cpp:663
 msgid "Can't create thread"
 msgstr "無法創建執行緒"
 
-#: ../src/msw/thread.cpp:676
+#: ../src/msw/thread.cpp:682
 msgid "Couldn't terminate thread"
 msgstr "無法終止執行緒"
 
-#: ../src/msw/thread.cpp:786
+#: ../src/msw/thread.cpp:792
 msgid "Cannot wait for thread termination"
 msgstr "無法等候執行緒終結"
 
-#: ../src/msw/thread.cpp:864
+#: ../src/msw/thread.cpp:870
 #, c-format
 msgid "Cannot suspend thread %lx"
 msgstr "無法中止執行緒 %lx"
 
-#: ../src/msw/thread.cpp:894
+#: ../src/msw/thread.cpp:900
 #, c-format
 msgid "Cannot resume thread %lx"
 msgstr "無法繼續執行緒 %lx"
 
-#: ../src/msw/thread.cpp:923
+#: ../src/msw/thread.cpp:929
 msgid "Couldn't get the current thread pointer"
 msgstr "無法取得目前執行緒指標"
 
-#: ../src/msw/thread.cpp:1326
+#: ../src/msw/thread.cpp:1332
 msgid ""
 "Thread module initialization failed: impossible to allocate index in thread "
 "local storage"
 msgstr "執行緒模組初始化失敗：無法在「執行緒內部儲存區」配置索引"
 
-#: ../src/msw/thread.cpp:1338
+#: ../src/msw/thread.cpp:1344
 msgid ""
 "Thread module initialization failed: cannot store value in thread local "
 "storage"
@@ -6244,12 +6232,12 @@ msgstr "無法載入 “%s” 資源。"
 msgid "Failed to lock resource \"%s\"."
 msgstr "無法鎖定 “%s” 資源。"
 
-#: ../src/msw/utils.cpp:1182
+#: ../src/msw/utils.cpp:1180
 #, c-format
 msgid "build %lu"
 msgstr "組建 %lu"
 
-#: ../src/msw/utils.cpp:1190
+#: ../src/msw/utils.cpp:1188
 msgid ", 64-bit edition"
 msgstr "，64 位元版"
 
@@ -6261,46 +6249,46 @@ msgstr "無法創建匿名管道"
 msgid "Failed to redirect the child process IO"
 msgstr "重新導向子程序的「輸入/輸出」失敗"
 
-#: ../src/msw/utilsexc.cpp:873
+#: ../src/msw/utilsexc.cpp:871
 #, c-format
 msgid "Execution of command '%s' failed"
 msgstr "'%s' 指令執行失敗"
 
-#: ../src/msw/volume.cpp:335
+#: ../src/msw/volume.cpp:333
 msgid "Failed to load mpr.dll."
 msgstr "無法載入 mpr.dll。"
 
-#: ../src/msw/volume.cpp:515
+#: ../src/msw/volume.cpp:506
 #, c-format
 msgid "Cannot read typename from '%s'!"
 msgstr "無法從 ”%s” 讀取類型名稱！"
 
-#: ../src/msw/volume.cpp:627
+#: ../src/msw/volume.cpp:618
 #, c-format
 msgid "Cannot load icon from '%s'."
 msgstr "無法從 '%s' 載入圖示。"
 
-#: ../src/msw/webview_ie.cpp:998
+#: ../src/msw/webview_ie.cpp:1000
 msgid "Failed to find web view emulation level in the registry"
 msgstr "無法在登錄檔尋找網頁檢視模擬等級"
 
-#: ../src/msw/webview_ie.cpp:1007
+#: ../src/msw/webview_ie.cpp:1009
 msgid "Failed to set web view to modern emulation level"
 msgstr "無法設定網頁檢視至現代模擬等級"
 
-#: ../src/msw/webview_ie.cpp:1015
+#: ../src/msw/webview_ie.cpp:1017
 msgid "Failed to reset web view to standard emulation level"
 msgstr "無法重設網頁檢視至標準模擬等級"
 
-#: ../src/msw/webview_ie.cpp:1037
+#: ../src/msw/webview_ie.cpp:1039
 msgid "Can't run JavaScript script without a valid HTML document"
 msgstr "需要有效 HTML 文件才能執行 JavaScript 文稿"
 
-#: ../src/msw/webview_ie.cpp:1044
+#: ../src/msw/webview_ie.cpp:1046
 msgid "Can't get the JavaScript object"
 msgstr "無法取得 JavaScript 物件"
 
-#: ../src/msw/webview_ie.cpp:1058
+#: ../src/msw/webview_ie.cpp:1060
 msgid "failed to evaluate"
 msgstr "無法評估"
 
@@ -6333,7 +6321,7 @@ msgid "Check to make the font italic."
 msgstr "勾選後可設定為斜體。"
 
 #. TRANSLATORS: Label of underlined font
-#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:601
+#: ../src/osx/carbon/fontdlg.cpp:366 ../src/propgrid/advprops.cpp:599
 #: ../src/richtext/richtextfontpage.cpp:359
 msgid "Underlined"
 msgstr "加底線"
@@ -6400,15 +6388,33 @@ msgstr "<任何打字字體>"
 msgid "File type:"
 msgstr "檔案類型："
 
-#: ../src/osx/cocoa/menu.mm:281
+#: ../src/osx/cocoa/menu.mm:243
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Window"
+msgstr "視窗"
+
+#: ../src/osx/cocoa/menu.mm:260
+#, fuzzy
+msgctxt "macOS menu name"
+msgid "Help"
+msgstr "說明"
+
+#: ../src/osx/cocoa/menu.mm:299
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Minimize"
 msgstr "最小化(&N)"
 
-#: ../src/osx/cocoa/menu.mm:286
+#: ../src/osx/cocoa/menu.mm:304
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Zoom"
 msgstr "縮放"
 
-#: ../src/osx/cocoa/menu.mm:292
+#: ../src/osx/cocoa/menu.mm:310
+#, fuzzy
+msgctxt "macOS menu item"
 msgid "Bring All to Front"
 msgstr "全部放置最上層"
 
@@ -6425,461 +6431,461 @@ msgstr "'%s' 字型檔案不存在。"
 #: ../src/osx/fontutil.cpp:89
 #, c-format
 msgid ""
-"Font file \"%s\" cannot be used as it is not inside the font directory \"%s"
-"\"."
+"Font file \"%s\" cannot be used as it is not inside the font directory "
+"\"%s\"."
 msgstr "'%s' 字型檔因為不在' %s' 字型目錄內而無法使用。"
 
-#: ../src/osx/menu_osx.cpp:491
+#: ../src/osx/menu_osx.cpp:496
 #, c-format
 msgctxt "macOS menu item"
 msgid "About %s"
 msgstr "關於 %s"
 
-#: ../src/osx/menu_osx.cpp:494
+#: ../src/osx/menu_osx.cpp:499
 msgctxt "macOS menu item"
 msgid "About..."
 msgstr "關於..."
 
-#: ../src/osx/menu_osx.cpp:502
+#: ../src/osx/menu_osx.cpp:507
 msgctxt "macOS menu item"
 msgid "Preferences..."
 msgstr "喜好設定..."
 
-#: ../src/osx/menu_osx.cpp:507
+#: ../src/osx/menu_osx.cpp:512
 msgctxt "macOS menu item"
 msgid "Services"
 msgstr "服務"
 
-#: ../src/osx/menu_osx.cpp:514
+#: ../src/osx/menu_osx.cpp:519
 #, c-format
 msgctxt "macOS menu item"
 msgid "Hide %s"
 msgstr "隱藏 %s"
 
-#: ../src/osx/menu_osx.cpp:517
+#: ../src/osx/menu_osx.cpp:522
 msgctxt "macOS menu item"
 msgid "Hide Application"
 msgstr "隱藏應用程式"
 
-#: ../src/osx/menu_osx.cpp:520
+#: ../src/osx/menu_osx.cpp:525
 msgctxt "macOS menu item"
 msgid "Hide Others"
 msgstr "隱藏其他"
 
-#: ../src/osx/menu_osx.cpp:522
+#: ../src/osx/menu_osx.cpp:527
 msgctxt "macOS menu item"
 msgid "Show All"
 msgstr "全部顯示"
 
-#: ../src/osx/menu_osx.cpp:528
+#: ../src/osx/menu_osx.cpp:533
 #, c-format
 msgctxt "macOS menu item"
 msgid "Quit %s"
 msgstr "結束 %s"
 
-#: ../src/osx/menu_osx.cpp:531
+#: ../src/osx/menu_osx.cpp:536
 msgctxt "macOS menu item"
 msgid "Quit Application"
 msgstr "結束應用程式"
 
-#: ../src/osx/webview_webkit.mm:285
+#: ../src/osx/webview_webkit.mm:316
 msgid "Printing is not supported by the system web control"
 msgstr "系統網頁控制元件不支援列印"
 
-#: ../src/osx/webview_webkit.mm:294
+#: ../src/osx/webview_webkit.mm:325
 msgid "Print operation could not be initialized"
 msgstr "無法初始化列印作業"
 
 #. TRANSLATORS: Label of font point size
-#: ../src/propgrid/advprops.cpp:573
+#: ../src/propgrid/advprops.cpp:571
 msgid "Point Size"
 msgstr "字點大小"
 
 #. TRANSLATORS: Label of font face name
-#: ../src/propgrid/advprops.cpp:583
+#: ../src/propgrid/advprops.cpp:581
 msgid "Face Name"
 msgstr "字體名稱"
 
 #. TRANSLATORS: Label of font style
-#: ../src/propgrid/advprops.cpp:591 ../src/richtext/richtextformatdlg.cpp:332
+#: ../src/propgrid/advprops.cpp:589 ../src/richtext/richtextformatdlg.cpp:332
 msgid "Style"
 msgstr "樣式"
 
 #. TRANSLATORS: Label of font weight
-#: ../src/propgrid/advprops.cpp:596
+#: ../src/propgrid/advprops.cpp:594
 msgid "Weight"
 msgstr "粗細"
 
 #. TRANSLATORS: Label of font family
-#: ../src/propgrid/advprops.cpp:605
+#: ../src/propgrid/advprops.cpp:603
 msgid "Family"
 msgstr "字族"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:774
+#: ../src/propgrid/advprops.cpp:770
 msgid "AppWorkspace"
 msgstr "AppWorkspace"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:775
+#: ../src/propgrid/advprops.cpp:771
 msgid "ActiveBorder"
 msgstr "有效邊框"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:776
+#: ../src/propgrid/advprops.cpp:772
 msgid "ActiveCaption"
 msgstr "有效標題"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:777
+#: ../src/propgrid/advprops.cpp:773
 msgid "ButtonFace"
 msgstr "按鈕正面"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:778
+#: ../src/propgrid/advprops.cpp:774
 msgid "ButtonHighlight"
 msgstr "按鈕反白"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:779
+#: ../src/propgrid/advprops.cpp:775
 msgid "ButtonShadow"
 msgstr "按鈕陰影"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:780
+#: ../src/propgrid/advprops.cpp:776
 msgid "ButtonText"
 msgstr "按鈕文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:781
+#: ../src/propgrid/advprops.cpp:777
 msgid "CaptionText"
 msgstr "CaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:782
+#: ../src/propgrid/advprops.cpp:778
 msgid "ControlDark"
 msgstr "ControlDark"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:783
+#: ../src/propgrid/advprops.cpp:779
 msgid "ControlLight"
 msgstr "ControlLight"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:785
+#: ../src/propgrid/advprops.cpp:781
 msgid "GrayText"
 msgstr "灰階文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:786
+#: ../src/propgrid/advprops.cpp:782
 msgid "Highlight"
 msgstr "反白"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:787
+#: ../src/propgrid/advprops.cpp:783
 msgid "HighlightText"
 msgstr "反白文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:788
+#: ../src/propgrid/advprops.cpp:784
 msgid "InactiveBorder"
 msgstr "InactiveBorder"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:789
+#: ../src/propgrid/advprops.cpp:785
 msgid "InactiveCaption"
 msgstr "InactiveCaption"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:790
+#: ../src/propgrid/advprops.cpp:786
 msgid "InactiveCaptionText"
 msgstr "InactiveCaptionText"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:791
+#: ../src/propgrid/advprops.cpp:787
 msgid "Menu"
 msgstr "選單"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:792
+#: ../src/propgrid/advprops.cpp:788
 msgid "Scrollbar"
 msgstr "Scrollbar"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:793
+#: ../src/propgrid/advprops.cpp:789
 msgid "Tooltip"
 msgstr "工具提示"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:794
+#: ../src/propgrid/advprops.cpp:790
 msgid "TooltipText"
 msgstr "工具提示文字"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:795
+#: ../src/propgrid/advprops.cpp:791
 msgid "Window"
 msgstr "視窗"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:796
+#: ../src/propgrid/advprops.cpp:792
 msgid "WindowFrame"
 msgstr "視窗框"
 
 #. TRANSLATORS: Keyword of system colour
-#: ../src/propgrid/advprops.cpp:797
+#: ../src/propgrid/advprops.cpp:793
 msgid "WindowText"
 msgstr "視窗文字"
 
 #. TRANSLATORS: Custom colour choice entry
-#: ../src/propgrid/advprops.cpp:798 ../src/propgrid/advprops.cpp:1476
-#: ../src/propgrid/advprops.cpp:1519
+#: ../src/propgrid/advprops.cpp:794 ../src/propgrid/advprops.cpp:1468
+#: ../src/propgrid/advprops.cpp:1511
 msgid "Custom"
 msgstr "自訂"
 
-#: ../src/propgrid/advprops.cpp:1501
+#: ../src/propgrid/advprops.cpp:1493
 msgid "Black"
 msgstr "黑色"
 
-#: ../src/propgrid/advprops.cpp:1502
+#: ../src/propgrid/advprops.cpp:1494
 msgid "Maroon"
 msgstr "栗子色"
 
-#: ../src/propgrid/advprops.cpp:1503
+#: ../src/propgrid/advprops.cpp:1495
 msgid "Navy"
 msgstr "海軍藍"
 
-#: ../src/propgrid/advprops.cpp:1504
+#: ../src/propgrid/advprops.cpp:1496
 msgid "Purple"
 msgstr "紫色"
 
-#: ../src/propgrid/advprops.cpp:1505
+#: ../src/propgrid/advprops.cpp:1497
 msgid "Teal"
 msgstr "鴨綠色"
 
-#: ../src/propgrid/advprops.cpp:1506
+#: ../src/propgrid/advprops.cpp:1498
 msgid "Gray"
 msgstr "灰色"
 
-#: ../src/propgrid/advprops.cpp:1507
+#: ../src/propgrid/advprops.cpp:1499
 msgid "Green"
 msgstr "綠色"
 
-#: ../src/propgrid/advprops.cpp:1508
+#: ../src/propgrid/advprops.cpp:1500
 msgid "Olive"
 msgstr "橄欖色"
 
-#: ../src/propgrid/advprops.cpp:1509
+#: ../src/propgrid/advprops.cpp:1501
 msgid "Brown"
 msgstr "梡色"
 
-#: ../src/propgrid/advprops.cpp:1510
+#: ../src/propgrid/advprops.cpp:1502
 msgid "Blue"
 msgstr "藍色"
 
-#: ../src/propgrid/advprops.cpp:1511
+#: ../src/propgrid/advprops.cpp:1503
 msgid "Fuchsia"
 msgstr "紫紅色"
 
-#: ../src/propgrid/advprops.cpp:1512
+#: ../src/propgrid/advprops.cpp:1504
 msgid "Red"
 msgstr "紅色"
 
-#: ../src/propgrid/advprops.cpp:1513
+#: ../src/propgrid/advprops.cpp:1505
 msgid "Orange"
 msgstr "橙色"
 
-#: ../src/propgrid/advprops.cpp:1514
+#: ../src/propgrid/advprops.cpp:1506
 msgid "Silver"
 msgstr "銀色"
 
-#: ../src/propgrid/advprops.cpp:1515
+#: ../src/propgrid/advprops.cpp:1507
 msgid "Lime"
 msgstr "青檸色"
 
-#: ../src/propgrid/advprops.cpp:1516
+#: ../src/propgrid/advprops.cpp:1508
 msgid "Aqua"
 msgstr "水藍色"
 
-#: ../src/propgrid/advprops.cpp:1517
+#: ../src/propgrid/advprops.cpp:1509
 msgid "Yellow"
 msgstr "黃色"
 
-#: ../src/propgrid/advprops.cpp:1518
+#: ../src/propgrid/advprops.cpp:1510
 msgid "White"
 msgstr "白色"
 
-#: ../src/propgrid/advprops.cpp:1654
+#: ../src/propgrid/advprops.cpp:1642
 msgctxt "system cursor name"
 msgid "Default"
 msgstr "預設名"
 
-#: ../src/propgrid/advprops.cpp:1655
+#: ../src/propgrid/advprops.cpp:1643
 msgctxt "system cursor name"
 msgid "Arrow"
 msgstr "箭頭"
 
-#: ../src/propgrid/advprops.cpp:1656
+#: ../src/propgrid/advprops.cpp:1644
 msgctxt "system cursor name"
 msgid "Right Arrow"
 msgstr "右箭頭"
 
-#: ../src/propgrid/advprops.cpp:1657
+#: ../src/propgrid/advprops.cpp:1645
 msgctxt "system cursor name"
 msgid "Blank"
 msgstr "空白"
 
-#: ../src/propgrid/advprops.cpp:1658
+#: ../src/propgrid/advprops.cpp:1646
 msgctxt "system cursor name"
 msgid "Bullseye"
 msgstr "標靶"
 
-#: ../src/propgrid/advprops.cpp:1659
+#: ../src/propgrid/advprops.cpp:1647
 msgctxt "system cursor name"
 msgid "Character"
 msgstr "字元"
 
-#: ../src/propgrid/advprops.cpp:1660
+#: ../src/propgrid/advprops.cpp:1648
 msgctxt "system cursor name"
 msgid "Cross"
 msgstr "十字"
 
-#: ../src/propgrid/advprops.cpp:1661
+#: ../src/propgrid/advprops.cpp:1649
 msgctxt "system cursor name"
 msgid "Hand"
 msgstr "處理"
 
-#: ../src/propgrid/advprops.cpp:1662
+#: ../src/propgrid/advprops.cpp:1650
 msgctxt "system cursor name"
 msgid "I-Beam"
 msgstr "工字"
 
-#: ../src/propgrid/advprops.cpp:1663
+#: ../src/propgrid/advprops.cpp:1651
 msgctxt "system cursor name"
 msgid "Left Button"
 msgstr "左鍵"
 
-#: ../src/propgrid/advprops.cpp:1664
+#: ../src/propgrid/advprops.cpp:1652
 msgctxt "system cursor name"
 msgid "Magnifier"
 msgstr "放大鏡"
 
-#: ../src/propgrid/advprops.cpp:1665
+#: ../src/propgrid/advprops.cpp:1653
 msgctxt "system cursor name"
 msgid "Middle Button"
 msgstr "中鍵"
 
-#: ../src/propgrid/advprops.cpp:1666
+#: ../src/propgrid/advprops.cpp:1654
 msgctxt "system cursor name"
 msgid "No Entry"
 msgstr "禁止入內"
 
-#: ../src/propgrid/advprops.cpp:1667
+#: ../src/propgrid/advprops.cpp:1655
 msgctxt "system cursor name"
 msgid "Paint Brush"
 msgstr "筆刷"
 
-#: ../src/propgrid/advprops.cpp:1668
+#: ../src/propgrid/advprops.cpp:1656
 msgctxt "system cursor name"
 msgid "Pencil"
 msgstr "鉛筆"
 
-#: ../src/propgrid/advprops.cpp:1669
+#: ../src/propgrid/advprops.cpp:1657
 msgctxt "system cursor name"
 msgid "Point Left"
 msgstr "向左指"
 
-#: ../src/propgrid/advprops.cpp:1670
+#: ../src/propgrid/advprops.cpp:1658
 msgctxt "system cursor name"
 msgid "Point Right"
 msgstr "向右指"
 
-#: ../src/propgrid/advprops.cpp:1671
+#: ../src/propgrid/advprops.cpp:1659
 msgctxt "system cursor name"
 msgid "Question Arrow"
 msgstr "問題箭頭"
 
-#: ../src/propgrid/advprops.cpp:1672
+#: ../src/propgrid/advprops.cpp:1660
 msgctxt "system cursor name"
 msgid "Right Button"
 msgstr "右鍵"
 
-#: ../src/propgrid/advprops.cpp:1673
+#: ../src/propgrid/advprops.cpp:1661
 msgctxt "system cursor name"
 msgid "Sizing NE-SW"
 msgstr "縮放 (東北至西南)"
 
-#: ../src/propgrid/advprops.cpp:1674
+#: ../src/propgrid/advprops.cpp:1662
 msgctxt "system cursor name"
 msgid "Sizing N-S"
 msgstr "縮放 (南至北)"
 
-#: ../src/propgrid/advprops.cpp:1675
+#: ../src/propgrid/advprops.cpp:1663
 msgctxt "system cursor name"
 msgid "Sizing NW-SE"
 msgstr "縮放 (東南至西北)"
 
-#: ../src/propgrid/advprops.cpp:1676
+#: ../src/propgrid/advprops.cpp:1664
 msgctxt "system cursor name"
 msgid "Sizing W-E"
 msgstr "縮放 (東至西)"
 
-#: ../src/propgrid/advprops.cpp:1677
+#: ../src/propgrid/advprops.cpp:1665
 msgctxt "system cursor name"
 msgid "Sizing"
 msgstr "縮放"
 
-#: ../src/propgrid/advprops.cpp:1678
+#: ../src/propgrid/advprops.cpp:1666
 msgctxt "system cursor name"
 msgid "Spraycan"
 msgstr "噴漆"
 
-#: ../src/propgrid/advprops.cpp:1679
+#: ../src/propgrid/advprops.cpp:1667
 msgctxt "system cursor name"
 msgid "Wait"
 msgstr "等待"
 
-#: ../src/propgrid/advprops.cpp:1680
+#: ../src/propgrid/advprops.cpp:1668
 msgctxt "system cursor name"
 msgid "Watch"
 msgstr "計時"
 
-#: ../src/propgrid/advprops.cpp:1681
+#: ../src/propgrid/advprops.cpp:1669
 msgctxt "system cursor name"
 msgid "Wait Arrow"
 msgstr "等待箭頭"
 
-#: ../src/propgrid/advprops.cpp:2053
+#: ../src/propgrid/advprops.cpp:2024
 msgid "Make a selection:"
 msgstr "請選擇："
 
-#: ../src/propgrid/manager.cpp:405
+#: ../src/propgrid/manager.cpp:401
 msgid "Property"
 msgstr "屬性"
 
-#: ../src/propgrid/manager.cpp:406
+#: ../src/propgrid/manager.cpp:402
 msgid "Value"
 msgstr "值"
 
-#: ../src/propgrid/manager.cpp:1701
+#: ../src/propgrid/manager.cpp:1691
 msgid "Categorized Mode"
 msgstr "分類化模式"
 
-#: ../src/propgrid/manager.cpp:1727
+#: ../src/propgrid/manager.cpp:1717
 msgid "Alphabetic Mode"
 msgstr "字母順序模式"
 
 #. TRANSLATORS: Name of Boolean false value
-#: ../src/propgrid/propgrid.cpp:197
+#: ../src/propgrid/propgrid.cpp:208
 msgid "False"
 msgstr "假"
 
 #. TRANSLATORS: Name of Boolean true value
-#: ../src/propgrid/propgrid.cpp:199
+#: ../src/propgrid/propgrid.cpp:210
 msgid "True"
 msgstr "真"
 
 #. TRANSLATORS: Text  displayed for unspecified value
-#: ../src/propgrid/propgrid.cpp:381
+#: ../src/propgrid/propgrid.cpp:396
 msgid "Unspecified"
 msgstr "未指定"
 
@@ -6892,48 +6898,48 @@ msgstr "屬性錯誤"
 msgid "You have entered invalid value. Press ESC to cancel editing."
 msgstr "輸入了無效的值，按 ESC 以取消編輯。"
 
-#: ../src/propgrid/propgrid.cpp:6650
+#: ../src/propgrid/propgrid.cpp:6577
 #, c-format
 msgid "Error in resource: %s"
 msgstr "資源錯誤：%s"
 
-#: ../src/propgrid/propgridiface.cpp:379
+#: ../src/propgrid/propgridiface.cpp:377
 #, c-format
 msgid ""
 "Type operation \"%s\" failed: Property labeled \"%s\" is of type \"%s\", NOT "
 "\"%s\"."
 msgstr "類型操作 “%s” 失敗：標示為 “%s” 的屬性是 “%s” 類型，而非 “%s”。"
 
-#: ../src/propgrid/props.cpp:155
+#: ../src/propgrid/props.cpp:156
 #, c-format
 msgid "Unknown base %d. Base 10 will be used."
 msgstr "未知 Base %d。將使用 Base 10。"
 
-#: ../src/propgrid/props.cpp:309
+#: ../src/propgrid/props.cpp:306
 #, c-format
 msgid "Value must be %s or higher."
 msgstr "值必須大於或等於 %s。"
 
-#: ../src/propgrid/props.cpp:314 ../src/propgrid/props.cpp:341
+#: ../src/propgrid/props.cpp:311 ../src/propgrid/props.cpp:338
 #, c-format
 msgid "Value must be between %s and %s."
 msgstr "值必須介於 %s 和 %s 之間。"
 
-#: ../src/propgrid/props.cpp:336
+#: ../src/propgrid/props.cpp:333
 #, c-format
 msgid "Value must be %s or less."
 msgstr "值必須小於或等於 %s。"
 
-#: ../src/propgrid/props.cpp:1114
+#: ../src/propgrid/props.cpp:1093
 #, c-format
 msgid "Not %s"
 msgstr "非 %s"
 
-#: ../src/propgrid/props.cpp:1901
+#: ../src/propgrid/props.cpp:1866
 msgid "Choose a directory:"
 msgstr "選擇目錄："
 
-#: ../src/propgrid/props.cpp:2196
+#: ../src/propgrid/props.cpp:2151
 msgid "Choose a file"
 msgstr "選擇檔案"
 
@@ -7400,117 +7406,117 @@ msgstr "內縮"
 msgid "Outset"
 msgstr "外貼"
 
-#: ../src/richtext/richtextbuffer.cpp:3522
+#: ../src/richtext/richtextbuffer.cpp:3519
 msgid "Change Style"
 msgstr "變更樣式"
 
-#: ../src/richtext/richtextbuffer.cpp:3705
+#: ../src/richtext/richtextbuffer.cpp:3702
 msgid "Change Object Style"
 msgstr "變更物件樣式"
 
-#: ../src/richtext/richtextbuffer.cpp:3978
-#: ../src/richtext/richtextbuffer.cpp:8174
+#: ../src/richtext/richtextbuffer.cpp:3975
+#: ../src/richtext/richtextbuffer.cpp:8175
 msgid "Change Properties"
 msgstr "變更屬性"
 
-#: ../src/richtext/richtextbuffer.cpp:4350
+#: ../src/richtext/richtextbuffer.cpp:4347
 msgid "Change List Style"
 msgstr "變更清單樣式"
 
-#: ../src/richtext/richtextbuffer.cpp:4523
+#: ../src/richtext/richtextbuffer.cpp:4520
 msgid "Renumber List"
 msgstr "重新編號清單"
 
-#: ../src/richtext/richtextbuffer.cpp:7867
-#: ../src/richtext/richtextbuffer.cpp:7897
-#: ../src/richtext/richtextbuffer.cpp:7939
-#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1495
+#: ../src/richtext/richtextbuffer.cpp:7868
+#: ../src/richtext/richtextbuffer.cpp:7898
+#: ../src/richtext/richtextbuffer.cpp:7940
+#: ../src/richtext/richtextctrl.cpp:1287 ../src/richtext/richtextctrl.cpp:1481
 msgid "Insert Text"
 msgstr "插入文字"
 
-#: ../src/richtext/richtextbuffer.cpp:8023
-#: ../src/richtext/richtextbuffer.cpp:8983
+#: ../src/richtext/richtextbuffer.cpp:8024
+#: ../src/richtext/richtextbuffer.cpp:8982
 msgid "Insert Image"
 msgstr "插入圖片"
 
-#: ../src/richtext/richtextbuffer.cpp:8070
+#: ../src/richtext/richtextbuffer.cpp:8071
 msgid "Insert Object"
 msgstr "插入物件"
 
-#: ../src/richtext/richtextbuffer.cpp:8112
+#: ../src/richtext/richtextbuffer.cpp:8113
 msgid "Insert Field"
 msgstr "插入欄位"
 
-#: ../src/richtext/richtextbuffer.cpp:8410
+#: ../src/richtext/richtextbuffer.cpp:8411
 msgid "Too many EndStyle calls!"
 msgstr "調用 EndStyle 太多次！"
 
-#: ../src/richtext/richtextbuffer.cpp:8785
+#: ../src/richtext/richtextbuffer.cpp:8786
 msgid "files"
 msgstr "檔案"
 
-#: ../src/richtext/richtextbuffer.cpp:9386
+#: ../src/richtext/richtextbuffer.cpp:9383
 msgid "standard/circle"
 msgstr "標準/圓形"
 
-#: ../src/richtext/richtextbuffer.cpp:9387
+#: ../src/richtext/richtextbuffer.cpp:9384
 msgid "standard/circle-outline"
 msgstr "標準/圓框"
 
-#: ../src/richtext/richtextbuffer.cpp:9388
+#: ../src/richtext/richtextbuffer.cpp:9385
 msgid "standard/square"
 msgstr "標準/方形"
 
-#: ../src/richtext/richtextbuffer.cpp:9389
+#: ../src/richtext/richtextbuffer.cpp:9386
 msgid "standard/diamond"
 msgstr "標準/菱形"
 
-#: ../src/richtext/richtextbuffer.cpp:9390
+#: ../src/richtext/richtextbuffer.cpp:9387
 msgid "standard/triangle"
 msgstr "標準/三角形"
 
-#: ../src/richtext/richtextbuffer.cpp:9429
+#: ../src/richtext/richtextbuffer.cpp:9426
 msgid "Box Properties"
 msgstr "文字方塊屬性"
 
-#: ../src/richtext/richtextbuffer.cpp:10012
+#: ../src/richtext/richtextbuffer.cpp:10009
 msgid "Multiple Cell Properties"
 msgstr "儲存格屬性 (多個)"
 
-#: ../src/richtext/richtextbuffer.cpp:10014
+#: ../src/richtext/richtextbuffer.cpp:10011
 msgid "Cell Properties"
 msgstr "儲存格屬性"
 
-#: ../src/richtext/richtextbuffer.cpp:11265
+#: ../src/richtext/richtextbuffer.cpp:11262
 msgid "Set Cell Style"
 msgstr "設定儲存格樣式"
 
-#: ../src/richtext/richtextbuffer.cpp:11339
+#: ../src/richtext/richtextbuffer.cpp:11336
 msgid "Delete Row"
 msgstr "刪除橫列"
 
-#: ../src/richtext/richtextbuffer.cpp:11389
+#: ../src/richtext/richtextbuffer.cpp:11386
 msgid "Delete Column"
 msgstr "刪除欄位"
 
-#: ../src/richtext/richtextbuffer.cpp:11440
+#: ../src/richtext/richtextbuffer.cpp:11437
 msgid "Add Row"
 msgstr "加入橫列"
 
-#: ../src/richtext/richtextbuffer.cpp:11503
+#: ../src/richtext/richtextbuffer.cpp:11500
 msgid "Add Column"
 msgstr "加入欄位"
 
-#: ../src/richtext/richtextbuffer.cpp:11546
+#: ../src/richtext/richtextbuffer.cpp:11543
 msgid "Table Properties"
 msgstr "表格屬性"
 
-#: ../src/richtext/richtextbuffer.cpp:12909
+#: ../src/richtext/richtextbuffer.cpp:12906
 msgid "Picture Properties"
 msgstr "圖片屬性"
 
-#: ../src/richtext/richtextbuffer.cpp:13179
-#: ../src/richtext/richtextbuffer.cpp:13289
+#: ../src/richtext/richtextbuffer.cpp:13176
+#: ../src/richtext/richtextbuffer.cpp:13286
 msgid "image"
 msgstr "影像"
 
@@ -7718,24 +7724,24 @@ msgstr "~"
 msgid "Drag"
 msgstr "拖曳"
 
-#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1585
+#: ../src/richtext/richtextctrl.cpp:1346 ../src/richtext/richtextctrl.cpp:1567
 msgid "Delete Text"
 msgstr "刪除文字"
 
-#: ../src/richtext/richtextctrl.cpp:1563
+#: ../src/richtext/richtextctrl.cpp:1545
 msgid "Remove Bullet"
 msgstr "移除項目符號"
 
-#: ../src/richtext/richtextctrl.cpp:3099
+#: ../src/richtext/richtextctrl.cpp:3075
 msgid "The text couldn't be saved."
 msgstr "無法儲存文字。"
 
-#: ../src/richtext/richtextctrl.cpp:3674
+#: ../src/richtext/richtextctrl.cpp:3650
 msgid "Replace"
 msgstr "更改"
 
 #: ../src/richtext/richtextfontpage.cpp:147
-#: ../src/richtext/richtextsymboldlg.cpp:397
+#: ../src/richtext/richtextsymboldlg.cpp:385
 msgid "&Font:"
 msgstr "字型(&F)："
 
@@ -8704,53 +8710,53 @@ msgstr "清單樣式"
 msgid "Box styles"
 msgstr "文字方塊樣式"
 
-#: ../src/richtext/richtextsymboldlg.cpp:402
-#: ../src/richtext/richtextsymboldlg.cpp:404
+#: ../src/richtext/richtextsymboldlg.cpp:390
+#: ../src/richtext/richtextsymboldlg.cpp:392
 msgid "The font from which to take the symbol."
 msgstr "符號使用該字型。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:410
+#: ../src/richtext/richtextsymboldlg.cpp:397
 msgid "&Subset:"
 msgstr "子集合(&S):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:418
-#: ../src/richtext/richtextsymboldlg.cpp:420
+#: ../src/richtext/richtextsymboldlg.cpp:402
+#: ../src/richtext/richtextsymboldlg.cpp:404
 msgid "Shows a Unicode subset."
 msgstr "顯示 Unicode 子集。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:431
+#: ../src/richtext/richtextsymboldlg.cpp:413
 msgid "xxxx"
 msgstr "xxxx"
 
-#: ../src/richtext/richtextsymboldlg.cpp:436
+#: ../src/richtext/richtextsymboldlg.cpp:418
 msgid "&Character code:"
 msgstr "字元碼(&C):"
 
-#: ../src/richtext/richtextsymboldlg.cpp:440
-#: ../src/richtext/richtextsymboldlg.cpp:442
+#: ../src/richtext/richtextsymboldlg.cpp:422
+#: ../src/richtext/richtextsymboldlg.cpp:424
 msgid "The character code."
 msgstr "字元碼。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:448
+#: ../src/richtext/richtextsymboldlg.cpp:429
 msgid "&From:"
 msgstr "從(&F)："
 
-#: ../src/richtext/richtextsymboldlg.cpp:456
-#: ../src/richtext/richtextsymboldlg.cpp:457
-#: ../src/richtext/richtextsymboldlg.cpp:458
+#: ../src/richtext/richtextsymboldlg.cpp:434
+#: ../src/richtext/richtextsymboldlg.cpp:435
+#: ../src/richtext/richtextsymboldlg.cpp:436
 msgid "Unicode"
 msgstr "萬國碼(Unicode)"
 
-#: ../src/richtext/richtextsymboldlg.cpp:459
-#: ../src/richtext/richtextsymboldlg.cpp:461
+#: ../src/richtext/richtextsymboldlg.cpp:437
+#: ../src/richtext/richtextsymboldlg.cpp:439
 msgid "The range to show."
 msgstr "顯示範圍。"
 
-#: ../src/richtext/richtextsymboldlg.cpp:469
+#: ../src/richtext/richtextsymboldlg.cpp:445
 msgid "Insert"
 msgstr "插入"
 
-#: ../src/richtext/richtextsymboldlg.cpp:503
+#: ../src/richtext/richtextsymboldlg.cpp:479
 msgid "(Normal text)"
 msgstr "(正常文字)"
 
@@ -8934,7 +8940,7 @@ msgstr "無法從 kqueue 取得事件"
 msgid "Media playback error: %s"
 msgstr "媒體播放出錯：%s"
 
-#: ../src/unix/mediactrl.cpp:1234
+#: ../src/unix/mediactrl.cpp:1229
 #, c-format
 msgid "Failed to prepare playing \"%s\"."
 msgstr "無法準備以播放 “%s”。"
@@ -9034,77 +9040,77 @@ msgstr "聲音資料格式不支援。"
 msgid "Couldn't open audio: %s"
 msgstr "無法開啟音訊：%s"
 
-#: ../src/unix/threadpsx.cpp:1028
+#: ../src/unix/threadpsx.cpp:1029
 msgid "Cannot retrieve thread scheduling policy."
 msgstr "無法擷取執行緒排程政策。"
 
-#: ../src/unix/threadpsx.cpp:1053
+#: ../src/unix/threadpsx.cpp:1054
 #, c-format
 msgid "Cannot get priority range for scheduling policy %d."
 msgstr "無法取得排程政策 %d 的優先順序範圍。"
 
-#: ../src/unix/threadpsx.cpp:1061
+#: ../src/unix/threadpsx.cpp:1062
 msgid "Thread priority setting is ignored."
 msgstr "忽略執行緒優先順序設定。"
 
-#: ../src/unix/threadpsx.cpp:1216
+#: ../src/unix/threadpsx.cpp:1217
 msgid ""
 "Failed to join a thread, potential memory leak detected - please restart the "
 "program"
 msgstr "無法加入執行緒，偵測到潛在的記憶體流失 - 請重新啟動程式"
 
-#: ../src/unix/threadpsx.cpp:1347
+#: ../src/unix/threadpsx.cpp:1348
 #, c-format
 msgid "Failed to set thread concurrency level to %lu"
 msgstr "無法設定執行緒的同時性等級為 %lu"
 
-#: ../src/unix/threadpsx.cpp:1473
+#: ../src/unix/threadpsx.cpp:1474
 #, c-format
 msgid "Failed to set thread priority %d."
 msgstr "無法設定執行緒的優先等級為 %d。"
 
-#: ../src/unix/threadpsx.cpp:1654
+#: ../src/unix/threadpsx.cpp:1655
 msgid "Failed to terminate a thread."
 msgstr "無法終止執行緒。"
 
-#: ../src/unix/threadpsx.cpp:1875
+#: ../src/unix/threadpsx.cpp:1881
 msgid "Thread module initialization failed: failed to create thread key"
 msgstr "執行緒模組初始化失敗：無法創建執行緒機碼"
 
-#: ../src/unix/utilsunx.cpp:338
+#: ../src/unix/utilsunx.cpp:336
 msgid "Impossible to get child process input"
 msgstr "無法取得子程序的輸入"
 
-#: ../src/unix/utilsunx.cpp:388
+#: ../src/unix/utilsunx.cpp:386
 msgid "Can't write to child process's stdin"
 msgstr "無法寫入子系程序的標準輸入"
 
-#: ../src/unix/utilsunx.cpp:648
+#: ../src/unix/utilsunx.cpp:640
 #, c-format
 msgid "Failed to execute '%s'\n"
 msgstr "無法執行 '%s'\n"
 
-#: ../src/unix/utilsunx.cpp:682
+#: ../src/unix/utilsunx.cpp:674
 msgid "Fork failed"
 msgstr "創建分支失敗"
 
-#: ../src/unix/utilsunx.cpp:705
+#: ../src/unix/utilsunx.cpp:697
 msgid "Failed to set process priority"
 msgstr "無法設定執行緒的優先等級"
 
-#: ../src/unix/utilsunx.cpp:716
+#: ../src/unix/utilsunx.cpp:708
 msgid "Failed to redirect child process input/output"
 msgstr "重新導向子程序的「輸入/輸出」失敗"
 
-#: ../src/unix/utilsunx.cpp:820
+#: ../src/unix/utilsunx.cpp:812
 msgid "Failed to set up non-blocking pipe, the program might hang."
 msgstr "無法設置非阻斷管線，程式也許已經當掉。"
 
-#: ../src/unix/utilsunx.cpp:1028
+#: ../src/unix/utilsunx.cpp:1020
 msgid "Cannot get the hostname"
 msgstr "無法取得主機名稱"
 
-#: ../src/unix/utilsunx.cpp:1064
+#: ../src/unix/utilsunx.cpp:1056
 msgid "Cannot get the official hostname"
 msgstr "無法取得正式的主機名稱"
 
@@ -9120,12 +9126,12 @@ msgstr "無法切換喚醒管線到非阻斷模式"
 msgid "Failed to read from wake-up pipe"
 msgstr "無法從喚醒管線讀取"
 
-#: ../src/x11/app.cpp:127
+#: ../src/x11/app.cpp:126
 #, c-format
 msgid "Invalid geometry specification '%s'"
 msgstr "幾何規格 '%s' 無效"
 
-#: ../src/x11/app.cpp:170
+#: ../src/x11/app.cpp:169
 msgid "wxWidgets could not open display. Exiting."
 msgstr "wxWidgets 無法開啟顯示設備。程式結束中。"
 
@@ -9139,30 +9145,59 @@ msgstr "關閉 “%s” 顯示器時失敗"
 msgid "Failed to open display \"%s\"."
 msgstr "無法開啟顯示 “%s”。"
 
-#: ../src/xml/xml.cpp:925
+#: ../src/xml/xml.cpp:882
 #, c-format
 msgid "XML parsing error: '%s' at line %d"
 msgstr "XML 解析錯誤： '%s' 在第 %d 列"
 
-#: ../src/xrc/xmlres.cpp:418
+#: ../src/xrc/xmlres.cpp:443
 #, c-format
 msgid "Cannot load resources from '%s'."
 msgstr "無法從 '%s' 檔案載入資源。"
 
-#: ../src/xrc/xmlres.cpp:756
+#: ../src/xrc/xmlres.cpp:794
 #, c-format
 msgid "Cannot open resources file '%s'."
 msgstr "無法開啟資源檔 '%s'。"
 
-#: ../src/xrc/xmlres.cpp:774
+#: ../src/xrc/xmlres.cpp:803
 #, c-format
 msgid "Cannot load resources from file '%s'."
 msgstr "無法從 '%s' 檔案載入資源。"
 
-#: ../src/xrc/xmlres.cpp:2744
+#: ../src/xrc/xmlres.cpp:2725
 #, c-format
 msgid "Creating %s \"%s\" failed."
 msgstr "無法創建 %s “%s”。"
+
+#~ msgid "Printing "
+#~ msgstr "正在列印 "
+
+#~ msgid "Failed to insert text in the control."
+#~ msgstr "無法於控制元件插入文字。"
+
+#~ msgid "Please choose a valid font."
+#~ msgstr "請選擇有效字型。"
+
+#, c-format
+#~ msgid "Failed to display HTML document in %s encoding"
+#~ msgstr "無法以 %s 編碼顯示 HTML 文件"
+
+#, c-format
+#~ msgid "wxWidgets could not open display for '%s': exiting."
+#~ msgstr "wxWidgets 無法開啟 ‘%s’ 顯示設備：已經存在。"
+
+#~ msgid "Filter"
+#~ msgstr "篩選器"
+
+#~ msgid "Directories"
+#~ msgstr "目錄"
+
+#~ msgid "Files"
+#~ msgstr "檔案"
+
+#~ msgid "Selection"
+#~ msgstr "選擇"
 
 #~ msgid "conversion to 8-bit encoding failed"
 #~ msgstr "無法轉換成八位元編碼"
@@ -9330,8 +9365,8 @@ msgstr "無法創建 %s “%s”。"
 #~ msgstr "資料渲染器無法渲染該值，型態為: "
 
 #~ msgid ""
-#~ "Do you want to overwrite the command used to %s files with extension \"%s"
-#~ "\" ?\n"
+#~ "Do you want to overwrite the command used to %s files with extension "
+#~ "\"%s\" ?\n"
 #~ "Current value is \n"
 #~ "%s, \n"
 #~ "New value is \n"


### PR DESCRIPTION
At least commit f7d0742715d16a76bf7fbe125484e5dead0754ea added several messages with context. To make use of their translations it is necessary to regenerate wxstd.pot and update all .po files.

This PR updates wxstd.pot and all .po files. Additionally, the translations of the German message catalog have been updated.