### PR TITLE
Fix wxFLEX_GROWMODE_ALL in wxFlexGridSizer with proportions

### DIFF
--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2104,16 +2104,23 @@ void wxFlexGridSizer::AdjustForGrowables(const wxSize& sz, const wxSize& origina
     }
 #endif // wxDEBUG_LEVEL
 
+    // Use growable columns proportions if we are flexible in this direction.
+    const wxArrayInt* const growableColsProportions =
+        (m_flexDirection & wxHORIZONTAL) || (m_growMode == wxFLEX_GROWMODE_SPECIFIED)
+            ? &m_growableColsProportions
+            : nullptr;
 
-    if ( (m_flexDirection & wxHORIZONTAL) || (m_growMode != wxFLEX_GROWMODE_NONE) )
+    // And do anything at all with the columns if we're either flexible or must
+    // resize all columns uniformly (otherwise we use wxFLEX_GROWMODE_NONE and
+    // there is nothing to do).
+    if ( growableColsProportions || (m_growMode == wxFLEX_GROWMODE_ALL) )
     {
         DoAdjustForGrowables
         (
             sz.x - minSize.x,
             m_growableCols,
             m_colWidths,
-            m_growMode == wxFLEX_GROWMODE_SPECIFIED ? &m_growableColsProportions
-                                                    : nullptr
+            growableColsProportions
         );
 
         // This gives nested objects that benefit from knowing one size
@@ -2141,13 +2148,18 @@ void wxFlexGridSizer::AdjustForGrowables(const wxSize& sz, const wxSize& origina
                 sz.x - minSize.x,
                 m_growableCols,
                 m_colWidths,
-                m_growMode == wxFLEX_GROWMODE_SPECIFIED ? &m_growableColsProportions
-                                                        : nullptr
+                growableColsProportions
             );
         }
     }
 
-    if ( (m_flexDirection & wxVERTICAL) || (m_growMode != wxFLEX_GROWMODE_NONE) )
+    // Same as above but for the rows.
+    const wxArrayInt* const growableRowsProportions =
+        (m_flexDirection & wxVERTICAL) || (m_growMode == wxFLEX_GROWMODE_SPECIFIED)
+            ? &m_growableRowsProportions
+            : nullptr;
+
+    if ( growableRowsProportions || (m_growMode == wxFLEX_GROWMODE_ALL) )
     {
         // pass nullptr instead of proportions if the grow mode is ALL as we
         // should treat all rows as having proportion of 1 then
@@ -2156,8 +2168,7 @@ void wxFlexGridSizer::AdjustForGrowables(const wxSize& sz, const wxSize& origina
             sz.y - minSize.y,
             m_growableRows,
             m_rowHeights,
-            m_growMode == wxFLEX_GROWMODE_SPECIFIED ? &m_growableRowsProportions
-                                                    : nullptr
+            growableRowsProportions
         );
     }
 }

--- a/tests/sizers/gridsizer.cpp
+++ b/tests/sizers/gridsizer.cpp
@@ -179,3 +179,37 @@ TEST_CASE_METHOD(GridSizerTestCase,
         m_sizer->Add(10, 10, wxSizerFlags().Expand().Centre())
     );
 }
+
+TEST_CASE_METHOD(GridSizerTestCase,
+                 "wxGridSizer::GrowMode",
+                 "[grid-sizer][sizer]")
+{
+    wxVector<wxWindow*> children;
+    for ( int n = 0; n < 4; n++ )
+    {
+        children.push_back(new wxWindow(m_win, wxID_ANY));
+    }
+
+    // Proportions of growable columns should be respected.
+    m_sizer->AddGrowableCol(0, 1);
+    m_sizer->AddGrowableCol(1, 4);
+
+    // However proportions of growable rows should not because we use
+    // wxFLEX_GROWMODE_ALL which tells the sizer to grow all rows uniformly.
+    m_sizer->AddGrowableRow(0, 1);
+    m_sizer->AddGrowableRow(1, 4);
+
+    m_sizer->SetFlexibleDirection(wxHORIZONTAL);
+    m_sizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_ALL);
+
+    // Make both dimensions divisible by 5 to avoid dealing with extra pixels.
+    m_win->SetClientSize(100, 100);
+
+    SetChildren(children, wxSizerFlags().Expand());
+
+    // Check that we have different widths but same heights for all children.
+    CHECK( children[0]->GetSize() == wxSize(20, 50) );
+    CHECK( children[1]->GetSize() == wxSize(80, 50) );
+    CHECK( children[2]->GetSize() == wxSize(20, 50) );
+    CHECK( children[3]->GetSize() == wxSize(80, 50) );
+}


### PR DESCRIPTION
Setting wxFLEX_GROWMODE_ALL for the non-flexible direction broke handling of proportions in the flexible direction which were unexpectedly not taken into account at all any more due to not passing them to DoAdjustForGrowables().

Fix this by still respecting the proportions in this case and add a test case to ensure this doesn't get broken again.

Closes #23251.