### PR TITLE
Don't use `-mthreads` option when building with MinGW

### DIFF
--- a/configure
+++ b/configure
@@ -35027,53 +35027,6 @@ $as_echo "$wx_cv_type_abi_forced_unwind" >&6; }
         fi
       fi
     fi
-else
-    if test "$wxUSE_THREADS" = "yes" ; then
-      case "${host}" in
-        x86_64-*-mingw* )
-        ;;
-        *-*-mingw32* )
-                        { $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler supports -mthreads" >&5
-$as_echo_n "checking if compiler supports -mthreads... " >&6; }
-if ${wx_cv_cflags_mthread+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-
-                    CFLAGS_OLD="$CFLAGS"
-                    CFLAGS="-mthreads $CFLAGS"
-                    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  wx_cv_cflags_mthread=yes
-else
-  wx_cv_cflags_mthread=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $wx_cv_cflags_mthread" >&5
-$as_echo "$wx_cv_cflags_mthread" >&6; }
-
-            if test "$wx_cv_cflags_mthread" = "yes"; then
-                                WXCONFIG_CFLAGS="$WXCONFIG_CFLAGS -mthreads"
-                LDFLAGS="$LDFLAGS -mthreads"
-            else
-                                CFLAGS="$CFLAGS_OLD"
-            fi
-        ;;
-      esac
-    fi
 fi
 
 ac_fn_c_check_func "$LINENO" "localtime_r" "ac_cv_func_localtime_r"

--- a/configure.in
+++ b/configure.in
@@ -4240,11 +4240,9 @@ dnl flush the cache
 AC_CACHE_SAVE
 
 dnl ---------------------------------------------------------------------------
-dnl thread support for Unix (for Win32 and OS/2 see past
-dnl                          the next matching "else")
+dnl thread support for Unix (other platforms don't need anything special)
 dnl ---------------------------------------------------------------------------
 
-dnl under MSW (except mingw32) we always have thread support
 if test "$TOOLKIT" != "MSW"; then
 
     dnl the code below:
@@ -4623,37 +4621,6 @@ if test "$TOOLKIT" != "MSW"; then
             AC_DEFINE(HAVE_ABI_FORCEDUNWIND)
         fi
       fi
-    fi
-dnl from if !MSW
-else
-    if test "$wxUSE_THREADS" = "yes" ; then
-      case "${host}" in
-        x86_64-*-mingw* )
-        ;;
-        *-*-mingw32* )
-            dnl check if the compiler accepts -mthreads
-            AC_CACHE_CHECK([if compiler supports -mthreads],
-                wx_cv_cflags_mthread,
-                [
-                    CFLAGS_OLD="$CFLAGS"
-                    CFLAGS="-mthreads $CFLAGS"
-                    AC_TRY_COMPILE([], [],
-                        wx_cv_cflags_mthread=yes,
-                        wx_cv_cflags_mthread=no
-                    )
-                ]
-            )
-
-            if test "$wx_cv_cflags_mthread" = "yes"; then
-                dnl it does, use it
-                WXCONFIG_CFLAGS="$WXCONFIG_CFLAGS -mthreads"
-                LDFLAGS="$LDFLAGS -mthreads"
-            else
-                dnl it doesn't
-                CFLAGS="$CFLAGS_OLD"
-            fi
-        ;;
-      esac
     fi
 fi
 


### PR DESCRIPTION
This option seems to be obsolete and was only ever needed for classic MinGW32 which is not even supported any more.

This basically reverts a0b9e27fd4 (Applied Fabian Wenzel's patches to add -mthreads for threads to work in MinGW., 2002-08-28).

See #23314.