### PR TITLE
Cancel in progress builds of PRs when a new one starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -45,6 +45,10 @@ on:
       - '*.yml'
       - 'wxwidgets.props'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -59,6 +59,10 @@ on:
     - 'CMakeLists.txt'
     - 'wxwidgets.props'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci_mac_xcode.yml
+++ b/.github/workflows/ci_mac_xcode.yml
@@ -59,6 +59,10 @@ on:
     - 'CMakeLists.txt'
     - 'wxwidgets.props'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci_msw.yml
+++ b/.github/workflows/ci_msw.yml
@@ -49,6 +49,10 @@ on:
       - '*.yml'
       - 'CMakeLists.txt'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -53,6 +53,10 @@ on:
       - 'wxwidgets.props'
       - 'CMakeLists.txt'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -53,6 +53,7 @@ on:
       - 'wxwidgets.props'
       - 'CMakeLists.txt'
 
+# Ensure we have at most a single build running for the given PR.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Add a snippet based on the example in

https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

to all CI workflows to cancel the currently running build when a new one starts. This should ensure that we don't keep building the old version of the PR after a new one has been pushed.