### PR TITLE
Add support for initializer_list on arrays

### DIFF
--- a/include/wx/arrstr.h
+++ b/include/wx/arrstr.h
@@ -16,9 +16,7 @@
 #include "wx/dynarray.h"
 
 #include <vector>
-#include "wx/beforestd.h"
 #include <initializer_list>
-#include "wx/afterstd.h"
 
 // these functions are only used in STL build now but we define them in any
 // case for compatibility with the existing code outside of the library which
@@ -84,8 +82,8 @@ public:
     wxArrayString(size_t sz, const char** a);
     wxArrayString(size_t sz, const wchar_t** a);
     wxArrayString(size_t sz, const wxString* a);
-    template<typename _IList>
-    wxArrayString(std::initializer_list<_IList> list) : wxArrayStringBase(list) { }
+    template<typename U>
+    wxArrayString(std::initializer_list<U> list) : wxArrayStringBase(list) { }
 
     int Index(const wxString& str, bool bCase = true, bool bFromEnd = false) const;
 
@@ -188,8 +186,8 @@ public:
     // copy ctor
   wxArrayString(const wxArrayString& array);
     // list constructor
-  template<typename _IList>
-  wxArrayString(std::initializer_list<_IList> list) { Init(false); assign(list.begin(), list.end()); }
+  template<typename U>
+  wxArrayString(std::initializer_list<U> list) { Init(false); assign(list.begin(), list.end()); }
     // assignment operator
   wxArrayString& operator=(const wxArrayString& src);
     // not virtual, this class should not be derived from

--- a/include/wx/arrstr.h
+++ b/include/wx/arrstr.h
@@ -16,6 +16,9 @@
 #include "wx/dynarray.h"
 
 #include <vector>
+#include "wx/beforestd.h"
+#include <initializer_list>
+#include "wx/afterstd.h"
 
 // these functions are only used in STL build now but we define them in any
 // case for compatibility with the existing code outside of the library which
@@ -81,6 +84,8 @@ public:
     wxArrayString(size_t sz, const char** a);
     wxArrayString(size_t sz, const wchar_t** a);
     wxArrayString(size_t sz, const wxString* a);
+    template<typename _IList>
+    wxArrayString(std::initializer_list<_IList> list) : wxArrayStringBase(list) { }
 
     int Index(const wxString& str, bool bCase = true, bool bFromEnd = false) const;
 
@@ -182,6 +187,9 @@ public:
   wxArrayString(size_t sz, const wxString* a);
     // copy ctor
   wxArrayString(const wxArrayString& array);
+    // list constructor
+  template<typename _IList>
+  wxArrayString(std::initializer_list<_IList> list) { Init(false); assign(list.begin(), list.end()); }
     // assignment operator
   wxArrayString& operator=(const wxArrayString& src);
     // not virtual, this class should not be derived from

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -15,9 +15,7 @@
 
 #include "wx/vector.h"
 
-#include "wx/beforestd.h"
 #include <initializer_list>
-#include "wx/afterstd.h"
 
 /*
   This header defines legacy dynamic arrays and object arrays (i.e. arrays
@@ -109,8 +107,8 @@ public:
         : base_vec(first, last)
     { }
 
-    template<typename _IList>
-    wxBaseArray(std::initializer_list<_IList> list) : base_vec(list) {}
+    template<typename U>
+    wxBaseArray(std::initializer_list<U> list) : base_vec(list.begin(), list.end()) {}
 
     void Empty() { this->clear(); }
     void Clear() { this->clear(); }
@@ -522,8 +520,8 @@ private:
         name(size_t n, Base::const_reference v) : Base(n, v) { }              \
         template <class InputIterator>                                        \
         name(InputIterator first, InputIterator last) : Base(first, last) { } \
-        template<typename _IList>                                             \
-        name(std::initializer_list<_IList> list) : Base(list) { }             \
+        template<typename U>                                                  \
+        name(std::initializer_list<U> list) : Base(list.begin(), list.end()) { } \
     }
 
 

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -15,6 +15,10 @@
 
 #include "wx/vector.h"
 
+#include "wx/beforestd.h"
+#include <initializer_list>
+#include "wx/afterstd.h"
+
 /*
   This header defines legacy dynamic arrays and object arrays (i.e. arrays
   which own their elements) classes.
@@ -104,6 +108,9 @@ public:
     wxBaseArray(InputIterator first, InputIterator last)
         : base_vec(first, last)
     { }
+
+    template<typename _IList>
+    wxBaseArray(std::initializer_list<_IList> list) : base_vec(list) {}
 
     void Empty() { this->clear(); }
     void Clear() { this->clear(); }
@@ -515,6 +522,8 @@ private:
         name(size_t n, Base::const_reference v) : Base(n, v) { }              \
         template <class InputIterator>                                        \
         name(InputIterator first, InputIterator last) : Base(first, last) { } \
+        template<typename _IList>                                             \
+        name(std::initializer_list<_IList> list) : Base(list) { }             \
     }
 
 

--- a/interface/wx/arrstr.h
+++ b/interface/wx/arrstr.h
@@ -90,9 +90,9 @@ public:
     wxArrayString(size_t sz, const wxString* arr);
 
     /**
-        Constructs the container with the contents of the initializer_list @list.
+        Constructs the container with the contents of the initializer_list @a list.
 
-        @since 3.2.2
+        @since 3.2.3
     */
     template<typename T>
     wxArrayString(std::initializer_list<T> list);

--- a/interface/wx/arrstr.h
+++ b/interface/wx/arrstr.h
@@ -90,6 +90,14 @@ public:
     wxArrayString(size_t sz, const wxString* arr);
 
     /**
+        Constructs the container with the contents of the initializer_list @list.
+
+        @since 3.2.2
+    */
+    template<typename T>
+    wxArrayString(std::initializer_list<T> list);
+
+    /**
         Destructor frees memory occupied by the array strings. For performance
         reasons it is not virtual, so this class should not be derived from.
     */

--- a/interface/wx/dynarray.h
+++ b/interface/wx/dynarray.h
@@ -272,6 +272,14 @@ public:
     wxObjArray(const wxObjArray& array);
 
     /**
+        Constructs the container with the contents of the initializer_list @list.
+
+        @since 3.2.2
+    */
+    template<typename T>
+    wxArray(std::initializer_list<T> list);
+
+    /**
         Performs a shallow array copy (i.e.\ doesn't copy the objects pointed to
         even if the source array contains the items of pointer type).
     */

--- a/interface/wx/dynarray.h
+++ b/interface/wx/dynarray.h
@@ -272,9 +272,9 @@ public:
     wxObjArray(const wxObjArray& array);
 
     /**
-        Constructs the container with the contents of the initializer_list @list.
+        Constructs the container with the contents of the initializer_list @a list.
 
-        @since 3.2.2
+        @since 3.2.3
     */
     template<typename T>
     wxArray(std::initializer_list<T> list);

--- a/tests/arrays/arrays.cpp
+++ b/tests/arrays/arrays.cpp
@@ -346,9 +346,13 @@ TEST_CASE("wxArrayString", "[dynarray]")
     CHECK( a8[1] == "human" );
     CHECK( a8[4] == "alligator" );
 
-    a8 = { wxT("Foo") };
+    a8 = { wxT("Foo") };    // Test operator=
     CHECK( a8.size() == 1 );
     CHECK( a8[0] == "Foo" );
+
+    // Same test with std::initializer_list<std::string>
+    wxArrayString a9( { std::string("dog"), std::string("human"), std::string("condor"), std::string("thermit"), std::string("alligator") } );
+    CHECK( a9.size() == 5 );
 }
 
 TEST_CASE("wxSortedArrayString", "[dynarray]")
@@ -633,8 +637,8 @@ TEST_CASE("wxDynArray::" #name, "[dynarray]")                                 \
     CHECK( b.Index( 6 ) == wxNOT_FOUND );                            \
     CHECK( b.Index( 17 ) == 3 );                                     \
                                                                      \
-    wxArray##name c( { 1, 2, 3, 4, 5 } );                            \
-    CHECK( c.size() == 5 );                                          \
+    wxArray##name c({1,2,3});                                        \
+    CHECK(c.size() == 3);                                            \
 }
 
 TestArrayOf(UShort)

--- a/tests/arrays/arrays.cpp
+++ b/tests/arrays/arrays.cpp
@@ -340,6 +340,15 @@ TEST_CASE("wxArrayString", "[dynarray]")
     CHECK( a7.size() == 1 );
 
     wxCLANG_WARNING_RESTORE(self-assign-overloaded)
+
+    wxArrayString a8( { wxT("dog"), wxT("human"), wxT("condor"), wxT("thermit"), wxT("alligator") } );
+    CHECK( a8.size() == 5 );
+    CHECK( a8[1] == "human" );
+    CHECK( a8[4] == "alligator" );
+
+    a8 = { wxT("Foo") };
+    CHECK( a8.size() == 1 );
+    CHECK( a8[0] == "Foo" );
 }
 
 TEST_CASE("wxSortedArrayString", "[dynarray]")
@@ -623,6 +632,9 @@ TEST_CASE("wxDynArray::" #name, "[dynarray]")                                 \
     CHECK( b.Index( 5 ) == 2 );                                      \
     CHECK( b.Index( 6 ) == wxNOT_FOUND );                            \
     CHECK( b.Index( 17 ) == 3 );                                     \
+                                                                     \
+    wxArray##name c( { 1, 2, 3, 4, 5 } );                            \
+    CHECK( c.size() == 5 );                                          \
 }
 
 TestArrayOf(UShort)


### PR DESCRIPTION
Hello,

Class `wxArrayString` is used all throughout the project in many different components. This pull-requests intends to improve the developer experience by adding support for `std::initializer_list` and syntactic sugar to simplify the initialization of `wxArrayString` and other arrays.

Exemple:
```
wxArrayString choices;
choices.Add( _T( "Choice 1" ) );
choices.Add( _T( "Choice 2" ) );
wxChoice* choiceControl = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, choices );

// OR

wxChoice* choiceControl = new wxChoice( this, wxID_ANY );
choiceControl->Append( { _T( "Choice 1" ), _T( "Choice 2" ) } );

// Replaced by:
wxChoice* choiceControl = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, { _T( "Choice 1" ), _T( "Choice 2" ) } );
```

I wasn't sure about adding a constructor based on `std::vector<std::string>` or more generally `std::vector<T>` too. Any suggestions about this are welcome.