### PR TITLE
Add wxWebViewEvent::IsTargetMainFrame()

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -76,6 +76,7 @@ public:
 
     // WebView Events tokens
     EventRegistrationToken m_navigationStartingToken = { };
+    EventRegistrationToken m_frameNavigationStartingToken = { };
     EventRegistrationToken m_sourceChangedToken = { };
     EventRegistrationToken m_navigationCompletedToken = { };
     EventRegistrationToken m_newWindowRequestedToken = { };
@@ -87,6 +88,7 @@ public:
 
     // WebView Event handlers
     HRESULT OnNavigationStarting(ICoreWebView2* sender, ICoreWebView2NavigationStartingEventArgs* args);
+    HRESULT OnFrameNavigationStarting(ICoreWebView2* sender, ICoreWebView2NavigationStartingEventArgs* args);
     HRESULT OnSourceChanged(ICoreWebView2* sender, ICoreWebView2SourceChangedEventArgs* args);
     HRESULT OnNavigationCompleted(ICoreWebView2* sender, ICoreWebView2NavigationCompletedEventArgs* args);
     HRESULT OnNewWindowRequested(ICoreWebView2* sender, ICoreWebView2NewWindowRequestedEventArgs* args);
@@ -99,6 +101,8 @@ public:
 
     HRESULT OnEnvironmentCreated(HRESULT result, ICoreWebView2Environment* environment);
     HRESULT OnWebViewCreated(HRESULT result, ICoreWebView2Controller* webViewController);
+
+    HRESULT HandleNavigationStarting(ICoreWebView2NavigationStartingEventArgs* args, bool mainFrame);
 
     wxVector<wxSharedPtr<wxWebViewHistoryItem> > m_historyList;
     int m_historyPosition;

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -336,6 +336,7 @@ public:
     {}
 
     bool IsError() const { return GetInt() == 0; }
+    bool IsTargetMainFrame() const { return GetInt() == 1; }
 
     const wxString& GetURL() const { return m_url; }
     const wxString& GetTarget() const { return m_target; }

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -1668,6 +1668,16 @@ public:
         @since 3.1.6
     */
     bool IsError() const;
+
+    /**
+        Returns true if the navigation target is the main frame. Only valid
+        for events of type @c wxEVT_WEBVIEW_NAVIGATING
+
+        @note This is only available with the macOS and the Edge backend.
+
+        @since 3.3.0
+    */
+    bool IsTargetMainFrame() const;
 };
 
 

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -897,7 +897,7 @@ void WebFrame::OnNavigationRequest(wxWebViewEvent& evt)
     }
 
     wxLogMessage("%s", "Navigation request to '" + evt.GetURL() + "' (target='" +
-    evt.GetTarget() + "')");
+    evt.GetTarget() + "')" + ((evt.IsTargetMainFrame()) ? " mainFrame" : ""));
 
     //If we don't want to handle navigation then veto the event and navigation
     //will not take place, we also need to stop the loading animation

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -851,6 +851,9 @@ wxString nsErrorToWxHtmlError(NSError* error, wxWebViewNavigationError* out)
                          webKitWindow->GetId(),
                          wxCFStringRef::AsString( url ), "", navFlags);
 
+    if (navigationAction.targetFrame && navigationAction.targetFrame.isMainFrame)
+        event.SetInt(1);
+
     if (webKitWindow && webKitWindow->GetEventHandler())
         webKitWindow->GetEventHandler()->ProcessEvent(event);
 


### PR DESCRIPTION
Allows to determine if a navigation is happening in the main frame or an embedded iframe when handling `wxEVT_WEBVIEW_NAVIGATING`.

Additionally implement previously missing `wxEVT_WEBVIEW_NAVIGATING` events for frames with the Edge backend.