### PR TITLE
AUI Toolbar Changes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -104,6 +104,15 @@ Changes in behaviour which may result in build errors
 - wxTEST_DIALOG() macro now must be followed by semicolon, whereas previously
   it was only supposed to, but it wasn't mandatory to use one after it.
 
+- The type of the second argument for wxAuiToolBarArt::ShowDropdown changed
+  from wxAuiToolBarItemArray to wxAuiToolBarItemList. This argument now
+  provides a list of pointers to the wxAuiToolBarItems in the dropdown instead
+  of providing the actual wxAuiToolBarItems.
+
+- The type for m_items, m_customOverflowPrepend and m_customOverflowAppend
+  in wxAuiToolBar changed from wxAuiToolBarItemArray to wxAuiToolBarItemList,
+  and they now hold a list of pointers to the items instead of the actual items
+  themselves.
 
 3.3.0: (released 2022-??-??)
 ----------------------------

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -255,7 +255,9 @@ private:
 };
 
 #ifndef SWIG
+// wxAuiToolBarItemArray is deprecated but kept for backwards compatibility
 WX_DECLARE_USER_EXPORTED_OBJARRAY(wxAuiToolBarItem, wxAuiToolBarItemArray, WXDLLIMPEXP_AUI);
+WX_DECLARE_EXPORTED_LIST(wxAuiToolBarItem, wxAuiToolBarItemList);
 #endif
 
 
@@ -345,7 +347,7 @@ public:
 
     virtual int ShowDropDown(
                          wxWindow* wnd,
-                         const wxAuiToolBarItemArray& items) = 0;
+                         const wxAuiToolBarItemList& items) = 0;
 
     // Provide opportunity for subclasses to recalculate colours
     virtual void UpdateColoursFromSystem() {}
@@ -433,7 +435,7 @@ public:
     virtual void SetElementSize(int elementId, int size) override;
 
     virtual int ShowDropDown(wxWindow* wnd,
-                             const wxAuiToolBarItemArray& items) override;
+                             const wxAuiToolBarItemList& items) override;
 
     virtual void UpdateColoursFromSystem() override;
 
@@ -494,11 +496,23 @@ public:
     bool SetFont(const wxFont& font) override;
 
 
+    wxAuiToolBarItem* AddTool(wxAuiToolBarItem* item);
+
     wxAuiToolBarItem* AddTool(int toolId,
                  const wxString& label,
                  const wxBitmapBundle& bitmap,
                  const wxString& shortHelpString = wxEmptyString,
-                 wxItemKind kind = wxITEM_NORMAL);
+                 wxItemKind kind = wxITEM_NORMAL)
+    {
+        return AddTool(toolId,
+                label,
+                bitmap,
+                wxBitmapBundle(),
+                kind,
+                shortHelpString,
+                wxEmptyString,
+                nullptr);
+    }
 
     wxAuiToolBarItem* AddTool(int toolId,
                  const wxString& label,
@@ -560,6 +574,7 @@ public:
     bool GetToolFits(int toolId) const;
     wxRect GetToolRect(int toolId) const;
     bool GetToolFitsByIndex(int toolId) const;
+    bool GetToolBarItemFits(wxAuiToolBarItem* item) const;
     bool GetToolBarFits() const;
 
     void SetMargins(const wxSize& size) { SetMargins(size.x, size.x, size.y, size.y); }
@@ -617,8 +632,12 @@ public:
     wxString GetToolLongHelp(int toolId) const;
     void SetToolLongHelp(int toolId, const wxString& helpString);
 
+    // Preserved for API compatibility, shouldn't be used
     void SetCustomOverflowItems(const wxAuiToolBarItemArray& prepend,
                                 const wxAuiToolBarItemArray& append);
+
+    void SetCustomOverflowItems(const wxAuiToolBarItemList& prepend,
+                                const wxAuiToolBarItemList& append);
 
     // get size of hint rectangle for a particular dock location
     wxSize GetHintSize(int dockDirection) const;
@@ -668,7 +687,7 @@ protected: // handlers
 
 protected:
 
-    wxAuiToolBarItemArray m_items;      // array of toolbar items
+    wxAuiToolBarItemList m_items;       // Toolbar items
     wxAuiToolBarArt* m_art;             // art provider
     wxBoxSizer* m_sizer;                // main sizer for toolbar
     wxAuiToolBarItem* m_actionItem;    // item that's being acted upon (pressed)
@@ -678,8 +697,8 @@ protected:
     wxSizerItem* m_overflowSizerItem;
     wxSize m_absoluteMinSize;
     wxPoint m_actionPos;               // position of left-mouse down
-    wxAuiToolBarItemArray m_customOverflowPrepend;
-    wxAuiToolBarItemArray m_customOverflowAppend;
+    wxAuiToolBarItemList m_customOverflowPrepend;
+    wxAuiToolBarItemList m_customOverflowAppend;
 
     int m_buttonWidth;
     int m_buttonHeight;

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -141,7 +141,9 @@ public:
         m_alignment = wxALIGN_CENTER;
     }
 
-    void Assign(const wxAuiToolBarItem& c)
+    virtual ~wxAuiToolBarItem() {}
+
+    virtual void Assign(const wxAuiToolBarItem& c)
     {
         m_window = c.m_window;
         m_label = c.m_label;
@@ -166,60 +168,60 @@ public:
     }
 
 
-    void SetWindow(wxWindow* w) { m_window = w; }
-    wxWindow* GetWindow() { return m_window; }
+    virtual void SetWindow(wxWindow* w) { m_window = w; }
+    virtual wxWindow* GetWindow() { return m_window; }
 
-    void SetId(int newId) { m_toolId = newId; }
-    int GetId() const { return m_toolId; }
+    virtual void SetId(int newId) { m_toolId = newId; }
+    virtual int GetId() const { return m_toolId; }
 
-    void SetKind(int newKind) { m_kind = newKind; }
-    int GetKind() const { return m_kind; }
+    virtual void SetKind(int newKind) { m_kind = newKind; }
+    virtual int GetKind() const { return m_kind; }
 
-    void SetState(int newState) { m_state = newState; }
-    int GetState() const { return m_state; }
+    virtual void SetState(int newState) { m_state = newState; }
+    virtual int GetState() const { return m_state; }
 
-    void SetSizerItem(wxSizerItem* s) { m_sizerItem = s; }
-    wxSizerItem* GetSizerItem() const { return m_sizerItem; }
+    virtual void SetSizerItem(wxSizerItem* s) { m_sizerItem = s; }
+    virtual wxSizerItem* GetSizerItem() const { return m_sizerItem; }
 
-    void SetLabel(const wxString& s) { m_label = s; }
-    const wxString& GetLabel() const { return m_label; }
+    virtual void SetLabel(const wxString& s) { m_label = s; }
+    virtual const wxString& GetLabel() const { return m_label; }
 
-    void SetBitmap(const wxBitmapBundle& bmp) { m_bitmap = bmp; }
-    const wxBitmapBundle& GetBitmapBundle() const { return m_bitmap; }
-    wxBitmap GetBitmapFor(wxWindow* wnd) const { return m_bitmap.GetBitmapFor(wnd); }
-    wxBitmap GetBitmap() const { return GetBitmapFor(m_window); }
+    virtual void SetBitmap(const wxBitmapBundle& bmp) { m_bitmap = bmp; }
+    virtual const wxBitmapBundle& GetBitmapBundle() const { return m_bitmap; }
+    virtual wxBitmap GetBitmapFor(wxWindow* wnd) const { return m_bitmap.GetBitmapFor(wnd); }
+    virtual wxBitmap GetBitmap() const { return GetBitmapFor(m_window); }
 
-    void SetDisabledBitmap(const wxBitmapBundle& bmp) { m_disabledBitmap = bmp; }
-    const wxBitmapBundle& GetDisabledBitmapBundle() const { return m_disabledBitmap; }
-    wxBitmap GetDisabledBitmapFor(wxWindow* wnd) const { return m_disabledBitmap.GetBitmapFor(wnd); }
-    wxBitmap GetDisabledBitmap() const { return GetBitmapFor(m_window); }
+    virtual void SetDisabledBitmap(const wxBitmapBundle& bmp) { m_disabledBitmap = bmp; }
+    virtual const wxBitmapBundle& GetDisabledBitmapBundle() const { return m_disabledBitmap; }
+    virtual wxBitmap GetDisabledBitmapFor(wxWindow* wnd) const { return m_disabledBitmap.GetBitmapFor(wnd); }
+    virtual wxBitmap GetDisabledBitmap() const { return GetBitmapFor(m_window); }
 
     // Return the bitmap for the current state, normal or disabled.
-    wxBitmap GetCurrentBitmapFor(wxWindow* wnd) const;
+    virtual wxBitmap GetCurrentBitmapFor(wxWindow* wnd) const;
 
-    void SetHoverBitmap(const wxBitmapBundle& bmp) { m_hoverBitmap = bmp; }
-    const wxBitmapBundle& GetHoverBitmapBundle() const { return m_hoverBitmap; }
-    wxBitmap GetHoverBitmap() const { return m_hoverBitmap.GetBitmapFor(m_window); }
+    virtual void SetHoverBitmap(const wxBitmapBundle& bmp) { m_hoverBitmap = bmp; }
+    virtual const wxBitmapBundle& GetHoverBitmapBundle() const { return m_hoverBitmap; }
+    virtual wxBitmap GetHoverBitmap() const { return m_hoverBitmap.GetBitmapFor(m_window); }
 
-    void SetShortHelp(const wxString& s) { m_shortHelp = s; }
-    const wxString& GetShortHelp() const { return m_shortHelp; }
+    virtual void SetShortHelp(const wxString& s) { m_shortHelp = s; }
+    virtual const wxString& GetShortHelp() const { return m_shortHelp; }
 
-    void SetLongHelp(const wxString& s) { m_longHelp = s; }
-    const wxString& GetLongHelp() const { return m_longHelp; }
+    virtual void SetLongHelp(const wxString& s) { m_longHelp = s; }
+    virtual const wxString& GetLongHelp() const { return m_longHelp; }
 
-    void SetMinSize(const wxSize& s) { m_minSize = s; }
-    const wxSize& GetMinSize() const { return m_minSize; }
+    virtual void SetMinSize(const wxSize& s) { m_minSize = s; }
+    virtual const wxSize& GetMinSize() const { return m_minSize; }
 
-    void SetSpacerPixels(int s) { m_spacerPixels = s; }
-    int GetSpacerPixels() const { return m_spacerPixels; }
+    virtual void SetSpacerPixels(int s) { m_spacerPixels = s; }
+    virtual int GetSpacerPixels() const { return m_spacerPixels; }
 
-    void SetProportion(int p) { m_proportion = p; }
-    int GetProportion() const { return m_proportion; }
+    virtual void SetProportion(int p) { m_proportion = p; }
+    virtual int GetProportion() const { return m_proportion; }
 
-    void SetActive(bool b) { m_active = b; }
-    bool IsActive() const { return m_active; }
+    virtual void SetActive(bool b) { m_active = b; }
+    virtual bool IsActive() const { return m_active; }
 
-    void SetHasDropDown(bool b)
+    virtual void SetHasDropDown(bool b)
     {
         wxCHECK_RET( !b || m_kind == wxAUI_TB_ITEM_NORMAL,
                      wxS("Only normal tools can have drop downs") );
@@ -227,26 +229,26 @@ public:
         m_dropDown = b;
     }
 
-    bool HasDropDown() const { return m_dropDown; }
+    virtual bool HasDropDown() const { return m_dropDown; }
 
-    void SetSticky(bool b) { m_sticky = b; }
-    bool IsSticky() const { return m_sticky; }
+    virtual void SetSticky(bool b) { m_sticky = b; }
+    virtual bool IsSticky() const { return m_sticky; }
 
-    void SetUserData(long l) { m_userData = l; }
-    long GetUserData() const { return m_userData; }
+    virtual void SetUserData(long l) { m_userData = l; }
+    virtual long GetUserData() const { return m_userData; }
 
-    void SetClientData(wxObject* l) { m_clientData = l; }
-    wxObject* GetClientData() const { return m_clientData; }
+    virtual void SetClientData(wxObject* l) { m_clientData = l; }
+    virtual wxObject* GetClientData() const { return m_clientData; }
 
-    void SetAlignment(int l) { m_alignment = l; }
-    int GetAlignment() const { return m_alignment; }
+    virtual void SetAlignment(int l) { m_alignment = l; }
+    virtual int GetAlignment() const { return m_alignment; }
 
-    bool CanBeToggled() const
+    virtual bool CanBeToggled() const
     {
         return m_kind == wxAUI_TB_ITEM_CHECK || m_kind == wxAUI_TB_ITEM_RADIO;
     }
 
-private:
+protected:
 
     wxWindow* m_window;          // item's associated window
     wxString m_label;            // label displayed on the item

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -45,6 +45,22 @@ enum wxAuiToolBarStyle
     wxAUI_TB_DEFAULT_STYLE = 0
 };
 
+enum wxAuiToolBarItemKind
+{
+    // The wxITEM_* values used to be used for these item types,
+    // so preserve the value associated with the item type for
+    // better compatibility.
+    wxAUI_TB_ITEM_NORMAL    = wxITEM_NORMAL,
+    wxAUI_TB_ITEM_CHECK     = wxITEM_CHECK,
+    wxAUI_TB_ITEM_RADIO     = wxITEM_RADIO,
+    wxAUI_TB_ITEM_SEPARATOR = wxITEM_SEPARATOR,
+
+    // These are specific to the AUI toolbar
+    wxAUI_TB_ITEM_CONTROL = wxITEM_MAX,
+    wxAUI_TB_ITEM_LABEL,
+    wxAUI_TB_ITEM_SPACER
+};
+
 enum wxAuiToolBarArtSetting
 {
     wxAUI_TBART_SEPARATOR_SIZE = 0,
@@ -114,7 +130,7 @@ public:
         m_sizerItem = nullptr;
         m_spacerPixels = 0;
         m_toolId = 0;
-        m_kind = wxITEM_NORMAL;
+        m_kind = wxAUI_TB_ITEM_NORMAL;
         m_state = 0;  // normal, enabled
         m_proportion = 0;
         m_active = true;
@@ -205,7 +221,7 @@ public:
 
     void SetHasDropDown(bool b)
     {
-        wxCHECK_RET( !b || m_kind == wxITEM_NORMAL,
+        wxCHECK_RET( !b || m_kind == wxAUI_TB_ITEM_NORMAL,
                      wxS("Only normal tools can have drop downs") );
 
         m_dropDown = b;
@@ -227,7 +243,7 @@ public:
 
     bool CanBeToggled() const
     {
-        return m_kind == wxITEM_CHECK || m_kind == wxITEM_RADIO;
+        return m_kind == wxAUI_TB_ITEM_CHECK || m_kind == wxAUI_TB_ITEM_RADIO;
     }
 
 private:
@@ -502,7 +518,7 @@ public:
                  const wxString& label,
                  const wxBitmapBundle& bitmap,
                  const wxString& shortHelpString = wxEmptyString,
-                 wxItemKind kind = wxITEM_NORMAL)
+                 int kind = wxAUI_TB_ITEM_NORMAL)
     {
         return AddTool(toolId,
                 label,
@@ -518,7 +534,7 @@ public:
                  const wxString& label,
                  const wxBitmapBundle& bitmap,
                  const wxBitmapBundle& disabledBitmap,
-                 wxItemKind kind,
+                 int kind,
                  const wxString& shortHelpString,
                  const wxString& longHelpString,
                  wxObject* clientData);
@@ -535,7 +551,7 @@ public:
                 wxEmptyString,
                 bitmap,
                 disabledBitmap,
-                toggle ? wxITEM_CHECK : wxITEM_NORMAL,
+                toggle ? wxAUI_TB_ITEM_CHECK : wxAUI_TB_ITEM_NORMAL,
                 shortHelpString,
                 longHelpString,
                 clientData);

--- a/include/wx/aui/barartmsw.h
+++ b/include/wx/aui/barartmsw.h
@@ -76,7 +76,7 @@ public:
     virtual void SetElementSize(int elementId, int size) override;
 
     virtual int ShowDropDown(wxWindow* wnd,
-        const wxAuiToolBarItemArray& items) override;
+        const wxAuiToolBarItemList& items) override;
 
 private:
     bool m_themed;

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -252,6 +252,9 @@ wxEventType wxEVT_AUITOOLBAR_BEGIN_DRAG;
     tooltip text which is popped up when the mouse pointer enters the tool and the long
     help string for the applications status bar (currently not implemented).
 
+    Note, since 3.3.0 wxAuiToolBarItem has a virtual destructor and virtual methods,
+    and therefore can be inherited from.
+
     @library{wxaui}
     @category{aui}
 */
@@ -265,37 +268,46 @@ public:
     wxAuiToolBarItem();
 
     /**
+       Default destructor
+
+       @since 3.3.0
+    */
+    virtual ~wxAuiToolBarItem();
+
+    /**
       Assigns the properties of the wxAuiToolBarItem "c" to this.
     */
-    wxAuiToolBarItem(const wxAuiToolBarItem& c);
+    virtual wxAuiToolBarItem(const wxAuiToolBarItem& c);
 
     /**
        Assigns the properties of the wxAuiToolBarItem "c" to this, returning a pointer to this.
     */
-    wxAuiToolBarItem& operator=(const wxAuiToolBarItem& c);
+    virtual wxAuiToolBarItem& operator=(const wxAuiToolBarItem& c);
 
     /**
       Assigns the properties of the wxAuiToolBarItem "c" to this.
     */
-    void Assign(const wxAuiToolBarItem& c);
+    virtual void Assign(const wxAuiToolBarItem& c);
 
     /**
       Assigns a window to the toolbar item.
     */
-    void SetWindow(wxWindow* w);
+    virtual void SetWindow(wxWindow* w);
+
     /**
       Returns the wxWindow* associated to the toolbar item.
     */
-    wxWindow* GetWindow();
+    virtual wxWindow* GetWindow();
 
     /**
       Sets the toolbar item identifier.
     */
-    void SetId(int new_id);
+    virtual void SetId(int new_id);
+
     /**
       Returns the toolbar item identifier.
     */
-    int GetId() const;
+    virtual int GetId() const;
 
     /**
       Sets the wxAuiToolBarItem kind, must be a value from #wxAuiToolBarItemKind.
@@ -304,7 +316,7 @@ public:
             @c wxITEM_CHECK, @c wxITEM_RADIO or @c wxITEM_SEPARATOR. For 3.3.0 and later,
             kind is a #wxAuiToolBarItemKind.
     */
-    void SetKind(int new_kind);
+    virtual void SetKind(int new_kind);
 
     /**
       Returns the toolbar item kind.
@@ -315,139 +327,153 @@ public:
 
       @return a #wxAuiToolBarItemKind value saying the kind of item the tool is.
     */
-    int GetKind() const;
+    virtual int GetKind() const;
 
     /**
       Set the current state of the toolbar item.
 
       @param new_state is an or'd combination of flags from wxAuiPaneButtonState
     */
-    void SetState(int new_state);
+    virtual void SetState(int new_state);
+
     /**
       Gets the current state of the toolbar item.
 
       @return an or'd combination of flags from wxAuiPaneButtonState representing the current state
     */
-    int GetState() const;
+    virtual int GetState() const;
 
     /**
 
     */
-    void SetSizerItem(wxSizerItem* s);
-    /**
-
-    */
-    wxSizerItem* GetSizerItem() const;
+    virtual void SetSizerItem(wxSizerItem* s);
 
     /**
 
     */
-    void SetLabel(const wxString& s);
-    /**
-
-    */
-    const wxString& GetLabel() const;
+    virtual wxSizerItem* GetSizerItem() const;
 
     /**
 
     */
-    void SetBitmap(const wxBitmapBundle& bmp);
-    /**
-
-    */
-    wxBitmap GetBitmap() const;
+    virtual void SetLabel(const wxString& s);
 
     /**
 
     */
-    void SetDisabledBitmap(const wxBitmapBundle& bmp);
-    /**
-
-    */
-    wxBitmap GetDisabledBitmap() const;
+    virtual const wxString& GetLabel() const;
 
     /**
 
     */
-    void SetHoverBitmap(const wxBitmapBundle& bmp);
-    /**
-
-    */
-    wxBitmap GetHoverBitmap() const;
+    virtual void SetBitmap(const wxBitmapBundle& bmp);
 
     /**
 
     */
-    void SetShortHelp(const wxString& s);
-    /**
-
-    */
-    const wxString& GetShortHelp() const;
+    virtual wxBitmap GetBitmap() const;
 
     /**
 
     */
-    void SetLongHelp(const wxString& s);
-    /**
-
-    */
-    const wxString& GetLongHelp() const;
+    virtual void SetDisabledBitmap(const wxBitmapBundle& bmp);
 
     /**
 
     */
-    void SetMinSize(const wxSize& s);
-    /**
-
-    */
-    const wxSize& GetMinSize() const;
+    virtual wxBitmap GetDisabledBitmap() const;
 
     /**
 
     */
-    void SetSpacerPixels(int s);
-    /**
-
-    */
-    int GetSpacerPixels() const;
+    virtual void SetHoverBitmap(const wxBitmapBundle& bmp);
 
     /**
 
     */
-    void SetProportion(int p);
-    /**
-
-    */
-    int GetProportion() const;
+    virtual wxBitmap GetHoverBitmap() const;
 
     /**
 
     */
-    void SetActive(bool b);
+    virtual void SetShortHelp(const wxString& s);
+
     /**
 
     */
-    bool IsActive() const;
+    virtual const wxString& GetShortHelp() const;
+
+    /**
+
+    */
+    virtual void SetLongHelp(const wxString& s);
+
+    /**
+
+    */
+    virtual const wxString& GetLongHelp() const;
+
+    /**
+
+    */
+    virtual void SetMinSize(const wxSize& s);
+
+    /**
+
+    */
+    virtual const wxSize& GetMinSize() const;
+
+    /**
+
+    */
+    virtual void SetSpacerPixels(int s);
+
+    /**
+
+    */
+    virtual int GetSpacerPixels() const;
+
+    /**
+
+    */
+    virtual void SetProportion(int p);
+
+    /**
+
+    */
+    virtual int GetProportion() const;
+
+    /**
+
+    */
+    virtual void SetActive(bool b);
+
+    /**
+
+    */
+    virtual bool IsActive() const;
 
     /**
         Set whether this tool has a drop down button.
 
         This is only valid for wxITEM_NORMAL tools.
     */
-    void SetHasDropDown(bool b);
+    virtual void SetHasDropDown(bool b);
+
     /**
         Returns whether the toolbar item has an associated drop down button.
     */
-    bool HasDropDown() const;
+    virtual bool HasDropDown() const;
 
     /**
 
     */
-    void SetSticky(bool b);
+    virtual void SetSticky(bool b);
+
     /**
 
     */
-    bool IsSticky() const;
+    virtual bool IsSticky() const;
 
     /**
         Associates a number with the item.
@@ -456,7 +482,7 @@ public:
 
         @see GetUserData()
     */
-    void SetUserData(long userData);
+    virtual void SetUserData(long userData);
 
     /**
         Get number associated with the item.
@@ -465,7 +491,7 @@ public:
 
         @see SetUserData()
     */
-    long GetUserData() const;
+    virtual long GetUserData() const;
 
     /**
         Associates a wxObject with the item.
@@ -476,7 +502,7 @@ public:
 
         @since 3.3.0
     */
-    void SetClientData(wxObject* clientData);
+    virtual void SetClientData(wxObject* clientData);
 
     /**
         Get wxObject associated with the item.
@@ -487,23 +513,24 @@ public:
 
         @since 3.3.0
     */
-    wxObject* GetClientData() const;
+    virtual wxObject* GetClientData() const;
 
     /**
 
     */
-    void SetAlignment(int l);
+    virtual void SetAlignment(int l);
+
     /**
 
     */
-    int GetAlignment() const;
+    virtual int GetAlignment() const;
 
     /**
         Returns whether the toolbar item can be toggled.
 
         @since 3.1.5
      */
-    bool CanBeToggled() const;
+    virtual bool CanBeToggled() const;
 };
 
 /**

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -82,6 +82,51 @@ enum wxAuiToolBarStyle
 };
 
 /**
+    Possible values for the kind of a wxAuiToolBarItem
+
+    @since 3.3.0
+    @library{wxaui}
+    @category{aui}
+ */
+enum wxAuiToolBarItemKind
+{
+    /**
+      Normal AUI toolbar item.
+     */
+    wxAUI_TB_ITEM_NORMAL = wxITEM_NORMAL,
+
+    /**
+      Checkable AUI toolbar item.
+     */
+    wxAUI_TB_ITEM_CHECK = wxITEM_CHECK,
+
+    /**
+      Radio button AUI toolbar item.
+     */
+    wxAUI_TB_ITEM_RADIO = wxITEM_RADIO,
+
+    /**
+      Separator item for an AUI toolbar.
+     */
+    wxAUI_TB_ITEM_SEPARATOR = wxITEM_SEPARATOR,
+
+    /**
+      AUI Toolbar item containing a generic control.
+     */
+    wxAUI_TB_ITEM_CONTROL = wxITEM_MAX,
+
+    /**
+      Text label item for an AUI toolbar.
+     */
+    wxAUI_TB_ITEM_LABEL,
+
+    /**
+      Empty space for an AUI toolbar.
+     */
+    wxAUI_TB_ITEM_SPACER
+};
+
+/**
     wxAuiToolBarArtSetting
 
     @library{wxaui}
@@ -201,11 +246,11 @@ wxEventType wxEVT_AUITOOLBAR_BEGIN_DRAG;
     See also @ref wxAuiToolBar and @ref overview_aui.
 
     It has a unique id (except for the separators which always have id = -1), the
-    style (telling whether it is a normal button, separator or a control), the
-    state (toggled or not, enabled or not) and short and long help strings. The
-    default implementations use the short help string for the tooltip text which
-    is popped up when the mouse pointer enters the tool and the long help string
-    for the applications status bar (currently not implemented).
+    style (a value from #wxAuiToolBarItemKind telling whether it is a normal button,
+    separator or a control), the state (toggled or not, enabled or not) and short and
+    long help strings. The default implementations use the short help string for the
+    tooltip text which is popped up when the mouse pointer enters the tool and the long
+    help string for the applications status bar (currently not implemented).
 
     @library{wxaui}
     @category{aui}
@@ -253,15 +298,22 @@ public:
     int GetId() const;
 
     /**
-      Sets the wxAuiToolBarItem kind.
+      Sets the wxAuiToolBarItem kind, must be a value from #wxAuiToolBarItemKind.
+
+      @note Before 3.3.0, the kind parameter was a #wxItemKind of either @c wxITEM_NORMAL,
+            @c wxITEM_CHECK, @c wxITEM_RADIO or @c wxITEM_SEPARATOR. For 3.3.0 and later,
+            kind is a #wxAuiToolBarItemKind.
     */
     void SetKind(int new_kind);
 
     /**
       Returns the toolbar item kind.
 
-      @return one of @c wxITEM_NORMAL, @c wxITEM_CHECK or @c wxITEM_RADIO,
-      @c wxITEM_SEPARATOR, @c wxITEM_CONTROL, @c wxITEM_SPACER, @c wxITEM_LABEL,
+      @note Before 3.3.0, the kind parameter was a #wxItemKind of either @c wxITEM_NORMAL,
+            @c wxITEM_CHECK, @c wxITEM_RADIO or @c wxITEM_SEPARATOR. For 3.3.0 and later,
+            kind is a #wxAuiToolBarItemKind.
+
+      @return a #wxAuiToolBarItemKind value saying the kind of item the tool is.
     */
     int GetKind() const;
 
@@ -752,18 +804,22 @@ public:
 
         This function works similarly to the corresponding wxToolBar::AddTool()
         overloads. Note that before 3.3.0 the @a client_data parameter was not used.
+
+        Before 3.3.0, the kind parameter was a #wxItemKind of either @c wxITEM_NORMAL,
+        @c wxITEM_CHECK, @c wxITEM_RADIO or @c wxITEM_SEPARATOR. For 3.3.0 and later, kind
+        is a #wxAuiToolBarItemKind.
      */
     wxAuiToolBarItem* AddTool(int toolId,
                  const wxString& label,
                  const wxBitmapBundle& bitmap,
                  const wxString& short_help_string = wxEmptyString,
-                 wxItemKind kind = wxITEM_NORMAL);
+                 int kind = wxAUI_TB_ITEM_NORMAL);
 
     wxAuiToolBarItem* AddTool(int toolId,
                  const wxString& label,
                  const wxBitmapBundle& bitmap,
                  const wxBitmapBundle& disabled_bitmap,
-                 wxItemKind kind,
+                 int kind,
                  const wxString& short_help_string,
                  const wxString& long_help_string,
                  wxObject* client_data);

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -539,9 +539,15 @@ public:
     virtual int GetElementSize(int element_id) = 0;
     virtual void SetElementSize(int element_id, int size) = 0;
 
+    /**
+     * @note Until 3.3.0, the second argument was of type @c wxAuiToolBarItemArray,
+     *       which contained an array of the toolbar item objects. Now the argument
+     *       is of type @c wxAuiToolBarItenList and contains a list of pointers to
+     *       the toolbar items.
+     */
     virtual int ShowDropDown(
                          wxWindow* wnd,
-                         const wxAuiToolBarItemArray& items) = 0;
+                         const wxAuiToolBarItemList& items) = 0;
 };
 
 
@@ -630,8 +636,14 @@ public:
     virtual int GetElementSize(int element);
     virtual void SetElementSize(int element_id, int size);
 
+    /**
+     * @note Until 3.3.0, the second argument was of type @c wxAuiToolBarItemArray,
+     *       which contained an array of the toolbar item objects. Now the argument
+     *       is of type @c wxAuiToolBarItenList and contains a list of pointers to
+     *       the toolbar items.
+     */
     virtual int ShowDropDown(wxWindow* wnd,
-                             const wxAuiToolBarItemArray& items);
+                             const wxAuiToolBarItemList& items);
 };
 
 
@@ -763,6 +775,15 @@ public:
                  wxObject* client_data = nullptr,
                  const wxString& short_help_string = wxEmptyString,
                  const wxString& long_help_string = wxEmptyString);
+
+    /**
+       Add a tool to the toolbar.
+
+       Note that the toolbar takes ownership of @c item.
+
+       @since 3.3.0
+     */
+    wxAuiToolBarItem* AddTool(wxAuiToolBarItem* item);
     ///@}
 
     wxAuiToolBarItem* AddLabel(int toolId,
@@ -841,6 +862,11 @@ public:
     wxRect GetToolRect(int toolId) const;
     bool GetToolFitsByIndex(int toolId) const;
     bool GetToolBarFits() const;
+
+    /**
+        @since 3.3.0
+     */
+    bool GetToolBarItemFits(wxAuiToolBarItem* item) const;
 
     void SetMargins(const wxSize& size);
     void SetMargins(int x, int y);
@@ -943,6 +969,17 @@ public:
       @param append are the items to show after any overflow items
 
       @note The toolbar must have the @c wxAUI_TB_OVERFLOW style.
+
+      @since 3.3.0
+     */
+    void SetCustomOverflowItems(const wxAuiToolBarItemList& prepend,
+                                const wxAuiToolBarItemList& append);
+
+    /**
+      @deprecated This function is deprecated since version 3.3.0 and
+                  provided for backwards compatibility only. Use the
+                  @c wxAuiToolBarItemList version of @c wxAuiToolBar::SetCustomOverflowItems
+                  instead.
      */
     void SetCustomOverflowItems(const wxAuiToolBarItemArray& prepend,
                                 const wxAuiToolBarItemArray& append);

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -771,11 +771,11 @@ MyFrame::MyFrame(wxWindow* parent,
     wxAuiToolBarItemList append_items;
 
     wxAuiToolBarItem* item1 = new wxAuiToolBarItem();
-    item1->SetKind(wxITEM_SEPARATOR);
+    item1->SetKind(wxAUI_TB_ITEM_SEPARATOR);
     append_items.Append(item1);
 
     wxAuiToolBarItem* item2 = new wxAuiToolBarItem();
-    item2->SetKind(wxITEM_NORMAL);
+    item2->SetKind(wxAUI_TB_ITEM_NORMAL);
     item2->SetId(ID_CustomizeToolbar);
     item2->SetLabel(_("Customize..."));
     append_items.Append(item2);
@@ -798,11 +798,11 @@ MyFrame::MyFrame(wxWindow* parent,
     append_items.clear();
 
     item1 = new wxAuiToolBarItem();
-    item1->SetKind(wxITEM_SEPARATOR);
+    item1->SetKind(wxAUI_TB_ITEM_SEPARATOR);
     append_items.Append(item1);
 
     item2 = new wxAuiToolBarItem();
-    item2->SetKind(wxITEM_NORMAL);
+    item2->SetKind(wxAUI_TB_ITEM_NORMAL);
     item2->SetId(ID_CustomizeToolbar);
     item2->SetLabel(_("Customize..."));
     append_items.Append(item2);
@@ -833,11 +833,11 @@ MyFrame::MyFrame(wxWindow* parent,
     append_items.clear();
 
     item1 = new wxAuiToolBarItem();
-    item1->SetKind(wxITEM_SEPARATOR);
+    item1->SetKind(wxAUI_TB_ITEM_SEPARATOR);
     append_items.Append(item1);
 
     item2 = new wxAuiToolBarItem();
-    item2->SetKind(wxITEM_NORMAL);
+    item2->SetKind(wxAUI_TB_ITEM_NORMAL);
     item2->SetId(ID_CustomizeToolbar);
     item2->SetLabel(_("Customize..."));
     append_items.Append(item2);
@@ -845,18 +845,18 @@ MyFrame::MyFrame(wxWindow* parent,
     wxAuiToolBar* tb3 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW);
     wxBitmapBundle tb3_bmp1 = wxArtProvider::GetBitmapBundle(wxART_FOLDER, wxART_OTHER, wxSize(16,16));
-    tb3->AddTool(ID_SampleItem+16, "Check 1", tb3_bmp1, "Check 1", wxITEM_CHECK);
-    tb3->AddTool(ID_SampleItem+17, "Check 2", tb3_bmp1, "Check 2", wxITEM_CHECK);
-    tb3->AddTool(ID_SampleItem+18, "Check 3", tb3_bmp1, "Check 3", wxITEM_CHECK);
-    tb3->AddTool(ID_SampleItem+19, "Check 4", tb3_bmp1, "Check 4", wxITEM_CHECK);
+    tb3->AddTool(ID_SampleItem+16, "Check 1", tb3_bmp1, "Check 1", wxAUI_TB_ITEM_CHECK);
+    tb3->AddTool(ID_SampleItem+17, "Check 2", tb3_bmp1, "Check 2", wxAUI_TB_ITEM_CHECK);
+    tb3->AddTool(ID_SampleItem+18, "Check 3", tb3_bmp1, "Check 3", wxAUI_TB_ITEM_CHECK);
+    tb3->AddTool(ID_SampleItem+19, "Check 4", tb3_bmp1, "Check 4", wxAUI_TB_ITEM_CHECK);
     tb3->AddSeparator();
-    tb3->AddTool(ID_SampleItem+20, "Radio 1", tb3_bmp1, "Radio 1", wxITEM_RADIO);
-    tb3->AddTool(ID_SampleItem+21, "Radio 2", tb3_bmp1, "Radio 2", wxITEM_RADIO);
-    tb3->AddTool(ID_SampleItem+22, "Radio 3", tb3_bmp1, "Radio 3", wxITEM_RADIO);
+    tb3->AddTool(ID_SampleItem+20, "Radio 1", tb3_bmp1, "Radio 1", wxAUI_TB_ITEM_RADIO);
+    tb3->AddTool(ID_SampleItem+21, "Radio 2", tb3_bmp1, "Radio 2", wxAUI_TB_ITEM_RADIO);
+    tb3->AddTool(ID_SampleItem+22, "Radio 3", tb3_bmp1, "Radio 3", wxAUI_TB_ITEM_RADIO);
     tb3->AddSeparator();
-    tb3->AddTool(ID_SampleItem+23, "Radio 1 (Group 2)", tb3_bmp1, "Radio 1 (Group 2)", wxITEM_RADIO);
-    tb3->AddTool(ID_SampleItem+24, "Radio 2 (Group 2)", tb3_bmp1, "Radio 2 (Group 2)", wxITEM_RADIO);
-    tb3->AddTool(ID_SampleItem+25, "Radio 3 (Group 2)", tb3_bmp1, "Radio 3 (Group 2)", wxITEM_RADIO);
+    tb3->AddTool(ID_SampleItem+23, "Radio 1 (Group 2)", tb3_bmp1, "Radio 1 (Group 2)", wxAUI_TB_ITEM_RADIO);
+    tb3->AddTool(ID_SampleItem+24, "Radio 2 (Group 2)", tb3_bmp1, "Radio 2 (Group 2)", wxAUI_TB_ITEM_RADIO);
+    tb3->AddTool(ID_SampleItem+25, "Radio 3 (Group 2)", tb3_bmp1, "Radio 3 (Group 2)", wxAUI_TB_ITEM_RADIO);
     tb3->SetCustomOverflowItems(prepend_items, append_items);
     tb3->Realize();
 
@@ -866,11 +866,11 @@ MyFrame::MyFrame(wxWindow* parent,
     append_items.clear();
 
     item1 = new wxAuiToolBarItem();
-    item1->SetKind(wxITEM_SEPARATOR);
+    item1->SetKind(wxAUI_TB_ITEM_SEPARATOR);
     append_items.Append(item1);
 
     item2 = new wxAuiToolBarItem();
-    item2->SetKind(wxITEM_NORMAL);
+    item2->SetKind(wxAUI_TB_ITEM_NORMAL);
     item2->SetId(ID_CustomizeToolbar);
     item2->SetLabel(_("Customize..."));
     append_items.Append(item2);
@@ -906,11 +906,11 @@ MyFrame::MyFrame(wxWindow* parent,
     append_items.clear();
 
     item1 = new wxAuiToolBarItem();
-    item1->SetKind(wxITEM_SEPARATOR);
+    item1->SetKind(wxAUI_TB_ITEM_SEPARATOR);
     append_items.Append(item1);
 
     item2 = new wxAuiToolBarItem();
-    item2->SetKind(wxITEM_NORMAL);
+    item2->SetKind(wxAUI_TB_ITEM_NORMAL);
     item2->SetId(ID_CustomizeToolbar);
     item2->SetLabel(_("Customize..."));
     append_items.Append(item2);

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -766,17 +766,19 @@ MyFrame::MyFrame(wxWindow* parent,
 
 
     // prepare a few custom overflow elements for the toolbars' overflow buttons
+    // The toolbar takes ownership of the pointers to these items
+    wxAuiToolBarItemList prepend_items;
+    wxAuiToolBarItemList append_items;
 
-    wxAuiToolBarItemArray prepend_items;
-    wxAuiToolBarItemArray append_items;
-    wxAuiToolBarItem item;
-    item.SetKind(wxITEM_SEPARATOR);
-    append_items.Add(item);
-    item.SetKind(wxITEM_NORMAL);
-    item.SetId(ID_CustomizeToolbar);
-    item.SetLabel(_("Customize..."));
-    append_items.Add(item);
+    wxAuiToolBarItem* item1 = new wxAuiToolBarItem();
+    item1->SetKind(wxITEM_SEPARATOR);
+    append_items.Append(item1);
 
+    wxAuiToolBarItem* item2 = new wxAuiToolBarItem();
+    item2->SetKind(wxITEM_NORMAL);
+    item2->SetId(ID_CustomizeToolbar);
+    item2->SetLabel(_("Customize..."));
+    append_items.Append(item2);
 
     // create some toolbars
     wxAuiToolBar* tb1 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
@@ -790,6 +792,20 @@ MyFrame::MyFrame(wxWindow* parent,
     tb1->SetCustomOverflowItems(prepend_items, append_items);
     tb1->Realize();
 
+    // Create new overflow menu items because each toolbar needs its own items to own.
+    // Don't delete the ones we had before, since the toolbar now owns those.
+    prepend_items.clear();
+    append_items.clear();
+
+    item1 = new wxAuiToolBarItem();
+    item1->SetKind(wxITEM_SEPARATOR);
+    append_items.Append(item1);
+
+    item2 = new wxAuiToolBarItem();
+    item2->SetKind(wxITEM_NORMAL);
+    item2->SetId(ID_CustomizeToolbar);
+    item2->SetLabel(_("Customize..."));
+    append_items.Append(item2);
 
     wxAuiToolBar* tb2 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW | wxAUI_TB_HORIZONTAL);
@@ -811,6 +827,20 @@ MyFrame::MyFrame(wxWindow* parent,
     tb2->EnableTool(ID_SampleItem+6, false);
     tb2->Realize();
 
+    // Create new overflow menu items because each toolbar needs its own items to own.
+    // Don't delete the ones we had before, since the toolbar now owns those.
+    prepend_items.clear();
+    append_items.clear();
+
+    item1 = new wxAuiToolBarItem();
+    item1->SetKind(wxITEM_SEPARATOR);
+    append_items.Append(item1);
+
+    item2 = new wxAuiToolBarItem();
+    item2->SetKind(wxITEM_NORMAL);
+    item2->SetId(ID_CustomizeToolbar);
+    item2->SetLabel(_("Customize..."));
+    append_items.Append(item2);
 
     wxAuiToolBar* tb3 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW);
@@ -830,6 +860,20 @@ MyFrame::MyFrame(wxWindow* parent,
     tb3->SetCustomOverflowItems(prepend_items, append_items);
     tb3->Realize();
 
+    // Create new overflow menu items because each toolbar needs its own items to own.
+    // Don't delete the ones we had before, since the toolbar now owns those.
+    prepend_items.clear();
+    append_items.clear();
+
+    item1 = new wxAuiToolBarItem();
+    item1->SetKind(wxITEM_SEPARATOR);
+    append_items.Append(item1);
+
+    item2 = new wxAuiToolBarItem();
+    item2->SetKind(wxITEM_NORMAL);
+    item2->SetId(ID_CustomizeToolbar);
+    item2->SetLabel(_("Customize..."));
+    append_items.Append(item2);
 
     wxAuiToolBar* tb4 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE |
@@ -856,6 +900,20 @@ MyFrame::MyFrame(wxWindow* parent,
     tb4->AddControl(choice);
     tb4->Realize();
 
+    // Create new overflow menu items because each toolbar needs its own items to own.
+    // Don't delete the ones we had before, since the toolbar now owns those.
+    prepend_items.clear();
+    append_items.clear();
+
+    item1 = new wxAuiToolBarItem();
+    item1->SetKind(wxITEM_SEPARATOR);
+    append_items.Append(item1);
+
+    item2 = new wxAuiToolBarItem();
+    item2->SetKind(wxITEM_NORMAL);
+    item2->SetId(ID_CustomizeToolbar);
+    item2->SetLabel(_("Customize..."));
+    append_items.Append(item2);
 
     wxAuiToolBar* tb5 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW | wxAUI_TB_VERTICAL);

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2244,7 +2244,7 @@ void wxAuiToolBar::DoIdleUpdate()
             if (evt.GetSetChecked())
             {
                 // make sure we aren't checking an item that can't be
-                if (item->m_kind != wxAUI_TB_ITEM_CHECK && item->m_kind != wxAUI_TB_ITEM_RADIO)
+                if (!item->CanBeToggled())
                     continue;
 
                 bool is_checked = (item->m_state & wxAUI_BUTTON_STATE_CHECKED) ? true : false;
@@ -2670,7 +2670,7 @@ void wxAuiToolBar::OnLeftUp(wxMouseEvent& evt)
             wxCommandEvent e(wxEVT_MENU, m_actionItem->m_toolId);
             e.SetEventObject(this);
 
-            if (hitItem->m_kind == wxAUI_TB_ITEM_CHECK || hitItem->m_kind == wxAUI_TB_ITEM_RADIO)
+            if (hitItem->CanBeToggled())
             {
                 const bool toggle = !(m_actionItem->m_state & wxAUI_BUTTON_STATE_CHECKED);
 

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -56,15 +56,6 @@ wxIMPLEMENT_CLASS(wxAuiToolBar, wxControl);
 wxIMPLEMENT_DYNAMIC_CLASS(wxAuiToolBarEvent, wxEvent);
 
 
-// missing wxITEM_* items
-enum
-{
-    wxITEM_CONTROL = wxITEM_MAX,
-    wxITEM_LABEL,
-    wxITEM_SPACER
-};
-
-
 wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
                              const wxColour& color);
 
@@ -766,7 +757,7 @@ int wxAuiGenericToolBarArt::ShowDropDown(wxWindow* wnd,
 
     for (wxAuiToolBarItem* item : items)
     {
-        if (item->GetKind() == wxITEM_NORMAL)
+        if (item->GetKind() == wxAUI_TB_ITEM_NORMAL)
         {
             wxString text = item->GetShortHelp();
             if (text.empty())
@@ -781,7 +772,7 @@ int wxAuiGenericToolBarArt::ShowDropDown(wxWindow* wnd,
             menuPopup.Append(m);
             items_added++;
         }
-        else if (item->GetKind() == wxITEM_SEPARATOR)
+        else if (item->GetKind() == wxAUI_TB_ITEM_SEPARATOR)
         {
             if (items_added > 0)
                 menuPopup.AppendSeparator();
@@ -977,7 +968,7 @@ wxAuiToolBarItem* wxAuiToolBar::AddTool(int tool_id,
                            const wxString& label,
                            const wxBitmapBundle& bitmap,
                            const wxBitmapBundle& disabledBitmap,
-                           wxItemKind kind,
+                           int kind,
                            const wxString& shortHelpString,
                            const wxString& longHelpString,
                            wxObject* client_data)
@@ -1019,7 +1010,7 @@ wxAuiToolBarItem* wxAuiToolBar::AddControl(wxControl* control,
     item->m_toolId = control->GetId();
     item->m_state = 0;
     item->m_proportion = 0;
-    item->m_kind = wxITEM_CONTROL;
+    item->m_kind = wxAUI_TB_ITEM_CONTROL;
     item->m_sizerItem = nullptr;
     item->m_minSize = control->GetEffectiveMinSize();
     item->m_userData = 0;
@@ -1047,7 +1038,7 @@ wxAuiToolBarItem* wxAuiToolBar::AddLabel(int tool_id,
     item->m_toolId = tool_id;
     item->m_state = 0;
     item->m_proportion = 0;
-    item->m_kind = wxITEM_LABEL;
+    item->m_kind = wxAUI_TB_ITEM_LABEL;
     item->m_sizerItem = nullptr;
     item->m_minSize = min_size;
     item->m_userData = 0;
@@ -1068,7 +1059,7 @@ wxAuiToolBarItem* wxAuiToolBar::AddSeparator()
     item->m_toolId = -1;
     item->m_state = 0;
     item->m_proportion = 0;
-    item->m_kind = wxITEM_SEPARATOR;
+    item->m_kind = wxAUI_TB_ITEM_SEPARATOR;
     item->m_sizerItem = nullptr;
     item->m_minSize = wxDefaultSize;
     item->m_userData = 0;
@@ -1091,7 +1082,7 @@ wxAuiToolBarItem* wxAuiToolBar::AddSpacer(int pixels)
     item->m_toolId = -1;
     item->m_state = 0;
     item->m_proportion = 0;
-    item->m_kind = wxITEM_SPACER;
+    item->m_kind = wxAUI_TB_ITEM_SPACER;
     item->m_sizerItem = nullptr;
     item->m_minSize = wxDefaultSize;
     item->m_userData = 0;
@@ -1114,7 +1105,7 @@ wxAuiToolBarItem* wxAuiToolBar::AddStretchSpacer(int proportion)
     item->m_toolId = -1;
     item->m_state = 0;
     item->m_proportion = proportion;
-    item->m_kind = wxITEM_SPACER;
+    item->m_kind = wxAUI_TB_ITEM_SPACER;
     item->m_sizerItem = nullptr;
     item->m_minSize = wxDefaultSize;
     item->m_userData = 0;
@@ -1548,7 +1539,7 @@ void wxAuiToolBar::ToggleTool(int tool_id, bool state)
 
     if ( tool && tool->CanBeToggled() )
     {
-        if (tool->m_kind == wxITEM_RADIO)
+        if (tool->m_kind == wxAUI_TB_ITEM_RADIO)
         {
             int idx, count;
             idx = GetToolIndex(tool_id);
@@ -1559,13 +1550,13 @@ void wxAuiToolBar::ToggleTool(int tool_id, bool state)
                 int i;
                 for (i = idx + 1; i < count; ++i)
                 {
-                    if (m_items[i]->m_kind != wxITEM_RADIO)
+                    if (m_items[i]->m_kind != wxAUI_TB_ITEM_RADIO)
                         break;
                     m_items[i]->m_state &= ~wxAUI_BUTTON_STATE_CHECKED;
                 }
                 for (i = idx - 1; i >= 0; i--)
                 {
-                    if (m_items[i]->m_kind != wxITEM_RADIO)
+                    if (m_items[i]->m_kind != wxAUI_TB_ITEM_RADIO)
                         break;
                     m_items[i]->m_state &= ~wxAUI_BUTTON_STATE_CHECKED;
                 }
@@ -1573,7 +1564,7 @@ void wxAuiToolBar::ToggleTool(int tool_id, bool state)
 
             tool->m_state |= wxAUI_BUTTON_STATE_CHECKED;
         }
-         else if (tool->m_kind == wxITEM_CHECK)
+         else if (tool->m_kind == wxAUI_TB_ITEM_CHECK)
         {
             if (state == true)
                 tool->m_state |= wxAUI_BUTTON_STATE_CHECKED;
@@ -1963,7 +1954,7 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
 
         switch (item->m_kind)
         {
-            case wxITEM_LABEL:
+            case wxAUI_TB_ITEM_LABEL:
             {
                 wxSize size = m_art->GetLabelSize(dc, this, *item);
                 sizerItem = sizer->Add(size.x + (m_toolBorderPadding*2),
@@ -1976,9 +1967,9 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
                 break;
             }
 
-            case wxITEM_CHECK:
-            case wxITEM_NORMAL:
-            case wxITEM_RADIO:
+            case wxAUI_TB_ITEM_CHECK:
+            case wxAUI_TB_ITEM_NORMAL:
+            case wxAUI_TB_ITEM_RADIO:
             {
                 wxSize size = m_art->GetToolSize(dc, this, *item);
                 sizerItem = sizer->Add(size.x + (m_toolBorderPadding*2),
@@ -1992,7 +1983,7 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
                 break;
             }
 
-            case wxITEM_SEPARATOR:
+            case wxAUI_TB_ITEM_SEPARATOR:
             {
                 if (horizontal)
                     sizerItem = sizer->Add(separatorSize, 1, 0, wxEXPAND);
@@ -2006,14 +1997,14 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
                 break;
             }
 
-            case wxITEM_SPACER:
+            case wxAUI_TB_ITEM_SPACER:
                 if (item->m_proportion > 0)
                     sizerItem = sizer->AddStretchSpacer(item->m_proportion);
                 else
                     sizerItem = sizer->Add(item->m_spacerPixels, 1);
                 break;
 
-            case wxITEM_CONTROL:
+            case wxAUI_TB_ITEM_CONTROL:
             {
                 wxSizerItem* ctrl_m_sizerItem;
 
@@ -2253,7 +2244,7 @@ void wxAuiToolBar::DoIdleUpdate()
             if (evt.GetSetChecked())
             {
                 // make sure we aren't checking an item that can't be
-                if (item->m_kind != wxITEM_CHECK && item->m_kind != wxITEM_RADIO)
+                if (item->m_kind != wxAUI_TB_ITEM_CHECK && item->m_kind != wxAUI_TB_ITEM_RADIO)
                     continue;
 
                 bool is_checked = (item->m_state & wxAUI_BUTTON_STATE_CHECKED) ? true : false;
@@ -2476,7 +2467,7 @@ void wxAuiToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
         switch ( item->m_kind )
         {
-            case wxITEM_NORMAL:
+            case wxAUI_TB_ITEM_NORMAL:
                 // draw a regular or dropdown button
                 if (!item->m_dropDown)
                     m_art->DrawButton(dc, this, *item, item_rect);
@@ -2484,23 +2475,23 @@ void wxAuiToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
                     m_art->DrawDropDownButton(dc, this, *item, item_rect);
                 break;
 
-            case wxITEM_CHECK:
-            case wxITEM_RADIO:
+            case wxAUI_TB_ITEM_CHECK:
+            case wxAUI_TB_ITEM_RADIO:
                 // draw a toggle button
                 m_art->DrawButton(dc, this, *item, item_rect);
                 break;
 
-            case wxITEM_SEPARATOR:
+            case wxAUI_TB_ITEM_SEPARATOR:
                 // draw a separator
                 m_art->DrawSeparator(dc, this, item_rect);
                 break;
 
-            case wxITEM_LABEL:
+            case wxAUI_TB_ITEM_LABEL:
                 // draw a text label only
                 m_art->DrawLabel(dc, this, *item, item_rect);
                 break;
 
-            case wxITEM_CONTROL:
+            case wxAUI_TB_ITEM_CONTROL:
                 // draw the control's label
                 m_art->DrawControlLabel(dc, this, *item, item_rect);
                 break;
@@ -2679,7 +2670,7 @@ void wxAuiToolBar::OnLeftUp(wxMouseEvent& evt)
             wxCommandEvent e(wxEVT_MENU, m_actionItem->m_toolId);
             e.SetEventObject(this);
 
-            if (hitItem->m_kind == wxITEM_CHECK || hitItem->m_kind == wxITEM_RADIO)
+            if (hitItem->m_kind == wxAUI_TB_ITEM_CHECK || hitItem->m_kind == wxAUI_TB_ITEM_RADIO)
             {
                 const bool toggle = !(m_actionItem->m_state & wxAUI_BUTTON_STATE_CHECKED);
 
@@ -2836,7 +2827,7 @@ void wxAuiToolBar::OnMiddleUp(wxMouseEvent& evt)
 
     if (m_actionItem && hitItem == m_actionItem)
     {
-        if (hitItem->m_kind == wxITEM_NORMAL)
+        if (hitItem->m_kind == wxAUI_TB_ITEM_NORMAL)
         {
             wxAuiToolBarEvent e(wxEVT_AUITOOLBAR_MIDDLE_CLICK, m_actionItem->m_toolId);
             e.SetEventObject(this);

--- a/src/aui/barartmsw.cpp
+++ b/src/aui/barartmsw.cpp
@@ -445,7 +445,7 @@ void wxAuiMSWToolBarArt::SetElementSize(int elementId, int size)
 }
 
 int wxAuiMSWToolBarArt::ShowDropDown(wxWindow* wnd,
-    const wxAuiToolBarItemArray& items)
+    const wxAuiToolBarItemList& items)
 {
     return wxAuiGenericToolBarArt::ShowDropDown(wnd, items);
 }

--- a/src/xrc/xh_auitoolb.cpp
+++ b/src/xrc/xh_auitoolb.cpp
@@ -56,13 +56,13 @@ wxObject *wxAuiToolBarXmlHandler::DoCreateResource()
             return nullptr;
         }
 
-        wxItemKind kind = wxITEM_NORMAL;
+        wxAuiToolBarItemKind kind = wxAUI_TB_ITEM_NORMAL;
         if (GetBool(wxS("radio")))
-            kind = wxITEM_RADIO;
+            kind = wxAUI_TB_ITEM_RADIO;
 
         if (GetBool(wxS("toggle")))
         {
-            if ( kind != wxITEM_NORMAL )
+            if ( kind != wxAUI_TB_ITEM_NORMAL )
             {
                 ReportParamError
                 (
@@ -71,7 +71,7 @@ wxObject *wxAuiToolBarXmlHandler::DoCreateResource()
                 );
             }
 
-            kind = wxITEM_CHECK;
+            kind = wxAUI_TB_ITEM_CHECK;
         }
 #if wxUSE_MENUS
         // check whether we have dropdown tag inside


### PR DESCRIPTION
This PR makes two sets of changes to the AUI toolbar, which nominally breaks a bit of the API in some places (but a lot of effort was made to preserve API for most of the changes.

The first change is to change the container type used by wxAuiToolBar to be a list of pointers instead of an array of items. This allows wxAuiToolBarItem to be subclassed, and then for those subclasses to be used in the toolbar. This is similar to how a wxMenu operates (and since wxMenu was built that way, I initially thought the toolbar would work that way also). I actually do have a usecase for subclassing a tool, specifically to add multiple kinds of additional data/metadata to a tool (so it is better to subclass it than use a struct in the client data).

This change to a list from an array also allows for quite a bit of modernization of the loops in the AUI toolbar, replacing the older ones using indices with range-based for loops over the items. (the previous array implementation didn't have the proper iterators for range-based for loops for this code).

The second set of changes adds AUI-specific item IDs and actually exports them. The AUI toolbar uses 7 different values for kind, but only 4 were ever exported (since they were also in `wxItemKind`), so the other three were internal-only. This change exports them all in the user-facing API, while giving them the prefix `wxAUI_TB_ITEM_*`.


Overall, I have tried to preserve as much API as I can, but did decide to break the API in the toolbar art class in a non-backwards compatible way (but the fix is simple). This means that I did leave the original overflow item set method as a deprecated method (and marked as such). In order to preserve the API for the AUI-specific item ID change, I modified the toolbar `AddTool` methods to use `ints` instead of `wxitemKind`, allowing either the existing `wxitemKind` values or the new `wxAuiToolBarItemKind` values to be used (and I have kept the numerical values for those two types linked as well so that existing code still works with no changes).