### PR TITLE
Fix using Wine in wxMSW cross-CI workflow

### DIFF
--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -100,14 +100,12 @@ jobs:
 
           case "${HOST_TRIPLET}" in
             x86_64-w64-mingw32)
-              packages="$packages g++-mingw-w64-x86-64 wine64 xvfb"
-              winerun=wine64
+              packages="$packages g++-mingw-w64-x86-64 wine wine64 xvfb"
               ;;
 
             i686-w64-mingw32)
               dpkg --add-architecture i386
               packages="$packages g++-mingw-w64-i686 wine32 libgl1:i386 xvfb:i386"
-              winerun=wine
               ;;
 
             *)
@@ -119,7 +117,7 @@ jobs:
           apt-get -q -o=Dpkg::Use-Pty=0 update
           apt-get -q -o=Dpkg::Use-Pty=0 -y install $packages
 
-          echo "wxTEST_RUNNER=${winerun}" >> $GITHUB_ENV
+          echo "wxTEST_RUNNER=wine" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Since 8.0~repack-3 version of the Debian Wine package, installing wine64 doesn't create wine64 symlink any more and wine package needs to be installed to do it, apparently due to the changes done to fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1029536

This resulted in the tests not running any more because we used wine64 for running them. Just use "wine" now and install wine package, as it should still run 64-bit binaries just fine.