### PR TITLE
Add CMakePresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,6 @@
 /utils/wxrc/wxrc_vc[789].sln
 
 /3rdparty/webview2
+
+/build/cmake/output
+CMakePresetsUser.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,136 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "common",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build/cmake/output/${presetName}"
+        },
+        {
+            "name": "with_samples",
+            "hidden": true,
+            "cacheVariables": {
+                "wxBUILD_SAMPLES": "ALL"
+            }
+        },
+        {
+            "name": "msw_base",
+            "description": "Base configuration for MSW",
+            "hidden": true,
+            "inherits": "common",
+            "cacheVariables": {
+                "wxUSE_WEBVIEW_EDGE": "ON"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "msw_vc17_samples",
+            "inherits": [
+                "with_samples",
+                "msw_base"
+            ],
+            "displayName": "MSW Visual Studio 2022 (with Samples)",
+            "generator": "Visual Studio 17 2022"
+        },
+        {
+            "name": "msw_vc17",
+            "inherits": "msw_base",
+            "displayName": "MSW Visual Studio 2022",
+            "generator": "Visual Studio 17 2022"
+        },
+        {
+            "name": "msw_vc16_samples",
+            "inherits": [
+                "with_samples",
+                "msw_base"
+            ],
+            "displayName": "MSW Visual Studio 2019 (with Samples)",
+            "generator": "Visual Studio 16 2019"
+        },
+        {
+            "name": "msw_vc16",
+            "inherits": "msw_base",
+            "displayName": "MSW Visual Studio 2019",
+            "generator": "Visual Studio 16 2019"
+        },
+        {
+            "name": "msw_vc15_samples",
+            "inherits": [
+                "with_samples",
+                "msw_base"
+            ],
+            "displayName": "MSW Visual Studio 2017 (with Samples)",
+            "generator": "Visual Studio 15 2017"
+        },
+        {
+            "name": "msw_vc15",
+            "inherits": "msw_base",
+            "displayName": "MSW Visual Studio 2017",
+            "generator": "Visual Studio 15 2017"
+        },
+        {
+            "name": "msw_vc14_samples",
+            "inherits": [
+                "with_samples",
+                "msw_base"
+            ],
+            "displayName": "MSW Visual Studio 2015 (with Samples)",
+            "generator": "Visual Studio 14 2015"
+        },
+        {
+            "name": "msw_vc14",
+            "inherits": "msw_base",
+            "displayName": "MSW Visual Studio 2015",
+            "generator": "Visual Studio 14 2015"
+        },
+        {
+            "name": "osx_base",
+            "hidden": true,
+            "description": "Base configuration for OSX",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
+            "name": "osx_xcode_samples",
+            "inherits": [
+                "with_samples",
+                "osx_base"
+            ],
+            "displayName": "macOS Xcode (with Samples)",
+            "generator": "Xcode"
+        },
+        {
+            "name": "osx_xcode",
+            "inherits": "osx_base",
+            "displayName": "macOS Xcode",
+            "generator": "Xcode"
+        },
+        {
+            "name": "osx_make_samples",
+            "inherits": [
+                "with_samples",
+                "osx_base"
+            ],
+            "displayName": "macOS Make (with Samples)",
+            "generator": "Unix Makefiles"
+        },
+        {
+            "name": "osx_make",
+            "inherits": "osx_base",
+            "displayName": "macOS Make",
+            "generator": "Unix Makefiles"
+        }
+    ]
+}


### PR DESCRIPTION
I've recently started using [CMakePresets.json](https://cmake.org/cmake/help/v3.26/manual/cmake-presets.7.html) and I think it would be a good addition to include in the wxWidgets repository. (Additional introduction in the [Visual Studio Blog](https://devblogs.microsoft.com/cppblog/cmake-presets-integration-in-visual-studio-and-visual-studio-code/))

Basically what it does is to preconfigure various cmake configuration/generation settings.
This allows for easier CMake usage from the CMake GUI, Visual Studio and Visual Studio Code. Additionally it also allows to specify these presets from the cmake CLI via the --preset command line.

I think this simplifies configuring builds significantly for everyone especially for newcomers (to cmake and/or wxWidgets)
I've included a few presets I think could be useful for contributors and library users alike.

Obviously these should be expanded to contain some other common configurations (Linux, MinGW, ?). Additionally presets for offical binaries could make sense.
But I wanted to check what others think before adding more.



Here are a few screenshots how the presets are currently presented in GUI tools:

How it looks in CMake GUI:
![image](https://user-images.githubusercontent.com/5075894/224165440-fe2d0061-4c21-4f4b-a8a3-b4f9283ad872.png)

In Visual Studio Code (when opening the wxWidgets folder):
![image](https://user-images.githubusercontent.com/5075894/224165568-1f067090-02c3-4080-a0ad-8bbb13c231ab.png)

In Visual Studio (when opening the wxWidgets folder):
![image](https://user-images.githubusercontent.com/5075894/224165852-a61cecd9-6a9c-4960-aa61-c8562a1a066a.png)
