### PR TITLE
Fix painting of wxStaticBox siblings inside it in wxMSW

### DIFF
--- a/include/wx/msw/statbox.h
+++ b/include/wx/msw/statbox.h
@@ -70,6 +70,8 @@ public:
     // returns true if the platform should explicitly apply a theme border
     virtual bool CanApplyThemeBorder() const override { return false; }
 
+    virtual void MSWOnDisabledComposited() override;
+
 protected:
     virtual wxSize DoGetBestSize() const override;
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -553,6 +553,10 @@ public:
     // incompatible with this style.
     void MSWDisableComposited();
 
+    // This function is called for all child windows when compositing is
+    // disabled for their parent.
+    virtual void MSWOnDisabledComposited() { }
+
     // synthesize a wxEVT_LEAVE_WINDOW event and set m_mouseInWindow to false
     void GenerateMouseLeave();
 

--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -1084,10 +1084,9 @@ private:
     // Return true if this particular window is not a child of the static box.
     bool CheckIfNonBoxChild(wxWindow* win) const;
 
-    // Set to 1 if any items _not_ using the associated static box as parent
-    // are added to this sizer, to 0 if there are none and to -1 if we have to
-    // check whether there are any.
-    int m_hasNonBoxChildren = 0;
+    // Set to true if there are any items _not_ using the associated static box
+    // as parent in this sizer (either directly in it or in its child sizers).
+    bool m_hasNonBoxChildren = false;
 
     wxDECLARE_CLASS(wxStaticBoxSizer);
     wxDECLARE_NO_COPY_CLASS(wxStaticBoxSizer);

--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -1077,6 +1077,11 @@ protected:
     virtual wxSizerItem* DoInsert(size_t index, wxSizerItem *item) override;
 
 private:
+    // Set to true if any items _not_ using the associated static box as parent
+    // are added to this sizer: this is still supported for backwards
+    // compatibility but is not recommended.
+    bool m_hasNonBoxChildren = false;
+
     wxDECLARE_CLASS(wxStaticBoxSizer);
     wxDECLARE_NO_COPY_CLASS(wxStaticBoxSizer);
 };

--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -1074,6 +1074,8 @@ public:
 protected:
     wxStaticBox   *m_staticBox;
 
+    virtual wxSizerItem* DoInsert(size_t index, wxSizerItem *item) override;
+
 private:
     wxDECLARE_CLASS(wxStaticBoxSizer);
     wxDECLARE_NO_COPY_CLASS(wxStaticBoxSizer);

--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -1077,10 +1077,17 @@ protected:
     virtual wxSizerItem* DoInsert(size_t index, wxSizerItem *item) override;
 
 private:
-    // Set to true if any items _not_ using the associated static box as parent
-    // are added to this sizer: this is still supported for backwards
-    // compatibility but is not recommended.
-    bool m_hasNonBoxChildren = false;
+    // Return true if we have any by recursively examining all children of this
+    // sizer.
+    bool CheckForNonBoxChildren(wxSizer* sizer) const;
+
+    // Return true if this particular window is not a child of the static box.
+    bool CheckIfNonBoxChild(wxWindow* win) const;
+
+    // Set to 1 if any items _not_ using the associated static box as parent
+    // are added to this sizer, to 0 if there are none and to -1 if we have to
+    // check whether there are any.
+    int m_hasNonBoxChildren = 0;
 
     wxDECLARE_CLASS(wxStaticBoxSizer);
     wxDECLARE_NO_COPY_CLASS(wxStaticBoxSizer);

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -784,6 +784,10 @@ public:
     // needed just for extended runtime
     const wxWindowList& GetWindowChildren() const { return GetChildren() ; }
 
+        // call the specified functor for all children, recursively
+    template <typename T>
+    void CallForEachChild(const T& fn);
+
         // get the window before/after this one in the parents children list,
         // returns nullptr if this is the first/last window
     wxWindow *GetPrevSibling() const { return DoGetSibling(OrderBefore); }
@@ -2055,6 +2059,15 @@ private:
 inline wxWindow *wxWindowBase::GetGrandParent() const
 {
     return m_parent ? m_parent->GetParent() : nullptr;
+}
+
+template <typename T>
+void wxWindowBase::CallForEachChild(const T& fn)
+{
+    fn(static_cast<wxWindow*>(this));
+
+    for ( auto& child : GetChildren() )
+        child->CallForEachChild(fn);
 }
 
 // ----------------------------------------------------------------------------

--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -1943,8 +1943,9 @@ public:
     and will delete it in the wxStaticBoxSizer destructor.
 
     Note that since wxWidgets 2.9.1 you are strongly encouraged to create the windows
-    which are added to wxStaticBoxSizer as children of wxStaticBox itself, see
-    this class documentation for more details.
+    which are added to wxStaticBoxSizer as children of wxStaticBox itself and
+    failure to do so will result in warning messages in debug builds. Please see
+    wxStaticBox documentation for more details.
 
     Example of use of this class:
     @code

--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -1944,8 +1944,12 @@ public:
 
     Note that since wxWidgets 2.9.1 you are strongly encouraged to create the windows
     which are added to wxStaticBoxSizer as children of wxStaticBox itself and
-    failure to do so will result in warning messages in debug builds. Please see
-    wxStaticBox documentation for more details.
+    failure to do so will result in warning messages in debug builds, even if
+    creating them using the static box parent as parent still works too (but
+    note that items using different parents can't be used inside the same
+    sizer, i.e. all of them should be children either of the box itself or of
+    its parent and an assert will be triggered if this is not the case).
+    Please see wxStaticBox documentation for more details.
 
     Example of use of this class:
     @code

--- a/interface/wx/statbox.h
+++ b/interface/wx/statbox.h
@@ -11,14 +11,23 @@
     A static box is a rectangle drawn around other windows to denote
     a logical grouping of items.
 
-    Note that while the previous versions required that windows appearing
-    inside a static box be created as its siblings (i.e. use the same parent as
-    the static box itself), since wxWidgets 2.9.1 it is possible to create
-    them as children of wxStaticBox itself and doing this is strongly
-    recommended and avoids several different repainting problems that could
-    happen when creating the other windows as siblings of the box.
+    Typically wxStaticBox is not used directly, but only via wxStaticBoxSizer
+    class which lays out its elements inside a box.
 
-    So the recommended way to create static box and the controls inside it is:
+    If you do use it directly, please note that while the previous versions
+    required that windows appearing inside a static box be created as its
+    siblings (i.e. use the same parent as the static box itself), since
+    wxWidgets 2.9.1 it is strongly recommended to create them as children of
+    wxStaticBox itself, as doing this avoids problems with repainting that
+    could happen when creating the other windows as siblings of the box.
+    Notably, in wxMSW, siblings of the static box are not drawn at all inside
+    it when compositing is used, which is the case by default, and
+    wxWindow::MSWDisableComposited() must be explicitly called to fix this.
+    Creating windows located inside the static box as its children avoids this
+    problem and works well whether compositing is used or not.
+
+    To summarize, the correct way to create static box and the controls inside
+    it is:
     @code
         void MyFrame::CreateControls()
         {
@@ -29,13 +38,6 @@
             ...
         }
     @endcode
-
-    Creating the windows with the static box parent (i.e. @c panel in the
-    example above) as parent still works but can result in refresh and repaint
-    problems.
-
-    Also note that there is a specialized wxSizer class (wxStaticBoxSizer) which can
-    be used as an easier way to pack items into a static box.
 
     @library{wxcore}
     @category{ctrl}

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -593,6 +593,30 @@ public:
     virtual void AddChild(wxWindow* child);
 
     /**
+        Invoke the given functor for all children of the given window
+        recursively.
+
+        This function calls @a functor for the window itself and then for all
+        of its children, recursively.
+
+        Example of using it for implementing a not very smart translation
+        function:
+        @code
+        void MyFrame::OnTranslate(wxCommandEvent&) {
+            CallForEachChild([](wxWindow* win) {
+                wxString rest;
+                if ( win->GetLabel().StartsWith("Hello ", &rest) )
+                    win->SetLabel("Bonjour " + rest);
+            });
+        }
+        @endcode
+
+        @since 3.3.0
+     */
+    template <typename T>
+    void CallForEachChild(const T& functor);
+
+    /**
         Destroys all children of a window. Called automatically by the destructor.
     */
     bool DestroyChildren();

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2780,56 +2780,74 @@ wxStaticBoxSizer::~wxStaticBoxSizer()
         m_staticBox->WXDestroyWithoutChildren();
 }
 
-wxSizerItem* wxStaticBoxSizer::DoInsert(size_t index, wxSizerItem* item)
+bool wxStaticBoxSizer::CheckForNonBoxChildren(wxSizer* sizer) const
 {
-    if ( wxWindow* const win = item->GetWindow() )
+    for ( wxSizerItemList::compatibility_iterator node = sizer->GetChildren().GetFirst();
+          node;
+          node = node->GetNext() )
     {
-        // Warn if the window is not a child of the static box, which it really
-        // should be, even if we still support using the box parent as parent
-        // too for compatibility.
-        if ( !m_staticBox->IsDescendant(win) )
-        {
-            m_hasNonBoxChildren = true;
+        wxSizerItem *const item = node->GetData();
 
-            wxLogDebug("Element %s of wxStaticBoxSizer should be created "
-                       "as child of its wxStaticBox and not of %s.",
-                       wxDumpWindow(win),
-                       wxDumpWindow(win->GetParent()));
+        if ( wxWindow* const win = item->GetWindow() )
+        {
+            if ( CheckIfNonBoxChild(win) )
+                return true;
+        }
+        else if ( wxSizer* const subsizer = item->GetSizer() )
+        {
+            if ( CheckForNonBoxChildren(subsizer) )
+                return true;
+        }
+    }
+
+    return false;
+}
+
+bool wxStaticBoxSizer::CheckIfNonBoxChild(wxWindow* win) const
+{
+    if ( m_staticBox->IsDescendant(win) )
+        return false;
+
+    // Warn if the window is not a child of the static box, which it really
+    // should be, even if we still support using the box parent as parent
+    // too for compatibility.
+    wxLogDebug("Element %s of wxStaticBoxSizer should be created "
+               "as child of its wxStaticBox and not of %s.",
+               wxDumpWindow(win),
+               wxDumpWindow(win->GetParent()));
 
 #ifdef __WXMSW__
-            // Additionally, under MSW the windows inside a static box are not
-            // drawn at all when compositing is used, so we have to disable it.
-            //
-            // An alternative could be to Reparent() the window to the static
-            // box, but it might break the existing code and as we only allow
-            // this for compatibility in the first place, it seems better not
-            // to risk it.
-            m_staticBox->MSWDisableComposited();
+    // Additionally, under MSW the windows inside a static box are not
+    // drawn at all when compositing is used, so we have to disable it.
+    //
+    // An alternative could be to Reparent() the window to the static
+    // box, but it might break the existing code and as we only allow
+    // this for compatibility in the first place, it seems better not
+    // to risk it.
+    m_staticBox->MSWDisableComposited();
 #endif // __WXMSW__
-        }
 
-        // Also check for the non-supported scenario in which both windows
-        // using box as their parent and the ones using its parent are used:
-        // this won't work correctly because the latter ones won't use the
-        // required offset and so won't be laid out correctly, see the code
-        // dealing with m_position in RepositionChildren() below.
-        if ( m_hasNonBoxChildren && !m_staticBox->GetChildren().empty() )
+    return true;
+}
+
+wxSizerItem* wxStaticBoxSizer::DoInsert(size_t index, wxSizerItem* item)
+{
+    // Check if we have any non-box children unless we already know that we do.
+    if ( !m_hasNonBoxChildren )
+    {
+        if ( wxWindow* const win = item->GetWindow() )
         {
-            wxASSERT_MSG
-            (
-                !m_hasNonBoxChildren,
-                "All items of wxStaticBoxSizer must use the same parent.\n"
-                "\n"
-                "It is strongly recommended to use the associated static box "
-                "as the parent for all of them, but if not, all items must "
-                "use the containing window as parent.\n"
-                "\n"
-                "Mixing items using different parents inside the same sizer "
-                "is NOT supported."
-            );
-
-            // One assert is enough, so reset it to avoid giving it again.
-            m_hasNonBoxChildren = false;
+            // We can check immediately if we have any non-box children and
+            // it's better to do it here, for example to allow putting a
+            // breakpoint on wxLogDebug() message above and immediately seeing
+            // where the item is inserted from, if it's not clear otherwise.
+            m_hasNonBoxChildren = CheckIfNonBoxChild(win);
+        }
+        else if ( item->IsSizer() )
+        {
+            // We can't check immediately as elements can be added to the child
+            // sizer after adding it to this one, so schedule a check for later.
+            m_hasNonBoxChildren = -1;
         }
     }
 
@@ -2848,7 +2866,11 @@ void wxStaticBoxSizer::RepositionChildren(const wxSize& minSize)
     m_size.y -= top_border + other_border;
 
     wxPoint old_pos( m_position );
-    if (m_staticBox->GetChildren().GetCount() > 0)
+
+    if ( m_hasNonBoxChildren == -1 )
+        m_hasNonBoxChildren = CheckForNonBoxChildren(this);
+
+    if ( !m_hasNonBoxChildren )
     {
 #if defined( __WXGTK__ )
         // if the wxStaticBox has created a wxPizza to contain its children
@@ -2876,6 +2898,30 @@ void wxStaticBoxSizer::RepositionChildren(const wxSize& minSize)
         // case we need to position them with coordinates relative to our common parent
         m_position.x += other_border;
         m_position.y += top_border;
+
+        // Also check for the non-supported scenario in which both windows
+        // using box as their parent and the ones using its parent are used:
+        // this won't work correctly because the latter ones won't use the
+        // required offset and so won't be laid out correctly, see the code
+        // dealing with m_position in RepositionChildren() below.
+        if ( !m_staticBox->GetChildren().empty() )
+        {
+            wxASSERT_MSG
+            (
+                !m_hasNonBoxChildren,
+                "All items of wxStaticBoxSizer must use the same parent.\n"
+                "\n"
+                "It is strongly recommended to use the associated static box "
+                "as the parent for all of them, but if not, all items must "
+                "use the containing window as parent.\n"
+                "\n"
+                "Mixing items using different parents inside the same sizer "
+                "is NOT supported."
+            );
+
+            // One assert is enough, so reset it to avoid giving it again.
+            m_hasNonBoxChildren = false;
+        }
     }
 
     wxBoxSizer::RepositionChildren(minSize);

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2789,6 +2789,8 @@ wxSizerItem* wxStaticBoxSizer::DoInsert(size_t index, wxSizerItem* item)
         // too for compatibility.
         if ( !m_staticBox->IsDescendant(win) )
         {
+            m_hasNonBoxChildren = true;
+
             wxLogDebug("Element %s of wxStaticBoxSizer should be created "
                        "as child of its wxStaticBox and not of %s.",
                        wxDumpWindow(win),
@@ -2804,6 +2806,30 @@ wxSizerItem* wxStaticBoxSizer::DoInsert(size_t index, wxSizerItem* item)
             // to risk it.
             m_staticBox->MSWDisableComposited();
 #endif // __WXMSW__
+        }
+
+        // Also check for the non-supported scenario in which both windows
+        // using box as their parent and the ones using its parent are used:
+        // this won't work correctly because the latter ones won't use the
+        // required offset and so won't be laid out correctly, see the code
+        // dealing with m_position in RepositionChildren() below.
+        if ( m_hasNonBoxChildren && !m_staticBox->GetChildren().empty() )
+        {
+            wxASSERT_MSG
+            (
+                !m_hasNonBoxChildren,
+                "All items of wxStaticBoxSizer must use the same parent.\n"
+                "\n"
+                "It is strongly recommended to use the associated static box "
+                "as the parent for all of them, but if not, all items must "
+                "use the containing window as parent.\n"
+                "\n"
+                "Mixing items using different parents inside the same sizer "
+                "is NOT supported."
+            );
+
+            // One assert is enough, so reset it to avoid giving it again.
+            m_hasNonBoxChildren = false;
         }
     }
 

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2867,8 +2867,30 @@ void wxStaticBoxSizer::RepositionChildren(const wxSize& minSize)
 
     wxPoint old_pos( m_position );
 
-    if ( m_hasNonBoxChildren == -1 )
-        m_hasNonBoxChildren = CheckForNonBoxChildren(this);
+    switch ( m_hasNonBoxChildren )
+    {
+        case 0:
+            // We didn't have any sibling children so far, but if we don't have
+            // any real children neither, chances are that they could have been
+            // added, so check for this: but if we do have real children, don't
+            // bother doing anything as this would result in extra overhead for
+            // every re-layout.
+            if ( !m_staticBox->GetChildren().empty() )
+                break;
+
+            wxFALLTHROUGH;
+
+        case -1:
+            // We don't know yet, check.
+            m_hasNonBoxChildren = CheckForNonBoxChildren(this);
+            break;
+
+        case 1:
+            // We already know that we have some and we don't support replacing
+            // the existing sibling children with real children, so don't
+            // bother doing anything.
+            break;
+    }
 
     if ( !m_hasNonBoxChildren )
     {

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2839,14 +2839,7 @@ wxSizerItem* wxStaticBoxSizer::DoInsert(size_t index, wxSizerItem* item)
         // breakpoint on wxLogDebug() message above and immediately seeing
         // where the item is inserted from, if it's not clear otherwise.
         if ( CheckIfNonBoxChild(win) )
-            m_hasNonBoxChildren = 1;
-    }
-    else if ( item->IsSizer() )
-    {
-        // We can't check immediately as elements can be added to the child
-        // sizer after adding it to this one, so schedule a check for later.
-        if ( !m_hasNonBoxChildren )
-            m_hasNonBoxChildren = -1;
+            m_hasNonBoxChildren = true;
     }
 
     return wxBoxSizer::DoInsert(index, item);
@@ -2865,30 +2858,12 @@ void wxStaticBoxSizer::RepositionChildren(const wxSize& minSize)
 
     wxPoint old_pos( m_position );
 
-    switch ( m_hasNonBoxChildren )
-    {
-        case 0:
-            // We didn't have any sibling children so far, but if we don't have
-            // any real children neither, chances are that they could have been
-            // added, so check for this: but if we do have real children, don't
-            // bother doing anything as this would result in extra overhead for
-            // every re-layout.
-            if ( !m_staticBox->GetChildren().empty() )
-                break;
-
-            wxFALLTHROUGH;
-
-        case -1:
-            // We don't know yet, check.
-            m_hasNonBoxChildren = CheckForNonBoxChildren(this);
-            break;
-
-        case 1:
-            // We already know that we have some and we don't support replacing
-            // the existing sibling children with real children, so don't
-            // bother doing anything.
-            break;
-    }
+    // If we didn't have any sibling children so far, but we don't have any
+    // real children neither, chances are that they could have been added, so
+    // check for this (but if we do have real children, don't bother doing
+    // anything as this would result in extra overhead for every re-layout).
+    if ( !m_hasNonBoxChildren && m_staticBox->GetChildren().empty() )
+        m_hasNonBoxChildren = CheckForNonBoxChildren(this);
 
     if ( !m_hasNonBoxChildren )
     {

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2824,7 +2824,7 @@ bool wxStaticBoxSizer::CheckIfNonBoxChild(wxWindow* win) const
     // box, but it might break the existing code and as we only allow
     // this for compatibility in the first place, it seems better not
     // to risk it.
-    m_staticBox->MSWDisableComposited();
+    win->MSWDisableComposited();
 #endif // __WXMSW__
 
     return true;

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2780,6 +2780,36 @@ wxStaticBoxSizer::~wxStaticBoxSizer()
         m_staticBox->WXDestroyWithoutChildren();
 }
 
+wxSizerItem* wxStaticBoxSizer::DoInsert(size_t index, wxSizerItem* item)
+{
+    if ( wxWindow* const win = item->GetWindow() )
+    {
+        // Warn if the window is not a child of the static box, which it really
+        // should be, even if we still support using the box parent as parent
+        // too for compatibility.
+        if ( !m_staticBox->IsDescendant(win) )
+        {
+            wxLogDebug("Element %s of wxStaticBoxSizer should be created "
+                       "as child of its wxStaticBox and not of %s.",
+                       wxDumpWindow(win),
+                       wxDumpWindow(win->GetParent()));
+
+#ifdef __WXMSW__
+            // Additionally, under MSW the windows inside a static box are not
+            // drawn at all when compositing is used, so we have to disable it.
+            //
+            // An alternative could be to Reparent() the window to the static
+            // box, but it might break the existing code and as we only allow
+            // this for compatibility in the first place, it seems better not
+            // to risk it.
+            m_staticBox->MSWDisableComposited();
+#endif // __WXMSW__
+        }
+    }
+
+    return wxBoxSizer::DoInsert(index, item);
+}
+
 void wxStaticBoxSizer::RepositionChildren(const wxSize& minSize)
 {
     int top_border, other_border;

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2832,23 +2832,21 @@ bool wxStaticBoxSizer::CheckIfNonBoxChild(wxWindow* win) const
 
 wxSizerItem* wxStaticBoxSizer::DoInsert(size_t index, wxSizerItem* item)
 {
-    // Check if we have any non-box children unless we already know that we do.
-    if ( !m_hasNonBoxChildren )
+    if ( wxWindow* const win = item->GetWindow() )
     {
-        if ( wxWindow* const win = item->GetWindow() )
-        {
-            // We can check immediately if we have any non-box children and
-            // it's better to do it here, for example to allow putting a
-            // breakpoint on wxLogDebug() message above and immediately seeing
-            // where the item is inserted from, if it's not clear otherwise.
-            m_hasNonBoxChildren = CheckIfNonBoxChild(win);
-        }
-        else if ( item->IsSizer() )
-        {
-            // We can't check immediately as elements can be added to the child
-            // sizer after adding it to this one, so schedule a check for later.
+        // We can check immediately if we have any non-box children and
+        // it's better to do it here, for example to allow putting a
+        // breakpoint on wxLogDebug() message above and immediately seeing
+        // where the item is inserted from, if it's not clear otherwise.
+        if ( CheckIfNonBoxChild(win) )
+            m_hasNonBoxChildren = 1;
+    }
+    else if ( item->IsSizer() )
+    {
+        // We can't check immediately as elements can be added to the child
+        // sizer after adding it to this one, so schedule a check for later.
+        if ( !m_hasNonBoxChildren )
             m_hasNonBoxChildren = -1;
-        }
     }
 
     return wxBoxSizer::DoInsert(index, item);

--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -106,13 +106,18 @@ bool wxStaticBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 
 bool wxStaticBox::ShouldUseCustomPaint() const
 {
-    // When not using double buffering, we paint the box ourselves by default
-    // because using the standard control default WM_PAINT handler results in
-    // awful flicker. However this can be disabled by setting a system option
-    // which can be useful if the application paints on the box itself (which
-    // should be avoided, but some existing code does it).
-    return !IsDoubleBuffered() &&
-            !wxSystemOptions::IsFalse(wxT("msw.staticbox.optimized-paint"));
+    // We currently always custom paint the box because we can't rely on double
+    // buffering remaining on even if it is on now, i.e. IsDoubleBuffered()
+    // could return true right but WS_EX_COMPOSITED could get turned off later
+    // because MSWDisableComposited() is called and this would make default
+    // WM_PAINT not work correctly any longer. A probably better solution would
+    // be to notify all windows from MSWDisableComposited() when the double
+    // buffered status changes.
+    //
+    // Still allow be disabling this by setting a system option which can be
+    // useful if the application paints on the box itself (which should be
+    // avoided, but some existing code does it).
+    return !wxSystemOptions::IsFalse(wxT("msw.staticbox.optimized-paint"));
 }
 
 void wxStaticBox::UseCustomPaint()

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1701,7 +1701,10 @@ void wxWindowMSW::MSWDisableComposited()
         if ( win->IsTopLevel() )
             break;
 
-        wxMSWWinExStyleUpdater(GetHwndOf(win)).TurnOff(WS_EX_COMPOSITED);
+        wxMSWWinExStyleUpdater updater(GetHwndOf(win));
+        updater.TurnOff(WS_EX_COMPOSITED);
+        if ( updater.Apply() )
+            win->CallForEachChild([](wxWindow* w) { w->MSWOnDisabledComposited(); });
     }
 }
 


### PR DESCRIPTION
Disable compositing when adding a window which is not a child of wxStaticBox to wxStaticBoxSizer as sibling windows can't be painted correctly inside one another when compositing is on.

Also add a debug warning when not using the static box as parent for the windows inside it and emphasize even more strongly that this is not the right way to do it in the documentation.

Closes #23182.