### PR TITLE
Use Curl socket type instead of wxSOCKET_T in wxWebRequestCURL

### DIFF
--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -258,8 +258,21 @@ wxWebRequestCURL::wxWebRequestCURL(wxWebSession & session,
     // Enable redirection handling
     curl_easy_setopt(m_handle, CURLOPT_FOLLOWLOCATION, 1L);
     // Limit redirect to HTTP
-    curl_easy_setopt(m_handle, CURLOPT_REDIR_PROTOCOLS,
-        CURLPROTO_HTTP | CURLPROTO_HTTPS);
+    #if CURL_AT_LEAST_VERSION(7, 85, 0)
+    if ( wxWebSessionCURL::CurlRuntimeAtLeastVersion(7, 85, 0) )
+    {
+        curl_easy_setopt(m_handle, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+    }
+    else
+    #endif // curl >= 7.85
+    {
+        wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
+        curl_easy_setopt(m_handle, CURLOPT_REDIR_PROTOCOLS,
+            CURLPROTO_HTTP | CURLPROTO_HTTPS);
+
+        wxGCC_WARNING_RESTORE(deprecated-declarations)
+    }
     // Enable all supported authentication methods
     curl_easy_setopt(m_handle, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
     curl_easy_setopt(m_handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -105,10 +105,16 @@ wxWebResponseCURL::wxWebResponseCURL(wxWebRequestCURL& request) :
         else
     #endif
         {
+            // We know that these constants are deprecated, but we still need
+            // to use them with this old version.
+            wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
             curl_easy_setopt(GetHandle(), CURLOPT_PROGRESSFUNCTION,
                              wxCURLProgress);
             curl_easy_setopt(GetHandle(), CURLOPT_PROGRESSDATA,
                              static_cast<void*>(this));
+
+            wxGCC_WARNING_RESTORE(deprecated-declarations)
         }
 
     // Have curl call the progress callback.


### PR DESCRIPTION
It makes more sense in this curl-specific code and also fixes compilation with wxUSE_SOCKETS==0 as a side effect (see #23256).

No real changes.