### PR TITLE
Don't try using `-mthreads` with clang

### DIFF
--- a/configure
+++ b/configure
@@ -37171,7 +37171,7 @@ else
         x86_64-*-mingw* )
         ;;
         *-*-mingw32* )
-                        { $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler supports -mthreads" >&5
+                                                { $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler supports -mthreads" >&5
 $as_echo_n "checking if compiler supports -mthreads... " >&6; }
 if ${wx_cv_cflags_mthread+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -37185,6 +37185,10 @@ else
 int
 main ()
 {
+
+#ifdef __clang__
+#error no
+#endif
 
   ;
   return 0;

--- a/configure.in
+++ b/configure.in
@@ -5251,13 +5251,20 @@ else
         x86_64-*-mingw* )
         ;;
         *-*-mingw32* )
-            dnl check if the compiler accepts -mthreads
+            dnl check if the compiler is gcc and accepts -mthreads (clang just
+            dnl ignores this option but it doesn't need it, so explicitly fail
+            dnl the test for it)
             AC_CACHE_CHECK([if compiler supports -mthreads],
                 wx_cv_cflags_mthread,
                 [
                     CFLAGS_OLD="$CFLAGS"
                     CFLAGS="-mthreads $CFLAGS"
-                    AC_TRY_COMPILE([], [],
+                    AC_TRY_COMPILE([],
+                        [
+#ifdef __clang__
+#error no
+#endif
+                        ],
                         wx_cv_cflags_mthread=yes,
                         wx_cv_cflags_mthread=no
                     )


### PR DESCRIPTION
This option is useless with it and is, at best, ignored or, at worst, results in errors if it happens to be used together with -Werror, -Wunused-command-line-argument

See #23314.