### PR TITLE
Print current page option added to use current page option in Windows print dialog

### DIFF
--- a/include/wx/cmndata.h
+++ b/include/wx/cmndata.h
@@ -160,6 +160,7 @@ public:
     int GetMinPage() const { return m_printMinPage; }
     int GetMaxPage() const { return m_printMaxPage; }
     int GetNoCopies() const { return m_printNoCopies; }
+    int GetCurrentPage() const { return m_printCurrentPage; }
     bool GetAllPages() const { return m_printAllPages; }
     bool GetSelection() const { return m_printSelection; }
     bool GetCollate() const { return m_printCollate; }
@@ -170,20 +171,25 @@ public:
     void SetMinPage(int v) { m_printMinPage = v; }
     void SetMaxPage(int v) { m_printMaxPage = v; }
     void SetNoCopies(int v) { m_printNoCopies = v; }
+    void SetCurrentPage(int v) { m_printCurrentPage = v; }
     void SetAllPages(bool flag) { m_printAllPages = flag; }
     void SetSelection(bool flag) { m_printSelection = flag; }
     void SetCollate(bool flag) { m_printCollate = flag; }
     void SetPrintToFile(bool flag) { m_printToFile = flag; }
+    void SetSelectCurrentPage(bool flag) { m_printSelectCurrentPage = flag; }
 
     void EnablePrintToFile(bool flag) { m_printEnablePrintToFile = flag; }
     void EnableSelection(bool flag) { m_printEnableSelection = flag; }
     void EnablePageNumbers(bool flag) { m_printEnablePageNumbers = flag; }
     void EnableHelp(bool flag) { m_printEnableHelp = flag; }
+    void EnableCurrentPage(bool flag) { m_printEnableCurrentPage = flag; }
 
     bool GetEnablePrintToFile() const { return m_printEnablePrintToFile; }
     bool GetEnableSelection() const { return m_printEnableSelection; }
     bool GetEnablePageNumbers() const { return m_printEnablePageNumbers; }
     bool GetEnableHelp() const { return m_printEnableHelp; }
+    bool GetEnableCurrentPage() const { return m_printEnableCurrentPage; }
+    bool GetSelectCurrentPage() const { return m_printSelectCurrentPage; }
 
     // Is this data OK for showing the print dialog?
     bool Ok() const { return IsOk(); }
@@ -201,6 +207,7 @@ private:
     int             m_printMinPage;
     int             m_printMaxPage;
     int             m_printNoCopies;
+    int             m_printCurrentPage;
     bool            m_printAllPages;
     bool            m_printCollate;
     bool            m_printToFile;
@@ -209,6 +216,8 @@ private:
     bool            m_printEnablePageNumbers;
     bool            m_printEnableHelp;
     bool            m_printEnablePrintToFile;
+    bool            m_printEnableCurrentPage;
+    bool            m_printSelectCurrentPage;
     wxPrintData     m_printData;
 
 private:

--- a/include/wx/cmndata.h
+++ b/include/wx/cmndata.h
@@ -160,36 +160,34 @@ public:
     int GetMinPage() const { return m_printMinPage; }
     int GetMaxPage() const { return m_printMaxPage; }
     int GetNoCopies() const { return m_printNoCopies; }
-    int GetCurrentPage() const { return m_printCurrentPage; }
     bool GetAllPages() const { return m_printAllPages; }
     bool GetSelection() const { return m_printSelection; }
     bool GetCollate() const { return m_printCollate; }
     bool GetPrintToFile() const { return m_printToFile; }
+    bool GetCurrentPage() const { return m_printCurrentPage; }
 
     void SetFromPage(int v) { m_printFromPage = v; }
     void SetToPage(int v) { m_printToPage = v; }
     void SetMinPage(int v) { m_printMinPage = v; }
     void SetMaxPage(int v) { m_printMaxPage = v; }
     void SetNoCopies(int v) { m_printNoCopies = v; }
-    void SetCurrentPage(int v) { m_printCurrentPage = v; }
     void SetAllPages(bool flag) { m_printAllPages = flag; }
     void SetSelection(bool flag) { m_printSelection = flag; }
     void SetCollate(bool flag) { m_printCollate = flag; }
     void SetPrintToFile(bool flag) { m_printToFile = flag; }
-    void SetSelectCurrentPage(bool flag) { m_printSelectCurrentPage = flag; }
+    void SetCurrentPage(bool flag) { m_printCurrentPage = flag; }
 
     void EnablePrintToFile(bool flag) { m_printEnablePrintToFile = flag; }
     void EnableSelection(bool flag) { m_printEnableSelection = flag; }
     void EnablePageNumbers(bool flag) { m_printEnablePageNumbers = flag; }
-    void EnableHelp(bool flag) { m_printEnableHelp = flag; }
     void EnableCurrentPage(bool flag) { m_printEnableCurrentPage = flag; }
+    void EnableHelp(bool flag) { m_printEnableHelp = flag; }
 
     bool GetEnablePrintToFile() const { return m_printEnablePrintToFile; }
     bool GetEnableSelection() const { return m_printEnableSelection; }
+    bool GetEnableCurrentPage() const { return m_printEnableCurrentPage; }
     bool GetEnablePageNumbers() const { return m_printEnablePageNumbers; }
     bool GetEnableHelp() const { return m_printEnableHelp; }
-    bool GetEnableCurrentPage() const { return m_printEnableCurrentPage; }
-    bool GetSelectCurrentPage() const { return m_printSelectCurrentPage; }
 
     // Is this data OK for showing the print dialog?
     bool Ok() const { return IsOk(); }
@@ -207,17 +205,16 @@ private:
     int             m_printMinPage;
     int             m_printMaxPage;
     int             m_printNoCopies;
-    int             m_printCurrentPage;
     bool            m_printAllPages;
+    bool            m_printSelection;
+    bool            m_printCurrentPage;
     bool            m_printCollate;
     bool            m_printToFile;
-    bool            m_printSelection;
     bool            m_printEnableSelection;
     bool            m_printEnablePageNumbers;
+    bool            m_printEnableCurrentPage;
     bool            m_printEnableHelp;
     bool            m_printEnablePrintToFile;
-    bool            m_printEnableCurrentPage;
-    bool            m_printSelectCurrentPage;
     wxPrintData     m_printData;
 
 private:

--- a/include/wx/prntbase.h
+++ b/include/wx/prntbase.h
@@ -278,6 +278,7 @@ public:
     virtual bool HasPage(int page);
     virtual bool OnPrintPage(int page) = 0;
     virtual void GetPageInfo(int *minPage, int *maxPage, int *pageFrom, int *pageTo);
+    virtual bool IsPageSelected(int page);
 
     virtual wxString GetTitle() const { return m_printoutTitle; }
 

--- a/interface/wx/cmndata.h
+++ b/interface/wx/cmndata.h
@@ -607,9 +607,12 @@ public:
     void SetSelection(bool flag);
 
     /**
-        Selects the "Current Page" radio button. The effect of printing the
-        current page depends on how the application implements this command, if at
-        all.
+        Selects the "Current Page" radio button when the dialog is initially shown.
+        
+        If this button is selected when the dialog is accepted, only the current
+        page (as defined by the application) should be printed.
+        
+        This only function can only be called if EnableCurrentPage() is called as well.
 
         @since 3.3.0
     */

--- a/interface/wx/cmndata.h
+++ b/interface/wx/cmndata.h
@@ -608,10 +608,10 @@ public:
 
     /**
         Selects the "Current Page" radio button when the dialog is initially shown.
-        
+
         If this button is selected when the dialog is accepted, only the current
         page (as defined by the application) should be printed.
-        
+
         This only function can only be called if EnableCurrentPage() is called as well.
 
         @since 3.3.0

--- a/interface/wx/cmndata.h
+++ b/interface/wx/cmndata.h
@@ -545,7 +545,8 @@ public:
     /**
         Returns @true if the user requested that the current page be printed
         (where "current page" is a concept specific to the application).
-
+        It only makes sense to call this function if EnableCurrentPage() had been
+        called before, otherwise it always returns @false.
         @since 3.3.0
     */
     bool GetCurrentPage() const;

--- a/interface/wx/cmndata.h
+++ b/interface/wx/cmndata.h
@@ -490,6 +490,13 @@ public:
     void EnableSelection(bool flag);
 
     /**
+        Enables or disables the "Current Page" radio button.
+
+        @since 3.3.0
+    */
+    void EnableCurrentPage(bool flag);
+
+    /**
         Returns @true if the user requested that all pages be printed.
     */
     bool GetAllPages() const;
@@ -534,6 +541,14 @@ public:
         (where "selection" is a concept specific to the application).
     */
     bool GetSelection() const;
+
+    /**
+        Returns @true if the user requested that the current page be printed
+        (where "current page" is a concept specific to the application).
+
+        @since 3.3.0
+    */
+    bool GetCurrentPage() const;
 
     /**
         Returns the @e "print to" page number, as entered by the user.
@@ -589,6 +604,15 @@ public:
         all.
     */
     void SetSelection(bool flag);
+
+    /**
+        Selects the "Current Page" radio button. The effect of printing the
+        current page depends on how the application implements this command, if at
+        all.
+
+        @since 3.3.0
+    */
+    void SetCurrentPage(bool flag);
 
     /**
         @deprecated This function has been deprecated since version 2.5.4.

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -705,6 +705,13 @@ public:
         and maximum page values that the user can select, and the required page range to
         be printed.
 
+        If the user has decided to print only selected pages, then pageFrom and pageTo are
+        used to limit the page range and IsPageSelected() is used to query whether the page
+        is selected.
+
+        If the user only wants to print the current page, then pageFrom and pageTo are used
+        to set the current page by setting pageFrom = pageTo.
+
         By default this returns (1, 32000) for the page minimum and maximum values, and
         (1, 1) for the required page range.
 
@@ -772,6 +779,14 @@ public:
         HasPage behaves as if the document has only one page.
     */
     virtual bool HasPage(int pageNum);
+
+    /**
+        Should be overridden to return @true if this page is selected, or @false
+        if not. The default implementation always returns @false.
+
+        @since 3.3.0
+    */
+    virtual bool IsPageSelected(int pageNum);
 
     /**
         Returns @true if the printout is currently being used for previewing.

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -705,7 +705,7 @@ public:
         and maximum page values that the user can select, and the required page range to
         be printed.
 
-        If the user has decided to print only selected pages, then pageFrom and pageTo are
+        If the user has decided to print only selected pages, then @a pageFrom and @a pageTo are
         used to limit the page range and IsPageSelected() is used to query whether the page
         is selected.
 

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -709,8 +709,7 @@ public:
         used to limit the page range and IsPageSelected() is used to query whether the page
         is selected.
 
-        If the user only wants to print the current page, then pageFrom and pageTo are used
-        to set the current page by setting pageFrom = pageTo.
+        If the user only wants to print the current page, then @a pageFrom and @a pageTo are both set to the current page number.
 
         By default this returns (1, 32000) for the page minimum and maximum values, and
         (1, 1) for the required page range.

--- a/samples/printing/printing.cpp
+++ b/samples/printing/printing.cpp
@@ -11,7 +11,6 @@
 // For compilers that support precompilation, includes "wx/wx.h".
 #include "wx/wxprec.h"
 
-
 #ifndef WX_PRECOMP
     #include "wx/wx.h"
     #include "wx/log.h"
@@ -392,8 +391,7 @@ void MyFrame::OnPrintPreview(wxCommandEvent& WXUNUSED(event))
 {
     // Pass two printout objects: for preview, and possible printing.
     wxPrintDialogData printDialogData(* g_printData);
-    wxPrintPreview *preview =
-        new wxPrintPreview(new MyPrintout(this, &printDialogData), new MyPrintout(this, &printDialogData), &printDialogData);
+    wxPrintPreview *preview = new wxPrintPreview(new MyPrintout(this, &printDialogData), new MyPrintout(this, &printDialogData), &printDialogData);
     if (!preview->IsOk())
     {
         delete preview;
@@ -424,7 +422,7 @@ void MyFrame::OnPrintPS(wxCommandEvent& WXUNUSED(event))
     wxPrintDialogData printDialogData(* g_printData);
 
     wxPostScriptPrinter printer(&printDialogData);
-    MyPrintout printout(this, "My printout");
+    MyPrintout printout(this, &printer.GetPrintDialogData(), "My printout");
     printer.Print(this, &printout, true/*prompt*/);
 
     (*g_printData) = printer.GetPrintDialogData().GetPrintData();
@@ -434,7 +432,7 @@ void MyFrame::OnPrintPreviewPS(wxCommandEvent& WXUNUSED(event))
 {
     // Pass two printout objects: for preview, and possible printing.
     wxPrintDialogData printDialogData(* g_printData);
-    wxPrintPreview *preview = new wxPrintPreview(new MyPrintout(this), new MyPrintout(this), &printDialogData);
+    wxPrintPreview *preview = new wxPrintPreview(new MyPrintout(this, &printDialogData), new MyPrintout(this, &printDialogData), &printDialogData);
     wxPreviewFrame *frame = new wxPreviewFrame(preview, this, "Demo Print Preview");
     frame->Initialize();
     frame->Centre(wxBOTH);

--- a/samples/printing/printing.h
+++ b/samples/printing/printing.h
@@ -87,7 +87,11 @@ class MyPrintout: public wxPrintout
 {
 public:
     MyPrintout(MyFrame* frame, wxPrintDialogData* printDlgData, const wxString& title = "My printout")
-        : wxPrintout(title), m_frame(frame), m_printDlgData(printDlgData) {}
+        : wxPrintout(title)
+    {
+        m_frame = frame;
+        m_printDlgData = printDlgData;
+    }
 
     virtual bool OnPrintPage(int page) override;
     virtual bool HasPage(int page) override;

--- a/samples/printing/printing.h
+++ b/samples/printing/printing.h
@@ -86,13 +86,14 @@ private:
 class MyPrintout: public wxPrintout
 {
 public:
-    MyPrintout(MyFrame* frame, const wxString &title = "My printout")
-        : wxPrintout(title) { m_frame=frame; }
+    MyPrintout(MyFrame* frame, wxPrintDialogData* printDlgData, const wxString& title = "My printout")
+        : wxPrintout(title), m_frame(frame), m_printDlgData(printDlgData) {}
 
     virtual bool OnPrintPage(int page) override;
     virtual bool HasPage(int page) override;
     virtual bool OnBeginDocument(int startPage, int endPage) override;
     virtual void GetPageInfo(int *minPage, int *maxPage, int *selPageFrom, int *selPageTo) override;
+    virtual bool IsPageSelected(int pageNum) override;
 
     void DrawPageOne();
     void DrawPageTwo();
@@ -102,6 +103,7 @@ public:
 
 private:
     MyFrame *m_frame;
+    wxPrintDialogData* m_printDlgData;
 };
 
 

--- a/src/common/cmndata.cpp
+++ b/src/common/cmndata.cpp
@@ -178,12 +178,15 @@ wxPrintDialogData::wxPrintDialogData()
     m_printMinPage = 0;
     m_printMaxPage = 0;
     m_printNoCopies = 1;
+    m_printCurrentPage = 0;
     m_printAllPages = false;
     m_printCollate = false;
     m_printToFile = false;
     m_printSelection = false;
     m_printEnableSelection = false;
     m_printEnablePageNumbers = true;
+    m_printEnableCurrentPage = false;
+    m_printSelectCurrentPage = false;
 
     wxPrintFactory* factory = wxPrintFactory::GetFactory();
     m_printEnablePrintToFile = ! factory->HasOwnPrintToFile();
@@ -205,6 +208,7 @@ wxPrintDialogData::wxPrintDialogData(const wxPrintData& printData)
     m_printMinPage = 1;
     m_printMaxPage = 9999;
     m_printNoCopies = 1;
+    m_printCurrentPage = 0;
     // On Mac the Print dialog always defaults to "All Pages"
 #ifdef __WXMAC__
     m_printAllPages = true;
@@ -218,6 +222,8 @@ wxPrintDialogData::wxPrintDialogData(const wxPrintData& printData)
     m_printEnablePageNumbers = true;
     m_printEnablePrintToFile = true;
     m_printEnableHelp = false;
+    m_printEnableCurrentPage = false;
+    m_printSelectCurrentPage = false;
 }
 
 wxPrintDialogData::~wxPrintDialogData()
@@ -231,6 +237,7 @@ void wxPrintDialogData::operator=(const wxPrintDialogData& data)
     m_printMinPage = data.m_printMinPage;
     m_printMaxPage = data.m_printMaxPage;
     m_printNoCopies = data.m_printNoCopies;
+    m_printCurrentPage = data.m_printCurrentPage;
     m_printAllPages = data.m_printAllPages;
     m_printCollate = data.m_printCollate;
     m_printToFile = data.m_printToFile;
@@ -239,6 +246,8 @@ void wxPrintDialogData::operator=(const wxPrintDialogData& data)
     m_printEnablePageNumbers = data.m_printEnablePageNumbers;
     m_printEnableHelp = data.m_printEnableHelp;
     m_printEnablePrintToFile = data.m_printEnablePrintToFile;
+    m_printEnableCurrentPage = data.m_printEnableCurrentPage;
+    m_printSelectCurrentPage = data.m_printSelectCurrentPage;
     m_printData = data.m_printData;
 }
 

--- a/src/common/cmndata.cpp
+++ b/src/common/cmndata.cpp
@@ -178,15 +178,14 @@ wxPrintDialogData::wxPrintDialogData()
     m_printMinPage = 0;
     m_printMaxPage = 0;
     m_printNoCopies = 1;
-    m_printCurrentPage = 0;
     m_printAllPages = false;
     m_printCollate = false;
     m_printToFile = false;
     m_printSelection = false;
+    m_printCurrentPage = false;
     m_printEnableSelection = false;
     m_printEnablePageNumbers = true;
     m_printEnableCurrentPage = false;
-    m_printSelectCurrentPage = false;
 
     wxPrintFactory* factory = wxPrintFactory::GetFactory();
     m_printEnablePrintToFile = ! factory->HasOwnPrintToFile();
@@ -208,22 +207,23 @@ wxPrintDialogData::wxPrintDialogData(const wxPrintData& printData)
     m_printMinPage = 1;
     m_printMaxPage = 9999;
     m_printNoCopies = 1;
-    m_printCurrentPage = 0;
+
     // On Mac the Print dialog always defaults to "All Pages"
 #ifdef __WXMAC__
     m_printAllPages = true;
 #else
     m_printAllPages = false;
 #endif
+
     m_printCollate = false;
     m_printToFile = false;
     m_printSelection = false;
+    m_printCurrentPage = false;
     m_printEnableSelection = false;
     m_printEnablePageNumbers = true;
+    m_printEnableCurrentPage = false;
     m_printEnablePrintToFile = true;
     m_printEnableHelp = false;
-    m_printEnableCurrentPage = false;
-    m_printSelectCurrentPage = false;
 }
 
 wxPrintDialogData::~wxPrintDialogData()
@@ -237,17 +237,16 @@ void wxPrintDialogData::operator=(const wxPrintDialogData& data)
     m_printMinPage = data.m_printMinPage;
     m_printMaxPage = data.m_printMaxPage;
     m_printNoCopies = data.m_printNoCopies;
-    m_printCurrentPage = data.m_printCurrentPage;
     m_printAllPages = data.m_printAllPages;
     m_printCollate = data.m_printCollate;
     m_printToFile = data.m_printToFile;
     m_printSelection = data.m_printSelection;
+    m_printCurrentPage = data.m_printCurrentPage;
     m_printEnableSelection = data.m_printEnableSelection;
     m_printEnablePageNumbers = data.m_printEnablePageNumbers;
     m_printEnableHelp = data.m_printEnableHelp;
     m_printEnablePrintToFile = data.m_printEnablePrintToFile;
     m_printEnableCurrentPage = data.m_printEnableCurrentPage;
-    m_printSelectCurrentPage = data.m_printSelectCurrentPage;
     m_printData = data.m_printData;
 }
 

--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -635,6 +635,11 @@ void wxPrintout::GetPageInfo(int *minPage, int *maxPage, int *fromPage, int *toP
     *toPage = 1;
 }
 
+bool wxPrintout::IsPageSelected(int WXUNUSED(page))
+{
+    return false;
+}
+
 bool wxPrintout::SetUp(wxDC& dc)
 {
     wxCHECK_MSG( dc.IsOk(), false, "should have a valid DC to set up" );

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -892,6 +892,10 @@ bool wxWindowsPrintDialog::ConvertToNative( wxPrintDialogData &data )
         pd->lpPageRanges = new PRINTPAGERANGE[1];
         pd->lpPageRanges[0].nFromPage = (DWORD)data.GetFromPage();
         pd->lpPageRanges[0].nToPage = (DWORD)data.GetToPage();
+
+        // PrintDlgEx returns E_INVALIDARG if nFromPage is greater than nToPage
+        if (pd->lpPageRanges[0].nToPage < pd->lpPageRanges[0].nFromPage)
+            pd->lpPageRanges[0].nToPage = pd->lpPageRanges[0].nFromPage;
     }
 
     pd->Flags = PD_RETURNDC;

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -907,7 +907,7 @@ bool wxWindowsPrintDialog::ConvertToNative( wxPrintDialogData &data )
     pd->hInstance = nullptr;
     pd->lphPropertyPages = nullptr;
     pd->lpCallback = nullptr;
- 
+
     if ( data.GetAllPages() )
         pd->Flags |= PD_ALLPAGES;
     if ( data.GetSelection() )
@@ -990,7 +990,7 @@ bool wxWindowsPrintDialog::ConvertFromNative( wxPrintDialogData &data )
     data.EnableSelection( ((pd->Flags & PD_NOSELECTION) != PD_NOSELECTION) );
     data.EnablePageNumbers( ((pd->Flags & PD_NOPAGENUMS) != PD_NOPAGENUMS) );
     data.EnableHelp( ((pd->Flags & PD_SHOWHELP) == PD_SHOWHELP) );
-   
+
 #if(WINVER >= 0x0500)
     data.SetSelectCurrentPage(((pd->Flags & PD_CURRENTPAGE) == PD_CURRENTPAGE));
     data.EnableCurrentPage(((pd->Flags & PD_NOCURRENTPAGE) != PD_NOCURRENTPAGE));

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -793,11 +793,16 @@ bool wxWindowsPrintDialog::Create(wxWindow *p, wxPrintDialogData* data)
 
 wxWindowsPrintDialog::~wxWindowsPrintDialog()
 {
-    PRINTDLG *pd = (PRINTDLG *) m_printDlg;
+    PRINTDLGEX* pd = (PRINTDLGEX*) m_printDlg;
+
     if (pd && pd->hDevMode)
         GlobalFree(pd->hDevMode);
+
+    if (pd && pd->lpPageRanges)
+        GlobalFree(pd->lpPageRanges);
+
     if ( pd )
-        delete pd;
+        GlobalFree(pd);
 
     if (m_destroyDC && m_printerDC)
         delete m_printerDC;
@@ -814,11 +819,11 @@ int wxWindowsPrintDialog::ShowModal()
 
     ConvertToNative( m_printDialogData );
 
-    PRINTDLG *pd = (PRINTDLG*) m_printDlg;
-
+    PRINTDLGEX* pd = (PRINTDLGEX*) m_printDlg;
     pd->hwndOwner = hWndParent;
 
-    bool ret = (PrintDlg( pd ) != 0);
+    HRESULT dlgRes = PrintDlgEx(pd);
+    bool ret = (dlgRes == S_OK && pd->dwResultAction == PD_RESULT_PRINT);
 
     pd->hwndOwner = 0;
 
@@ -852,14 +857,16 @@ bool wxWindowsPrintDialog::ConvertToNative( wxPrintDialogData &data )
         (wxWindowsPrintNativeData *) data.GetPrintData().GetNativeData();
     data.GetPrintData().ConvertToNative();
 
-    PRINTDLG *pd = (PRINTDLG*) m_printDlg;
+    PRINTDLGEX* pd = (PRINTDLGEX*) m_printDlg;
 
     // Shouldn't have been defined anywhere
     if (pd)
         return false;
 
-    pd = new PRINTDLG;
-    memset( pd, 0, sizeof(PRINTDLG) );
+    pd = (LPPRINTDLGEX) GlobalAlloc(GPTR, sizeof(PRINTDLGEX));
+    if (!pd)
+        return false;
+
     m_printDlg = (void*) pd;
 
     pd->hDevMode = static_cast<HGLOBAL>(native_data->GetDevMode());
@@ -871,26 +878,35 @@ bool wxWindowsPrintDialog::ConvertToNative( wxPrintDialogData &data )
     pd->hDevNames = static_cast<HGLOBAL>(native_data->GetDevNames());
     native_data->SetDevNames(nullptr);
 
-
     pd->hDC = nullptr;
-    pd->nFromPage = (WORD)data.GetFromPage();
-    pd->nToPage = (WORD)data.GetToPage();
-    pd->nMinPage = (WORD)data.GetMinPage();
-    pd->nMaxPage = (WORD)data.GetMaxPage();
-    pd->nCopies = (WORD)data.GetNoCopies();
+    pd->nStartPage = START_PAGE_GENERAL;
+    pd->nMinPage = (DWORD)data.GetMinPage();
+    pd->nMaxPage = (DWORD)data.GetMaxPage();
+    pd->nCopies = (DWORD)data.GetNoCopies();
+
+    // currently only one page range is supported
+    pd->nPageRanges = 1;
+    pd->nMaxPageRanges = 1;
+    pd->lpPageRanges = (LPPRINTPAGERANGE) GlobalAlloc(GPTR, 1 * sizeof(PRINTPAGERANGE));
+    if (pd->lpPageRanges)
+    {
+        pd->lpPageRanges[0].nFromPage = (DWORD)data.GetFromPage();
+        pd->lpPageRanges[0].nToPage = (DWORD)data.GetToPage();
+    }
+    else
+    {
+        pd->nPageRanges = 0;
+        pd->nMaxPageRanges = 0;
+        pd->Flags |= PD_NOPAGENUMS;
+    }
 
     pd->Flags = PD_RETURNDC;
-    pd->lStructSize = sizeof( PRINTDLG );
+    pd->lStructSize = sizeof(PRINTDLGEX);
 
     pd->hwndOwner = nullptr;
     pd->hInstance = nullptr;
-    pd->lCustData = 0;
-    pd->lpfnPrintHook = nullptr;
-    pd->lpfnSetupHook = nullptr;
-    pd->lpPrintTemplateName = nullptr;
-    pd->lpSetupTemplateName = nullptr;
-    pd->hPrintTemplate = nullptr;
-    pd->hSetupTemplate = nullptr;
+    pd->lphPropertyPages = nullptr;
+    pd->lpCallback = nullptr;
 
     if ( data.GetAllPages() )
         pd->Flags |= PD_ALLPAGES;
@@ -911,12 +927,19 @@ bool wxWindowsPrintDialog::ConvertToNative( wxPrintDialogData &data )
     if ( data.GetEnableHelp() )
         pd->Flags |= PD_SHOWHELP;
 
+#if(WINVER >= 0x0500)
+    if (!data.GetEnableCurrentPage())
+        pd->Flags |= PD_NOCURRENTPAGE;
+    if (data.GetSelectCurrentPage())
+        pd->Flags |= PD_CURRENTPAGE;
+#endif
+
     return true;
 }
 
 bool wxWindowsPrintDialog::ConvertFromNative( wxPrintDialogData &data )
 {
-    PRINTDLG *pd = (PRINTDLG*) m_printDlg;
+    PRINTDLGEX* pd = (PRINTDLGEX*) m_printDlg;
     if ( pd == nullptr )
         return false;
 
@@ -949,8 +972,12 @@ bool wxWindowsPrintDialog::ConvertFromNative( wxPrintDialogData &data )
     // into wxWidgets form.
     native_data->TransferTo( data.GetPrintData() );
 
-    data.SetFromPage( pd->nFromPage );
-    data.SetToPage( pd->nToPage );
+    if (pd->lpPageRanges)
+    {
+        data.SetFromPage(pd->lpPageRanges[0].nFromPage);
+        data.SetToPage(pd->lpPageRanges[0].nToPage);
+    }
+
     data.SetMinPage( pd->nMinPage );
     data.SetMaxPage( pd->nMaxPage );
     data.SetNoCopies( pd->nCopies );
@@ -963,6 +990,11 @@ bool wxWindowsPrintDialog::ConvertFromNative( wxPrintDialogData &data )
     data.EnableSelection( ((pd->Flags & PD_NOSELECTION) != PD_NOSELECTION) );
     data.EnablePageNumbers( ((pd->Flags & PD_NOPAGENUMS) != PD_NOPAGENUMS) );
     data.EnableHelp( ((pd->Flags & PD_SHOWHELP) == PD_SHOWHELP) );
+
+#if(WINVER >= 0x0500)
+    data.SetSelectCurrentPage(((pd->Flags & PD_CURRENTPAGE) == PD_CURRENTPAGE));
+    data.EnableCurrentPage(((pd->Flags & PD_NOCURRENTPAGE) != PD_NOCURRENTPAGE));
+#endif
 
     return true;
 }

--- a/src/msw/printwin.cpp
+++ b/src/msw/printwin.cpp
@@ -164,16 +164,15 @@ bool wxWindowsPrinter::Print(wxWindow *parent, wxPrintout *printout, bool prompt
 
     int minPageNum = minPage, maxPageNum = maxPage;
 
-    if ( !(m_printDialogData.GetAllPages() || m_printDialogData.GetSelection()) )
+    if (m_printDialogData.GetCurrentPage() || m_printDialogData.GetSelection())
+    {
+        minPageNum = fromPage;
+        maxPageNum = toPage;
+    }
+    else if ( !m_printDialogData.GetAllPages() )
     {
         minPageNum = m_printDialogData.GetFromPage();
         maxPageNum = m_printDialogData.GetToPage();
-    }
-
-    if (m_printDialogData.GetEnableCurrentPage() && m_printDialogData.GetSelectCurrentPage())
-    {
-        minPageNum = m_printDialogData.GetCurrentPage();
-        maxPageNum = minPageNum;
     }
 
     // The dc we get from the PrintDialog will do multiple copies without help
@@ -204,6 +203,10 @@ bool wxWindowsPrinter::Print(wxWindow *parent, wxPrintout *printout, bool prompt
               pn <= maxPageNum && printout->HasPage(pn);
               pn++ )
         {
+            // allow non-consecutive selected pages
+            if (m_printDialogData.GetSelection() && !printout->IsPageSelected(pn))
+                continue;
+
             win->SetProgress(pn - minPageNum + 1,
                              maxPageNum - minPageNum + 1,
                              copyCount, maxCopyCount);

--- a/src/msw/printwin.cpp
+++ b/src/msw/printwin.cpp
@@ -170,6 +170,12 @@ bool wxWindowsPrinter::Print(wxWindow *parent, wxPrintout *printout, bool prompt
         maxPageNum = m_printDialogData.GetToPage();
     }
 
+    if (m_printDialogData.GetEnableCurrentPage() && m_printDialogData.GetSelectCurrentPage())
+    {
+        minPageNum = m_printDialogData.GetCurrentPage();
+        maxPageNum = minPageNum;
+    }
+
     // The dc we get from the PrintDialog will do multiple copies without help
     // if the device supports it. Loop only if we have created a dc from our
     // own m_printDialogData or the device does not support multiple copies.


### PR DESCRIPTION
The pull request makes it possible to use the print current page option of the Windows print dialog.

![image](https://user-images.githubusercontent.com/33447587/224433417-04db63d2-be73-4ff4-a3d1-bd38b91b6318.png)

I have added three new members to wxPrintDialogData which can be used to control the new feature:
`int m_printCurrentPage` - the page number of the current page
`bool m_printEnableCurrentPage` - used to enable/disable the current page field in print dialog
`bool m_printSelectCurrentPage` - if set to true, the current page field is selected when the dialog is shown

By default the print current page option is disabled. Therefore the extension is 100% compatible with the old code.

This extension uses the new properties only for the Windows port. I don't know whether an option for a current page is also available in other dialogs so that these ones could be extended as well.



 