### PR TITLE
Add wxSUBRELEASE_NUMBER to wxGetLibraryVersionInfo() if non-zero

### DIFF
--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1377,18 +1377,28 @@ int wxMessageBox(const wxString& message, const wxString& caption, long style,
 
 wxVersionInfo wxGetLibraryVersionInfo()
 {
+    // Only add the last build component to the version if it's non-zero, it's
+    // pretty useless otherwise.
+    wxString ver = wxString::Format
+                   (
+                        wxS("%d.%d.%d"),
+                        wxMAJOR_VERSION,
+                        wxMINOR_VERSION,
+                        wxRELEASE_NUMBER
+                   );
+    if ( wxSUBRELEASE_NUMBER )
+        ver += wxString::Format(wxS(".%d"), wxSUBRELEASE_NUMBER);
+
     // don't translate these strings, they're for diagnostics purposes only
     wxString msg;
     msg.Printf(wxS("wxWidgets Library (%s port)\n")
-               wxS("Version %d.%d.%d (Unicode: %s, debug level: %d),\n")
+               wxS("Version %s (Unicode: %s, debug level: %d),\n")
 #if !wxUSE_REPRODUCIBLE_BUILD
                wxS("compiled at %s %s\n\n")
 #endif
                wxS("Runtime version of toolkit used is %d.%d.\n"),
                wxPlatformInfo::Get().GetPortIdName(),
-               wxMAJOR_VERSION,
-               wxMINOR_VERSION,
-               wxRELEASE_NUMBER,
+               ver,
 #if wxUSE_UNICODE_UTF8
                "UTF-8",
 #else


### PR DESCRIPTION
Keep using just the first three components of the version if wxSUBRELEASE_NUMBER is 0, but do add it to the version if it isn't, to allow distinguishing x.y.z releases from x.y.z.w hot-fixes.