### PR TITLE
Add wxWebViewConfiguration

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -108,7 +108,7 @@ public:
     HRESULT OnAddScriptToExecuteOnDocumentedCreatedCompleted(HRESULT errorCode, LPCWSTR id);
     HRESULT OnWindowCloseRequested(ICoreWebView2* sender, IUnknown* args);
 
-    HRESULT OnEnvironmentCreated(HRESULT result, ICoreWebView2Environment* environment);
+    void EnvironmentAvailable(ICoreWebView2Environment* environment);
     HRESULT OnWebViewCreated(HRESULT result, ICoreWebView2Controller* webViewController);
 
     HRESULT HandleNavigationStarting(ICoreWebView2NavigationStartingEventArgs* args, bool mainFrame);
@@ -130,8 +130,6 @@ public:
 #if !wxUSE_WEBVIEW_EDGE_STATIC
     static wxDynamicLibrary ms_loaderDll;
 #endif
-    static wxString ms_browserExecutableDir;
-
     static bool Initialize();
 
     static void Uninitialize();

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -113,6 +113,8 @@ public:
 
     HRESULT HandleNavigationStarting(ICoreWebView2NavigationStartingEventArgs* args, bool mainFrame);
 
+    void SendErrorEventForAPI(const wxString& api, HRESULT errorCode);
+
     wxVector<wxSharedPtr<wxWebViewHistoryItem> > m_historyList;
     int m_historyPosition;
     bool m_historyLoadingFromList;

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -51,6 +51,7 @@ class wxWebViewEdgeParentWindowInfo;
 class wxWebViewEdgeImpl
 {
 public:
+    explicit wxWebViewEdgeImpl(wxWebViewEdge* webview, const wxWebViewConfiguration& config);
     explicit wxWebViewEdgeImpl(wxWebViewEdge* webview);
     ~wxWebViewEdgeImpl();
 
@@ -59,11 +60,11 @@ public:
     wxWebViewEdge* CreateChildWebView(std::shared_ptr<wxWebViewEdgeParentWindowInfo> parentWindowInfo);
 
     wxWebViewEdge* m_ctrl;
+    wxWebViewConfiguration m_config;
 
     wxCOMPtr<ICoreWebView2Environment> m_webViewEnvironment;
     wxCOMPtr<ICoreWebView2_2> m_webView;
     wxCOMPtr<ICoreWebView2Controller> m_webViewController;
-    wxCOMPtr<ICoreWebView2EnvironmentOptions> m_webViewEnvironmentOptions;
     std::shared_ptr<wxWebViewEdgeParentWindowInfo> m_parentWindowInfo;
 
     bool m_initialized;

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -25,6 +25,8 @@ public:
 
     wxWebViewEdge();
 
+    explicit wxWebViewEdge(const wxWebViewConfiguration& config);
+
     wxWebViewEdge(wxWindow* parent,
         wxWindowID id,
         const wxString& url = wxWebViewDefaultURLStr,
@@ -103,7 +105,6 @@ public:
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) override;
 
     virtual void* GetNativeBackend() const override;
-    virtual void* GetNativeConfiguration() const override;
 
     static void MSWSetBrowserExecutableDir(const wxString& path);
 
@@ -128,6 +129,7 @@ class WXDLLIMPEXP_WEBVIEW wxWebViewFactoryEdge : public wxWebViewFactory
 {
 public:
     virtual wxWebView* Create() override { return new wxWebViewEdge; }
+    virtual wxWebView* CreateWithConfig(const wxWebViewConfiguration& config) override;
     virtual wxWebView* Create(wxWindow* parent,
         wxWindowID id,
         const wxString& url = wxWebViewDefaultURLStr,
@@ -140,6 +142,7 @@ public:
     }
     virtual bool IsAvailable() override;
     virtual wxVersionInfo GetVersionInfo() override;
+    virtual wxWebViewConfiguration CreateConfiguration() override;
 };
 
 #endif // wxUSE_WEBVIEW && wxUSE_WEBVIEW_EDGE && defined(__WXMSW__)

--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -28,27 +28,13 @@
 WX_DECLARE_STRING_HASH_MAP(wxSharedPtr<wxWebViewHandler>, wxStringToWebHandlerMap);
 
 class wxWebViewWindowInfoWebKit;
+class wxWebViewConfigurationImplWebKit;
 
 class WXDLLIMPEXP_WEBVIEW wxWebViewWebKit : public wxWebView
 {
 public:
-    wxDECLARE_DYNAMIC_CLASS(wxWebViewWebKit);
+    explicit wxWebViewWebKit(const wxWebViewConfiguration& config, wxWebViewWindowInfoWebKit* parentWindowInfo = nullptr);
 
-    wxWebViewWebKit(wxWebViewWindowInfoWebKit* parentWindowInfo = nullptr)
-    {
-        m_parentWindowInfo = parentWindowInfo;
-        Init();
-    }
-    wxWebViewWebKit(wxWindow *parent,
-                    wxWindowID winID = wxID_ANY,
-                    const wxString& strURL = wxASCII_STR(wxWebViewDefaultURLStr),
-                    const wxPoint& pos = wxDefaultPosition,
-                    const wxSize& size = wxDefaultSize, long style = 0,
-                    const wxString& name = wxASCII_STR(wxWebViewNameStr))
-    {
-        Init();
-        Create(parent, winID, strURL, pos, size, style, name);
-    }
     bool Create(wxWindow *parent,
                 wxWindowID winID = wxID_ANY,
                 const wxString& strURL = wxASCII_STR(wxWebViewDefaultURLStr),
@@ -112,7 +98,6 @@ public:
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) override;
 
     virtual void* GetNativeBackend() const override { return m_webView; }
-    virtual void* GetNativeConfiguration() const override { return m_webViewConfiguration; }
 
 protected:
     virtual void DoSetPage(const wxString& html, const wxString& baseUrl) override;
@@ -120,7 +105,7 @@ protected:
     wxDECLARE_EVENT_TABLE();
 
 private:
-    WX_NSObject m_webViewConfiguration;
+    wxWebViewConfiguration m_configuration;
     OSXWebViewPtr m_webView;
     wxStringToWebHandlerMap m_handlers;
     wxString m_customUserAgent;
@@ -135,7 +120,8 @@ private:
 class WXDLLIMPEXP_WEBVIEW wxWebViewFactoryWebKit : public wxWebViewFactory
 {
 public:
-    virtual wxWebView* Create() override { return new wxWebViewWebKit; }
+    virtual wxWebView* Create() override { return CreateWithConfig(CreateConfiguration()); }
+    virtual wxWebView* CreateWithConfig(const wxWebViewConfiguration& config) override { return new wxWebViewWebKit(config); }
     virtual wxWebView* Create(wxWindow* parent,
                               wxWindowID id,
                               const wxString& url = wxWebViewDefaultURLStr,
@@ -143,8 +129,15 @@ public:
                               const wxSize& size = wxDefaultSize,
                               long style = 0,
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) override
-    { return new wxWebViewWebKit(parent, id, url, pos, size, style, name); }
+    {
+        auto webView = CreateWithConfig(CreateConfiguration());
+        if (webView->Create(parent, id, url, pos, size, style, name))
+            return webView;
+        else
+            return nullptr;
+    }
     virtual wxVersionInfo GetVersionInfo() override;
+    virtual wxWebViewConfiguration CreateConfiguration() override;
 };
 
 #endif // wxUSE_WEBVIEW && wxUSE_WEBVIEW_WEBKIT

--- a/include/wx/private/webview.h
+++ b/include/wx/private/webview.h
@@ -15,6 +15,8 @@ class WXDLLIMPEXP_WEBVIEW wxWebViewConfigurationImpl
 public:
     virtual ~wxWebViewConfigurationImpl() = default;
     virtual void* GetNativeConfiguration() const { return nullptr; }
+    virtual void SetDataPath(const wxString& WXUNUSED(path)) {}
+    virtual wxString GetDataPath() const { return wxString{}; }
 };
 
 #endif // _WX_PRIVATE_WEBVIEW_H_

--- a/include/wx/private/webview.h
+++ b/include/wx/private/webview.h
@@ -1,0 +1,20 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/webview.h
+// Purpose:     wxWebView implementation classes
+// Author:      Tobias Taschner
+// Created:     2023-03-16
+// Copyright:   (c) 2023 wxWidgets development team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_WEBVIEW_H_
+#define _WX_PRIVATE_WEBVIEW_H_
+
+class WXDLLIMPEXP_WEBVIEW wxWebViewConfigurationImpl
+{
+public:
+    virtual ~wxWebViewConfigurationImpl() = default;
+    virtual void* GetNativeConfiguration() const { return nullptr; }
+};
+
+#endif // _WX_PRIVATE_WEBVIEW_H_

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -144,6 +144,22 @@ private:
     wxString m_virtualHost;
 };
 
+class wxWebViewConfigurationImpl;
+
+class WXDLLIMPEXP_WEBVIEW wxWebViewConfiguration
+{
+public:
+    explicit wxWebViewConfiguration(const wxString& backend, wxWebViewConfigurationImpl* impl);
+    void* GetNativeConfiguration() const;
+
+    const wxString& GetBackend() const { return m_backend; }
+
+    wxWebViewConfigurationImpl* GetImpl() const { return m_impl.get(); }
+private:
+    wxString m_backend;
+    std::shared_ptr<wxWebViewConfigurationImpl> m_impl;
+};
+
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewNameStr[];
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewDefaultURLStr[];
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendDefault[];
@@ -155,6 +171,7 @@ class WXDLLIMPEXP_WEBVIEW wxWebViewFactory : public wxObject
 {
 public:
     virtual wxWebView* Create() = 0;
+    virtual wxWebView* CreateWithConfig(const wxWebViewConfiguration& WXUNUSED(config)) { return Create(); }
     virtual wxWebView* Create(wxWindow* parent,
                               wxWindowID id,
                               const wxString& url = wxASCII_STR(wxWebViewDefaultURLStr),
@@ -164,6 +181,7 @@ public:
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) = 0;
     virtual bool IsAvailable() { return true; }
     virtual wxVersionInfo GetVersionInfo() { return wxVersionInfo(); }
+    virtual wxWebViewConfiguration CreateConfiguration();
 };
 
 WX_DECLARE_STRING_HASH_MAP(wxSharedPtr<wxWebViewFactory>, wxStringWebViewFactoryMap);
@@ -190,6 +208,7 @@ public:
     // Factory methods allowing the use of custom factories registered with
     // RegisterFactory
     static wxWebView* New(const wxString& backend = wxASCII_STR(wxWebViewBackendDefault));
+    static wxWebView* New(const wxWebViewConfiguration& config);
     static wxWebView* New(wxWindow* parent,
                           wxWindowID id,
                           const wxString& url = wxASCII_STR(wxWebViewDefaultURLStr),
@@ -203,6 +222,7 @@ public:
                                 wxSharedPtr<wxWebViewFactory> factory);
     static bool IsBackendAvailable(const wxString& backend);
     static wxVersionInfo GetBackendVersionInfo(const wxString& backend = wxASCII_STR(wxWebViewBackendDefault));
+    static wxWebViewConfiguration NewConfiguration(const wxString& backend = wxASCII_STR(wxWebViewBackendDefault));
 
     // General methods
     virtual void EnableContextMenu(bool enable = true)
@@ -297,7 +317,6 @@ public:
 
     //Get the pointer to the underlying native engine.
     virtual void* GetNativeBackend() const = 0;
-    virtual void* GetNativeConfiguration() const { return nullptr; }
     //Find function
     virtual long Find(const wxString& text, int flags = wxWEBVIEW_FIND_DEFAULT);
 

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -151,6 +151,8 @@ class WXDLLIMPEXP_WEBVIEW wxWebViewConfiguration
 public:
     explicit wxWebViewConfiguration(const wxString& backend, wxWebViewConfigurationImpl* impl);
     void* GetNativeConfiguration() const;
+    void SetDataPath(const wxString& path);
+    wxString GetDataPath() const;
 
     const wxString& GetBackend() const { return m_backend; }
 

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -273,6 +273,9 @@ public:
         Additional instances of wxWebView must be created using the same
         wxWebViewConfiguration instance.
 
+        All settings @b must be set before creating a new web view with
+        wxWebView::New().
+
         The return value needs to be down-casted to the appropriate type
         depending on the platform: under macOS, it's a
         <a href="https://developer.apple.com/documentation/webkit/wkwebviewconfiguration">WKWebViewConfiguration</a>
@@ -312,6 +315,28 @@ public:
         Returns the backend identifier for which this configuration was created.
     */
     wxString GetBackend() const;
+
+    /**
+        Set the data path for the webview.
+
+        This is the path where the webview stores its data, such as cookies,
+        local storage, etc.
+        @param path The path to the data directory.
+
+        @note This is only used by the Edge backend.
+    */
+    void SetDataPath(const wxString& path);
+
+    /**
+        Returns the data path for the webview.
+
+        This is the path where the webview stores its data, such as cookies,
+        local storage, etc.
+        @return The path to the data directory.
+
+        @note This is only used by the Edge backend.
+    */
+    wxString GetDataPath() const;
 };
 
 

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -247,6 +247,75 @@ public:
 };
 
 /**
+    @class wxWebViewConfiguration
+
+    This class allows access to web view configuration options and settings,
+    that have to be specified before placing a webview in a window with
+    wxWebView::Create().
+
+    @since 3.3.0
+    @library{wxwebview}
+    @category{webview}
+
+    @see wxWebView::NewConfiguration()
+ */
+class WXDLLIMPEXP_WEBVIEW wxWebViewConfiguration
+{
+public:
+    /**
+        Return the pointer to the native configuration used during creation of
+        a wxWebView.
+
+        When using two-step creation this method can be used to customize
+        configuration options not available via GetNativeBackend()
+        after using Create().
+
+        Additional instances of wxWebView must be created using the same
+        wxWebViewConfiguration instance.
+
+        The return value needs to be down-casted to the appropriate type
+        depending on the platform: under macOS, it's a
+        <a href="https://developer.apple.com/documentation/webkit/wkwebviewconfiguration">WKWebViewConfiguration</a>
+        pointer, under Windows with Edge it's a pointer to
+        <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions">ICoreWebView2EnvironmentOptions</a>.
+        With other backends/platforms it's not implemented.
+
+        The following pseudo code shows how to use this method with two-step
+        creation to set no user action requirement to play video in a
+        web view:
+        @code
+            #if defined(__WXMSW__)
+            #include "webview2EnvironmentOptions.h"
+            #elif defined(__WXOSX__)
+            #import "WebKit/WebKit.h"
+            #endif
+
+            wxWebViewConfiguration config = wxWebView::NewConfiguration();
+
+            #if defined(__WXMSW__)
+            ICoreWebView2EnvironmentOptions* webViewOptions =
+                (ICoreWebView2EnvironmentOptions*) config->GetNativeConfiguration();
+            webViewOptions->put_AdditionalBrowserArguments("--autoplay-policy=no-user-gesture-required");
+            #elif defined(__WXOSX__)
+            WKWebViewConfiguration* webViewConfiguration =
+                (WKWebViewConfiguration*) config->GetNativeConfiguration();
+            webViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+            #endif
+
+            wxWebView* webView = wxWebView::New(config);
+            webView->Create(this, wxID_ANY, "https://www.wxwidgets.org");
+        @endcode
+    */
+    virtual void* GetNativeConfiguration() const { return nullptr; }
+
+    /**
+        Returns the backend identifier for which this configuration was created.
+    */
+    wxString GetBackend() const;
+};
+
+
+/**
     @class wxWebViewHandlerRequest
 
     A class giving access to various parameters of a webview request.
@@ -451,6 +520,18 @@ public:
     virtual wxWebView* Create() = 0;
 
     /**
+        Function to create a new wxWebView with two-step creation
+        with a wxWebViewConfiguration, wxWebView::Create should be
+        called on the returned object.
+
+        @return the created wxWebView
+        @since 3.3.0
+
+        @see CreateConfiguration()
+    */
+    virtual wxWebView* CreateWithConfig(const wxWebViewConfiguration& config);
+
+    /**
         Function to create a new wxWebView with parameters.
         @param parent Parent window for the control
         @param id ID of this control
@@ -487,6 +568,14 @@ public:
         @since 3.1.5
     */
     virtual wxVersionInfo GetVersionInfo();
+
+    /**
+        Create a wxWebViewConfiguration object for wxWebView instances
+        created by this factory.
+
+        @since 3.3.0
+    */
+    virtual wxWebViewConfiguration CreateConfiguration();
 };
 
 /**
@@ -848,6 +937,16 @@ public:
     static wxWebView* New(const wxString& backend = wxWebViewBackendDefault);
 
     /**
+        Factory function to create a new wxWebView with two-step creation,
+        wxWebView::Create should be called on the returned object.
+
+        @param config a configuration object create with NewConfiguration().
+        @return The created wxWebView
+        @since 3.3.0
+     */
+    static wxWebView* New(const wxWebViewConfiguration& config);
+
+    /**
         Factory function to create a new wxWebView using a wxWebViewFactory.
         @param parent Parent window for the control
         @param id ID of this control
@@ -907,6 +1006,13 @@ public:
     static wxVersionInfo GetBackendVersionInfo(const wxString& backend = wxWebViewBackendDefault);
 
     /**
+        Create a new wxWebViewConfiguration object.
+
+        @since 3.3.0
+    */
+    static wxWebViewConfiguration NewConfiguration(const wxString& backend = wxWebViewBackendDefault);
+
+    /**
         Get the title of the current web page, or its URL/path if title is not
         available.
     */
@@ -944,48 +1050,6 @@ public:
         @since 2.9.5
      */
     virtual void* GetNativeBackend() const = 0;
-
-    /**
-        Return the pointer to the native configuration used during creation of
-        this control.
-
-        When using two-step creation this method can be used to customize
-        configuration options not available via GetNativeBackend()
-        after using Create().
-
-        The return value needs to be down-casted to the appropriate type
-        depending on the platform: under macOS, it's a
-        <a href="https://developer.apple.com/documentation/webkit/wkwebviewconfiguration">WKWebViewConfiguration</a>
-        pointer, under Windows with Edge it's a pointer to
-        <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions">ICoreWebView2EnvironmentOptions</a>.
-        With other backends/platforms it's not implemented.
-
-        The following pseudo code shows how to use this method with two-step
-        creation to set no user action requirement to play video in a
-        web view:
-        @code
-            #if defined(__WXMSW__)
-            #include "webview2.h"
-            #elif defined(__WXOSX__)
-            #import "WebKit/WebKit.h"
-            #endif
-
-            wxWebView* webView = wxWebView::New();
-            #if defined(__WXMSW__)
-            ICoreWebView2EnvironmentOptions* webViewOptions =
-                (ICoreWebView2EnvironmentOptions*) webView->GetNativeConfiguration();
-            webViewOptions->put_AdditionalBrowserArguments("--autoplay-policy=no-user-gesture-required");
-            #elif defined(__WXOSX__)
-            WKWebViewConfiguration* webViewConfiguration =
-                (WKWebViewConfiguration*) webView->GetNativeConfiguration();
-            webViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
-            #endif
-            webView->Create(this, wxID_ANY, "https://www.wxwidgets.org");
-        @endcode
-
-        @since 3.3.0
-    */
-   virtual void* GetNativeConfiguration() const;
 
     /**
         Get the HTML source code of the currently displayed document.

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -15,6 +15,7 @@
 #include "wx/webview.h"
 #include "wx/filesys.h"
 #include "wx/mstream.h"
+#include "wx/private/webview.h"
 
 #if defined(__WXOSX__)
 #include "wx/osx/webview_webkit.h"
@@ -54,6 +55,26 @@ wxDEFINE_EVENT( wxEVT_WEBVIEW_TITLE_CHANGED, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_FULLSCREEN_CHANGED, wxWebViewEvent);
 wxDEFINE_EVENT( wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED, wxWebViewEvent);
 wxDEFINE_EVENT( wxEVT_WEBVIEW_SCRIPT_RESULT, wxWebViewEvent);
+
+// wxWebViewConfigurationDefault
+class wxWebViewConfigurationImplDefault : public wxWebViewConfigurationImpl
+{
+public:
+    virtual void* GetNativeConfiguration() const override
+    {
+        return nullptr;
+    }
+};
+
+// wxWebViewConfiguration
+wxWebViewConfiguration::wxWebViewConfiguration(const wxString& backend, wxWebViewConfigurationImpl* impl):
+    m_backend(backend), m_impl(impl)
+{ }
+
+void* wxWebViewConfiguration::GetNativeConfiguration() const
+{
+    return m_impl->GetNativeConfiguration();
+}
 
 // wxWebViewHandlerRequest
 wxString wxWebViewHandlerRequest::GetDataString(const wxMBConv& conv) const
@@ -371,6 +392,17 @@ wxWebView* wxWebView::New(const wxString& backend)
 }
 
 // static
+wxWebView* wxWebView::New(const wxWebViewConfiguration& config)
+{
+    wxStringWebViewFactoryMap::iterator iter = FindFactory(config.GetBackend());
+
+    if(iter == m_factoryMap.end())
+        return nullptr;
+    else
+        return (*iter).second->CreateWithConfig(config);
+}
+
+// static
 wxWebView* wxWebView::New(wxWindow* parent, wxWindowID id, const wxString& url,
                           const wxPoint& pos, const wxSize& size,
                           const wxString& backend, long style,
@@ -409,6 +441,15 @@ wxVersionInfo wxWebView::GetBackendVersionInfo(const wxString& backend)
         return iter->second->GetVersionInfo();
     else
         return wxVersionInfo();
+}
+
+wxWebViewConfiguration wxWebView::NewConfiguration(const wxString& backend)
+{
+    wxStringWebViewFactoryMap::iterator iter = FindFactory(backend);
+    if (iter != m_factoryMap.end())
+        return iter->second->CreateConfiguration();
+    else
+        return wxWebViewConfiguration(backend, new wxWebViewConfigurationImplDefault);
 }
 
 // static
@@ -456,6 +497,11 @@ void wxWebView::InitFactoryMap()
         RegisterFactory(wxWebViewBackendWebKit, wxSharedPtr<wxWebViewFactory>
                                                        (new wxWebViewFactoryWebKit));
 #endif
+}
+
+wxWebViewConfiguration wxWebViewFactory::CreateConfiguration()
+{
+    return wxWebViewConfiguration(wxWebViewBackendDefault, new wxWebViewConfigurationImplDefault);
 }
 
 #endif // wxUSE_WEBVIEW

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -76,6 +76,16 @@ void* wxWebViewConfiguration::GetNativeConfiguration() const
     return m_impl->GetNativeConfiguration();
 }
 
+void wxWebViewConfiguration::SetDataPath(const wxString &path)
+{
+    m_impl->SetDataPath(path);
+}
+
+wxString wxWebViewConfiguration::GetDataPath() const
+{
+    return m_impl->GetDataPath();
+}
+
 // wxWebViewHandlerRequest
 wxString wxWebViewHandlerRequest::GetDataString(const wxMBConv& conv) const
 {

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -260,6 +260,7 @@ class wxWebViewConfigurationImplEdge : public wxWebViewConfigurationImpl
 public:
     wxWebViewConfigurationImplEdge()
     {
+        m_dataPath = wxStandardPaths::Get().GetUserLocalDataDir();
 #ifdef __VISUALC__
         m_webViewEnvironmentOptions = Make<CoreWebView2EnvironmentOptions>().Get();
         m_webViewEnvironmentOptions->put_Language(wxUILocale::GetCurrent().GetLocaleId().GetName().wc_str());
@@ -271,7 +272,11 @@ public:
         return m_webViewEnvironmentOptions;
     }
 
+    virtual void SetDataPath(const wxString& path) override { m_dataPath = path;}
+    virtual wxString GetDataPath() const override { return m_dataPath; }
+
     wxCOMPtr<ICoreWebView2EnvironmentOptions> m_webViewEnvironmentOptions;
+    wxString m_dataPath;
 };
 
 // wxWebViewNewWindowInfoEdge
@@ -431,8 +436,6 @@ bool wxWebViewEdgeImpl::Create()
     m_historyEnabled = true;
     m_historyPosition = -1;
 
-    wxString userDataPath = wxStandardPaths::Get().GetUserLocalDataDir();
-
     if (m_parentWindowInfo)
     {
         OnEnvironmentCreated(S_OK, m_parentWindowInfo->m_impl->m_webViewEnvironment);
@@ -442,7 +445,7 @@ bool wxWebViewEdgeImpl::Create()
     {
         HRESULT hr = wxCreateCoreWebView2EnvironmentWithOptions(
             ms_browserExecutableDir.wc_str(),
-            userDataPath.wc_str(),
+            m_config.GetDataPath().wc_str(),
             (ICoreWebView2EnvironmentOptions*) m_config.GetNativeConfiguration(),
             Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(this,
                 &wxWebViewEdgeImpl::OnEnvironmentCreated).Get());


### PR DESCRIPTION
In 40ff38b63b594e6a82bf6f7845e0ac2cb8ae2449 `wxWebView::GetNativeConfiguration()` was
added which isn't suitable if multiple `wxWebViewEdge` instances are created with
different options (as they must share the same options). To prevent such errors
the previous method is replaced by the new class `wxWebViewConfiguration` which
can be shared between various `wxWebView` instances.

This explicitly breaks API to improve usage (previous API wasn't available before 3.3.0).

In the future the new class could also enable a good way to wrap various common options/configurations available via native API.