### PR TITLE
Fix setting locale to `wxLANGUAGE_UKRAINIAN` (#23210)

### DIFF
--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -117,7 +117,7 @@ const char* wxLanguageInfo::TrySetLocale() const
     // Prefer to use the locale names instead of locale identifiers if
     // supported, both at the OS level (LOCALE_SNAME) and by the CRT (check by
     // calling setlocale()).
-    const char* const retloc = wxSetlocale(LC_ALL, LocaleTag);
+    const char* const retloc = wxSetlocale(LC_ALL, GetCanonicalWithRegion());
     if ( retloc )
         return retloc;
 


### PR DESCRIPTION
Use GetCanonicalWithRegion() (instead of LocaleTag)  in the Windows implementation of method wxLanguageInfo::TrySetLocale() - as is done in the non-Windows implementation of this method. (see https://github.com/wxWidgets/wxWidgets/issues/23210)