### PR TITLE
Change Line Break mode of wxStaticText on macOS to match MSW and GTK

### DIFF
--- a/src/osx/cocoa/stattext.mm
+++ b/src/osx/cocoa/stattext.mm
@@ -157,7 +157,7 @@ wxWidgetImplType* wxWidgetImpl::CreateStaticText( wxWindowMac* wxpeer,
     [v setBezeled:NO];
     [v setBordered:NO];
 
-    NSLineBreakMode linebreak = NSLineBreakByClipping;
+    NSLineBreakMode linebreak = NSLineBreakByWordWrapping;
     if ( style & wxST_ELLIPSIZE_MASK )
     {
         if ( style & wxST_ELLIPSIZE_MIDDLE )


### PR DESCRIPTION
See #23341