### PR TITLE
Fix GSource leak from idle processing

### DIFF
--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -142,12 +142,9 @@ bool wxApp::DoIdle()
         gs_focusChange = 0;
     }
 
-    bool needMore;
-    do {
-        ProcessPendingEvents();
+    ProcessPendingEvents();
+    const bool needMore = ProcessIdle();
 
-        needMore = ProcessIdle();
-    } while (needMore && gtk_events_pending() == 0);
     gdk_threads_leave();
 
 #if wxUSE_THREADS


### PR DESCRIPTION
It is apparently not safe to call gtk_events_pending() from the idle callback, as it can result in GLib failing to properly dereference some GSource objects. This leads to increasingly large amounts of CPU time being spent in GLib processing internal lists of these GSource objects. So avoid calling gtk_events_pending(), as it is not strictly necessary because our idle source will remain installed if wxIdleEvent::RequestMore() is used, and if no events have arrived the idle callback will be invoked again. See #23364