### PR TITLE
Document wxGLCanvas::CreateSurface()

### DIFF
--- a/interface/wx/glcanvas.h
+++ b/interface/wx/glcanvas.h
@@ -887,6 +887,19 @@ public:
                const wxString& name = "GLCanvas",
                const wxPalette& palette = wxNullPalette);
 
+
+    /**
+       Re-creates EGLSurface. To be used after a reparent or other
+       changes that may invalidate the EGL drawing surface.
+
+       Only available when wxUSE_GLCANVAS_EGL is enabled.
+
+       @return @true if surface is successfully recreated
+
+       @since 3.2.3
+    */
+    bool CreateSurface();
+
     /**
         Determines if a canvas having the specified attributes is available.
         This only applies for visual attributes, not rendering context attributes.

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -458,6 +458,12 @@ bool wxGLCanvasEGL::CreateSurface()
         return false;
     }
 
+    if ( m_surface != EGL_NO_SURFACE )
+    {
+        eglDestroySurface(m_surface, m_display);
+        m_surface = EGL_NO_SURFACE;
+    }
+
     GdkWindow *window = GTKGetDrawingWindow();
 #ifdef GDK_WINDOWING_X11
     if (wxGTKImpl::IsX11(window))


### PR DESCRIPTION
It is needed to be able to re-create the EGL drawing surface after the window layout have changed, such as after a reparent of the canvas or of it's grandparents.

The functionality is already there, so this is mostly a documentation to keep the functionality available in future versions.

Also destroy the surface before re-creating the surface, so the user don't have to do that.

Would really like if this could be back-ported to 3.2 branch as seen in the since tag.