### PR TITLE
Add support for client data to wxAuiToolBar

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -249,8 +249,8 @@ private:
     bool m_active;               // true if the item is currently active
     bool m_dropDown;             // true if the item has a dropdown button
     bool m_sticky;               // overrides button states if true (always active)
-    long m_userData;             // user-specified data
-    wxObject* m_clientData;      // client data
+    long m_userData;             // number associated with the item
+    wxObject* m_clientData;      // pointer to a wxObject associated with the item
     int m_alignment;             // sizer alignment flag, defaults to wxCENTER, may be wxEXPAND or any other
 };
 
@@ -566,7 +566,7 @@ public:
     void SetMargins(int x, int y) { SetMargins(x, x, y, y); }
     void SetMargins(int left, int right, int top, int bottom);
 
-    void SetToolClientData (int tool_id, wxObject *client_data);
+    void SetToolClientData (int tool_id, wxObject* client_data);
     wxObject* GetToolClientData(int tool_id) const;
 
     void SetToolBitmapSize(const wxSize& size);

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -121,6 +121,7 @@ public:
         m_dropDown = true;
         m_sticky = true;
         m_userData = 0;
+        m_clientData = nullptr;
         m_alignment = wxALIGN_CENTER;
     }
 
@@ -144,6 +145,7 @@ public:
         m_dropDown = c.m_dropDown;
         m_sticky = c.m_sticky;
         m_userData = c.m_userData;
+        m_clientData = c.m_clientData;
         m_alignment = c.m_alignment;
     }
 
@@ -217,6 +219,9 @@ public:
     void SetUserData(long l) { m_userData = l; }
     long GetUserData() const { return m_userData; }
 
+    void SetClientData(wxObject* l) { m_clientData = l; }
+    wxObject* GetClientData() const { return m_clientData; }
+
     void SetAlignment(int l) { m_alignment = l; }
     int GetAlignment() const { return m_alignment; }
 
@@ -244,7 +249,8 @@ private:
     bool m_active;               // true if the item is currently active
     bool m_dropDown;             // true if the item has a dropdown button
     bool m_sticky;               // overrides button states if true (always active)
-    long m_userData;            // user-specified data
+    long m_userData;             // user-specified data
+    wxObject* m_clientData;      // client data
     int m_alignment;             // sizer alignment flag, defaults to wxCENTER, may be wxEXPAND or any other
 };
 
@@ -559,6 +565,9 @@ public:
     void SetMargins(const wxSize& size) { SetMargins(size.x, size.x, size.y, size.y); }
     void SetMargins(int x, int y) { SetMargins(x, x, y, y); }
     void SetMargins(int left, int right, int top, int bottom);
+
+    void SetToolClientData (int tool_id, wxObject *client_data);
+    wxObject* GetToolClientData(int tool_id) const;
 
     void SetToolBitmapSize(const wxSize& size);
     wxSize GetToolBitmapSize() const;

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -398,13 +398,34 @@ public:
     bool IsSticky() const;
 
     /**
-
+        Associates a number with the item
+        @param UserData Number to associate
+        @sa GetUserData()
     */
-    void SetUserData(long l);
-    /**
+    void SetUserData(long UserData);
 
+    /**
+        Get number associated with the item
+        @return Associated number
+        @sa SetUserData()
     */
     long GetUserData() const;
+
+    /**
+        Associates a wxObject with the item
+        @param ClientData Pointer to the wxObject
+        @sa GetClientData()
+        @since 3.3.0
+    */
+    void SetClientData(wxObject* ClientData);
+
+    /**
+        Get wxObject associated with the item
+        @return Pointer to the associated wxObject
+        @sa SetClientData()
+        @since 3.3.0
+    */
+    wxObject* GetClientData() const;
 
     /**
 
@@ -806,6 +827,24 @@ public:
     void SetMargins(const wxSize& size);
     void SetMargins(int x, int y);
     void SetMargins(int left, int right, int top, int bottom);
+
+    /**
+        Associates a wxObject with the item identified by Id
+        @param Id Identifier of the desired item
+        @param ClientData Pointer to the wxObject
+        @sa GetToolClientData()
+        @since 3.3.0
+    */
+    void SetToolClientData (int Id, wxObject* ClientData);
+
+    /**
+        Get wxObject associated with the item identified by Id
+        @param Id Identifier of the desired item
+        @return Pointer to the associated wxObject
+        @sa SetToolClientData()
+        @since 3.3.0
+    */
+    wxObject* GetToolClientData(int Id) const;
 
     void SetToolBitmapSize(const wxSize& size);
     wxSize GetToolBitmapSize() const;

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -985,7 +985,7 @@ wxAuiToolBarItem* wxAuiToolBar::AddTool(int tool_id,
                            wxItemKind kind,
                            const wxString& shortHelpString,
                            const wxString& longHelpString,
-                           wxObject* WXUNUSED(client_data))
+                           wxObject* client_data)
 {
     wxAuiToolBarItem item;
     item.m_window = nullptr;
@@ -1004,6 +1004,7 @@ wxAuiToolBarItem* wxAuiToolBar::AddTool(int tool_id,
     item.m_sizerItem = nullptr;
     item.m_minSize = wxDefaultSize;
     item.m_userData = 0;
+    item.m_clientData = client_data;
     item.m_sticky = false;
 
     if (item.m_toolId == wxID_ANY)
@@ -1258,6 +1259,24 @@ wxAuiToolBarItem* wxAuiToolBar::FindToolByIndex(int idx) const
         return nullptr;
 
     return &(m_items[idx]);
+}
+
+void wxAuiToolBar::SetToolClientData (int tool_id, wxObject *client_data)
+{
+    wxAuiToolBarItem* item = FindTool(tool_id);
+    if (!item)
+        return;
+
+    item->m_clientData = client_data;
+}
+
+wxObject* wxAuiToolBar::GetToolClientData(int tool_id) const
+{
+    wxAuiToolBarItem* item = FindTool(tool_id);
+    if (!item)
+        return nullptr;
+
+    return item->m_clientData;
 }
 
 void wxAuiToolBar::SetToolBitmapSize(const wxSize& WXUNUSED(size))


### PR DESCRIPTION
wxAuiToolBar::AddTool() discards client data parameter (issue #23271).
