### PR TITLE
wxOSX regression: default-widths for empty textfields

### DIFF
--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -200,6 +200,7 @@ wxSize wxTextCtrl::DoGetBestSize() const
 wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
 {
     static const int TEXTCTRL_BORDER_SIZE = 5;
+    static const int TEXTCTRL_MAX_EMPTY_WIDTH = 5;
 
     // Compute the default height if not specified.
     int hText = ylen;
@@ -237,11 +238,13 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
 
     // Keep using the same default 100px width as was used previously in the
     // special case of having invalid width.
-    wxSize size(xlen > 0 ? xlen : 100, hText);
+    // since this method is now called with native field widths, an empty field still
+    // has small positive xlen, therefore don't compare just with > 0 anymore
+    wxSize size(xlen > TEXTCTRL_MAX_EMPTY_WIDTH ? xlen : 100, hText);
 
     // Use extra margin size which works under macOS 10.15: note that we don't
     // need the vertical margin when using the automatically determined hText.
-    if ( xlen > 0 )
+    if ( xlen > TEXTCTRL_MAX_EMPTY_WIDTH )
         size.x += 4;
     if ( ylen > 0 )
         size.y += 2;


### PR DESCRIPTION
in the process of fixing #22374 by using native best sizes, empty fields were getting a small, but positive best width, this broke the trigger for using default widths for empty fields, see #23250