### PR TITLE
Improvements to `wxApp` initialization

### DIFF
--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -502,13 +502,13 @@ protected:
              m_appDisplayName,    // app display name ("My Application")
              m_className;         // class name
 
-    // the class defining the application behaviour, nullptr initially and created
-    // by GetTraits() when first needed
-    wxAppTraits *m_traits;
+    // allows customizing the application behaviour, created by GetTraits()
+    // when first needed
+    wxAppTraits *m_traits = nullptr;
 
     // the main event loop of the application (may be null if the loop hasn't
     // been started yet or has already terminated)
-    wxEventLoopBase *m_mainLoop;
+    wxEventLoopBase *m_mainLoop = nullptr;
 
 
     // pending events management vars:
@@ -529,7 +529,7 @@ protected:
 #endif
 
     // flag modified by Suspend/ResumeProcessingOfPendingEvents()
-    bool m_bDoPendingEventProcessing;
+    bool m_bDoPendingEventProcessing = true;
 
     friend class WXDLLIMPEXP_FWD_BASE wxEvtHandler;
 

--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -476,6 +476,10 @@ public:
     wxCmdLineArgsArray argv;
 
 protected:
+    // This function must be called at the end of wxApp ctor to indicate that
+    // wx part of the object is fully constructed.
+    void WXAppConstructed();
+
     // delete all objects in wxPendingDelete list
     //
     // called from ProcessPendingEvents()
@@ -531,6 +535,11 @@ protected:
     // flag modified by Suspend/ResumeProcessingOfPendingEvents()
     bool m_bDoPendingEventProcessing = true;
 
+private:
+    // flag set to true at the end of wxApp ctor, call WXAppConstructed() to
+    // set it
+    bool m_fullyConstructed = false;
+
     friend class WXDLLIMPEXP_FWD_BASE wxEvtHandler;
 
     // the application object is a singleton anyhow, there is no sense in
@@ -541,8 +550,11 @@ protected:
 #if defined(__UNIX__) && !defined(__WINDOWS__)
     #include "wx/unix/app.h"
 #else
-    // this has to be a class and not a typedef as we forward declare it
-    class wxAppConsole : public wxAppConsoleBase { };
+    class wxAppConsole : public wxAppConsoleBase
+    {
+    public:
+        wxAppConsole() { WXAppConstructed(); }
+    };
 #endif
 
 // ----------------------------------------------------------------------------

--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -550,11 +550,8 @@ private:
 #if defined(__UNIX__) && !defined(__WINDOWS__)
     #include "wx/unix/app.h"
 #else
-    class wxAppConsole : public wxAppConsoleBase
-    {
-    public:
-        wxAppConsole() { WXAppConstructed(); }
-    };
+    // this has to be a class and not a typedef as we forward declare it
+    class wxAppConsole : public wxAppConsoleBase { };
 #endif
 
 // ----------------------------------------------------------------------------

--- a/include/wx/dcsvg.h
+++ b/include/wx/dcsvg.h
@@ -16,7 +16,8 @@
 #include "wx/string.h"
 #include "wx/filename.h"
 #include "wx/dc.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 #define wxSVGVersion wxT("v0101")
 
@@ -271,8 +272,8 @@ private:
     bool                m_graphics_changed;  // set by Set{Brush,Pen}()
     int                 m_width, m_height;
     double              m_dpi;
-    wxScopedPtr<wxFileOutputStream> m_outfile;
-    wxScopedPtr<wxSVGBitmapHandler> m_bmp_handler; // class to handle bitmaps
+    std::unique_ptr<wxFileOutputStream> m_outfile;
+    std::unique_ptr<wxSVGBitmapHandler> m_bmp_handler; // class to handle bitmaps
     wxSVGShapeRenderingMode m_renderingMode;
 
     // The clipping nesting level is incremented by every call to

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -15,7 +15,9 @@
 
 #if wxUSE_GRID
 
-#include "wx/scopedptr.h"
+#if wxUSE_VALIDATORS
+    #include <memory>
+#endif
 
 class wxGridCellEditorEvtHandler : public wxEvtHandler
 {
@@ -102,7 +104,7 @@ protected:
 private:
     size_t                   m_maxChars;        // max number of chars allowed
 #if wxUSE_VALIDATORS
-    wxScopedPtr<wxValidator> m_validator;
+    std::unique_ptr<wxValidator> m_validator;
 #endif
     wxString                 m_value;
 };

--- a/include/wx/gtk/evtloop.h
+++ b/include/wx/gtk/evtloop.h
@@ -16,6 +16,8 @@
 
 typedef union  _GdkEvent        GdkEvent;
 
+#include <vector>
+
 class WXDLLIMPEXP_CORE wxGUIEventLoop : public wxEventLoopBase
 {
 public:
@@ -28,7 +30,7 @@ public:
     virtual void WakeUp() override;
 
     void StoreGdkEventForLaterProcessing(GdkEvent* ev)
-        { m_arrGdkEvents.Add(ev); }
+        { m_queuedGdkEvents.push_back(ev); }
 
 protected:
     virtual int DoRun() override;
@@ -38,8 +40,8 @@ private:
     // the exit code of this event loop
     int m_exitcode;
 
-    // used to temporarily store events in DoYield()
-    wxArrayPtrVoid m_arrGdkEvents;
+    // used to temporarily store events processed in DoYieldFor()
+    std::vector<GdkEvent*> m_queuedGdkEvents;
 
     wxDECLARE_NO_COPY_CLASS(wxGUIEventLoop);
 };

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -12,9 +12,10 @@
 
 #include "wx/ffile.h"
 #include "wx/hashmap.h"
-#include "wx/scopedptr.h"
 
 #include "wx/private/refcountermt.h"
+
+#include <memory>
 
 WX_DECLARE_STRING_HASH_MAP(wxString, wxWebRequestHeaderMap);
 
@@ -63,7 +64,7 @@ public:
 
     void SetData(const wxString& text, const wxString& contentType, const wxMBConv& conv = wxConvUTF8);
 
-    bool SetData(wxScopedPtr<wxInputStream>& dataStream, const wxString& contentType, wxFileOffset dataSize = wxInvalidOffset);
+    bool SetData(std::unique_ptr<wxInputStream>& dataStream, const wxString& contentType, wxFileOffset dataSize = wxInvalidOffset);
 
     void SetStorage(wxWebRequest::Storage storage) { m_storage = storage; }
 
@@ -111,7 +112,7 @@ protected:
     wxWebRequest::Storage m_storage;
     wxWebRequestHeaderMap m_headers;
     wxFileOffset m_dataSize;
-    wxScopedPtr<wxInputStream> m_dataStream;
+    std::unique_ptr<wxInputStream> m_dataStream;
     bool m_peerVerifyDisabled;
 
     wxWebRequestImpl(wxWebSession& session,
@@ -204,7 +205,7 @@ private:
 
     wxMemoryBuffer m_readBuffer;
     mutable wxFFile m_file;
-    mutable wxScopedPtr<wxInputStream> m_stream;
+    mutable std::unique_ptr<wxInputStream> m_stream;
 
     wxDECLARE_NO_COPY_CLASS(wxWebResponseImpl);
 };

--- a/include/wx/qt/app.h
+++ b/include/wx/qt/app.h
@@ -11,6 +11,8 @@
 
 #include <wx/scopedarray.h>
 
+#include <memory>
+
 class QApplication;
 class WXDLLIMPEXP_CORE wxApp : public wxAppBase
 {
@@ -21,7 +23,7 @@ public:
     virtual bool Initialize(int& argc, wxChar **argv) override;
 
 private:
-    wxScopedPtr<QApplication> m_qtApplication;
+    std::unique_ptr<QApplication> m_qtApplication;
     int m_qtArgc;
     wxScopedArray<char*> m_qtArgv;
 

--- a/include/wx/qt/dcclient.h
+++ b/include/wx/qt/dcclient.h
@@ -10,7 +10,7 @@
 
 #include "wx/qt/dc.h"
 
-#include "wx/scopedptr.h"
+#include <memory>
 
 class QPicture;
 
@@ -39,7 +39,7 @@ public:
 
     ~wxClientDCImpl();
 private:
-    wxScopedPtr<QPicture> m_pict;
+    std::unique_ptr<QPicture> m_pict;
 
     wxDECLARE_CLASS(wxClientDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxClientDCImpl);

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -9,6 +9,8 @@
 #ifndef _WX_QT_WINDOW_H_
 #define _WX_QT_WINDOW_H_
 
+#include <memory>
+
 class QShortcut;
 template < class T > class QList;
 
@@ -243,13 +245,13 @@ private:
     bool QtSetBackgroundStyle();
 
     QPicture *m_qtPicture;                                   // not owned
-    wxScopedPtr<QPainter> m_qtPainter;                       // always allocated
+    std::unique_ptr<QPainter> m_qtPainter;                   // always allocated
 
     bool m_mouseInside;
 
 #if wxUSE_ACCEL
     wxVector<QShortcut*> m_qtShortcuts; // owned by whatever GetHandle() returns
-    wxScopedPtr<wxQtShortcutHandler> m_qtShortcutHandler;    // always allocated
+    std::unique_ptr<wxQtShortcutHandler> m_qtShortcutHandler; // always allocated
     bool m_processingShortcut;
 #endif // wxUSE_ACCEL
 

--- a/include/wx/scopedptr.h
+++ b/include/wx/scopedptr.h
@@ -27,6 +27,9 @@
 #ifndef _WX_SCOPED_PTR_H_
 #define _WX_SCOPED_PTR_H_
 
+// Everything in this file is deprecated and must not be used any longer,
+// simply use std::unique_ptr<> instead.
+
 #include "wx/defs.h"
 #include "wx/checkeddelete.h"
 

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -21,7 +21,8 @@
 #include "wx/language.h"
 #include "wx/hashmap.h"
 #include "wx/strconv.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 // ============================================================================
 // global decls
@@ -75,7 +76,7 @@ class WXDLLIMPEXP_FWD_BASE wxTranslationsLoader;
 class WXDLLIMPEXP_FWD_BASE wxLocale;
 
 class wxPluralFormsCalculator;
-wxDECLARE_SCOPED_PTR(wxPluralFormsCalculator, wxPluralFormsCalculatorPtr)
+using wxPluralFormsCalculatorPtr = std::unique_ptr<wxPluralFormsCalculator>;
 
 // ----------------------------------------------------------------------------
 // wxMsgCatalog corresponds to one loaded message catalog.
@@ -86,7 +87,7 @@ class WXDLLIMPEXP_BASE wxMsgCatalog
 public:
     // Ctor is protected, because CreateFromXXX functions must be used,
     // but destruction should be unrestricted
-    ~wxMsgCatalog() = default;
+    ~wxMsgCatalog();
 
     // load the catalog from disk or from data; caller is responsible for
     // deleting them if not null
@@ -103,9 +104,7 @@ public:
     const wxString *GetString(const wxString& sz, unsigned n = UINT_MAX, const wxString& ct = wxEmptyString) const;
 
 protected:
-    wxMsgCatalog(const wxString& domain)
-        : m_pNext(nullptr), m_domain(domain)
-    {}
+    wxMsgCatalog(const wxString& domain);
 
 private:
     // variable pointing to the next element in a linked list (or nullptr)

--- a/interface/wx/scopedptr.h
+++ b/interface/wx/scopedptr.h
@@ -8,6 +8,11 @@
 /**
     @class wxScopedPtr
 
+    Deprecated equivalent of standard @c unique_ptr template class.
+
+    Please don't use this class, and especially its macro-based versions, in
+    the new code.
+
     This is a simple scoped smart pointer implementation that is similar to
     the Boost smart pointers (see http://www.boost.org) but rewritten
     to use macros instead.

--- a/samples/archive/archive.cpp
+++ b/samples/archive/archive.cpp
@@ -18,10 +18,11 @@
 #include "wx/app.h"
 #include "wx/cmdline.h"
 #include "wx/filename.h"
-#include "wx/scopedptr.h"
 #include "wx/vector.h"
 #include "wx/wfstream.h"
 #include "wx/zipstrm.h"
+
+#include <memory>
 
 class ArchiveApp: public wxAppConsole
 {
@@ -198,7 +199,7 @@ int ArchiveApp::DoCreate()
     wxTempFileOutputStream fileOutputStream(m_archiveFileName);
     if (m_archiveClassFactory)
     {
-        wxScopedPtr<wxArchiveOutputStream> archiveOutputStream(m_archiveClassFactory->NewStream(fileOutputStream));
+        std::unique_ptr<wxArchiveOutputStream> archiveOutputStream(m_archiveClassFactory->NewStream(fileOutputStream));
         if (m_archiveClassFactory->GetProtocol().IsSameAs("zip", false) && m_forceZip64)
             reinterpret_cast<wxZipOutputStream*>(archiveOutputStream.get())->SetFormat(wxZIP_FORMAT_ZIP64);
 
@@ -229,7 +230,7 @@ int ArchiveApp::DoCreate()
             return -1;
         }
 
-        wxScopedPtr<wxFilterOutputStream> filterOutputStream(m_filterClassFactory->NewStream(fileOutputStream));
+        std::unique_ptr<wxFilterOutputStream> filterOutputStream(m_filterClassFactory->NewStream(fileOutputStream));
         wxFileInputStream inputFileStream(*m_fileNames.begin());
         if (!inputFileStream.IsOk())
         {
@@ -253,7 +254,7 @@ int ArchiveApp::DoList()
 
     if (m_archiveClassFactory)
     {
-        wxScopedPtr<wxArchiveInputStream> archiveStream(m_archiveClassFactory->NewStream(fileInputStream));
+        std::unique_ptr<wxArchiveInputStream> archiveStream(m_archiveClassFactory->NewStream(fileInputStream));
         wxPrintf("Archive: %s\n", m_archiveFileName);
         wxPrintf("Length     Date       Time     Name\n");
         wxPrintf("---------- ---------- -------- ----\n");
@@ -291,7 +292,7 @@ int ArchiveApp::DoExtract()
 
     if (m_archiveClassFactory)
     {
-        wxScopedPtr<wxArchiveInputStream> archiveStream(m_archiveClassFactory->NewStream(fileInputStream));
+        std::unique_ptr<wxArchiveInputStream> archiveStream(m_archiveClassFactory->NewStream(fileInputStream));
         wxPrintf("Extracting from: %s\n", m_archiveFileName);
         for (wxArchiveEntry* entry = archiveStream->GetNextEntry(); entry;
              entry = archiveStream->GetNextEntry())
@@ -306,7 +307,7 @@ int ArchiveApp::DoExtract()
     }
     else
     {
-        wxScopedPtr<wxFilterInputStream> filterStream(m_filterClassFactory->NewStream(fileInputStream));
+        std::unique_ptr<wxFilterInputStream> filterStream(m_filterClassFactory->NewStream(fileInputStream));
         wxPrintf("Extracting single file from: %s\n", m_archiveFileName);
         wxTempFileOutputStream outputFileStream(wxFileName(m_archiveFileName).GetName());
         if (!CopyStreamData(*filterStream, outputFileStream, -1))

--- a/samples/exec/exec.cpp
+++ b/samples/exec/exec.cpp
@@ -52,7 +52,6 @@
 #include "wx/numdlg.h"
 #include "wx/textdlg.h"
 #include "wx/ffile.h"
-#include "wx/scopedptr.h"
 #include "wx/stopwatch.h"
 
 #include "wx/process.h"
@@ -62,6 +61,8 @@
 #ifdef __WINDOWS__
     #include "wx/dde.h"
 #endif // __WINDOWS__
+
+#include <memory>
 
 #ifndef wxHAS_IMAGES_IN_RESOURCES
     #include "../sample.xpm"
@@ -1121,7 +1122,7 @@ void MyFrame::OnShowCommandForExt(wxCommandEvent& WXUNUSED(event))
 
     s_ext = ext;
 
-    wxScopedPtr<wxFileType>
+    std::unique_ptr<wxFileType>
         ft(wxTheMimeTypesManager->GetFileTypeFromExtension(ext));
     if ( !ft )
     {

--- a/samples/image/image.cpp
+++ b/samples/image/image.cpp
@@ -24,7 +24,6 @@
 #include "wx/mstream.h"
 #include "wx/wfstream.h"
 #include "wx/quantize.h"
-#include "wx/scopedptr.h"
 #include "wx/stopwatch.h"
 #include "wx/versioninfo.h"
 #include "wx/artprov.h"
@@ -47,6 +46,8 @@
 #endif
 
 #include "canvas.h"
+
+#include <memory>
 
 #ifndef wxHAS_IMAGES_IN_RESOURCES
     #include "../sample.xpm"
@@ -1270,7 +1271,7 @@ private:
 
         // Use wxGraphicsContext if available for alpha support.
 #if wxUSE_GRAPHICS_CONTEXT
-        wxScopedPtr<wxGraphicsContext> const
+        std::unique_ptr<wxGraphicsContext> const
             gc(wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(dc));
 
         gc->DrawBitmap(m_bitmap, 0, 0, sizeWin.x, sizeWin.y);
@@ -1409,7 +1410,7 @@ private:
     void OnPaint(wxPaintEvent& WXUNUSED(event))
     {
         wxPaintDC dc(this);
-        wxScopedPtr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
+        std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
         wxGraphicsBitmap gb(gc->CreateBitmapFromImage(m_image));
 
         gc->SetFont(*wxNORMAL_FONT, *wxBLACK);

--- a/samples/ownerdrw/ownerdrw.cpp
+++ b/samples/ownerdrw/ownerdrw.cpp
@@ -159,8 +159,7 @@ void OwnerDrawnFrame::InitMenu()
     pItem->SetBitmaps(bmpBell);
     file_menu->Append(pItem);
 
-    pItem = new wxMenuItem(file_menu, Menu_Bitmap2, "So&und",
-                           "icon changes!", wxITEM_CHECK);
+    pItem = new wxMenuItem(file_menu, Menu_Bitmap2, "So&und with a very very very very very very long label", "", wxITEM_CHECK);
     pItem->SetFont(fontBmp);
     pItem->SetBitmaps(bmpSound, bmpNoSound);
     file_menu->Append(pItem);

--- a/samples/preferences/preferences.cpp
+++ b/samples/preferences/preferences.cpp
@@ -16,7 +16,6 @@
 #include "wx/app.h"
 #include "wx/config.h"
 #include "wx/panel.h"
-#include "wx/scopedptr.h"
 #include "wx/menu.h"
 #include "wx/checkbox.h"
 #include "wx/listbox.h"
@@ -24,6 +23,8 @@
 #include "wx/sizer.h"
 #include "wx/artprov.h"
 #include "wx/frame.h"
+
+#include <memory>
 
 // This struct combines the settings edited in the preferences dialog.
 struct MySettings
@@ -57,7 +58,7 @@ public:
 
 private:
     class MyFrame* m_frame;
-    wxScopedPtr<wxPreferencesEditor> m_prefEditor;
+    std::unique_ptr<wxPreferencesEditor> m_prefEditor;
     MySettings m_settings;
 };
 

--- a/samples/printing/printing.cpp
+++ b/samples/printing/printing.cpp
@@ -35,7 +35,8 @@
 
 #if wxUSE_GRAPHICS_CONTEXT
     #include "wx/graphics.h"
-    #include "wx/scopedptr.h"
+
+    #include <memory>
 #endif
 
 #ifdef __WXMAC__
@@ -212,7 +213,7 @@ void MyApp::Draw(wxDC&dc)
         dc.DrawBitmap( m_bitmap, dc.FromDIP(10), dc.FromDIP(10) );
 
 #if wxUSE_GRAPHICS_CONTEXT
-    wxScopedPtr<wxGraphicsContext> gc(wxGraphicsContext::CreateFromUnknownDC(dc));
+    std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::CreateFromUnknownDC(dc));
 
     if (gc)
     {

--- a/samples/shaped/shaped.cpp
+++ b/samples/shaped/shaped.cpp
@@ -36,9 +36,10 @@
 #include "wx/dcclient.h"
 #include "wx/graphics.h"
 #include "wx/image.h"
-#include "wx/scopedptr.h"
 #include "wx/sizer.h"
 #include "wx/slider.h"
+
+#include <memory>
 
 #ifndef wxHAS_IMAGES_IN_RESOURCES
     #include "../sample.xpm"
@@ -539,7 +540,7 @@ SeeThroughFrame::Create(wxWindow* parent)
 void SeeThroughFrame::OnPaint(wxPaintEvent& WXUNUSED(evt))
 {
     wxPaintDC dc(this);
-    wxScopedPtr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
+    std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
 
     // Draw 3 bands: one opaque, one semi-transparent and one transparent.
     const wxSize size = GetClientSize();

--- a/samples/sockets/client.cpp
+++ b/samples/sockets/client.cpp
@@ -28,7 +28,8 @@
 #include "wx/url.h"
 #include "wx/sstream.h"
 #include "wx/thread.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 // --------------------------------------------------------------------------
 // resources
@@ -590,7 +591,7 @@ void DoDownload(const wxString& urlname)
 
     // Try to get the input stream (connects to the given URL)
     wxLogMessage("Establishing connection to \"%s\"...", urlname);
-    const wxScopedPtr<wxInputStream> data(url.GetInputStream());
+    const std::unique_ptr<wxInputStream> data(url.GetInputStream());
     if ( !data.get() )
     {
         wxLogError("Failed to retrieve URL \"%s\"", urlname);

--- a/src/common/any.cpp
+++ b/src/common/any.cpp
@@ -25,7 +25,8 @@
 #include "wx/module.h"
 #include "wx/hashmap.h"
 #include "wx/hashset.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 using namespace wxPrivate;
 
@@ -118,9 +119,9 @@ private:
     wxVector<wxAnyToVariantRegistration*>   m_anyToVariantRegs;
 };
 
-static wxScopedPtr<wxAnyValueTypeGlobals>& GetAnyValueTypeGlobals()
+static std::unique_ptr<wxAnyValueTypeGlobals>& GetAnyValueTypeGlobals()
 {
-    static wxScopedPtr<wxAnyValueTypeGlobals> s_wxAnyValueTypeGlobals;
+    static std::unique_ptr<wxAnyValueTypeGlobals> s_wxAnyValueTypeGlobals;
     if ( !s_wxAnyValueTypeGlobals )
     {
         // Notice that it is _not_ sufficient to just initialize the static

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -74,6 +74,8 @@
     #include "wx/recguard.h"
 #endif // wxDEBUG_LEVEL
 
+#include <memory>
+
 // wxABI_VERSION can be defined when compiling applications but it should be
 // left undefined when compiling the library itself, it is then set to its
 // default value in version.h
@@ -397,7 +399,7 @@ bool wxAppConsoleBase::Yield(bool onlyIfNeeded)
     if ( loop )
        return loop->Yield(onlyIfNeeded);
 
-    wxScopedPtr<wxEventLoopBase> tmpLoop(CreateMainLoop());
+    std::unique_ptr<wxEventLoopBase> tmpLoop(CreateMainLoop());
     return tmpLoop->Yield(onlyIfNeeded);
 }
 

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -134,10 +134,6 @@ wxDEFINE_TIED_SCOPED_PTR_TYPE(wxEventLoopBase)
 
 wxAppConsoleBase::wxAppConsoleBase()
 {
-    m_traits = nullptr;
-    m_mainLoop = nullptr;
-    m_bDoPendingEventProcessing = true;
-
     ms_appInstance = reinterpret_cast<wxAppConsole *>(this);
 
 #ifdef __WXDEBUG__

--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -55,7 +55,6 @@
 #include "wx/stdpaths.h"
 #include "wx/vector.h"
 #include "wx/scopedarray.h"
-#include "wx/scopedptr.h"
 #include "wx/scopeguard.h"
 #include "wx/except.h"
 
@@ -67,6 +66,8 @@
 #else
     #include "wx/wfstream.h"
 #endif
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // wxWidgets macros
@@ -880,7 +881,7 @@ wxDocTemplate::~wxDocTemplate()
 wxDocument *wxDocTemplate::CreateDocument(const wxString& path, long flags)
 {
     // InitDocument() is supposed to delete the document object if its
-    // initialization fails so don't use wxScopedPtr<> here: this is fragile
+    // initialization fails so don't use unique_ptr<> here: this is fragile
     // but unavoidable because the default implementation uses CreateView()
     // which may -- or not -- create a wxView and if it does create it and its
     // initialization fails then the view destructor will delete the document
@@ -924,7 +925,7 @@ wxDocTemplate::InitDocument(wxDocument* doc, const wxString& path, long flags)
 
 wxView *wxDocTemplate::CreateView(wxDocument *doc, long flags)
 {
-    wxScopedPtr<wxView> view(DoCreateView());
+    std::unique_ptr<wxView> view(DoCreateView());
     if ( !view )
         return nullptr;
 

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -45,10 +45,7 @@
 #include "wx/thread.h"
 
 #if wxUSE_BASE
-    #include "wx/scopedptr.h"
-
-    wxDECLARE_SCOPED_PTR(wxEvent, wxEventPtr)
-    wxDEFINE_SCOPED_PTR(wxEvent, wxEventPtr)
+    #include <memory>
 #endif // wxUSE_BASE
 
 #if wxUSE_GUI
@@ -1341,7 +1338,7 @@ void wxEvtHandler::ProcessPendingEvents()
         }
     }
 
-    wxEventPtr event(pEvent);
+    std::unique_ptr<wxEvent> event(pEvent);
 
     // it's important we remove event from list before processing it, else a
     // nested event loop, for example from a modal dialog, might process the

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -34,7 +34,6 @@
 #include "wx/filename.h"
 #include "wx/dir.h"
 
-#include "wx/scopedptr.h"
 #include "wx/tokenzr.h"
 
 // there are just too many of those...
@@ -47,6 +46,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+
+#include <memory>
 
 #if defined(__WXMAC__)
     #include  "wx/osx/private.h"  // includes mac headers
@@ -669,7 +670,7 @@ bool wxDirExists(const wxString& pathName)
 
 // Get first file name matching given wild card.
 
-static wxScopedPtr<wxDir> gs_dir;
+static std::unique_ptr<wxDir> gs_dir;
 static wxString gs_dirPath;
 
 wxString wxFindFirstFile(const wxString& spec, int flags)

--- a/src/common/fs_filter.cpp
+++ b/src/common/fs_filter.cpp
@@ -16,10 +16,7 @@
 #ifndef WX_PRECOMP
 #endif
 
-#include "wx/scopedptr.h"
-
-wxDEFINE_SCOPED_PTR_TYPE(wxFSFile)
-wxDEFINE_SCOPED_PTR_TYPE(wxInputStream)
+#include <memory>
 
 //----------------------------------------------------------------------------
 // wxFilterFSHandler
@@ -44,15 +41,15 @@ wxFSFile* wxFilterFSHandler::OpenFile(
         return nullptr;
 
     wxString left = GetLeftLocation(location);
-    wxFSFilePtr leftFile(fs.OpenFile(left));
+    std::unique_ptr<wxFSFile> leftFile(fs.OpenFile(left));
     if (!leftFile.get())
         return nullptr;
 
-    wxInputStreamPtr leftStream(leftFile->DetachStream());
+    std::unique_ptr<wxInputStream> leftStream(leftFile->DetachStream());
     if (!leftStream.get() || !leftStream->IsOk())
         return nullptr;
 
-    wxInputStreamPtr stream(factory->NewStream(leftStream.release()));
+    std::unique_ptr<wxInputStream> stream(factory->NewStream(leftStream.release()));
 
     // The way compressed streams are supposed to be served is e.g.:
     //  Content-type: application/postscript

--- a/src/common/gifdecod.cpp
+++ b/src/common/gifdecod.cpp
@@ -23,8 +23,9 @@
 #include <string.h>
 #include "wx/gifdecod.h"
 #include "wx/scopedarray.h"
-#include "wx/scopedptr.h"
 #include "wx/scopeguard.h"
+
+#include <memory>
 
 enum
 {
@@ -64,10 +65,6 @@ public:
 
     wxDECLARE_NO_COPY_CLASS(GIFImage);
 };
-
-wxDECLARE_SCOPED_PTR(GIFImage, GIFImagePtr)
-wxDEFINE_SCOPED_PTR(GIFImage, GIFImagePtr)
-
 
 //---------------------------------------------------------------------------
 // GIFImage constructor
@@ -782,7 +779,7 @@ wxGIFErrorCode wxGIFDecoder::LoadGIF(wxInputStream& stream)
             case GIF_MARKER_SEP:
             {
                 // allocate memory for IMAGEN struct
-                GIFImagePtr pimg(new GIFImage());
+                std::unique_ptr<GIFImage> pimg(new GIFImage());
 
                 wxScopeGuard guardDestroy = wxMakeObjGuard(*this, &wxGIFDecoder::Destroy);
 

--- a/src/common/imagbmp.cpp
+++ b/src/common/imagbmp.cpp
@@ -30,12 +30,13 @@
 #include "wx/wfstream.h"
 #include "wx/quantize.h"
 #include "wx/scopedarray.h"
-#include "wx/scopedptr.h"
 #include "wx/anidecod.h"
 #include "wx/private/icondir.h"
 
 // For memcpy
 #include <string.h>
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // private functions
@@ -269,10 +270,10 @@ bool wxBMPHandler::SaveDib(wxImage *image,
     }
 
 #if wxUSE_PALETTE
-    wxScopedPtr<wxPalette> palette; // entries for quantized images
+    std::unique_ptr<wxPalette> palette; // entries for quantized images
 #endif // wxUSE_PALETTE
     wxScopedArray<wxUint8> rgbquad; // for the RGBQUAD bytes for the colormap
-    wxScopedPtr<wxImage> q_image;   // destination for quantized image
+    std::unique_ptr<wxImage> q_image;   // destination for quantized image
 
     // if <24bpp use quantization to reduce colors for *some* of the formats
     if ( (format == wxBMP_1BPP) || (format == wxBMP_4BPP) ||

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -66,7 +66,6 @@ public:
     wxDummyConsoleApp() { }
 
     virtual int OnRun() override { wxFAIL_MSG( wxT("unreachable code") ); return 0; }
-    virtual bool DoYield(bool, long) { return true; }
 
     wxDECLARE_NO_COPY_CLASS(wxDummyConsoleApp);
 };

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -296,13 +296,10 @@ bool wxEntryStart(int& argc, wxChar **argv)
     wxAppPtr app(wxTheApp);
     if ( !app.get() )
     {
-        // if not, he might have used wxIMPLEMENT_APP() to give us a
-        // function to create it
-        wxAppInitializerFunction fnCreate = wxApp::GetInitializerFunction();
-
-        if ( fnCreate )
+        // if they didn't, we should normally have the initializer function set
+        // up by wxIMPLEMENT_APP(), so use it to create one now
+        if ( auto fnCreate = wxApp::GetInitializerFunction() )
         {
-            // he did, try to create the custom wxApp object
             app.Set((*fnCreate)());
         }
     }

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -30,7 +30,6 @@
 #include "wx/init.h"
 #include "wx/atomic.h"
 
-#include "wx/scopedptr.h"
 #include "wx/except.h"
 
 #if defined(__WINDOWS__)
@@ -55,6 +54,8 @@
     #include <locale.h>
 #endif
 
+#include <memory>
+
 // ----------------------------------------------------------------------------
 // private classes
 // ----------------------------------------------------------------------------
@@ -72,13 +73,10 @@ public:
 
 // we need a special kind of auto pointer to wxApp which not only deletes the
 // pointer it holds in its dtor but also resets the global application pointer
-wxDECLARE_SCOPED_PTR(wxAppConsole, wxAppPtrBase)
-wxDEFINE_SCOPED_PTR(wxAppConsole, wxAppPtrBase)
-
-class wxAppPtr : public wxAppPtrBase
+class wxAppPtr : public std::unique_ptr<wxAppConsole>
 {
 public:
-    explicit wxAppPtr(wxAppConsole *ptr = nullptr) : wxAppPtrBase(ptr) { }
+    explicit wxAppPtr(wxAppConsole *ptr) : std::unique_ptr<wxAppConsole>(ptr) { }
     ~wxAppPtr()
     {
         if ( get() )

--- a/src/common/rendcmn.cpp
+++ b/src/common/rendcmn.cpp
@@ -28,8 +28,6 @@
 #include "wx/apptrait.h"
 #include "wx/renderer.h"
 
-#include "wx/scopedptr.h"
-
 #if wxUSE_DYNLIB_CLASS
     #include "wx/dynlib.h"
 #endif // wxUSE_DYNLIB_CLASS
@@ -38,7 +36,7 @@
 // wxRendererPtr: auto pointer holding the global renderer
 // ----------------------------------------------------------------------------
 
-typedef wxScopedPtr<wxRendererNative> wxRendererPtrBase;
+using wxRendererPtrBase = std::unique_ptr<wxRendererNative>;
 
 class wxRendererPtr : public wxRendererPtrBase
 {

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -32,8 +32,8 @@
 #include "wx/vector.h"
 #include "wx/listimpl.cpp"
 #include "wx/private/window.h"
-#include "wx/scopedptr.h"
 
+#include <memory>
 
 //---------------------------------------------------------------------------
 
@@ -832,7 +832,7 @@ wxSizerItem* wxSizer::DoInsert( size_t index, wxSizerItem *item )
         }
 
     private:
-        wxScopedPtr<wxSizerItem> m_item;
+        std::unique_ptr<wxSizerItem> m_item;
     };
 
     ContainingSizerGuard guard( item );
@@ -1527,7 +1527,7 @@ wxGridSizer::wxGridSizer( int rows, int cols, const wxSize& gap )
 wxSizerItem *wxGridSizer::DoInsert(size_t index, wxSizerItem *item)
 {
     // Ensure that the item will be deleted in case of exception.
-    wxScopedPtr<wxSizerItem> scopedItem( item );
+    std::unique_ptr<wxSizerItem> scopedItem( item );
 
     // if only the number of columns or the number of rows is specified for a
     // sizer, arbitrarily many items can be added to it but if both of them are

--- a/src/common/tarstrm.cpp
+++ b/src/common/tarstrm.cpp
@@ -22,7 +22,6 @@
 
 #include "wx/buffer.h"
 #include "wx/datetime.h"
-#include "wx/scopedptr.h"
 #include "wx/filename.h"
 #include "wx/thread.h"
 
@@ -33,6 +32,7 @@
 #include <grp.h>
 #endif
 
+#include <memory>
 
 /////////////////////////////////////////////////////////////////////////////
 // constants
@@ -629,8 +629,6 @@ void wxTarEntry::SetMode(int mode)
 /////////////////////////////////////////////////////////////////////////////
 // Input stream
 
-wxDEFINE_SCOPED_PTR_TYPE(wxTarEntry)
-
 wxTarInputStream::wxTarInputStream(wxInputStream& stream,
                                    wxMBConv& conv /*=wxConvLocal*/)
  :  wxArchiveInputStream(stream, conv)
@@ -672,7 +670,7 @@ wxTarEntry *wxTarInputStream::GetNextEntry()
     if (!IsOk())
         return nullptr;
 
-    wxTarEntryPtr entry(new wxTarEntry);
+    std::unique_ptr<wxTarEntry> entry(new wxTarEntry);
 
     entry->SetMode(GetHeaderNumber(TAR_MODE));
     entry->SetUserId(GetHeaderNumber(TAR_UID));
@@ -1088,7 +1086,7 @@ wxTarOutputStream::~wxTarOutputStream()
 
 bool wxTarOutputStream::PutNextEntry(wxTarEntry *entry)
 {
-    wxTarEntryPtr e(entry);
+    std::unique_ptr<wxTarEntry> e(entry);
 
     if (!CloseEntry())
         return false;

--- a/src/common/taskbarcmn.cpp
+++ b/src/common/taskbarcmn.cpp
@@ -22,7 +22,7 @@
     #include "wx/menu.h"
 #endif
 
-#include "wx/scopedptr.h"
+#include <memory>
 
 extern WXDLLIMPEXP_DATA_BASE(wxList) wxPendingDelete;
 
@@ -46,7 +46,7 @@ wxEND_EVENT_TABLE()
 
 void wxTaskBarIconBase::OnRightButtonDown(wxTaskBarIconEvent& WXUNUSED(event))
 {
-    wxScopedPtr<wxMenu> menuDeleter;
+    std::unique_ptr<wxMenu> menuDeleter;
     wxMenu *menu = GetPopupMenu();
     if ( !menu )
     {

--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -43,7 +43,6 @@
 #include "wx/filename.h"
 #include "wx/tokenzr.h"
 #include "wx/fontmap.h"
-#include "wx/scopedptr.h"
 #include "wx/stdpaths.h"
 #include "wx/version.h"
 #include "wx/private/threadinfo.h"
@@ -55,6 +54,8 @@
     #include "wx/msw/wrapwin.h"
     #include "wx/msw/missing.h"
 #endif
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // simple types
@@ -1084,7 +1085,7 @@ bool wxMsgCatalogFile::FillHash(wxStringToStringHashMap& hash,
     // conversion to use to convert catalog strings to the GUI encoding
     wxMBConv *inputConv = nullptr;
 
-    wxScopedPtr<wxMBConv> inputConvPtr; // just to delete inputConv if needed
+    std::unique_ptr<wxMBConv> inputConvPtr; // just to delete inputConv if needed
 
     if ( !m_charset.empty() )
     {
@@ -1157,7 +1158,7 @@ wxMsgCatalog::~wxMsgCatalog() = default;
 wxMsgCatalog *wxMsgCatalog::CreateFromFile(const wxString& filename,
                                            const wxString& domain)
 {
-    wxScopedPtr<wxMsgCatalog> cat(new wxMsgCatalog(domain));
+    std::unique_ptr<wxMsgCatalog> cat(new wxMsgCatalog(domain));
 
     wxMsgCatalogFile file;
 
@@ -1174,7 +1175,7 @@ wxMsgCatalog *wxMsgCatalog::CreateFromFile(const wxString& filename,
 wxMsgCatalog *wxMsgCatalog::CreateFromData(const wxScopedCharBuffer& data,
                                            const wxString& domain)
 {
-    wxScopedPtr<wxMsgCatalog> cat(new wxMsgCatalog(domain));
+    std::unique_ptr<wxMsgCatalog> cat(new wxMsgCatalog(domain));
 
     wxMsgCatalogFile file;
 

--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -383,22 +383,7 @@ bool wxPluralFormsScanner::nextToken()
 
 class wxPluralFormsNode;
 
-// NB: Can't use wxDEFINE_SCOPED_PTR_TYPE because wxPluralFormsNode is not
-//     fully defined yet:
-class wxPluralFormsNodePtr
-{
-public:
-    wxPluralFormsNodePtr(wxPluralFormsNode *p = nullptr) : m_p(p) {}
-    ~wxPluralFormsNodePtr();
-    wxPluralFormsNode& operator*() const { return *m_p; }
-    wxPluralFormsNode* operator->() const { return m_p; }
-    wxPluralFormsNode* get() const { return m_p; }
-    wxPluralFormsNode* release();
-    void reset(wxPluralFormsNode *p);
-
-private:
-    wxPluralFormsNode *m_p;
-};
+using wxPluralFormsNodePtr = std::unique_ptr<wxPluralFormsNode>;
 
 class wxPluralFormsNode
 {
@@ -415,26 +400,6 @@ private:
     wxPluralFormsToken m_token;
     wxPluralFormsNodePtr m_nodes[3];
 };
-
-wxPluralFormsNodePtr::~wxPluralFormsNodePtr()
-{
-    delete m_p;
-}
-wxPluralFormsNode* wxPluralFormsNodePtr::release()
-{
-    wxPluralFormsNode *p = m_p;
-    m_p = nullptr;
-    return p;
-}
-void wxPluralFormsNodePtr::reset(wxPluralFormsNode *p)
-{
-    if (p != m_p)
-    {
-        delete m_p;
-        m_p = p;
-    }
-}
-
 
 void wxPluralFormsNode::setNode(unsigned i, wxPluralFormsNode* n)
 {
@@ -517,8 +482,6 @@ private:
     wxPluralFormsToken::Number m_nplurals;
     wxPluralFormsNodePtr m_plural;
 };
-
-wxDEFINE_SCOPED_PTR(wxPluralFormsCalculator, wxPluralFormsCalculatorPtr)
 
 void wxPluralFormsCalculator::init(wxPluralFormsToken::Number nplurals,
                                 wxPluralFormsNode* plural)
@@ -1182,6 +1145,13 @@ bool wxMsgCatalogFile::FillHash(wxStringToStringHashMap& hash,
 // ----------------------------------------------------------------------------
 // wxMsgCatalog class
 // ----------------------------------------------------------------------------
+
+wxMsgCatalog::wxMsgCatalog(const wxString& domain)
+    : m_pNext(nullptr), m_domain(domain)
+{
+}
+
+wxMsgCatalog::~wxMsgCatalog() = default;
 
 /* static */
 wxMsgCatalog *wxMsgCatalog::CreateFromFile(const wxString& filename,

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -113,13 +113,13 @@ void wxWebRequestImpl::SetData(const wxString& text, const wxString& contentType
 {
     m_dataText = text.mb_str(conv);
 
-    wxScopedPtr<wxInputStream>
+    std::unique_ptr<wxInputStream>
         stream(new wxMemoryInputStream(m_dataText, m_dataText.length()));
     SetData(stream, contentType);
 }
 
 bool
-wxWebRequestImpl::SetData(wxScopedPtr<wxInputStream>& dataStream,
+wxWebRequestImpl::SetData(std::unique_ptr<wxInputStream>& dataStream,
                           const wxString& contentType,
                           wxFileOffset dataSize)
 {
@@ -431,7 +431,7 @@ wxWebRequest::SetData(wxInputStream* dataStream,
                       wxFileOffset dataSize)
 {
     // Ensure that the stream is destroyed even we return below.
-    wxScopedPtr<wxInputStream> streamPtr(dataStream);
+    std::unique_ptr<wxInputStream> streamPtr(dataStream);
 
     wxCHECK_IMPL( false );
 

--- a/src/dfb/app.cpp
+++ b/src/dfb/app.cpp
@@ -26,6 +26,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxEvtHandler);
 
 wxApp::wxApp()
 {
+    WXAppConstructed();
 }
 
 wxApp::~wxApp()

--- a/src/generic/activityindicator.cpp
+++ b/src/generic/activityindicator.cpp
@@ -30,7 +30,8 @@
 #endif // WX_PRECOMP
 
 #include "wx/graphics.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // constants
@@ -121,7 +122,7 @@ private:
     {
         wxPaintDC pdc(m_win);
 
-        wxScopedPtr<wxGraphicsContext> const
+        std::unique_ptr<wxGraphicsContext> const
             gc(wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(pdc));
 
         const wxSize size = m_win->GetClientSize();

--- a/src/generic/filepickerg.cpp
+++ b/src/generic/filepickerg.cpp
@@ -25,7 +25,7 @@
 #include "wx/filename.h"
 #include "wx/filepicker.h"
 
-#include "wx/scopedptr.h"
+#include <memory>
 
 
 // ============================================================================
@@ -89,7 +89,7 @@ bool wxGenericFileDirButton::Create(wxWindow *parent,
 
 void wxGenericFileDirButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
 {
-    wxScopedPtr<wxDialog> p(CreateDialog());
+    std::unique_ptr<wxDialog> p(CreateDialog());
     if (p->ShowModal() == wxID_OK)
     {
         // save updated path in m_path

--- a/src/generic/markuptext.cpp
+++ b/src/generic/markuptext.cpp
@@ -35,7 +35,8 @@
 
 #if wxUSE_GRAPHICS_CONTEXT
     #include "wx/graphics.h"
-    #include "wx/scopedptr.h"
+
+    #include <memory>
 #endif
 
 namespace
@@ -292,7 +293,7 @@ public:
 
 private:
 #if wxUSE_GRAPHICS_CONTEXT
-    wxScopedPtr<wxGraphicsContext> m_gc;
+    std::unique_ptr<wxGraphicsContext> m_gc;
 #endif
     wxWindow* const m_win;
     int const m_rendererFlags;

--- a/src/generic/preferencesg.cpp
+++ b/src/generic/preferencesg.cpp
@@ -30,9 +30,10 @@
 #include "wx/notebook.h"
 #include "wx/sizer.h"
 #include "wx/sharedptr.h"
-#include "wx/scopedptr.h"
 #include "wx/scopeguard.h"
 #include "wx/vector.h"
+
+#include <memory>
 
 namespace
 {
@@ -205,7 +206,7 @@ public:
 
     virtual void Show(wxWindow* parent) override
     {
-        wxScopedPtr<wxGenericPrefsDialog> dlg(CreateDialog(parent));
+        std::unique_ptr<wxGenericPrefsDialog> dlg(CreateDialog(parent));
 
         // Store it for Dismiss() but ensure that the pointer is reset to nullptr
         // when the dialog is destroyed on leaving this function.

--- a/src/generic/statbmpg.cpp
+++ b/src/generic/statbmpg.cpp
@@ -19,7 +19,8 @@
 
 #if wxUSE_GRAPHICS_CONTEXT
     #include "wx/graphics.h"
-    #include "wx/scopedptr.h"
+
+    #include <memory>
 #else
     #include "wx/image.h"
     #include "wx/math.h"
@@ -92,7 +93,7 @@ void wxGenericStaticBitmap::OnPaint(wxPaintEvent& WXUNUSED(event))
     wxDouble x = (drawSize.x - w) / 2;
     wxDouble y = (drawSize.y - h) / 2;
 #if wxUSE_GRAPHICS_CONTEXT
-    wxScopedPtr<wxGraphicsContext> const
+    std::unique_ptr<wxGraphicsContext> const
         gc(wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(dc));
     gc->DrawBitmap(bitmap, x, y, w, h);
 #else

--- a/src/generic/treelist.cpp
+++ b/src/generic/treelist.cpp
@@ -30,7 +30,8 @@
 #include "wx/dataview.h"
 #include "wx/renderer.h"
 #include "wx/scopedarray.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // Constants
@@ -486,7 +487,7 @@ wxTreeListModel::InsertItem(Node* parent,
         dvc->SetIndent(dvc->GetIndent());
     }
 
-    wxScopedPtr<Node>
+    std::unique_ptr<Node>
         newItem(new Node(parent, text, imageClosed, imageOpened, data));
 
     // If we have no children at all, then inserting as last child is the same

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -308,6 +308,8 @@ wxApp::wxApp()
 {
     m_isInAssert = false;
     m_idleSourceId = 0;
+
+    WXAppConstructed();
 }
 
 wxApp::~wxApp()

--- a/src/gtk/evtloop.cpp
+++ b/src/gtk/evtloop.cpp
@@ -385,18 +385,16 @@ void wxGUIEventLoop::DoYieldFor(long eventsToProcess)
     wxEventLoopBase::DoYieldFor(eventsToProcess);
 
     // put any unprocessed GDK events back in the queue
-    if ( !m_arrGdkEvents.IsEmpty() )
+    if ( !m_queuedGdkEvents.empty() )
     {
         GdkDisplay* disp = gdk_window_get_display(wxGetTopLevelGDK());
-        for (size_t i=0; i<m_arrGdkEvents.GetCount(); i++)
+        for ( GdkEvent* ev : m_queuedGdkEvents )
         {
-            GdkEvent* ev = (GdkEvent*)m_arrGdkEvents[i];
-
             // NOTE: gdk_display_put_event makes a copy of the event passed to it
             gdk_display_put_event(disp, ev);
             gdk_event_free(ev);
         }
 
-        m_arrGdkEvents.Clear();
+        m_queuedGdkEvents.clear();
     }
 }

--- a/src/gtk/menu.cpp
+++ b/src/gtk/menu.cpp
@@ -24,7 +24,8 @@
 
 #if wxUSE_ACCEL
     #include "wx/accel.h"
-    #include "wx/scopedptr.h"
+
+    #include <memory>
 #endif // wxUSE_ACCEL
 
 #include "wx/stockitem.h"
@@ -1433,7 +1434,7 @@ void GtkAccel::Init(const wxAcceleratorEntry* entry)
 
 GtkAccel::GtkAccel(const wxMenuItem* item)
 {
-    wxScopedPtr<wxAcceleratorEntry> accel(item->GetAccel());
+    std::unique_ptr<wxAcceleratorEntry> accel(item->GetAccel());
     Init(accel.get());
 
 #ifndef __WXGTK4__

--- a/src/gtk/nonownedwnd.cpp
+++ b/src/gtk/nonownedwnd.cpp
@@ -24,12 +24,13 @@
     #include "wx/dcclient.h"
     #include "wx/dcmemory.h"
     #include "wx/region.h"
-    #include "wx/scopedptr.h"
 #endif // WX_PRECOMP
 
 #include "wx/graphics.h"
 
 #include "wx/gtk/private/wrapgtk.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // wxNonOwnedWindowShapeImpl: base class for region and path-based classes.
@@ -162,7 +163,7 @@ private:
 #ifdef __WXGTK3__
         wxGraphicsContext* context = dc.GetGraphicsContext();
 #else
-        wxScopedPtr<wxGraphicsContext> context(wxGraphicsContext::Create(dc));
+        std::unique_ptr<wxGraphicsContext> context(wxGraphicsContext::Create(dc));
 #endif
         context->SetBrush(*wxWHITE);
         context->FillPath(path);
@@ -195,7 +196,7 @@ private:
 #ifdef __WXGTK3__
         wxGraphicsContext* context = dc.GetGraphicsContext();
 #else
-        wxScopedPtr<wxGraphicsContext> context(wxGraphicsContext::Create(dc));
+        std::unique_ptr<wxGraphicsContext> context(wxGraphicsContext::Create(dc));
 #endif
         context->SetPen(wxPen(*wxLIGHT_GREY, 2));
         context->StrokePath(m_path);

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -644,6 +644,45 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
 
     callBaseCleanup.Dismiss();
 
+    if ( !wxSystemOptions::GetOptionInt("msw.no-manifest-check") )
+    {
+        if ( GetComCtl32Version() < 610 )
+        {
+            // Check if we have wx resources in this program: this is not
+            // mandatory, but recommended and could be the simplest way to
+            // resolve the problem when not using MSVC.
+            wxString maybeNoResources;
+            if ( !::LoadIcon(wxGetInstance(), wxT("wxICON_AAA")) )
+            {
+                maybeNoResources = " (unless you don't include wx/msw/wx.rc "
+                    "from your resource file intentionally, you should do it "
+                    "and use the manifest defined in it)";
+            }
+
+            wxMessageBox
+            (
+                wxString::Format(R"(WARNING!
+
+This application doesn't use a correct manifest specifying
+the use of Common Controls Library v6%s.
+
+This is deprecated and won't be supported in the future
+wxWidgets versions, however for now you can still set
+"msw.no-manifest-check" system option to 1 (see
+https://docs.wxwidgets.org/latest/classwx_system_options.html
+for how to do it) to skip this check.
+
+Please use the appropriate manifest when building the
+application as described at
+https://docs.wxwidgets.org/latest/plat_msw_install.html#msw_manifest
+or contact us by posting to wx-dev@googlegroups.com
+if you believe not using the manifest should remain supported.
+)", maybeNoResources),
+                "wxWidgets Warning"
+            );
+        }
+    }
+
     return true;
 }
 
@@ -778,45 +817,6 @@ void wxApp::CleanUp()
 wxApp::wxApp()
 {
     m_printMode = wxPRINT_WINDOWS;
-
-    if ( !wxSystemOptions::GetOptionInt("msw.no-manifest-check") )
-    {
-        if ( GetComCtl32Version() < 610 )
-        {
-            // Check if we have wx resources in this program: this is not
-            // mandatory, but recommended and could be the simplest way to
-            // resolve the problem when not using MSVC.
-            wxString maybeNoResources;
-            if ( !::LoadIcon(wxGetInstance(), wxT("wxICON_AAA")) )
-            {
-                maybeNoResources = " (unless you don't include wx/msw/wx.rc "
-                    "from your resource file intentionally, you should do it "
-                    "and use the manifest defined in it)";
-            }
-
-            wxMessageBox
-            (
-                wxString::Format(R"(WARNING!
-
-This application doesn't use a correct manifest specifying
-the use of Common Controls Library v6%s.
-
-This is deprecated and won't be supported in the future
-wxWidgets versions, however for now you can still set
-"msw.no-manifest-check" system option to 1 (see
-https://docs.wxwidgets.org/latest/classwx_system_options.html
-for how to do it) to skip this check.
-
-Please use the appropriate manifest when building the
-application as described at
-https://docs.wxwidgets.org/latest/plat_msw_install.html#msw_manifest
-or contact us by posting to wx-dev@googlegroups.com
-if you believe not using the manifest should remain supported.
-)", maybeNoResources),
-                "wxWidgets Warning"
-            );
-        }
-    }
 
     WXAppConstructed();
 }

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -817,6 +817,8 @@ if you believe not using the manifest should remain supported.
             );
         }
     }
+
+    WXAppConstructed();
 }
 
 wxApp::~wxApp()

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -36,7 +36,6 @@
 #endif
 
 #include "wx/scopedarray.h"
-#include "wx/scopedptr.h"
 #include "wx/msw/private.h"
 #include "wx/msw/dc.h"
 
@@ -47,6 +46,8 @@
 #ifdef wxHAS_RAW_BITMAP
     #include "wx/rawbmp.h"
 #endif
+
+#include <memory>
 
 // missing from mingw32 header
 #ifndef CLR_INVALID
@@ -634,7 +635,7 @@ bool wxBitmap::CopyFromIcon(const wxIcon& icon, wxBitmapTransparency transp)
 
 bool wxBitmap::CopyFromDIB(const wxDIB& dib)
 {
-    wxScopedPtr<wxBitmapRefData> newData(new wxBitmapRefData);
+    std::unique_ptr<wxBitmapRefData> newData(new wxBitmapRefData);
     newData->CopyFromDIB(dib);
     if ( !newData->IsOk() )
         return false;

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -39,6 +39,7 @@
 #include "wx/file.h"
 #include "wx/quantize.h"
 #include "wx/scopedarray.h"
+#include "wx/scopedptr.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -39,12 +39,13 @@
 #include "wx/file.h"
 #include "wx/quantize.h"
 #include "wx/scopedarray.h"
-#include "wx/scopedptr.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
 #include <memory.h>
+
+#include <memory>
 
 #include "wx/msw/dib.h"
 
@@ -676,7 +677,7 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int dstDepth)
         {
             return false;
         }
-        wxScopedPtr<wxPalette> palette(tempPalette);
+        std::unique_ptr<wxPalette> palette(tempPalette);
         eightBitData.reset(tempEightBitData);
 
         // use palette's colors in result bitmap

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -41,7 +41,6 @@
 
 #include "wx/dynlib.h"
 #include "wx/filename.h"
-#include "wx/scopedptr.h"
 #include "wx/scopeguard.h"
 #include "wx/tokenzr.h"
 #include "wx/modalhook.h"
@@ -66,6 +65,8 @@
 
     #include "wx/msw/private/cotaskmemptr.h"
 #endif // wxUSE_IFILEOPENDIALOG
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // constants
@@ -579,7 +580,7 @@ public:
 
         // We pass the ID of the first control that will be added to the
         // combobox as the ctor argument.
-        wxScopedPtr<wxFileDialogChoiceImplFDC>
+        std::unique_ptr<wxFileDialogChoiceImplFDC>
             impl(new wxFileDialogChoiceImplFDC(m_fdc, m_lastId, m_lastAuxId - 1));
 
         for ( size_t i = 0; i < n; ++i )
@@ -1162,7 +1163,7 @@ static bool DoShowCommFileDialog(OPENFILENAME *of, long style, DWORD *err)
 {
     // Extra controls do not handle per-monitor DPI, fall back to system DPI
     // so entire file-dialog is resized.
-    wxScopedPtr<wxMSWImpl::AutoSystemDpiAware> dpiAwareness;
+    std::unique_ptr<wxMSWImpl::AutoSystemDpiAware> dpiAwareness;
     if ( of->Flags & OFN_ENABLEHOOK )
         dpiAwareness.reset(new wxMSWImpl::AutoSystemDpiAware());
 

--- a/src/msw/nonownedwnd.cpp
+++ b/src/msw/nonownedwnd.cpp
@@ -35,8 +35,9 @@
 #endif // wxUSE_GRAPHICS_CONTEXT
 
 #include "wx/dynlib.h"
-#include "wx/scopedptr.h"
 #include "wx/msw/missing.h"
+
+#include <memory>
 
 // ============================================================================
 // wxNonOwnedWindow implementation
@@ -91,7 +92,7 @@ public:
     {
         // Create the region corresponding to this path and set it as windows
         // shape.
-        wxScopedPtr<wxGraphicsContext> context(wxGraphicsContext::Create(win));
+        std::unique_ptr<wxGraphicsContext> context(wxGraphicsContext::Create(win));
         Region gr(static_cast<GraphicsPath*>(m_path.GetNativePath()));
         win->SetShape(
             wxRegion(
@@ -117,7 +118,7 @@ private:
         event.Skip();
 
         wxPaintDC dc(m_win);
-        wxScopedPtr<wxGraphicsContext> context(wxGraphicsContext::Create(dc));
+        std::unique_ptr<wxGraphicsContext> context(wxGraphicsContext::Create(dc));
         context->SetPen(wxPen(*wxLIGHT_GREY, 2));
         context->StrokePath(m_path);
     }

--- a/src/msw/taskbarbutton.cpp
+++ b/src/msw/taskbarbutton.cpp
@@ -25,12 +25,13 @@
 #include "wx/msw/private.h"
 #include "wx/msw/taskbarbutton.h"
 #include "wx/dynlib.h"
-#include "wx/scopedptr.h"
 #include "wx/msw/private/comptr.h"
 #include "wx/msw/private/cotaskmemptr.h"
 
 #include <shlwapi.h>
 #include <initguid.h>
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // Redefine the interfaces: ITaskbarList3, IObjectCollection,
@@ -566,9 +567,9 @@ private:
     wxCOMPtr<ICustomDestinationList>    m_destinationList;
     wxCOMPtr<IObjectArray>              m_objectArray;
 
-    wxScopedPtr<wxTaskBarJumpListCategory> m_tasks;
-    wxScopedPtr<wxTaskBarJumpListCategory> m_frequent;
-    wxScopedPtr<wxTaskBarJumpListCategory> m_recent;
+    std::unique_ptr<wxTaskBarJumpListCategory> m_tasks;
+    std::unique_ptr<wxTaskBarJumpListCategory> m_frequent;
+    std::unique_ptr<wxTaskBarJumpListCategory> m_recent;
     wxTaskBarJumpListCategories m_customCategories;
     bool m_recent_visible;
     bool m_frequent_visible;

--- a/src/osx/carbon/app.cpp
+++ b/src/osx/carbon/app.cpp
@@ -379,6 +379,8 @@ wxApp::wxApp()
     m_macCurrentEvent = nullptr ;
     m_macCurrentEventHandlerCallRef = nullptr ;
     m_macPool = sm_isEmbedded ? nullptr : new wxMacAutoreleasePool();
+
+    WXAppConstructed();
 }
 
 wxApp::~wxApp()

--- a/src/osx/carbon/dataobj.cpp
+++ b/src/osx/carbon/dataobj.cpp
@@ -32,6 +32,8 @@
 #include "wx/osx/private.h"
 #include "wx/osx/private/datatransfer.h"
 
+#include <memory>
+
 static CFStringRef kUTTypeTraditionalMacText = CFSTR("com.apple.traditional-mac-plain-text");
 
 static wxString privateUTIPrefix = "org.wxwidgets.private.";
@@ -423,7 +425,7 @@ bool wxDataObject::ReadFromSource(wxOSXDataSource * source)
             
             for ( size_t itemIndex = 0; itemIndex < itemCount && !transferred; ++itemIndex)
             {
-                wxScopedPtr<const wxOSXDataSourceItem> sitem(source->GetItem(itemIndex));
+                std::unique_ptr<const wxOSXDataSourceItem> sitem(source->GetItem(itemIndex));
                 
                 wxDataFormat::NativeFormat nativeFormat = sitem->AvailableType(typesarray);
                 CFDataRef flavorData = sitem->DoGetData(nativeFormat);

--- a/src/osx/cocoa/taskbar.mm
+++ b/src/osx/cocoa/taskbar.mm
@@ -19,10 +19,11 @@
     #include "wx/dcclient.h"
 #endif
 
-#include "wx/scopedptr.h"
 #include "wx/taskbar.h"
 
 #include "wx/osx/private.h"
+
+#include <memory>
 
 class wxTaskBarIconWindow;
 
@@ -105,7 +106,7 @@ protected:
 private:
     wxTaskBarIconDockImpl();
     wxMenu             *m_pMenu;
-    wxScopedPtr<wxMenu> m_menuDeleter;
+    std::unique_ptr<wxMenu> m_menuDeleter;
 };
 
 class wxTaskBarIconCustomStatusItemImpl;

--- a/src/osx/core/utilsexc_cf.cpp
+++ b/src/osx/core/utilsexc_cf.cpp
@@ -31,6 +31,8 @@
 
 #if wxUSE_EVENTLOOP_SOURCE
 
+#include <memory>
+
 namespace
 {
 
@@ -76,7 +78,7 @@ public:
     {
         wxCHECK_MSG( fd != -1, nullptr, "can't monitor invalid fd" );
 
-        wxScopedPtr<wxCFEventLoopSource>
+        std::unique_ptr<wxCFEventLoopSource>
             source(new wxCFEventLoopSource(handler, flags));
 
         CFSocketContext context = { 0, source.get(), nullptr, nullptr, nullptr };

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -31,12 +31,13 @@
 #endif
 
 #include "wx/osx/private.h"
-#include "wx/scopedptr.h"
 #include "wx/private/menuradio.h" // for wxMenuRadioItemsData
 
 // other standard headers
 // ----------------------
 #include <string.h>
+
+#include <memory>
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxMenuImpl, wxObject);
 
@@ -47,7 +48,7 @@ wxMenuImpl::~wxMenuImpl()
 // the (popup) menu title has this special menuid
 static const int idMenuTitle = -3;
 
-wxScopedPtr<wxMenu> gs_emptyMenuBar;
+std::unique_ptr<wxMenu> gs_emptyMenuBar;
 
 // ============================================================================
 // implementation

--- a/src/osx/nonownedwnd_osx.cpp
+++ b/src/osx/nonownedwnd_osx.cpp
@@ -533,7 +533,7 @@ bool wxNonOwnedWindow::DoSetRegionShape(const wxRegion& region)
 
 #if wxUSE_GRAPHICS_CONTEXT
 
-#include "wx/scopedptr.h"
+#include <memory>
 
 bool wxNonOwnedWindow::DoSetPathShape(const wxGraphicsPath& path)
 {
@@ -547,7 +547,7 @@ bool wxNonOwnedWindow::DoSetPathShape(const wxGraphicsPath& path)
         dc.SetBackground(*wxBLACK_BRUSH);
         dc.Clear();
 
-        wxScopedPtr<wxGraphicsContext> context(wxGraphicsContext::Create(dc));
+        std::unique_ptr<wxGraphicsContext> context(wxGraphicsContext::Create(dc));
         context->SetBrush(*wxWHITE_BRUSH);
         context->SetAntialiasMode(wxANTIALIAS_NONE);
         context->FillPath(path);

--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -20,6 +20,8 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxEvtHandler);
 wxApp::wxApp()
 {
     m_qtArgc = 0;
+
+    WXAppConstructed();
 }
 
 

--- a/src/qt/graphics.cpp
+++ b/src/qt/graphics.cpp
@@ -29,10 +29,11 @@
 #endif
 
 #include "wx/graphics.h"
-#include "wx/scopedptr.h"
 #include "wx/tokenzr.h"
 
 #include "wx/private/graphics.h"
+
+#include <memory>
 
 namespace
 {
@@ -1064,7 +1065,7 @@ protected:
 
 private:
     // This pointer may be empty if we don't own m_qtPainter.
-    wxScopedPtr<QPainter> m_ownedPainter;
+    std::unique_ptr<QPainter> m_ownedPainter;
 
     wxDECLARE_NO_COPY_CLASS(wxQtGraphicsContext);
 };

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -17,7 +17,6 @@
 #include "wx/ribbon/art.h"
 #include "wx/ribbon/bar.h"
 #include "wx/dcbuffer.h"
-#include "wx/scopedptr.h"
 
 #ifndef WX_PRECOMP
 #endif
@@ -25,6 +24,8 @@
 #ifdef __WXMSW__
 #include "wx/msw/private.h"
 #endif
+
+#include <memory>
 
 class wxRibbonToolBarToolBase
 {
@@ -242,7 +243,7 @@ wxRibbonToolBarToolBase* wxRibbonToolBar::InsertTool(
     wxASSERT(bitmap.IsOk());
 
     // Create the wxRibbonToolBarToolBase with parameters
-    wxScopedPtr<wxRibbonToolBarToolBase> tool(new wxRibbonToolBarToolBase);
+    std::unique_ptr<wxRibbonToolBarToolBase> tool(new wxRibbonToolBarToolBase);
     tool->id = tool_id;
     tool->bitmap = bitmap;
     if(bitmap_disabled.IsOk())

--- a/src/unix/appunix.cpp
+++ b/src/unix/appunix.cpp
@@ -16,13 +16,14 @@
 #endif
 
 #include "wx/evtloop.h"
-#include "wx/scopedptr.h"
 #include "wx/unix/private/wakeuppipe.h"
 #include "wx/private/fdiodispatcher.h"
 #include "wx/private/fdioeventloopsourcehandler.h"
 
 #include <signal.h>
 #include <unistd.h>
+
+#include <memory>
 
 #ifndef SA_RESTART
     // don't use for systems which don't define it (at least VMS and QNX)
@@ -134,7 +135,7 @@ wxFDIOHandler* wxAppConsole::RegisterSignalWakeUpPipe(wxFDIODispatcher& dispatch
     // we need a bridge to wxFDIODispatcher
     //
     // TODO: refactor the code so that only wxEventLoopSourceHandler is used
-    wxScopedPtr<wxFDIOHandler>
+    std::unique_ptr<wxFDIOHandler>
         fdioHandler(new wxFDIOEventLoopSourceHandler(m_signalWakeUpPipe));
 
     if ( !dispatcher.RegisterFD

--- a/src/unix/appunix.cpp
+++ b/src/unix/appunix.cpp
@@ -74,8 +74,6 @@ private:
 wxAppConsole::wxAppConsole()
 {
     m_signalWakeUpPipe = nullptr;
-
-    WXAppConstructed();
 }
 
 wxAppConsole::~wxAppConsole()

--- a/src/unix/appunix.cpp
+++ b/src/unix/appunix.cpp
@@ -74,6 +74,8 @@ private:
 wxAppConsole::wxAppConsole()
 {
     m_signalWakeUpPipe = nullptr;
+
+    WXAppConstructed();
 }
 
 wxAppConsole::~wxAppConsole()

--- a/src/unix/evtloopunix.cpp
+++ b/src/unix/evtloopunix.cpp
@@ -30,7 +30,6 @@
 #endif
 
 #include "wx/apptrait.h"
-#include "wx/scopedptr.h"
 #include "wx/thread.h"
 #include "wx/module.h"
 #include "wx/unix/private/timer.h"
@@ -44,6 +43,8 @@
 #if wxUSE_EVENTLOOP_SOURCE
     #include "wx/evtloopsrc.h"
 #endif // wxUSE_EVENTLOOP_SOURCE
+
+#include <memory>
 
 // ===========================================================================
 // wxEventLoop implementation
@@ -61,7 +62,7 @@ wxConsoleEventLoop::wxConsoleEventLoop()
     m_wakeupSource = nullptr;
 
     // Create the pipe.
-    wxScopedPtr<wxWakeUpPipeMT> wakeupPipe(new wxWakeUpPipeMT);
+    std::unique_ptr<wxWakeUpPipeMT> wakeupPipe(new wxWakeUpPipeMT);
     const int pipeFD = wakeupPipe->GetReadFd();
     if ( pipeFD == wxPipe::INVALID_FD )
         return;
@@ -119,7 +120,7 @@ public:
         // we need a bridge to wxFDIODispatcher
         //
         // TODO: refactor the code so that only wxEventLoopSourceHandler is used
-        wxScopedPtr<wxFDIOHandler>
+        std::unique_ptr<wxFDIOHandler>
             fdioHandler(new wxFDIOEventLoopSourceHandler(handler));
 
         if ( !wxFDIODispatcher::Get()->RegisterFD(fd, fdioHandler.get(), flags) )

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -26,8 +26,6 @@
     #include "wx/log.h"
 #endif //WX_PRECOMP
 
-#include "wx/scopedptr.h"
-
 #include "wx/gtk/private/wrapgtk.h"
 #include "wx/gtk/private/backend.h"
 #ifdef GDK_WINDOWING_WAYLAND
@@ -40,6 +38,8 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // wxGLContextAttrs: OpenGL rendering context attributes
@@ -583,7 +583,7 @@ EGLConfig *wxGLCanvasEGL::InitConfig(const wxGLAttributes& dispAttrs)
 /* static */
 bool wxGLCanvasBase::IsDisplaySupported(const wxGLAttributes& dispAttrs)
 {
-    wxScopedPtr<EGLConfig> config(wxGLCanvasEGL::InitConfig(dispAttrs));
+    std::unique_ptr<EGLConfig> config(wxGLCanvasEGL::InitConfig(dispAttrs));
     return config != nullptr;
 }
 

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -45,7 +45,6 @@
 #include "wx/apptrait.h"
 
 #include "wx/process.h"
-#include "wx/scopedptr.h"
 #include "wx/thread.h"
 
 #include "wx/cmdline.h"
@@ -62,6 +61,8 @@
 #include "wx/evtloop.h"
 #include "wx/mstream.h"
 #include "wx/private/fdioeventloopsourcehandler.h"
+
+#include <memory>
 
 #include <pwd.h>
 #include <sys/wait.h>       // waitpid()
@@ -546,12 +547,12 @@ int BlockUntilChildExit(wxExecuteData& execData)
 
     // Do register all the FDs we want to monitor here: first, the one used to
     // handle the signals asynchronously.
-    wxScopedPtr<wxFDIOHandler>
+    std::unique_ptr<wxFDIOHandler>
         signalHandler(wxTheApp->RegisterSignalWakeUpPipe(dispatcher));
 
 #if wxUSE_STREAMS
     // And then the two for the child output and error streams if necessary.
-    wxScopedPtr<wxFDIOHandler>
+    std::unique_ptr<wxFDIOHandler>
         stdoutHandler,
         stderrHandler;
     if ( execData.IsRedirected() )
@@ -622,7 +623,7 @@ long wxExecute(const char* const* argv, int flags, wxProcess* process,
 #endif // __DARWIN__
 
     // this struct contains all information which we use for housekeeping
-    wxScopedPtr<wxExecuteData> execDataPtr(new wxExecuteData);
+    std::unique_ptr<wxExecuteData> execDataPtr(new wxExecuteData);
     wxExecuteData& execData = *execDataPtr;
 
     execData.m_flags = flags;
@@ -1570,7 +1571,7 @@ wxAppTraits::RunLoopUntilChildExit(wxExecuteData& execData,
 
 #if wxUSE_STREAMS
     // Monitor the child streams if necessary.
-    wxScopedPtr<wxEventLoopSourceHandler>
+    std::unique_ptr<wxEventLoopSourceHandler>
         stdoutHandler,
         stderrHandler;
     if ( execData.IsRedirected() )

--- a/src/x11/app.cpp
+++ b/src/x11/app.cpp
@@ -217,6 +217,8 @@ wxApp::wxApp()
 #if !wxUSE_NANOX
     m_visualInfo = nullptr;
 #endif
+
+    WXAppConstructed();
 }
 
 wxApp::~wxApp()

--- a/src/xml/xml.cpp
+++ b/src/xml/xml.cpp
@@ -25,8 +25,9 @@
 #include "wx/datstrm.h"
 #include "wx/zstream.h"
 #include "wx/strconv.h"
-#include "wx/scopedptr.h"
 #include "wx/versioninfo.h"
+
+#include <memory>
 
 #include "expat.h" // from Expat
 
@@ -1139,7 +1140,7 @@ bool wxXmlDocument::Save(wxOutputStream& stream, int indentstep) const
     if ( !IsOk() )
         return false;
 
-    wxScopedPtr<wxMBConv> convMem, convFile;
+    std::unique_ptr<wxMBConv> convMem, convFile;
 
     convFile.reset(new wxCSConv(GetFileEncoding()));
 

--- a/src/xrc/xh_animatctrl.cpp
+++ b/src/xrc/xh_animatctrl.cpp
@@ -16,7 +16,8 @@
 #include "wx/xrc/xh_animatctrl.h"
 #include "wx/animate.h"
 #include "wx/generic/animate.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxAnimationCtrlXmlHandler, wxXmlResourceHandler);
 
@@ -57,7 +58,7 @@ wxObject *wxAnimationCtrlXmlHandler::DoCreateResource()
     if ( GetBool("hidden", 0) == 1 )
         ctrl->Hide();
 
-    wxScopedPtr<wxAnimation> animation(GetAnimation("animation", ctrl));
+    std::unique_ptr<wxAnimation> animation(GetAnimation("animation", ctrl));
     if ( animation )
         ctrl->SetAnimation(*animation);
 
@@ -85,7 +86,7 @@ wxAnimation* wxXmlResourceHandlerImpl::GetAnimation(const wxString& param,
         return nullptr;
 
     // load the animation from file
-    wxScopedPtr<wxAnimation> ani(ctrl ? new wxAnimation(ctrl->CreateAnimation())
+    std::unique_ptr<wxAnimation> ani(ctrl ? new wxAnimation(ctrl->CreateAnimation())
                                       : new wxAnimation);
 #if wxUSE_FILESYSTEM
     wxFSFile * const

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -39,7 +39,6 @@
 #include "wx/imaglist.h"
 #include "wx/dir.h"
 #include "wx/xml/xml.h"
-#include "wx/scopedptr.h"
 #include "wx/config.h"
 #include "wx/platinfo.h"
 
@@ -61,7 +60,7 @@ wxDateTime GetXRCFileModTime(const wxString& filename)
 {
 #if wxUSE_FILESYSTEM
     wxFileSystem fsys;
-    wxScopedPtr<wxFSFile> file(fsys.OpenFile(filename));
+    std::unique_ptr<wxFSFile> file(fsys.OpenFile(filename));
 
     return file ? file->GetModificationTime() : wxDateTime();
 #else // wxUSE_FILESYSTEM
@@ -777,7 +776,7 @@ wxXmlDocument *wxXmlResource::DoLoadFile(const wxString& filename)
 
 #if wxUSE_FILESYSTEM
     wxFileSystem fsys;
-    wxScopedPtr<wxFSFile> file(fsys.OpenFile(filename));
+    std::unique_ptr<wxFSFile> file(fsys.OpenFile(filename));
     if (file)
     {
         // Notice that we don't have ownership of the stream in this case, it
@@ -797,7 +796,7 @@ wxXmlDocument *wxXmlResource::DoLoadFile(const wxString& filename)
 
     wxString encoding(wxT("UTF-8"));
 
-    wxScopedPtr<wxXmlDocument> doc(new wxXmlDocument);
+    std::unique_ptr<wxXmlDocument> doc(new wxXmlDocument);
     if (!doc->Load(*stream, encoding))
     {
         wxLogError(_("Cannot load resources from file '%s'."), filename);

--- a/tests/archive/archivetest.h
+++ b/tests/archive/archivetest.h
@@ -12,7 +12,6 @@
 #define WX_TEST_ARCHIVE_ITERATOR
 
 #include "wx/archive.h"
-#include "wx/scopedptr.h"
 #include "wx/wfstream.h"
 
 #include <map>
@@ -220,7 +219,7 @@ protected:
 
     typedef std::map<wxString, TestEntry*> TestEntries;
     TestEntries m_testEntries;              // test data
-    wxScopedPtr<ClassFactoryT> m_factory;   // factory to make classes
+    std::unique_ptr<ClassFactoryT> m_factory;   // factory to make classes
     int m_options;                          // test options
     wxDateTime m_timeStamp;                 // timestamp to give test entries
     int m_id;                               // select between the possibilites

--- a/tests/archive/ziptest.cpp
+++ b/tests/archive/ziptest.cpp
@@ -17,6 +17,8 @@
 #include "archivetest.h"
 #include "wx/zipstrm.h"
 
+#include <memory>
+
 using std::string;
 
 
@@ -183,7 +185,7 @@ void ZipPipeTestCase::runTest()
     TestInputStream in(out, m_id % ((m_options & PipeIn) ? 4 : 3));
     wxZipInputStream zip(in);
 
-    wxScopedPtr<wxZipEntry> entry(zip.GetNextEntry());
+    std::unique_ptr<wxZipEntry> entry(zip.GetNextEntry());
     CPPUNIT_ASSERT(entry.get() != nullptr);
 
     if ((m_options & PipeIn) == 0)

--- a/tests/config/config.cpp
+++ b/tests/config/config.cpp
@@ -26,7 +26,6 @@
 #endif // WX_PRECOMP
 
 #include "wx/config.h"
-#include "wx/scopedptr.h"
 
 // Tests using wxColour can only be done when using GUI library and they
 // require template functions that are not supported by some ancient compilers.
@@ -46,95 +45,97 @@ TEST_CASE("wxConfig::ReadWriteLocal", "[config]")
 {
     wxString app = "wxConfigTestCase";
     wxString vendor = "wxWidgets";
-    wxScopedPtr<wxConfig> config(new wxConfig(app, vendor, "", "",
-                                              wxCONFIG_USE_LOCAL_FILE));
-    config->DeleteAll();
-    config->Write("string1", "abc");
-    config->Write("string2", wxString("def"));
-    config->Write("int1", 123);
-    config->Write(wxString("long1"), 234L);
-    config->Write("double1", 345.67);
-    config->Write("bool1", true);
 
     // See comment in regconf.cpp.
     const wxLongLong_t val64 = wxLL(0x8000000000000008);
-    config->Write("ll", val64);
-
     const wxULongLong_t uval64 = wxULL(0x9000000000000009);
-    config->Write("ull", uval64);
 
-    config->Write("size", size_t(UINT_MAX));
+    {
+    wxConfig config(app, vendor, "", "", wxCONFIG_USE_LOCAL_FILE);
+    config.DeleteAll();
+    config.Write("string1", "abc");
+    config.Write("string2", wxString("def"));
+    config.Write("int1", 123);
+    config.Write(wxString("long1"), 234L);
+    config.Write("double1", 345.67);
+    config.Write("bool1", true);
+
+    config.Write("ll", val64);
+
+    config.Write("ull", uval64);
+
+    config.Write("size", size_t(UINT_MAX));
 #ifdef TEST_WXCOLOUR
-    config->Write("color1", wxColour(11,22,33,44));
+    config.Write("color1", wxColour(11,22,33,44));
 #endif // TEST_WXCOLOUR
-    config->Flush();
+    config.Flush();
+    }
 
-    config.reset(new wxConfig(app, vendor, "", "",
-                              wxCONFIG_USE_LOCAL_FILE));
-    wxString string1 = config->Read("string1");
+    wxConfig config(app, vendor, "", "", wxCONFIG_USE_LOCAL_FILE);
+    wxString string1 = config.Read("string1");
     CHECK( string1 == "abc" );
-    string1 = config->Read("string1", "defaultvalue");
+    string1 = config.Read("string1", "defaultvalue");
     CHECK( string1 == "abc" );
 
     wxString string2;
-    bool r = config->Read("string2", &string2);
+    bool r = config.Read("string2", &string2);
     CHECK( r );
     CHECK( string2 == "def" );
 
-    r = config->Read("string2", &string2, "defaultvalue");
+    r = config.Read("string2", &string2, "defaultvalue");
     CHECK( r );
     CHECK( string2 == "def" );
 
-    int int1 = config->Read("int1", 5);
+    int int1 = config.Read("int1", 5);
     CHECK( int1 == 123 );
 
     long long1;
-    r = config->Read("long1", &long1);
+    r = config.Read("long1", &long1);
     CHECK( r );
     CHECK( long1 == 234L );
 
-    CHECK( config->ReadLong("long1", 0) == 234 );
+    CHECK( config.ReadLong("long1", 0) == 234 );
 
     double double1;
-    r = config->Read("double1", &double1);
+    r = config.Read("double1", &double1);
     CHECK( r );
     CHECK( double1 == 345.67 );
 
-    CHECK( config->ReadDouble("double1", 0) == double1 );
+    CHECK( config.ReadDouble("double1", 0) == double1 );
 
     bool bool1;
-    r = config->Read("foo", &bool1); // there is no "foo" key
+    r = config.Read("foo", &bool1); // there is no "foo" key
     CHECK( !r );
 
-    r = config->Read("bool1", &bool1);
+    r = config.Read("bool1", &bool1);
     CHECK( r );
     CHECK( bool1 == true );
 
-    CHECK( config->ReadBool("bool1", false) == bool1 );
+    CHECK( config.ReadBool("bool1", false) == bool1 );
 
     wxLongLong_t ll;
-    CHECK( config->Read("ll", &ll) );
+    CHECK( config.Read("ll", &ll) );
     CHECK( ll == val64 );
-    CHECK( config->ReadLongLong("ll", 0) == val64 );
+    CHECK( config.ReadLongLong("ll", 0) == val64 );
 
-    CHECK( config->Read("ull", &ll) );
+    CHECK( config.Read("ull", &ll) );
     CHECK( ll == static_cast<wxLongLong_t>(uval64) );
-    CHECK( config->ReadLongLong("ull", 0) == static_cast<wxLongLong_t>(uval64) );
+    CHECK( config.ReadLongLong("ull", 0) == static_cast<wxLongLong_t>(uval64) );
 
     size_t size;
-    CHECK( config->Read("size", &size) );
+    CHECK( config.Read("size", &size) );
     CHECK( size == UINT_MAX );
 
 #ifdef TEST_WXCOLOUR
     wxColour color1;
-    r = config->Read("color1", &color1);
+    r = config.Read("color1", &color1);
     CHECK( r );
     CHECK( color1 == wxColour(11,22,33,44) );
 
-    CHECK( config->ReadObject("color1", wxNullColour) == color1 );
+    CHECK( config.ReadObject("color1", wxNullColour) == color1 );
 #endif // TEST_WXCOLOUR
 
-    config->DeleteAll();
+    config.DeleteAll();
 }
 
 // Helper of RecordingDefaultsTest() test.
@@ -199,17 +200,16 @@ TEST_CASE("wxConfig::RecordingDefaults", "[config]")
 {
     wxString app = "wxConfigTestCaseRD";
     wxString vendor = "wxWidgets";
-    wxScopedPtr<wxConfig> config(new wxConfig(app, vendor, "", "",
-                                              wxCONFIG_USE_LOCAL_FILE));
-    config->DeleteAll();
-    config->SetRecordDefaults(false); // by default it is false
-    ReadValues(*config, false);
-    CHECK( config->GetNumberOfEntries() == 0 );
-    config->SetRecordDefaults(true);
-    size_t read = ReadValues(*config, false);
-    CHECK( config->GetNumberOfEntries() == read );
-    ReadValues(*config, true);
-    config->DeleteAll();
+    wxConfig config(app, vendor, "", "", wxCONFIG_USE_LOCAL_FILE);
+    config.DeleteAll();
+    config.SetRecordDefaults(false); // by default it is false
+    ReadValues(config, false);
+    CHECK( config.GetNumberOfEntries() == 0 );
+    config.SetRecordDefaults(true);
+    size_t read = ReadValues(config, false);
+    CHECK( config.GetNumberOfEntries() == read );
+    ReadValues(config, true);
+    config.DeleteAll();
 }
 
 #endif //wxUSE_CONFIG

--- a/tests/config/regconf.cpp
+++ b/tests/config/regconf.cpp
@@ -20,7 +20,7 @@
 
 #include "wx/msw/regconf.h"
 
-#include "wx/scopedptr.h"
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // test class
@@ -33,39 +33,38 @@ TEST_CASE("wxRegConfig::ReadWrite", "[regconfig][config][registry]")
 
     // NOTE: we use wxCONFIG_USE_LOCAL_FILE explicitly to test wxRegConfig
     //       with something different from the default value wxCONFIG_USE_GLOBAL_FILE
-    wxScopedPtr<wxConfigBase> config(new wxRegConfig(app, vendor, "", "",
-                                                     wxCONFIG_USE_LOCAL_FILE));
+    wxRegConfig config(app, vendor, "", "", wxCONFIG_USE_LOCAL_FILE);
 
     // test writing
-    config->SetPath("/group1");
-    CHECK( config->Write("entry1", "foo") );
-    config->SetPath("/group2");
-    CHECK( config->Write("entry1", "bar") );
+    config.SetPath("/group1");
+    CHECK( config.Write("entry1", "foo") );
+    config.SetPath("/group2");
+    CHECK( config.Write("entry1", "bar") );
 
-    CHECK( config->Write("int32", 1234567) );
+    CHECK( config.Write("int32", 1234567) );
 
     // Note that type of wxLL(0x8000000000000008) literal is somehow unsigned
     // long long with MinGW, not sure if it's a bug or not, but work around it
     // by specifying the type explicitly.
     const wxLongLong_t val64 = wxLL(0x8000000000000008);
-    CHECK( config->Write("int64", val64) );
+    CHECK( config.Write("int64", val64) );
 
     // test reading
     wxString str;
     long dummy;
 
-    config->SetPath("/");
-    CHECK( config->GetFirstGroup(str, dummy) );
+    config.SetPath("/");
+    CHECK( config.GetFirstGroup(str, dummy) );
     CHECK( str == "group1" );
-    CHECK( config->Read("group1/entry1", "INVALID DEFAULT") == "foo" );
-    CHECK( config->GetNextGroup(str, dummy) );
+    CHECK( config.Read("group1/entry1", "INVALID DEFAULT") == "foo" );
+    CHECK( config.GetNextGroup(str, dummy) );
     CHECK( str == "group2" );
-    CHECK( config->Read("group2/entry1", "INVALID DEFAULT") == "bar" );
+    CHECK( config.Read("group2/entry1", "INVALID DEFAULT") == "bar" );
 
-    CHECK( config->ReadLong("group2/int32", 0) == 1234567 );
-    CHECK( config->ReadLongLong("group2/int64", 0) == val64 );
+    CHECK( config.ReadLong("group2/int32", 0) == 1234567 );
+    CHECK( config.ReadLongLong("group2/int64", 0) == val64 );
 
-    config->DeleteAll();
+    config.DeleteAll();
 }
 
 TEST_CASE("wxRegKey::DeleteFromRedirectedView", "[registry][64bits]")

--- a/tests/controls/label.cpp
+++ b/tests/controls/label.cpp
@@ -19,10 +19,11 @@
 
 #include "wx/checkbox.h"
 #include "wx/control.h"
-#include "wx/scopedptr.h"
 #include "wx/stattext.h"
 
 #include "wx/generic/stattextg.h"
+
+#include <memory>
 
 namespace
 {
@@ -90,14 +91,14 @@ TEST_CASE("wxControl::Label", "[wxControl][label]")
 {
     SECTION("wxStaticText")
     {
-        const wxScopedPtr<wxStaticText>
+        const std::unique_ptr<wxStaticText>
             st(new wxStaticText(wxTheApp->GetTopWindow(), wxID_ANY, ORIGINAL_LABEL));
         DoTestLabel(st.get());
     }
 
     SECTION("wxStaticText/ellipsized")
     {
-        const wxScopedPtr<wxStaticText>
+        const std::unique_ptr<wxStaticText>
             st(new wxStaticText(wxTheApp->GetTopWindow(), wxID_ANY, ORIGINAL_LABEL,
                                 wxDefaultPosition, wxDefaultSize,
                                 wxST_ELLIPSIZE_START));
@@ -106,14 +107,14 @@ TEST_CASE("wxControl::Label", "[wxControl][label]")
 
     SECTION("wxGenericStaticText")
     {
-        const wxScopedPtr<wxGenericStaticText>
+        const std::unique_ptr<wxGenericStaticText>
             gst(new wxGenericStaticText(wxTheApp->GetTopWindow(), wxID_ANY, ORIGINAL_LABEL));
         DoTestLabel(gst.get());
     }
 
     SECTION("wxCheckBox")
     {
-        const wxScopedPtr<wxCheckBox>
+        const std::unique_ptr<wxCheckBox>
             cb(new wxCheckBox(wxTheApp->GetTopWindow(), wxID_ANY, ORIGINAL_LABEL));
         DoTestLabel(cb.get());
     }

--- a/tests/controls/notebooktest.cpp
+++ b/tests/controls/notebooktest.cpp
@@ -17,11 +17,12 @@
 #endif // WX_PRECOMP
 
 #include "wx/notebook.h"
-#include "wx/scopedptr.h"
 
 #include "asserthelper.h"
 #include "bookctrlbasetest.h"
 #include "testableframe.h"
+
+#include <memory>
 
 class NotebookTestCase : public BookCtrlBaseTestCase, public CppUnit::TestCase
 {
@@ -128,7 +129,7 @@ TEST_CASE("wxNotebook::AddPageEvents", "[wxNotebook][AddPage][event]")
     wxNotebook* const
         notebook = new wxNotebook(wxTheApp->GetTopWindow(), wxID_ANY,
                                   wxDefaultPosition, wxSize(400, 200));
-    wxScopedPtr<wxNotebook> cleanup(notebook);
+    std::unique_ptr<wxNotebook> cleanup(notebook);
 
     CHECK( notebook->GetSelection() == wxNOT_FOUND );
 
@@ -172,7 +173,7 @@ void NotebookTestCase::GetTabRect()
 {
     wxNotebook *notebook = new wxNotebook(wxTheApp->GetTopWindow(), wxID_ANY,
                                           wxDefaultPosition, wxSize(400, 200));
-    wxScopedPtr<wxNotebook> cleanup(notebook);
+    std::unique_ptr<wxNotebook> cleanup(notebook);
 
     notebook->AddPage(new wxPanel(notebook), "Page");
 
@@ -217,7 +218,7 @@ void NotebookTestCase::GetTabRect()
 
 void NotebookTestCase::HitTestFlags()
 {
-    wxScopedPtr<wxNotebook> notebook;
+    std::unique_ptr<wxNotebook> notebook;
 
 #if defined(__WXMSW__) || defined(__WXUNIVERSAL__)
     long style = 0;

--- a/tests/controls/radioboxtest.cpp
+++ b/tests/controls/radioboxtest.cpp
@@ -16,8 +16,9 @@
     #include "wx/radiobox.h"
 #endif // WX_PRECOMP
 
-#include "wx/scopedptr.h"
 #include "wx/tooltip.h"
+
+#include <memory>
 
 class RadioBoxTestCase
 {
@@ -195,7 +196,7 @@ TEST_CASE_METHOD(RadioBoxTestCase, "RadioBox::SetString", "[radiobox]")
 
 TEST_CASE("RadioBox::NoItems", "[radiobox]")
 {
-    wxScopedPtr<wxRadioBox>
+    std::unique_ptr<wxRadioBox>
         radio(new wxRadioBox(wxTheApp->GetTopWindow(), wxID_ANY, "Empty",
                              wxDefaultPosition, wxDefaultSize,
                              0, nullptr,

--- a/tests/controls/radiobuttontest.cpp
+++ b/tests/controls/radiobuttontest.cpp
@@ -24,6 +24,8 @@
 #include "testableframe.h"
 #include "testwindow.h"
 
+#include <memory>
+
 class RadioButtonTestCase
 {
 public:
@@ -89,22 +91,22 @@ TEST_CASE_METHOD(RadioButtonTestCase, "RadioButton::Group", "[radiobutton]")
     wxWindow* const parent = wxTheApp->GetTopWindow();
 
     // Create two different radio groups.
-    wxScopedPtr<wxRadioButton> g1radio0(new wxRadioButton(parent, wxID_ANY, "radio 1.0",
+    std::unique_ptr<wxRadioButton> g1radio0(new wxRadioButton(parent, wxID_ANY, "radio 1.0",
                                                 wxDefaultPosition, wxDefaultSize,
                                                 wxRB_GROUP));
 
-    wxScopedPtr<wxRadioButton> g1radio1(new wxRadioButton(parent, wxID_ANY, "radio 1.1"));
+    std::unique_ptr<wxRadioButton> g1radio1(new wxRadioButton(parent, wxID_ANY, "radio 1.1"));
 
-    wxScopedPtr<wxRadioButton> g2radio0(new wxRadioButton(parent, wxID_ANY, "radio 2.0",
+    std::unique_ptr<wxRadioButton> g2radio0(new wxRadioButton(parent, wxID_ANY, "radio 2.0",
                                                 wxDefaultPosition, wxDefaultSize,
                                                 wxRB_GROUP));
 
-    wxScopedPtr<wxRadioButton> g2radio1(new wxRadioButton(parent, wxID_ANY, "radio 2.1"));
+    std::unique_ptr<wxRadioButton> g2radio1(new wxRadioButton(parent, wxID_ANY, "radio 2.1"));
 
     // Check that having another control between radio buttons doesn't break
     // grouping.
-    wxScopedPtr<wxStaticText> text(new wxStaticText(parent, wxID_ANY, "Label"));
-    wxScopedPtr<wxRadioButton> g2radio2(new wxRadioButton(parent, wxID_ANY, "radio 2.2"));
+    std::unique_ptr<wxStaticText> text(new wxStaticText(parent, wxID_ANY, "Label"));
+    std::unique_ptr<wxRadioButton> g2radio2(new wxRadioButton(parent, wxID_ANY, "radio 2.2"));
 
     g1radio0->SetValue(true);
     g2radio0->SetValue(true);
@@ -174,24 +176,24 @@ TEST_CASE_METHOD(RadioButtonTestCase, "RadioButton::Group", "[radiobutton]")
 TEST_CASE_METHOD(RadioButtonTestCase, "RadioButton::Single", "[radiobutton]")
 {
     //Create a group of 2 buttons, having second button selected
-    wxScopedPtr<wxRadioButton> gradio0(new wxRadioButton(wxTheApp->GetTopWindow(),
+    std::unique_ptr<wxRadioButton> gradio0(new wxRadioButton(wxTheApp->GetTopWindow(),
         wxID_ANY, "wxRadioButton",
         wxDefaultPosition,
         wxDefaultSize, wxRB_GROUP));
 
-    wxScopedPtr<wxRadioButton> gradio1(new wxRadioButton(wxTheApp->GetTopWindow(),
+    std::unique_ptr<wxRadioButton> gradio1(new wxRadioButton(wxTheApp->GetTopWindow(),
         wxID_ANY, "wxRadioButton"));
 
     gradio1->SetValue(true);
 
     //Create a "single" button (by default it will not be selected)
-    wxScopedPtr<wxRadioButton> sradio(new wxRadioButton(wxTheApp->GetTopWindow(),
+    std::unique_ptr<wxRadioButton> sradio(new wxRadioButton(wxTheApp->GetTopWindow(),
         wxID_ANY, "wxRadioButton",
         wxDefaultPosition,
         wxDefaultSize, wxRB_SINGLE));
 
     //Create a non-grouped button and select it
-    wxScopedPtr<wxRadioButton> ngradio(new wxRadioButton(wxTheApp->GetTopWindow(),
+    std::unique_ptr<wxRadioButton> ngradio(new wxRadioButton(wxTheApp->GetTopWindow(),
         wxID_ANY, "wxRadioButton"));
 
     ngradio->SetValue(true);
@@ -214,7 +216,7 @@ TEST_CASE("RadioButton::Focus", "[radiobutton][focus]")
     // Create a container panel just to be able to destroy all the windows
     // created here at once by simply destroying it.
     wxWindow* const tlw = wxTheApp->GetTopWindow();
-    wxScopedPtr<wxPanel> parentPanel(new wxPanel(tlw));
+    std::unique_ptr<wxPanel> parentPanel(new wxPanel(tlw));
 
     // Create a panel containing 2 radio buttons and another control outside
     // this panel, so that we could give focus to something different and then

--- a/tests/controls/spinctrldbltest.cpp
+++ b/tests/controls/spinctrldbltest.cpp
@@ -17,8 +17,9 @@
 
 #include "testableframe.h"
 #include "wx/uiaction.h"
-#include "wx/scopedptr.h"
 #include "wx/spinctrl.h"
+
+#include <memory>
 
 class SpinCtrlDoubleTestCase
 {
@@ -55,7 +56,7 @@ TEST_CASE("SpinCtrlDouble::NoEventsInCtor", "[spinctrl][spinctrldouble]")
 {
     // Verify that creating the control does not generate any events. This is
     // unexpected and shouldn't happen.
-    wxScopedPtr<wxSpinCtrlDouble> m_spin(new wxSpinCtrlDouble);
+    std::unique_ptr<wxSpinCtrlDouble> m_spin(new wxSpinCtrlDouble);
 
     EventCounter updatedSpin(m_spin.get(), wxEVT_SPINCTRLDOUBLE);
     EventCounter updatedText(m_spin.get(), wxEVT_TEXT);
@@ -246,7 +247,7 @@ TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
 
 static inline unsigned int GetInitialDigits(double inc)
 {
-    wxScopedPtr<wxSpinCtrlDouble> sc(new wxSpinCtrlDouble
+    std::unique_ptr<wxSpinCtrlDouble> sc(new wxSpinCtrlDouble
         (
             wxTheApp->GetTopWindow(),
             wxID_ANY,

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -21,7 +21,6 @@
 #endif // WX_PRECOMP
 
 #include "wx/platinfo.h"
-#include "wx/scopedptr.h"
 #include "wx/uiaction.h"
 
 #if wxUSE_CLIPBOARD
@@ -38,6 +37,8 @@
 #include "textentrytest.h"
 #include "testableframe.h"
 #include "asserthelper.h"
+
+#include <memory>
 
 static const int TEXT_HEIGHT = 200;
 
@@ -1319,7 +1320,7 @@ TEST_CASE("wxTextCtrl::GetBestSize", "[wxTextCtrl][best-size]")
     {
         wxSize operator()(const wxString& text) const
         {
-            wxScopedPtr<wxTextCtrl>
+            std::unique_ptr<wxTextCtrl>
                 t(new wxTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY, text,
                                  wxDefaultPosition, wxDefaultSize,
                                  wxTE_MULTILINE));
@@ -1388,7 +1389,7 @@ TEST_CASE("wxTextCtrl::LongPaste", "[wxTextCtrl][clipboard][paste]")
         return;
     }
 
-    wxScopedPtr<wxTextCtrl>
+    std::unique_ptr<wxTextCtrl>
         text(new wxTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY, wxString(),
                             wxDefaultPosition, wxDefaultSize, style));
 
@@ -1431,7 +1432,7 @@ TEST_CASE("wxTextCtrl::EventsOnCreate", "[wxTextCtrl][event]")
 
     EventCounter updated(parent, wxEVT_TEXT);
 
-    wxScopedPtr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, "Hello"));
+    std::unique_ptr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, "Hello"));
 
     // Creating the control shouldn't result in any wxEVT_TEXT events.
     CHECK( updated.GetCount() == 0 );
@@ -1471,7 +1472,7 @@ TEST_CASE("wxTextCtrl::InitialCanUndo", "[wxTextCtrl][undo]")
     INFO("wxTextCtrl with style " << style);
 
     wxWindow* const parent = wxTheApp->GetTopWindow();
-    wxScopedPtr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, "",
+    std::unique_ptr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, "",
                                                 wxDefaultPosition,
                                                 wxDefaultSize,
                                                 style));
@@ -1494,7 +1495,7 @@ TEST_CASE("wxTextCtrl::EmptyUndoBuffer", "[wxTextCtrl][undo]")
         return;
     }
 
-    wxScopedPtr<wxTextCtrl> text(new wxTextCtrl(wxTheApp->GetTopWindow(),
+    std::unique_ptr<wxTextCtrl> text(new wxTextCtrl(wxTheApp->GetTopWindow(),
                                                 wxID_ANY, "",
                                                 wxDefaultPosition,
                                                 wxDefaultSize,

--- a/tests/controls/textentrytest.cpp
+++ b/tests/controls/textentrytest.cpp
@@ -22,8 +22,9 @@
 #include "textentrytest.h"
 #include "testableframe.h"
 
-#include "wx/scopedptr.h"
 #include "wx/uiaction.h"
+
+#include <memory>
 
 void TextEntryTestCase::SetValue()
 {
@@ -532,7 +533,7 @@ void TestProcessEnter(const TextLikeControlCreator& controlCreator)
 
     SECTION("Without wxTE_PROCESS_ENTER but with wxTE_MULTILINE")
     {
-        wxScopedPtr<TextLikeControlCreator>
+        std::unique_ptr<TextLikeControlCreator>
             multiLineCreator(controlCreator.CloneAsMultiLine());
         if ( !multiLineCreator )
             return;
@@ -544,7 +545,7 @@ void TestProcessEnter(const TextLikeControlCreator& controlCreator)
 
     SECTION("With wxTE_PROCESS_ENTER and wxTE_MULTILINE but skipping")
     {
-        wxScopedPtr<TextLikeControlCreator>
+        std::unique_ptr<TextLikeControlCreator>
             multiLineCreator(controlCreator.CloneAsMultiLine());
         if ( !multiLineCreator )
             return;
@@ -556,7 +557,7 @@ void TestProcessEnter(const TextLikeControlCreator& controlCreator)
 
     SECTION("With wxTE_PROCESS_ENTER and wxTE_MULTILINE without skipping")
     {
-        wxScopedPtr<TextLikeControlCreator>
+        std::unique_ptr<TextLikeControlCreator>
             multiLineCreator(controlCreator.CloneAsMultiLine());
         if ( !multiLineCreator )
             return;

--- a/tests/controls/windowtest.cpp
+++ b/tests/controls/windowtest.cpp
@@ -24,10 +24,11 @@
 #include "wx/caret.h"
 #include "wx/cshelp.h"
 #include "wx/dcclient.h"
-#include "wx/scopedptr.h"
 #include "wx/stopwatch.h"
 #include "wx/tooltip.h"
 #include "wx/wupdlock.h"
+
+#include <memory>
 
 class WindowTestCase
 {
@@ -443,8 +444,8 @@ TEST_CASE_METHOD(WindowTestCase, "Window::FindWindowBy", "[window]")
 TEST_CASE_METHOD(WindowTestCase, "Window::SizerErrors", "[window][sizer][error]")
 {
     wxWindow* const child = new wxWindow(m_window, wxID_ANY);
-    wxScopedPtr<wxSizer> const sizer1(new wxBoxSizer(wxHORIZONTAL));
-    wxScopedPtr<wxSizer> const sizer2(new wxBoxSizer(wxHORIZONTAL));
+    std::unique_ptr<wxSizer> const sizer1(new wxBoxSizer(wxHORIZONTAL));
+    std::unique_ptr<wxSizer> const sizer2(new wxBoxSizer(wxHORIZONTAL));
 
     REQUIRE_NOTHROW( sizer1->Add(child) );
 #ifdef __WXDEBUG__

--- a/tests/events/propagation.cpp
+++ b/tests/events/propagation.cpp
@@ -23,11 +23,12 @@
 #include "wx/docmdi.h"
 #include "wx/frame.h"
 #include "wx/menu.h"
-#include "wx/scopedptr.h"
 #include "wx/scopeguard.h"
 #include "wx/toolbar.h"
 #include "wx/uiaction.h"
 #include "wx/stopwatch.h"
+
+#include <memory>
 
 // FIXME: Currently under OS X testing paint event doesn't work because neither
 //        calling Refresh()+Update() nor even sending wxPaintEvent directly to
@@ -464,7 +465,7 @@ void EventPropagationTestCase::MenuEvent()
     wxMenu* const menu = CreateTestMenu(frame);
 #if wxUSE_MENUBAR
     wxMenuBar* const mb = menu->GetMenuBar();
-    wxScopedPtr<wxMenuBar> ensureMenuBarDestruction(mb);
+    std::unique_ptr<wxMenuBar> ensureMenuBarDestruction(mb);
     wxON_BLOCK_EXIT_OBJ1( *frame, wxFrame::SetMenuBar, (wxMenuBar*)nullptr );
 #endif
     // Check that wxApp gets the event exactly once.
@@ -537,7 +538,7 @@ void EventPropagationTestCase::DocView()
     // Set up the parent frame and its menu bar.
     wxDocManager docManager;
 
-    wxScopedPtr<wxDocMDIParentFrame>
+    std::unique_ptr<wxDocMDIParentFrame>
         parent(new wxDocMDIParentFrame(&docManager, nullptr, wxID_ANY, "Parent"));
 
     wxMenu* const menu = CreateTestMenu(parent.get());
@@ -565,7 +566,7 @@ void EventPropagationTestCase::DocView()
     wxDocument* const doc = docTemplate.CreateDocument("");
     wxView* const view = doc->GetFirstView();
 
-    wxScopedPtr<wxMDIChildFrame>
+    std::unique_ptr<wxMDIChildFrame>
         child(new wxDocMDIChildFrame(doc, view, parent.get(), wxID_ANY, "Child"));
 
     wxMenu* const menuChild = CreateTestMenu(child.get());

--- a/tests/filesys/filesystest.cpp
+++ b/tests/filesys/filesystest.cpp
@@ -22,7 +22,8 @@
 #if wxUSE_FILESYSTEM
 
 #include "wx/fs_mem.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // helpers
@@ -196,7 +197,7 @@ TEST_CASE("wxFileSystem::MemoryFSHandler", "[filesys][memoryfshandler][find]")
         }
 
     private:
-        wxScopedPtr<wxMemoryFSHandler> const m_handler;
+        std::unique_ptr<wxMemoryFSHandler> const m_handler;
     } autoMemoryFSHandler;
 
     wxMemoryFSHandler::AddFile("foo.txt", "foo contents");

--- a/tests/fswatcher/fswatchertest.cpp
+++ b/tests/fswatcher/fswatchertest.cpp
@@ -24,11 +24,12 @@
 #include "wx/filefn.h"
 #include "wx/fswatcher.h"
 #include "wx/log.h"
-#include "wx/scopedptr.h"
 #include "wx/stdpaths.h"
 #include "wx/vector.h"
 
 #include "testfile.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // local functions
@@ -347,7 +348,7 @@ protected:
     EventGenerator& eg;
     wxEventLoop m_loop;    // loop reference
 
-    wxScopedPtr<wxFileSystemWatcher> m_watcher;
+    std::unique_ptr<wxFileSystemWatcher> m_watcher;
 
     int m_eventTypes;  // Which event-types to watch. Normally all of them
 

--- a/tests/graphics/graphmatrix.cpp
+++ b/tests/graphics/graphmatrix.cpp
@@ -14,6 +14,8 @@
 #include "wx/graphics.h"
 #include "wx/dcmemory.h"
 
+#include <memory>
+
 static void InitState(wxGraphicsContext* gc);
 static void InvertMatrix(wxGraphicsContext* gc);
 static void Concat1(wxGraphicsContext* gc);
@@ -26,7 +28,7 @@ TEST_CASE("GraphicsMatrixTestCase::DefaultRenderer", "[graphmatrix][default]")
     wxMemoryDC dc(bmp);
     wxGraphicsRenderer* rend = wxGraphicsRenderer::GetDefaultRenderer();
     REQUIRE(rend);
-    wxScopedPtr<wxGraphicsContext> gc(rend->CreateContext(dc));
+    std::unique_ptr<wxGraphicsContext> gc(rend->CreateContext(dc));
     REQUIRE(gc.get());
 
     SECTION("InitState")
@@ -64,7 +66,7 @@ TEST_CASE("GraphicsMatrixTestCase::GDIPlusRenderer", "[graphmatrix][gdiplus]")
     wxMemoryDC dc(bmp);
     wxGraphicsRenderer* rend = wxGraphicsRenderer::GetGDIPlusRenderer();
     REQUIRE(rend);
-    wxScopedPtr<wxGraphicsContext> gc(rend->CreateContext(dc));
+    std::unique_ptr<wxGraphicsContext> gc(rend->CreateContext(dc));
     REQUIRE(gc.get());
 
     SECTION("InitState")
@@ -101,7 +103,7 @@ TEST_CASE("GraphicsMatrixTestCase::Direct2DRenderer", "[graphmatrix][direct2d]")
     wxMemoryDC dc(bmp);
     wxGraphicsRenderer* rend = wxGraphicsRenderer::GetDirect2DRenderer();
     REQUIRE(rend);
-    wxScopedPtr<wxGraphicsContext> gc(rend->CreateContext(dc));
+    std::unique_ptr<wxGraphicsContext> gc(rend->CreateContext(dc));
     REQUIRE(gc.get());
 
     SECTION("InitState")
@@ -140,7 +142,7 @@ TEST_CASE("GraphicsMatrixTestCase::CairoRenderer", "[graphmatrix][cairo]")
     wxMemoryDC dc(bmp);
     wxGraphicsRenderer* rend = wxGraphicsRenderer::GetCairoRenderer();
     REQUIRE(rend);
-    wxScopedPtr<wxGraphicsContext> gc(rend->CreateContext(dc));
+    std::unique_ptr<wxGraphicsContext> gc(rend->CreateContext(dc));
     REQUIRE(gc.get());
 
     SECTION("InitState")

--- a/tests/graphics/graphpath.cpp
+++ b/tests/graphics/graphpath.cpp
@@ -18,7 +18,8 @@
 #include "wx/bitmap.h"
 #include "wx/dcmemory.h"
 #include "wx/dcgraph.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 static void DoAllTests(wxGraphicsContext* gc);
 
@@ -30,7 +31,7 @@ TEST_CASE("GraphicsPathTestCase", "[path]")
 {
     wxBitmap bmp(500, 500);
     wxMemoryDC mdc(bmp);
-    wxScopedPtr<wxGraphicsContext> gc(wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(mdc));
+    std::unique_ptr<wxGraphicsContext> gc(wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(mdc));
     REQUIRE(gc);
     DoAllTests(gc.get());
 }
@@ -42,7 +43,7 @@ TEST_CASE("GraphicsPathTestCaseGDIPlus", "[path][gdi+]")
 {
     wxBitmap bmp(500, 500);
     wxMemoryDC mdc(bmp);
-    wxScopedPtr<wxGraphicsContext> gc(wxGraphicsRenderer::GetGDIPlusRenderer()->CreateContext(mdc));
+    std::unique_ptr<wxGraphicsContext> gc(wxGraphicsRenderer::GetGDIPlusRenderer()->CreateContext(mdc));
     REQUIRE(gc);
     DoAllTests(gc.get());
 }
@@ -56,7 +57,7 @@ TEST_CASE("GraphicsPathTestCaseDirect2D", "[path][d2d]")
 
     wxBitmap bmp(500, 500);
     wxMemoryDC mdc(bmp);
-    wxScopedPtr<wxGraphicsContext> gc(wxGraphicsRenderer::GetDirect2DRenderer()->CreateContext(mdc));
+    std::unique_ptr<wxGraphicsContext> gc(wxGraphicsRenderer::GetDirect2DRenderer()->CreateContext(mdc));
     REQUIRE(gc);
     DoAllTests(gc.get());
 }
@@ -69,7 +70,7 @@ TEST_CASE("GraphicsPathTestCaseCairo", "[path][cairo]")
 {
     wxBitmap bmp(500, 500);
     wxMemoryDC mdc(bmp);
-    wxScopedPtr<wxGraphicsContext> gc(wxGraphicsRenderer::GetCairoRenderer()->CreateContext(mdc));
+    std::unique_ptr<wxGraphicsContext> gc(wxGraphicsRenderer::GetCairoRenderer()->CreateContext(mdc));
     REQUIRE(gc);
     DoAllTests(gc.get());
 }

--- a/tests/html/htmlparser.cpp
+++ b/tests/html/htmlparser.cpp
@@ -20,7 +20,8 @@
 #endif // WX_PRECOMP
 
 #include "wx/html/winpars.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 // Test that parsing invalid HTML simply fails but doesn't crash for example.
 TEST_CASE("wxHtmlParser::ParseInvalid", "[html][parser][error]")
@@ -45,7 +46,7 @@ TEST_CASE("wxHtmlCell::Detach", "[html][cell]")
 {
     wxMemoryDC dc;
 
-    wxScopedPtr<wxHtmlContainerCell> const top(new wxHtmlContainerCell(nullptr));
+    std::unique_ptr<wxHtmlContainerCell> const top(new wxHtmlContainerCell(nullptr));
     wxHtmlContainerCell* const cont = new wxHtmlContainerCell(nullptr);
     wxHtmlCell* const cell1 = new wxHtmlWordCell("Hello", dc);
     wxHtmlCell* const cell2 = new wxHtmlColourCell(*wxRED);

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -31,10 +31,10 @@
 #include "wx/wfstream.h"
 #include "wx/clipbrd.h"
 #include "wx/dataobj.h"
-#include "wx/scopedptr.h"
 
 #include "testimage.h"
 
+#include <memory>
 
 #define CHECK_EQUAL_COLOUR_RGB(c1, c2) \
     CHECK( (int)c1.Red()   == (int)c2.Red() ); \
@@ -180,7 +180,7 @@ void ImageTestCase::LoadFromSocketStream()
     wxURL url(urlStr);
     REQUIRE( url.GetError() == wxURL_NOERR );
 
-    wxScopedPtr<wxInputStream> in_stream(url.GetInputStream());
+    std::unique_ptr<wxInputStream> in_stream(url.GetInputStream());
     REQUIRE( in_stream );
     REQUIRE( in_stream->IsOk() );
 

--- a/tests/lists/lists.cpp
+++ b/tests/lists/lists.cpp
@@ -18,7 +18,8 @@
 #endif // WX_PRECOMP
 
 #include "wx/list.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 // --------------------------------------------------------------------------
 // test class
@@ -243,7 +244,7 @@ void ElementsListNode::DeleteData()
 TEST_CASE("wxWindowList::Find", "[list]")
 {
     ListElement* const el = new ListElement(17);
-    wxScopedPtr<ListElementBase> elb(el);
+    std::unique_ptr<ListElementBase> elb(el);
 
     ElementsList l;
     l.Append(el);

--- a/tests/menu/accelentry.cpp
+++ b/tests/menu/accelentry.cpp
@@ -17,7 +17,8 @@
 #endif // WX_PRECOMP
 
 #include "wx/accel.h"
-#include "wx/scopedptr.h"
+
+#include <memory>
 
 namespace
 {
@@ -36,7 +37,7 @@ void CheckAccelEntry(const wxAcceleratorEntry& accel, int keycode, int flags)
  */
 TEST_CASE( "wxAcceleratorEntry::Create", "[accelentry]" )
 {
-    wxScopedPtr<wxAcceleratorEntry> pa;
+    std::unique_ptr<wxAcceleratorEntry> pa;
 
     SECTION( "Correct behavior" )
     {

--- a/tests/menu/menu.cpp
+++ b/tests/menu/menu.cpp
@@ -20,11 +20,12 @@
 #endif // WX_PRECOMP
 
 #include "wx/menu.h"
-#include "wx/scopedptr.h"
 #include "wx/translation.h"
 #include "wx/uiaction.h"
 
 #include <stdarg.h>
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // helper
@@ -668,7 +669,7 @@ namespace
 
 void VerifyAccelAssigned( wxString labelText, int keycode )
 {
-    const wxScopedPtr<wxAcceleratorEntry> entry(
+    const std::unique_ptr<wxAcceleratorEntry> entry(
         wxAcceleratorEntry::Create( labelText )
     );
 

--- a/tests/misc/guifuncs.cpp
+++ b/tests/misc/guifuncs.cpp
@@ -25,9 +25,10 @@
 #include "wx/clipbrd.h"
 #include "wx/dataobj.h"
 #include "wx/panel.h"
-#include "wx/scopedptr.h"
 
 #include "asserthelper.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // the tests
@@ -142,9 +143,9 @@ TEST_CASE("GUI::ClientToScreen", "[guifuncs]")
     wxWindow* const tlw = wxTheApp->GetTopWindow();
     REQUIRE( tlw );
 
-    wxScopedPtr<wxPanel> const
+    std::unique_ptr<wxPanel> const
         p1(new wxPanel(tlw, wxID_ANY, wxPoint(0, 0), wxSize(100, 50)));
-    wxScopedPtr<wxPanel> const
+    std::unique_ptr<wxPanel> const
         p2(new wxPanel(tlw, wxID_ANY, wxPoint(0, 50), wxSize(100, 50)));
     wxWindow* const
         b = new wxWindow(p2.get(), wxID_ANY, wxPoint(10, 10), wxSize(30, 10));
@@ -194,10 +195,10 @@ TEST_CASE("GUI::FindWindowAtPoint", "[guifuncs]")
     // assertion messages.
     parent->SetLabel("parent");
 
-    wxScopedPtr<wxWindow> btn1(new TestButton(parent, "1", wxPoint(10, 10)));
-    wxScopedPtr<wxWindow> btn2(new TestButton(parent, "2", wxPoint(10, 90)));
+    std::unique_ptr<wxWindow> btn1(new TestButton(parent, "1", wxPoint(10, 10)));
+    std::unique_ptr<wxWindow> btn2(new TestButton(parent, "2", wxPoint(10, 90)));
 
-    // No need to use wxScopedPtr<> for this one, it will be deleted by btn2.
+    // No need to use std::unique_ptr<> for this one, it will be deleted by btn2.
     wxWindow* btn3 = new TestButton(btn2.get(), "3", wxPoint(20, 20));
 
     // We need this to realize the windows created above under wxGTK.
@@ -233,7 +234,7 @@ TEST_CASE("wxWindow::Dump", "[window]")
 {
     CHECK_NOTHROW( wxDumpWindow(nullptr) );
 
-    wxScopedPtr<wxButton>
+    std::unique_ptr<wxButton>
         button(new wxButton(wxTheApp->GetTopWindow(), wxID_ANY, "bloordyblop"));
 
     const std::string s = wxDumpWindow(button.get()).utf8_string();

--- a/tests/net/socket.cpp
+++ b/tests/net/socket.cpp
@@ -23,12 +23,13 @@
 
 #include "wx/socket.h"
 #include "wx/url.h"
-#include "wx/scopedptr.h"
 #include "wx/sstream.h"
 #include "wx/evtloop.h"
 
-typedef wxScopedPtr<wxSockAddress> wxSockAddressPtr;
-typedef wxScopedPtr<wxSocketClient> wxSocketClientPtr;
+#include <memory>
+
+typedef std::unique_ptr<wxSockAddress> wxSockAddressPtr;
+typedef std::unique_ptr<wxSocketClient> wxSocketClientPtr;
 
 static wxString gs_serverHost(wxGetenv("WX_TEST_SERVER"));
 
@@ -294,7 +295,7 @@ void SocketTestCase::UrlTest()
 
     wxURL url("http://" + gs_serverHost);
 
-    const wxScopedPtr<wxInputStream> in(url.GetInputStream());
+    const std::unique_ptr<wxInputStream> in(url.GetInputStream());
     CPPUNIT_ASSERT( in.get() );
 
     wxStringOutputStream out;

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -23,6 +23,8 @@
 #include "wx/filename.h"
 #include "wx/wfstream.h"
 
+#include <memory>
+
 // This test uses httpbin service and by default uses the mirror at the
 // location below, which seems to be more reliable than the main site at
 // https://httpbin.org. Any other mirror, including a local one, which can be
@@ -394,7 +396,7 @@ TEST_CASE_METHOD(RequestFixture,
         return;
 
     Create("/put");
-    wxScopedPtr<wxInputStream> is(new wxFileInputStream("horse.png"));
+    std::unique_ptr<wxInputStream> is(new wxFileInputStream("horse.png"));
     REQUIRE( is->IsOk() );
 
     request.SetData(is.release(), "image/png");

--- a/tests/sizers/boxsizer.cpp
+++ b/tests/sizers/boxsizer.cpp
@@ -21,7 +21,7 @@
 
 #include "asserthelper.h"
 
-#include "wx/scopedptr.h"
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // test fixture
@@ -366,7 +366,7 @@ TEST_CASE_METHOD(BoxSizerTestCase, "BoxSizer::IncompatibleFlags", "[sizer]")
 #define ASSERT_SIZER_INVALID_FLAGS(f, msg) \
     WX_ASSERT_FAILS_WITH_ASSERT_MESSAGE( \
             "Expected assertion not generated for " msg, \
-            wxScopedPtr<wxSizerItem> item(new wxSizerItem(10, 10, 0, f)); \
+            std::unique_ptr<wxSizerItem> item(new wxSizerItem(10, 10, 0, f)); \
             sizer->Add(item.get()); \
             item.release() \
         )

--- a/tests/sizers/wrapsizer.cpp
+++ b/tests/sizers/wrapsizer.cpp
@@ -21,9 +21,11 @@
 
 #include "asserthelper.h"
 
+#include <memory>
+
 TEST_CASE("wxWrapSizer::CalcMin", "[wxWrapSizer]")
 {
-    wxScopedPtr<wxWindow> win(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
+    std::unique_ptr<wxWindow> win(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
     win->SetClientSize(180, 240);
 
     wxSizer *sizer = new wxWrapSizer(wxHORIZONTAL);
@@ -74,7 +76,7 @@ TEST_CASE("wxWrapSizer::CalcMin", "[wxWrapSizer]")
 
 TEST_CASE("wxWrapSizer::CalcMinFromMinor", "[wxWrapSizer]")
 {
-    wxScopedPtr<wxWindow> win(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
+    std::unique_ptr<wxWindow> win(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
     win->SetClientSize(180, 240);
 
     wxSizer* boxSizer = new wxBoxSizer(wxHORIZONTAL);

--- a/tests/streams/largefile.cpp
+++ b/tests/streams/largefile.cpp
@@ -29,8 +29,9 @@
 #endif
 
 #include "wx/filename.h"
-#include "wx/scopedptr.h"
 #include "wx/wfstream.h"
+
+#include <memory>
 
 #ifdef __WINDOWS__
     #include "wx/msw/wrapwin.h"
@@ -116,7 +117,7 @@ void LargeFileTest::runTest()
 
     // write a large file
     {
-        wxScopedPtr<wxOutputStream> out(MakeOutStream(tmpfile.m_name));
+        std::unique_ptr<wxOutputStream> out(MakeOutStream(tmpfile.m_name));
 
         // write 'A's at [ 0x7fffffbf, 0x7fffffff [
         pos = 0x7fffffff - size;
@@ -150,7 +151,7 @@ void LargeFileTest::runTest()
 
     // read the large file back
     {
-        wxScopedPtr<wxInputStream> in(MakeInStream(tmpfile.m_name));
+        std::unique_ptr<wxInputStream> in(MakeInStream(tmpfile.m_name));
         char buf[size];
 
         if (haveLFS) {
@@ -214,7 +215,7 @@ protected:
 
 wxInputStream *LargeFileTest_wxFile::MakeInStream(const wxString& name) const
 {
-    wxScopedPtr<wxFileInputStream> in(new wxFileInputStream(name));
+    std::unique_ptr<wxFileInputStream> in(new wxFileInputStream(name));
     CPPUNIT_ASSERT(in->IsOk());
     return in.release();
 }
@@ -246,7 +247,7 @@ protected:
 
 wxInputStream *LargeFileTest_wxFFile::MakeInStream(const wxString& name) const
 {
-    wxScopedPtr<wxFFileInputStream> in(new wxFFileInputStream(name));
+    std::unique_ptr<wxFFileInputStream> in(new wxFFileInputStream(name));
     CPPUNIT_ASSERT(in->IsOk());
     return in.release();
 }

--- a/tests/testwindow.h
+++ b/tests/testwindow.h
@@ -9,8 +9,9 @@
 #ifndef _WX_TESTS_TESTWINDOW_H_
 #define _WX_TESTS_TESTWINDOW_H_
 
-#include "wx/scopedptr.h"
 #include "wx/window.h"
+
+#include <memory>
 
 // We need to wrap wxWindow* in a class as specializing StringMaker for
 // wxWindow* doesn't seem to work.
@@ -19,7 +20,7 @@ class wxWindowPtr
 public:
     explicit wxWindowPtr(wxWindow* win) : m_win(win) {}
     template <typename W>
-    explicit wxWindowPtr(const wxScopedPtr<W>& win) : m_win(win.get()) {}
+    explicit wxWindowPtr(const std::unique_ptr<W>& win) : m_win(win.get()) {}
 
     wxString Dump() const
     {

--- a/tests/uris/url.cpp
+++ b/tests/uris/url.cpp
@@ -19,8 +19,9 @@
 
 #include "wx/url.h"
 #include "wx/mstream.h"
-#include "wx/scopedptr.h"
 #include "wx/utils.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // test class
@@ -76,7 +77,7 @@ void URLTestCase::GetInputStream()
     wxURL url("http://detectportal.firefox.com/");
     CPPUNIT_ASSERT_EQUAL(wxURL_NOERR, url.GetError());
 
-    wxScopedPtr<wxInputStream> in_stream(url.GetInputStream());
+    std::unique_ptr<wxInputStream> in_stream(url.GetInputStream());
     if ( !in_stream && IsAutomaticTest() )
     {
         // Sometimes the connection fails during CI runs, don't consider this

--- a/tests/window/clientsize.cpp
+++ b/tests/window/clientsize.cpp
@@ -18,7 +18,7 @@
     #include "wx/window.h"
 #endif // WX_PRECOMP
 
-#include "wx/scopedptr.h"
+#include <memory>
 
 #include "asserthelper.h"
 #include "waitforpaint.h"
@@ -44,7 +44,7 @@ TEST_CASE("wxWindow::ClientWindowSizeRoundTrip", "[window][client-size]")
 
 TEST_CASE("wxWindow::MinClientSize", "[window][client-size]")
 {
-    wxScopedPtr<wxWindow> w(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY,
+    std::unique_ptr<wxWindow> w(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY,
                                          wxDefaultPosition, wxDefaultSize,
                                          wxBORDER_THEME));
     w->SetSize(wxSize(1,1));
@@ -59,9 +59,9 @@ TEST_CASE("wxWindow::SetClientSize", "[window][client-size]")
     // Under wxGTK2 we need to have two children (at least) because if there
     // is exactly one child its size is set to fill the whole parent frame
     // and the window cannot be resized - see wxTopLevelWindowBase::Layout().
-    wxScopedPtr<wxWindow> w0(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
+    std::unique_ptr<wxWindow> w0(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
 #endif // wxGTK 2
-    wxScopedPtr<wxWindow> w(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
+    std::unique_ptr<wxWindow> w(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
 
     wxRect reqSize = wxTheApp->GetTopWindow()->GetClientRect();
     reqSize.Deflate(25);

--- a/tests/window/setsize.cpp
+++ b/tests/window/setsize.cpp
@@ -19,7 +19,7 @@
     #include "wx/window.h"
 #endif // WX_PRECOMP
 
-#include "wx/scopedptr.h"
+#include <memory>
 
 #include "asserthelper.h"
 #include "waitforpaint.h"
@@ -52,7 +52,7 @@ protected:
 
 TEST_CASE("wxWindow::SetSize", "[window][size]")
 {
-    wxScopedPtr<wxWindow> w(new MyWindow(wxTheApp->GetTopWindow()));
+    std::unique_ptr<wxWindow> w(new MyWindow(wxTheApp->GetTopWindow()));
 
     SECTION("Simple")
     {
@@ -73,7 +73,7 @@ TEST_CASE("wxWindow::SetSize", "[window][size]")
 
 TEST_CASE("wxWindow::GetBestSize", "[window][size][best-size]")
 {
-    wxScopedPtr<wxWindow> w(new MyWindow(wxTheApp->GetTopWindow()));
+    std::unique_ptr<wxWindow> w(new MyWindow(wxTheApp->GetTopWindow()));
 
     CHECK( wxSize(50, 250) == w->GetBestSize() );
 
@@ -86,7 +86,7 @@ TEST_CASE("wxWindow::GetBestSize", "[window][size][best-size]")
 
 TEST_CASE("wxWindow::MovePreservesSize", "[window][size][move]")
 {
-    wxScopedPtr<wxWindow>
+    std::unique_ptr<wxWindow>
         w(new wxFrame(wxTheApp->GetTopWindow(), wxID_ANY, "Test child frame"));
 
     // Unfortunately showing the window is asynchronous, at least when using

--- a/tests/xml/xmltest.cpp
+++ b/tests/xml/xmltest.cpp
@@ -18,10 +18,11 @@
 #endif // WX_PRECOMP
 
 #include "wx/xml/xml.h"
-#include "wx/scopedptr.h"
 #include "wx/sstream.h"
 
 #include <stdarg.h>
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // helpers for testing XML tree
@@ -107,7 +108,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( XmlTestCase, "XmlTestCase" );
 
 void XmlTestCase::InsertChild()
 {
-    wxScopedPtr<wxXmlNode> root(new wxXmlNode(wxXML_ELEMENT_NODE, "root"));
+    std::unique_ptr<wxXmlNode> root(new wxXmlNode(wxXML_ELEMENT_NODE, "root"));
     root->AddChild(new wxXmlNode(wxXML_ELEMENT_NODE, "1"));
     wxXmlNode *two = new wxXmlNode(wxXML_ELEMENT_NODE, "2");
     root->AddChild(two);
@@ -127,7 +128,7 @@ void XmlTestCase::InsertChild()
 
 void XmlTestCase::InsertChildAfter()
 {
-    wxScopedPtr<wxXmlNode> root(new wxXmlNode(wxXML_ELEMENT_NODE, "root"));
+    std::unique_ptr<wxXmlNode> root(new wxXmlNode(wxXML_ELEMENT_NODE, "root"));
 
     root->InsertChildAfter(new wxXmlNode(wxXML_ELEMENT_NODE, "1"), nullptr);
     CheckXml(root.get(), "1", nullptr);

--- a/tests/xml/xrctest.cpp
+++ b/tests/xml/xrctest.cpp
@@ -22,13 +22,14 @@
 #include "wx/fs_inet.h"
 #include "wx/imagxpm.h"
 #include "wx/xml/xml.h"
-#include "wx/scopedptr.h"
 #include "wx/sstream.h"
 #include "wx/wfstream.h"
 #include "wx/xrc/xmlres.h"
 #include "wx/xrc/xh_bmp.h"
 
 #include <stdarg.h>
+
+#include <memory>
 
 #include "testfile.h"
 
@@ -44,7 +45,7 @@ static const char *TEST_XRC_FILE = "test.xrc";
 void LoadXrcFrom(const wxString& xrcText)
 {
     wxStringInputStream sis(xrcText);
-    wxScopedPtr<wxXmlDocument> xmlDoc(new wxXmlDocument(sis, "UTF-8"));
+    std::unique_ptr<wxXmlDocument> xmlDoc(new wxXmlDocument(sis, "UTF-8"));
     REQUIRE( xmlDoc->IsOk() );
 
     // Load the xrc we've just created


### PR DESCRIPTION
This is mostly about fixing #23315 (and ensuring that it doesn't happen again), but also includes some cleanup including getting rid of `wx{DECLARE,DEFINE}_SCOPED_PTR` macros globally (and not only in `wxApp` code).