### PR TITLE
Fix utf8 iterator going past end of string in PosLenToImpl

### DIFF
--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -229,7 +229,7 @@ void wxString::PosLenToImpl(size_t pos, size_t len,
             // going beyond the end of the string, just as std::string does
             const const_iterator e(end());
             const_iterator i(b);
-            while ( len && i <= e )
+            while ( len && i < e )
             {
                 ++i;
                 --len;


### PR DESCRIPTION
Fix iterator going past end of string in PosLenToImpl which causes std::string exception dereferencing end()