### PR TITLE
Fix wxCollapsiblePane background inside wxNotebook under MSW

### DIFF
--- a/include/wx/generic/collheaderctrl.h
+++ b/include/wx/generic/collheaderctrl.h
@@ -44,6 +44,8 @@ public:
     virtual bool IsCollapsed() const override
         { return m_collapsed; }
 
+    virtual bool HasTransparentBackground() override { return true; }
+
 protected:
 
     virtual wxSize DoGetBestClientSize() const override;

--- a/src/generic/collpaneg.cpp
+++ b/src/generic/collpaneg.cpp
@@ -78,8 +78,7 @@ bool wxGenericCollapsiblePane::Create(wxWindow *parent,
 
     // create children and lay them out using a wxBoxSizer
     // (so that we automatically get RTL features)
-    m_pButton = new wxCollapsibleHeaderCtrl(this, wxID_ANY, label, wxPoint(0, 0),
-                             wxDefaultSize);
+    m_pButton = new wxCollapsibleHeaderCtrl(this, wxID_ANY, label, wxPoint(0, 0));
 
     m_sz->Add(m_pButton, wxSizerFlags().Border(wxALL, GetBorder()));
 


### PR DESCRIPTION
This fixes #23274 for me, but I don't understand how could it work before as I don't see any changes that could have broken it. Maybe it never actually worked?

@TcT2k Please let me know if you see any reason not to do this (speaking about the first commit here, the second one is trivial), TIA!