### PR TITLE
configure.in: Fix sockets/webRequest build error

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5966,6 +5966,12 @@ if test "$wxUSE_FS_INET" = "yes"; then
 fi
 
 if test "$wxUSE_WEBREQUEST" = "yes"; then
+    if test "$wxUSE_SOCKETS" != "yes"; then
+        AC_MSG_WARN(wxWebRequest classes require sockets... disabled)
+        wxUSE_WEBREQUEST=no
+    fi
+fi
+if test "$wxUSE_WEBREQUEST" = "yes"; then
     if test "$wxUSE_LIBCURL" = "yes"; then
         AC_DEFINE(wxUSE_WEBREQUEST_CURL)
         have_webrequest_backend=1


### PR DESCRIPTION
Fix build error when sockets are disabled at configure time but webRequest isn't:
```
wxWidgets-3.2.2/src/common/webrequest_curl.cpp:451:23: error: ‘wxSOCKET_T’ has not been declared
  451 |     bool StartPolling(wxSOCKET_T, int);
      |                       ^~~~~~~~~~
```
Since webrequest requires sockets, it needs to be disabled at configure time when sockets are disabled (the required header is there, so it's not the problem, the problem is that wxUSE_SOCKETS = 0 and the declarations are skipped).
Bug present also at least in 3.2.0 and 3.2.1, as far as I remember (maybe also earlier).
Feel free to modify the message shown to the user.

Configuration that causes the problem to appear follows. It's VeraCrypt (https://veracrypt.fr/en/) and its Makefile that cause the error to appear when called as `make NOGUI=1 WXSTATIC=1 WX_ROOT=/path/to/wxWidgets-3.2.2 wxbuild`.
```
--disable-gui --disable-debug_flag --disable-debug_gdb --disable-debug_info
 --enable-unicode -disable-shared --disable-dependency-tracking
 --enable-exceptions --enable-std_string --enable-dataobj
 --enable-mimetype --disable-protocol --disable-protocols --disable-url --disable-ipc
 --disable-sockets --disable-fs_inet --disable-ole --disable-docview --disable-clipboard
 --disable-help --disable-html --disable-mshtmlhelp --disable-htmlhelp
 --disable-mdi --disable-metafile --disable-webview --disable-xrc --disable-aui
 --disable-postscript --disable-printarch --disable-arcstream --disable-fs_archive
 --disable-fs_zip --disable-tarstream --disable-zipstream --disable-animatectrl
 --disable-bmpcombobox --disable-calendar --disable-caret --disable-checklst
 --disable-collpane --disable-colourpicker --disable-comboctrl --disable-datepick
 --disable-display --disable-dirpicker --disable-filepicker --disable-fontpicker
 --disable-grid --disable-dataviewctrl --disable-listbook --disable-odcombobox
 --disable-sash --disable-searchctrl --disable-slider --disable-splitter
 --disable-togglebtn --disable-toolbar --disable-tbarnative --disable-treebook
 --disable-toolbook --disable-tipwindow --disable-popupwin --disable-commondlg
 --disable-aboutdlg --disable-coldlg --disable-finddlg --disable-fontdlg
 --disable-numberdlg --disable-splash --disable-tipdlg --disable-progressdlg
 --disable-wizarddlg --disable-miniframe --disable-splines --disable-palette
 --disable-richtext --disable-dialupman --disable-debugreport --disable-filesystem
 --disable-rearrangectrl --disable-treelist --disable-richmsgdlg --disable-richtooltip 
 --disable-propgrid --disable-stc --without-libnotify --without-gtkprint
 --without-gnomevfs --disable-fsvolume --disable-fswatcher --disable-sound
 --disable-mediactrl --disable-joystick --disable-apple_ieee --disable-gif
 --disable-pcx --disable-tga --disable-iff --disable-gif --disable-pnm
 --disable-svg --without-expat --without-libtiff --without-libjpeg
 --without-libpng -without-regex --without-zlib
```