### PR TITLE
Run Ubuntu 18.04 builds in a container on GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,32 +56,37 @@ jobs:
   build:
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: Ubuntu 18.04 wxGTK 2
-            runner: ubuntu-18.04
+            runner: ubuntu-latest
+            container: ubuntu:18.04
             compiler_flags: -std=c++98
             gtk_version: 2
             use_xvfb: true
-          - name: Ubuntu 18.04 wxGTK 2 UTF-8
-            runner: ubuntu-18.04
-            gtk_version: 2
+          - name: Ubuntu 18.04 wxGTK UTF-8
+            runner: ubuntu-latest
+            container: ubuntu:18.04
             configure_flags: --enable-utf8 --enable-utf8only --enable-monolithic
             use_xvfb: true
-          - name: Ubuntu 18.04 wxGTK3 static
-            runner: ubuntu-18.04
+          - name: Ubuntu 18.04 wxGTK 3 static with gcc 4.8
+            runner: ubuntu-latest
+            compiler: g++-4.8
+            container: ubuntu:18.04
             compiler_flags: -std=c++98
             configure_flags: --disable-shared
             use_xvfb: true
           - name: Ubuntu 18.04 wxGTK 3 STL
-            runner: ubuntu-18.04
+            runner: ubuntu-latest
+            container: ubuntu:18.04
             configure_flags: --enable-cxx11 --enable-stl --disable-compat30
             use_xvfb: true
-          - name: Ubuntu 18.04 wxGTK 3 with clang
-            runner: ubuntu-18.04
-            compiler: clang
+          - name: Ubuntu 20.04 wxGTK 3 with clang
+            runner: ubuntu-20.04
+            compiler: clang++-10
             configure_flags: --disable-sys-libs
             use_xvfb: true
           - name: Ubuntu 20.04 wxGTK ANSI
@@ -95,20 +100,24 @@ jobs:
             use_asan: true
             use_xvfb: true
           - name: Ubuntu 18.04 wxX11
-            runner: ubuntu-18.04
+            runner: ubuntu-latest
+            container: ubuntu:18.04
             configure_flags: --with-x11 --enable-pch --disable-stc
             skip_samples: true
           - name: Ubuntu 18.04 wxDFB
-            runner: ubuntu-18.04
+            runner: ubuntu-latest
+            container: ubuntu:18.04
             configure_flags: --with-directfb --enable-pch --disable-stc
             skip_samples: true
             allow_warnings: true
           - name: Ubuntu 18.04 wxMotif
-            runner: ubuntu-18.04
+            runner: ubuntu-latest
+            container: ubuntu:18.04
             configure_flags: --with-motif --enable-pch --disable-stc
             skip_samples: true
           - name: Ubuntu 18.04 wxQt
-            runner: ubuntu-18.04
+            runner: ubuntu-latest
+            container: ubuntu:18.04
             configure_flags: --with-qt --enable-pch --without-opengl
             skip_samples: true
 
@@ -119,6 +128,43 @@ jobs:
       wxUSE_XVFB: ${{ matrix.use_xvfb && 1 || 0 }}
 
     steps:
+      - name: Set up build system
+        run: |
+          case '${{ matrix.container }}' in
+            ubuntu:*)
+              export DEBIAN_FRONTEND=noninteractive
+
+              if [ '${{ matrix.container }}' = 'ubuntu:18.04' ]; then
+                # First get the package containing /usr/bin/apt-add-repository.
+                apt-get update -qq
+                apt-get install -qq software-properties-common
+
+                # Git 2.17 in the official repository is too old to checkout
+                # submodules using it, so get a newer version.
+                apt-add-repository ppa:git-core/ppa
+              fi
+
+              compiler=${{ matrix.compiler }}
+
+              # Explanation for installing some less obvious packages:
+              #   - coreutils contains nproc used in proc_count.sh called below.
+              #   - locales contains locale-gen also used below.
+              #   - Python can't be installed using the action as usual because
+              #     it installs an ABI-incompatible version, see (wrongly, IMO)
+              #     closed https://github.com/actions/setup-python/issues/370
+              #   - xvfb is used for running the GUI tests.
+              apt-get update -qq
+              apt-get install -qq coreutils ${compiler-g++} git locales make pkg-config python3 python3-pip sudo xvfb
+              ;;
+
+            '')
+              ;;
+
+            *)
+              echo '::error ::Unknown container kind.'
+              exit 1
+          esac
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -142,13 +188,21 @@ jobs:
           # messages from WebKit tests that we're not interested in.
           echo NO_AT_BRIDGE=1 >> $GITHUB_ENV
 
-          case "${{ matrix.compiler }}" in
-            clang)
-              echo CC=clang >> $GITHUB_ENV
-              echo CXX='clang++ -stdlib=libc++' >> $GITHUB_ENV
-              echo LD=clang++ >> $GITHUB_ENV
+          compiler=${{ matrix.compiler }}
+          case "$compiler" in
+            clang++*)
+              echo CC=`echo $compiler | sed s/++//` >> $GITHUB_ENV
+              echo CXX="$compiler -stdlib=libc++" >> $GITHUB_ENV
+              echo LD=$compiler >> $GITHUB_ENV
 
               allow_warn_opt="-Wno-error=#warnings"
+              ;;
+
+            g++*)
+              echo CC=`echo $compiler | sed s/++/cc/` >> $GITHUB_ENV
+              echo CXX=$compiler >> $GITHUB_ENV
+              echo LD=$compiler >> $GITHUB_ENV
+              allow_warn_opt="-Wno-error=cpp"
               ;;
 
             '')
@@ -226,6 +280,7 @@ jobs:
           make -k $wxBUILD_ARGS "CXXFLAGS=$wxMAKEFILE_CXXFLAGS" "LDFLAGS=$wxMAKEFILE_LDFLAGS"
 
       - name: Setup Python
+        if: matrix.container == ''
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -277,6 +332,15 @@ jobs:
             wx_tests_selection='~[.] ~RichTextCtrlTestCase'
           fi
           ulimit -c unlimited
+
+          # This is exceedingly weird, but for some reason the first test using
+          # wxWebView in the build using clang under Ubuntu 20.04 fails (even
+          # if the timeout in the test is increased), so run it before really
+          # running the tests -- then they will succeed.
+          if [ '${{ matrix.compiler }}' = 'clang++-10' ]; then
+            xvfb-run -a -s '-screen 0 1600x1200x24' ./test_gui -c Title WebView >/dev/null 2>&1 || echo 'First wxWebView test failure ignored.'
+          fi
+
           /bin/bash -o pipefail -c "xvfb-run -a -s '-screen 0 1600x1200x24' ./test_gui -d 1 $wx_tests_selection 2>&1 | tee -a test_gui.out" || rc=$?
           if [ -n "$rc" ]; then
             if fgrep -q '(core dumped)' test_gui.out; then

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -53,8 +53,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 18.04 wxGTK 3
-            runner: ubuntu-18.04
+          - name: Ubuntu 22.04 wxGTK 3
+            runner: ubuntu-22.04
             cmake_generator: Unix Makefiles
             cmake_samples: ALL
           - name: macOS 10.15 wxOSX

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -11,6 +11,13 @@
 
 #if wxUSE_WEBVIEW && wxUSE_WEBVIEW_WEBKIT2
 
+// In Ubuntu 18.04 compiling glib.h with gcc 4.8 results in the warnings inside
+// it, and disabling them temporarily using wxGCC_WARNING_SUPPRESS/RESTORE
+// doesn't work (i.e. they're still given), so disable them globally here.
+#if wxCHECK_GCC_VERSION(4, 8) && !wxCHECK_GCC_VERSION(4, 9)
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include "wx/dir.h"
 #include "wx/dynlib.h"
 #include "wx/filename.h"


### PR DESCRIPTION
Ubuntu 18.04 runner environment is being deprecated, so use a container
running inside the latest Ubuntu runner environment instead.

This is a combined cherry-pick of several commits merged into master as
part of e6dfd9748f (Merge branch 'ci-use-containers', 2022-10-10)
excluding those removing pre-C++11 support, which is still needed in
this branch.
