### PR TITLE
Fix TSAN errors in thread unit tests

### DIFF
--- a/interface/wx/thread.h
+++ b/interface/wx/thread.h
@@ -486,8 +486,10 @@ public:
         will be executed in the context of the thread that called Delete() and
         <b>not</b> in this thread's context.
 
-        TestDestroy() will be true for the thread before OnDelete() gets
-        executed.
+        Note that TestDestroy() will block until OnDelete() returns, so this
+        function should return as quickly as possible and definitely shouldn't
+        perform any GUI actions nor try acquiring any locks, as this could
+        easily result in a deadlock.
 
         @since 2.9.2
 

--- a/src/common/threadinfo.cpp
+++ b/src/common/threadinfo.cpp
@@ -17,8 +17,9 @@
 
 #include "wx/tls.h"
 #include "wx/thread.h"
-#include "wx/sharedptr.h"
-#include "wx/vector.h"
+
+#include <memory>
+#include <vector>
 
 namespace
 {
@@ -36,7 +37,8 @@ inline wxCriticalSection& GetAllThreadInfosCS()
     return s_csAllThreadInfos;
 }
 
-typedef wxVector< wxSharedPtr<wxThreadSpecificInfo> > wxAllThreadInfos;
+using wxAllThreadInfos = std::vector<std::unique_ptr<wxThreadSpecificInfo>>;
+
 inline wxAllThreadInfos& GetAllThreadInfos()
 {
     static wxAllThreadInfos s_allThreadInfos;
@@ -64,7 +66,7 @@ wxThreadSpecificInfo& wxThreadSpecificInfo::Get()
         wxTHIS_THREAD_INFO = new wxThreadSpecificInfo;
         wxCriticalSectionLocker lock(GetAllThreadInfosCS());
         GetAllThreadInfos().push_back(
-                wxSharedPtr<wxThreadSpecificInfo>(wxTHIS_THREAD_INFO));
+                std::unique_ptr<wxThreadSpecificInfo>(wxTHIS_THREAD_INFO));
     }
     return *wxTHIS_THREAD_INFO;
 }

--- a/src/common/time.cpp
+++ b/src/common/time.cpp
@@ -37,6 +37,10 @@
     #endif
 #endif
 
+#ifdef WX_GMTOFF_IN_TM
+    #include <atomic>
+#endif
+
 #include <time.h>
 
 wxDECL_FOR_STRICT_MINGW32(void, tzset, (void));
@@ -119,12 +123,10 @@ struct tm *wxGmtime_r(const time_t* ticks, struct tm* temp)
 int wxGetTimeZone()
 {
 #ifdef WX_GMTOFF_IN_TM
-    // set to true when the timezone is set
-    static bool s_timezoneSet = false;
-    static long gmtoffset = LONG_MAX; // invalid timezone
+    static std::atomic<int> s_gmtoffset{INT_MAX}; // invalid timezone
 
     // ensure that the timezone variable is set by calling wxLocaltime_r
-    if ( !s_timezoneSet )
+    if ( s_gmtoffset == INT_MAX )
     {
         // just call wxLocaltime_r() instead of figuring out whether this
         // system supports tzset(), _tzset() or something else
@@ -132,20 +134,21 @@ int wxGetTimeZone()
         struct tm tm;
 
         wxLocaltime_r(&t, &tm);
-        s_timezoneSet = true;
 
         // note that GMT offset is the opposite of time zone and so to return
         // consistent results in both WX_GMTOFF_IN_TM and !WX_GMTOFF_IN_TM
         // cases we have to negate it
-        gmtoffset = -tm.tm_gmtoff;
+        int gmtoffset = static_cast<int>(-tm.tm_gmtoff);
 
         // this function is supposed to return the same value whether DST is
         // enabled or not, so we need to use an additional offset if DST is on
         // as tm_gmtoff already does include it
         if ( tm.tm_isdst )
             gmtoffset += 3600;
+
+        s_gmtoffset = gmtoffset;
     }
-    return (int)gmtoffset;
+    return s_gmtoffset;
 #elif defined(__WINE__)
     struct timeb tb;
     ftime(&tb);

--- a/src/msw/thread.cpp
+++ b/src/msw/thread.cpp
@@ -407,11 +407,6 @@ public:
 
     ~wxThreadInternal()
     {
-        Free();
-    }
-
-    void Free()
-    {
         if ( m_hThread )
         {
             if ( !::CloseHandle(m_hThread) )
@@ -684,8 +679,6 @@ wxThreadError wxThreadInternal::Kill()
         return wxTHREAD_MISC_ERROR;
     }
 
-    Free();
-
     return wxTHREAD_NO_ERROR;
 }
 
@@ -712,10 +705,11 @@ wxThreadInternal::WaitForTerminate(wxCriticalSection& cs,
     // as Delete() (which calls us) is always safe to call we need to consider
     // all possible states
     {
-        wxCriticalSectionLocker lock(cs);
+    wxCriticalSectionLocker lock(cs);
 
-        if ( m_state == STATE_NEW )
-        {
+    switch ( m_state )
+    {
+        case STATE_NEW:
             if ( shouldDelete )
             {
                 // WinThreadStart() will see it and terminate immediately, no
@@ -732,12 +726,34 @@ wxThreadInternal::WaitForTerminate(wxCriticalSection& cs,
             }
             //else: shouldResume is correctly set to false here, wait until
             //      someone else runs the thread and it finishes
-        }
-        else // running, paused, cancelled or even exited
-        {
-            shouldResume = m_state == STATE_PAUSED;
-        }
+            break;
+
+        case STATE_RUNNING:
+            // Nothing special to do, just wait for the thread to exit.
+            break;
+
+        case STATE_PAUSED:
+            shouldResume = true;
+            break;
+
+        case STATE_CANCELED:
+            // No need to cancel it again.
+            shouldDelete = false;
+            break;
+
+        case STATE_EXITED:
+            // We don't need to wait for the thread to exit if it already did,
+            // but doing it does no harm neither and it's a rare case not worth
+            // optimizing for.
+            //
+            // Just ensure we don't call OnDelete() again as we may have
+            // already done it (unfortunately we have no way of knowing if we
+            // did, but it seems better not to do it at all rather than do it
+            // twice).
+            threadToDelete = nullptr;
+            break;
     }
+    } // release cs
 
     // resume the thread if it is paused
     if ( shouldResume )
@@ -854,10 +870,6 @@ wxThreadInternal::WaitForTerminate(wxCriticalSection& cs,
 
     if ( pRc )
         *pRc = wxUIntToPtr(rc);
-
-    // we don't need the thread handle any more in any case
-    Free();
-
 
     return rc == THREAD_ERROR_EXIT ? wxTHREAD_MISC_ERROR : wxTHREAD_NO_ERROR;
 }
@@ -1221,8 +1233,6 @@ bool wxThread::SetNameForCurrent(const wxString &name)
 void wxThread::Exit(ExitCode status)
 {
     wxThreadInternal::DoThreadOnExit(this);
-
-    m_internal->Free();
 
     if ( IsDetached() )
     {

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -1583,6 +1583,10 @@ wxThreadError wxThread::Delete(ExitCode *rc, wxThreadWait WXUNUSED(waitMode))
     // anything at all).
     OnDelete();
 
+    // If it's currently paused, we need to resume it first.
+    if ( state == STATE_PAUSED )
+        m_internal->Resume();
+
     m_critsect.Leave();
 
     switch ( state )
@@ -1598,12 +1602,6 @@ wxThreadError wxThread::Delete(ExitCode *rc, wxThreadWait WXUNUSED(waitMode))
         case STATE_EXITED:
             // nothing to do
             break;
-
-        case STATE_PAUSED:
-            // resume the thread first
-            m_internal->Resume();
-
-            wxFALLTHROUGH;
 
         default:
             if ( !isDetached )

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -1774,6 +1774,8 @@ bool wxThread::TestDestroy()
 
     m_critsect.Enter();
 
+    const bool wasCancelled = m_internal->WasCancelled();
+
     if ( m_internal->GetState() == STATE_PAUSED )
     {
         m_internal->SetReallyPaused(true);
@@ -1791,7 +1793,7 @@ bool wxThread::TestDestroy()
         m_critsect.Leave();
     }
 
-    return m_internal->WasCancelled();
+    return wasCancelled;
 }
 
 wxThread::~wxThread()

--- a/tests/thread/misc.cpp
+++ b/tests/thread/misc.cpp
@@ -143,6 +143,7 @@ public:
         m_mutex->Unlock();
 
         //wxPrintf(wxT("Thread %lu finished to wait, exiting.\n"), GetId());
+        gs_cond.Post();
 
         return nullptr;
     }
@@ -389,29 +390,29 @@ void MiscThreadTestCase::TestThreadConditions()
     }
 
     // wait until all threads run
-    // NOTE: main thread is waiting for the other threads to start
     size_t nRunning = 0;
     while ( nRunning < WXSIZEOF(threads) )
     {
         CPPUNIT_ASSERT_EQUAL( wxSEMA_NO_ERROR, gs_cond.Wait() );
 
         nRunning++;
-
-        // note that main thread is already running
     }
 
     wxMilliSleep(500);
 
-#if 1
     // now wake one of them up
     CPPUNIT_ASSERT_EQUAL( wxCOND_NO_ERROR, condition.Signal() );
-#endif
 
-    wxMilliSleep(200);
+    CPPUNIT_ASSERT_EQUAL( wxSEMA_NO_ERROR, gs_cond.Wait() );
+    size_t nFinished = 1;
 
     // wake all the (remaining) threads up, so that they can exit
     CPPUNIT_ASSERT_EQUAL( wxCOND_NO_ERROR, condition.Broadcast() );
 
-    // give them time to terminate (dirty!)
-    wxMilliSleep(500);
+    while ( nFinished < WXSIZEOF(threads) )
+    {
+        CPPUNIT_ASSERT_EQUAL( wxSEMA_NO_ERROR, gs_cond.Wait() );
+
+        nFinished++;
+    }
 }


### PR DESCRIPTION
This should hopefully also fix an assert in unit tests happening from time to time in `MiscThreadTestCase::TestThreadDelete()`.