### PR TITLE
WebKit2GTK: Add wxWebViewConfiguration and child window support

### DIFF
--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -34,15 +34,9 @@ class WXDLLIMPEXP_WEBVIEW wxWebViewWebKit : public wxWebView
 public:
     wxWebViewWebKit();
 
-    wxWebViewWebKit(wxWindow *parent,
-           wxWindowID id = wxID_ANY,
-           const wxString& url = wxWebViewDefaultURLStr,
-           const wxPoint& pos = wxDefaultPosition,
-           const wxSize& size = wxDefaultSize, long style = 0,
-           const wxString& name = wxASCII_STR(wxWebViewNameStr))
-    {
-        Create(parent, id, url, pos, size, style, name);
-    }
+#if wxUSE_WEBVIEW_WEBKIT2
+    wxWebViewWebKit(const wxWebViewConfiguration& config);
+#endif
 
     virtual bool Create(wxWindow *parent,
            wxWindowID id = wxID_ANY,
@@ -200,6 +194,7 @@ private:
     //Used for webkit2 extension
     GDBusServer *m_dbusServer;
     GDBusProxy *m_extension;
+    wxWebViewConfiguration m_config;
 #endif
 
     wxDECLARE_DYNAMIC_CLASS(wxWebViewWebKit);
@@ -216,9 +211,18 @@ public:
                               const wxSize& size = wxDefaultSize,
                               long style = 0,
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) override
-    { return new wxWebViewWebKit(parent, id, url, pos, size, style, name); }
+    {
+        std::unique_ptr<wxWebView> webView(new wxWebViewWebKit);
+        if (webView->Create(parent, id, url, pos, size, style, name))
+            return webView.release();
+        else
+            return nullptr;
+    }
+
 #if wxUSE_WEBVIEW_WEBKIT2
     virtual wxVersionInfo GetVersionInfo() override;
+    virtual wxWebViewConfiguration CreateConfiguration() override;
+    virtual wxWebView* CreateWithConfig(const wxWebViewConfiguration& config) override;
 #endif
 };
 

--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -35,6 +35,7 @@ public:
     wxWebViewWebKit();
 
 #if wxUSE_WEBVIEW_WEBKIT2
+    wxWebViewWebKit(WebKitWebView* parentWebView, wxWebViewWebKit* parentWebViewCtrl);
     wxWebViewWebKit(const wxWebViewConfiguration& config);
 #endif
 

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -46,7 +46,7 @@ __CRT_UUID_DECL(ICoreWebView2WindowCloseRequestedEventHandler, 0x5c19e9e0,0x092f
 
 WX_DECLARE_STRING_HASH_MAP(wxSharedPtr<wxWebViewHandler>, wxStringToWebHandlerMap);
 
-class wxWebViewEdgeParentWindowInfo;
+class wxWebViewWindowFeaturesEdge;
 
 class wxWebViewEdgeImpl
 {
@@ -57,15 +57,15 @@ public:
 
     bool Create();
 
-    wxWebViewEdge* CreateChildWebView(std::shared_ptr<wxWebViewEdgeParentWindowInfo> parentWindowInfo);
-
     wxWebViewEdge* m_ctrl;
     wxWebViewConfiguration m_config;
 
     wxCOMPtr<ICoreWebView2Environment> m_webViewEnvironment;
     wxCOMPtr<ICoreWebView2_2> m_webView;
     wxCOMPtr<ICoreWebView2Controller> m_webViewController;
-    std::shared_ptr<wxWebViewEdgeParentWindowInfo> m_parentWindowInfo;
+
+    wxCOMPtr<ICoreWebView2NewWindowRequestedEventArgs> m_newWindowArgs;
+    wxCOMPtr<ICoreWebView2Deferral> m_newWindowDeferral;
 
     bool m_initialized;
     bool m_isBusy;

--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -27,13 +27,12 @@
 
 WX_DECLARE_STRING_HASH_MAP(wxSharedPtr<wxWebViewHandler>, wxStringToWebHandlerMap);
 
-class wxWebViewWindowInfoWebKit;
 class wxWebViewConfigurationImplWebKit;
 
 class WXDLLIMPEXP_WEBVIEW wxWebViewWebKit : public wxWebView
 {
 public:
-    explicit wxWebViewWebKit(const wxWebViewConfiguration& config, wxWebViewWindowInfoWebKit* parentWindowInfo = nullptr);
+    explicit wxWebViewWebKit(const wxWebViewConfiguration& config, WX_NSObject request = nullptr);
 
     bool Create(wxWindow *parent,
                 wxWindowID winID = wxID_ANY,
@@ -109,7 +108,7 @@ private:
     OSXWebViewPtr m_webView;
     wxStringToWebHandlerMap m_handlers;
     wxString m_customUserAgent;
-    wxWebViewWindowInfoWebKit* m_parentWindowInfo = nullptr;
+    WX_NSObject m_request;
 
     WX_NSObject m_navigationDelegate;
     WX_NSObject m_UIDelegate;

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -344,10 +344,14 @@ private:
     wxDECLARE_ABSTRACT_CLASS(wxWebView);
 };
 
-class WXDLLIMPEXP_WEBVIEW wxWebViewWindowInfo
+class WXDLLIMPEXP_WEBVIEW wxWebViewWindowFeatures
 {
 public:
-    virtual ~wxWebViewWindowInfo() = default;
+    wxWebViewWindowFeatures(wxWebView* childWebView);
+
+    virtual ~wxWebViewWindowFeatures();
+
+    wxWebView* GetChildWebView() const;
 
     virtual wxPoint GetPosition() const = 0;
 
@@ -361,9 +365,10 @@ public:
 
     virtual bool ShouldDisplayScrollBars() const = 0;
 
-    virtual wxWebView* CreateChildWebView() = 0;
+protected:
+    mutable bool m_childWebViewWasUsed;
+    std::unique_ptr<wxWebView> m_childWebView;
 };
-
 
 class WXDLLIMPEXP_WEBVIEW wxWebViewEvent : public wxNotifyEvent
 {
@@ -385,7 +390,7 @@ public:
 
     wxWebViewNavigationActionFlags GetNavigationAction() const { return m_actionFlags; }
     const wxString& GetMessageHandler() const { return m_messageHandler; }
-    wxWebViewWindowInfo* GetTargetWindowInfo() const { return (wxWebViewWindowInfo*)m_clientData; }
+    wxWebViewWindowFeatures* GetTargetWindowFeatures() const { return (wxWebViewWindowFeatures*)m_clientData; }
 
     virtual wxEvent* Clone() const override { return new wxWebViewEvent(*this); }
 private:
@@ -402,6 +407,7 @@ wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_NAVIGATED, wxWebVie
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_LOADED, wxWebViewEvent );
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_ERROR, wxWebViewEvent );
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_NEWWINDOW, wxWebViewEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_NEWWINDOW_FEATURES, wxWebViewEvent );
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED, wxWebViewEvent);
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_TITLE_CHANGED, wxWebViewEvent );
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_FULLSCREEN_CHANGED, wxWebViewEvent);

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -277,11 +277,16 @@ public:
         wxWebView::New().
 
         The return value needs to be down-casted to the appropriate type
-        depending on the platform: under macOS, it's a
-        <a href="https://developer.apple.com/documentation/webkit/wkwebviewconfiguration">WKWebViewConfiguration</a>
-        pointer, under Windows with Edge it's a pointer to
-        <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions">ICoreWebView2EnvironmentOptions</a>.
-        With other backends/platforms it's not implemented.
+        depending on the platform:
+            - macOS:
+              <a href="https://developer.apple.com/documentation/webkit/wkwebviewconfiguration">WKWebViewConfiguration</a>
+              pointer,
+            - Windows with Edge:
+              <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/icorewebview2environmentoptions">ICoreWebView2EnvironmentOptions</a>.
+            - WebKitGTK:
+              <a href="https://webkitgtk.org/reference/webkit2gtk/stable/class.WebContext.html">WebKitWebContext</a>
+              pointer.
+            - With other backends/platforms it's not implemented.
 
         The following pseudo code shows how to use this method with two-step
         creation to set no user action requirement to play video in a
@@ -323,7 +328,7 @@ public:
         local storage, etc.
         @param path The path to the data directory.
 
-        @note This is only used by the Edge backend.
+        @note This is only used by the Edge and WebKit2GTK+ backend.
     */
     void SetDataPath(const wxString& path);
 
@@ -334,7 +339,7 @@ public:
         local storage, etc.
         @return The path to the data directory.
 
-        @note This is only used by the Edge backend.
+        @note This is only used by the Edge and WebKit2GTK+ backend.
     */
     wxString GetDataPath() const;
 };

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -929,7 +929,7 @@ public:
        window features are available for the new window. For usage
        details see wxWebViewWindowFeatures.
        only available in wxWidgets 3.3.0 or later.
-    @event{wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED(id, func)}
+    @event{EVT_WEBVIEW_WINDOW_CLOSE_REQUESTED(id, func)}
        Process a @c wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED event, generated when
        a window is requested to be closed.
        only available in wxWidgets 3.3.0 or later.
@@ -945,7 +945,7 @@ public:
         Process a @c wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED event
         only available in wxWidgets 3.1.5 or later. For usage details see
         AddScriptMessageHandler().
-    @event{wxEVT_WEBVIEW_SCRIPT_RESULT(id, func)}
+    @event{EVT_WEBVIEW_SCRIPT_RESULT(id, func)}
         Process a @c wxEVT_WEBVIEW_SCRIPT_RESULT event
         only available in wxWidgets 3.1.6 or later. For usage details see
         RunScriptAsync().
@@ -1806,7 +1806,7 @@ public:
        window features are available for the new window. For usage
        details see wxWebViewWindowFeatures.
        only available in wxWidgets 3.3.0 or later.
-    @event{wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED(id, func)}
+    @event{EVT_WEBVIEW_WINDOW_CLOSE_REQUESTED(id, func)}
        Process a @c wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED event, generated when
        a window is requested to be closed.
        only available in wxWidgets 3.3.0 or later.
@@ -1822,7 +1822,7 @@ public:
         Process a @c wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED event
         only available in wxWidgets 3.1.5 or later. For usage details see
         wxWebView::AddScriptMessageHandler().
-    @event{wxEVT_WEBVIEW_SCRIPT_RESULT(id, func)}
+    @event{EVT_WEBVIEW_SCRIPT_RESULT(id, func)}
         Process a @c wxEVT_WEBVIEW_SCRIPT_RESULT event
         only available in wxWidgets 3.1.6 or later. For usage details see
         wxWebView::RunScriptAsync().
@@ -1912,3 +1912,4 @@ wxEventType wxEVT_WEBVIEW_TITLE_CHANGED;
 wxEventType wxEVT_WEBVIEW_FULLSCREEN_CHANGED;
 wxEventType wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED;
 wxEventType wxEVT_WEBVIEW_SCRIPT_RESULT;
+wxEventType wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED;

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -163,19 +163,63 @@ enum wxWebViewIE_EmulationLevel
 
 /**
     A class describing the window information for a new child window.
-    This class is available via wxWebViewEvent::GetTargetWindowInfo()
-    while handling @c wxEVT_WEBVIEW_NEWWINDOW.
 
-    If the new window should be created use CreateChildWebView() while
-    processing the event. This will ensure that the new web view is
-    accessible from JavaScript within the originating wxWebView.
+    An object of this class can be obtained using wxWebViewEvent::GetTargetWindowFeatures()
+    while handling @c wxEVT_WEBVIEW_NEWWINDOW_FEATURES.
 
+    If a @c wxEVT_WEBVIEW_NEWWINDOW is not vetoed, a @c wxEVT_WEBVIEW_NEWWINDOW_FEATURES
+    event will be sent to the application. The application can then create a new
+    window and call wxWebViewEvent::GetTargetWindowInfo() to get this class providing
+    information about the new window. A new child web view will be available
+    via GetChildWebView(). The application can then place the child web view into
+    the new window by calling wxWebView::Create() on the child web view.
+
+    Sample JavaScript opening a new window:
+    @code
+        window.open("http://www.wxwidgets.org", "newWindow", "width=400,height=400");
+    @endcode
+
+    Sample C++ code handling a new window request:
+    @code
+        // Bind new window handler
+        m_webView->Bind(wxEVT_WEBVIEW_NEWWINDOW, [](wxWebViewEvent& evt) {
+            if (evt.GetURL() == "http://badwebsite.com")
+                evt.Veto(); // Disallow new window for badwebsite.com
+            else
+                evt.Skip(); // Allow new window for all other websites
+        });
+
+        // Bind new window features handler
+        m_webView->Bind(wxEVT_WEBVIEW_NEWWINDOW_FEATURES, [](wxWebViewEvent& evt) {
+            // Get target window features
+            wxWebViewWindowFeatures* features = evt.GetTargetWindowFeatures();
+            // Create a top level window for the child web view
+            wxWindow* win = new wxWindow(this, wxID_ANY, features->GetPosition(), features->GetSize());
+            wxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+            win->SetSizer(sizer);
+            // Get the child web view
+            wxWebView* childWebView = features->GetChildWebView();
+            // Place the child web view into the window
+            childWebView->Create(win, wxID_ANY);
+            sizer->Add(childWebView, 1, wxEXPAND);
+        }
+    @endcode
 
     @since 3.3.0
 */
-class WXDLLIMPEXP_WEBVIEW wxWebViewWindowInfo
+class WXDLLIMPEXP_WEBVIEW wxWebViewWindowFeatures
 {
 public:
+    /**
+        Get the child web view for the target window.
+
+        This is available in the event handler for @c wxEVT_WEBVIEW_NEWWINDOW_FEATURES
+        and wxWebView::Create() @b must be called on the child web view directly.
+
+        The requested URL will be loaded automatically in the child web view.
+    */
+    wxWebView* GetChildWebView();
+
     /**
         Returns the position of the new window if specified by
         a @c window.open() call.
@@ -211,39 +255,6 @@ public:
         scroll bars as specified by a @c window.open() call.
     */
     virtual bool ShouldDisplayScrollBars() const = 0;
-
-    /**
-        Create a new child web view for the target window.
-
-        This @b must be created in the event handler for @c wxEVT_WEBVIEW_NEWWINDOW
-        and wxWebView::Create() @b must be called directly.
-
-        The requested URL will be loaded automatically in the new child web view.
-
-        Sample C++ code handling the event:
-        @code
-            // Bind handler
-            m_webView->Bind(wxEVT_WEBVIEW_NEWWINDOW, [](wxWebViewEvent& evt) {
-                // Get target window info
-                wxWebViewWindowInfo* info = evt.GetTargetWindowInfo();
-                // Create a top level window for the child web view
-                wxWindow* win = new wxWindow(this, wxID_ANY, info->GetPosition(), info->GetSize());
-                wxSizer* sizer = new wxBoxSizer(wxVERTICAL);
-                // Create the child web view
-                wxWebView* childWebView = info->CreateChildWebView();
-                // Place the child web view into the window
-                childWebView->Create(win, wxID_ANY);
-                sizer->Add(childWebView, 1, wxEXPAND);
-            });
-        @endcode
-
-        Sample JavaScript opening a new window:
-        @code
-            window.open("http://www.wxwidgets.org", "newWindow", "width=400,height=400");
-        @endcode
-
-    */
-    virtual wxWebView* CreateChildWebView() = 0;
 };
 
 /**
@@ -912,7 +923,12 @@ public:
        Process a @c wxEVT_WEBVIEW_NEWWINDOW event, generated when a new
        window is created. You must handle this event if you want anything to
        happen, for example to load the page in a new window or tab. For usage
-       details see wxWebViewWindowInfo::CreateChildWebView().
+       details see wxWebViewWindowFeatures.
+    @event{EVT_WEBVIEW_NEWWINDOW_FEATURES(id, func)}
+       Process a @c wxEVT_WEBVIEW_NEWWINDOW_FEATURES event, generated when
+       window features are available for the new window. For usage
+       details see wxWebViewWindowFeatures.
+       only available in wxWidgets 3.3.0 or later.
     @event{wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED(id, func)}
        Process a @c wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED event, generated when
        a window is requested to be closed.
@@ -1784,7 +1800,12 @@ public:
        Process a @c wxEVT_WEBVIEW_NEWWINDOW event, generated when a new
        window is created. You must handle this event if you want anything to
        happen, for example to load the page in a new window or tab. For usage
-       details see wxWebViewWindowInfo::CreateChildWebView().
+       details see wxWebViewWindowFeatures.
+    @event{EVT_WEBVIEW_NEWWINDOW_FEATURES(id, func)}
+       Process a @c wxEVT_WEBVIEW_NEWWINDOW_FEATURES event, generated when
+       window features are available for the new window. For usage
+       details see wxWebViewWindowFeatures.
+       only available in wxWidgets 3.3.0 or later.
     @event{wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED(id, func)}
        Process a @c wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED event, generated when
        a window is requested to be closed.
@@ -1852,14 +1873,14 @@ public:
 
     /**
         Get information about the target window. Only valid for events of type
-        @c wxEVT_WEBVIEW_NEWWINDOW
+        @c wxEVT_WEBVIEW_NEWWINDOW_FEATURES
 
-        @note This is only available with the macOS and the Edge backend.
+        @note This function is not implemented and always returns @NULL when using WebKit1 or Internet Explorer backend.
 
-        @see wxWebViewWindowInfo
+        @see wxWebViewWindowFeatures
         @since 3.3.0
     */
-    wxWebViewWindowInfo* GetTargetWindowInfo() const;
+    wxWebViewWindowFeatures* GetTargetWindowFeatures() const;
 
     /**
         Returns true the script execution failed. Only valid for events of type
@@ -1886,6 +1907,7 @@ wxEventType wxEVT_WEBVIEW_NAVIGATED;
 wxEventType wxEVT_WEBVIEW_LOADED;
 wxEventType wxEVT_WEBVIEW_ERROR;
 wxEventType wxEVT_WEBVIEW_NEWWINDOW;
+wxEventType wxEVT_WEBVIEW_NEWWINDOW_FEATURES;
 wxEventType wxEVT_WEBVIEW_TITLE_CHANGED;
 wxEventType wxEVT_WEBVIEW_FULLSCREEN_CHANGED;
 wxEventType wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED;

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -50,6 +50,7 @@ wxDEFINE_EVENT( wxEVT_WEBVIEW_NAVIGATED, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_LOADED, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_ERROR, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_NEWWINDOW, wxWebViewEvent );
+wxDEFINE_EVENT( wxEVT_WEBVIEW_NEWWINDOW_FEATURES, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_TITLE_CHANGED, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_FULLSCREEN_CHANGED, wxWebViewEvent);
@@ -84,6 +85,24 @@ void wxWebViewConfiguration::SetDataPath(const wxString &path)
 wxString wxWebViewConfiguration::GetDataPath() const
 {
     return m_impl->GetDataPath();
+}
+
+// wxWebViewWindowFeatures
+wxWebViewWindowFeatures::wxWebViewWindowFeatures(wxWebView * childWebView):
+    m_childWebViewWasUsed(false),
+    m_childWebView(childWebView)
+{ }
+
+wxWebViewWindowFeatures::~wxWebViewWindowFeatures()
+{
+    if (m_childWebViewWasUsed)
+        m_childWebView.release();
+}
+
+wxWebView *wxWebViewWindowFeatures::GetChildWebView() const
+{
+    m_childWebViewWasUsed = true;
+    return m_childWebView.get();
 }
 
 // wxWebViewHandlerRequest

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -38,6 +38,16 @@
 #include <JavaScriptCore/JSValueRef.h>
 #include <JavaScriptCore/JSStringRef.h>
 
+// Function to check webkit version at runtime
+bool wx_check_webkit_version(int major, int minor, int micro)
+{
+    const unsigned int version = webkit_get_major_version() * 10000 +
+                                 webkit_get_minor_version() * 100 +
+                                 webkit_get_micro_version();
+    const unsigned int required = major * 10000 + minor * 100 + micro;
+    return version >= required;
+}
+
 // Helper function to get string from Webkit JS result
 bool wxGetStringFromJSResult(WebKitJavascriptResult* js_result, wxString* output)
 {

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -353,6 +353,16 @@ wxgtk_webview_webkit_script_message_received(WebKitUserContentManager *WXUNUSED(
     webKitCtrl->HandleWindowEvent(event);
 }
 
+static void wxgtk_webview_webkit_close (WebKitWebView *WXUNUSED(web_view),
+                                        wxWebViewWebKit *webKitCtrl)
+{
+    wxWebViewEvent event(wxEVT_WEBVIEW_WINDOW_CLOSE_REQUESTED,
+                         webKitCtrl->GetId(),
+                         webKitCtrl->GetCurrentURL(),
+                         "");
+    webKitCtrl->HandleWindowEvent(event);
+}
+
 static gboolean
 wxgtk_webview_webkit_decide_policy(WebKitWebView *web_view,
                                    WebKitPolicyDecision *decision,
@@ -692,6 +702,9 @@ bool wxWebViewWebKit::Create(wxWindow *parent,
 
     g_signal_connect(m_web_view, "leave-fullscreen",
                      G_CALLBACK(wxgtk_webview_webkit_leave_fullscreen), this);
+
+    g_signal_connect(m_web_view, "close",
+                     G_CALLBACK(wxgtk_webview_webkit_close), this);
 
     WebKitFindController* findctrl = webkit_web_view_get_find_controller(m_web_view);
     g_signal_connect(findctrl, "counted-matches",

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -144,6 +144,23 @@ public:
     WebKitWindowProperties *m_properties;
 };
 
+wxWebViewNavigationActionFlags wxGetNavigationActionFlags(WebKitNavigationAction* navigation)
+{
+    wxWebViewNavigationActionFlags flags;
+    switch (webkit_navigation_action_get_navigation_type(navigation))
+    {
+        case WEBKIT_NAVIGATION_TYPE_LINK_CLICKED:
+        case WEBKIT_NAVIGATION_TYPE_FORM_SUBMITTED:
+        case WEBKIT_NAVIGATION_TYPE_FORM_RESUBMITTED:
+            flags = wxWEBVIEW_NAV_ACTION_USER;
+            break;
+        default:
+            flags = wxWEBVIEW_NAV_ACTION_OTHER;
+            break;
+    }
+    return flags;
+}
+
 // ----------------------------------------------------------------------------
 // GTK callbacks
 // ----------------------------------------------------------------------------
@@ -201,7 +218,8 @@ wxgtk_webview_webkit_navigation(WebKitWebView *,
     wxWebViewEvent event(wxEVT_WEBVIEW_NAVIGATING,
                          webKitCtrl->GetId(),
                          wxString( uri, wxConvUTF8 ),
-                         target);
+                         target,
+                         wxGetNavigationActionFlags(action));
     event.SetEventObject(webKitCtrl);
 
     webKitCtrl->HandleWindowEvent(event);
@@ -518,7 +536,8 @@ wxgtk_webview_webkit_create_webview(WebKitWebView *web_view,
     wxWebViewEvent event(wxEVT_WEBVIEW_NEWWINDOW,
                          webKitCtrl->GetId(),
                          url,
-                         "");
+                         "",
+                         wxGetNavigationActionFlags(navigation_action));
     event.SetEventObject(webKitCtrl);
     webKitCtrl->HandleWindowEvent(event);
 


### PR DESCRIPTION
Add some features to the WebKit2GTK backend that where recently added to Edge and macOS

wxWebViewConfiguration
==

Add support for more in depth configuration before creating a web view. Allows to customize the data path and access to the underlying context.

Add wxWebViewWindowFeatures and event
==

This replaces the previously implemented `wxWebViewWindowInfo`.

It explicitly **breaks** the previous API to enable WebKitGTK
integration and to make the usage in application code less error prone.

A new event `wxEVT_WEBVIEW_NEWWINDOW_FEATURES` is added to allow
access to the window features and the child web view.

New sample handling code looks like this:
```C++
// Bind new window handler
m_webView->Bind(wxEVT_WEBVIEW_NEWWINDOW, [](wxWebViewEvent& evt) {
    if (evt.GetURL() == "http://badwebsite.com")
        evt.Veto(); // Disallow new window for badwebsite.com
    else
        evt.Skip(); // Allow new window for all other websites
});
 
// Bind new window features handler
m_webView->Bind(wxEVT_WEBVIEW_NEWWINDOW_FEATURES, [](wxWebViewEvent& evt) {
    // Get target window features
    wxWebViewWindowFeatures* features = evt.GetTargetWindowFeatures();
    // Create a top level window for the child web view
    wxWindow* win = new wxWindow(this, wxID_ANY, features->GetPosition(), features->GetSize());
    wxSizer* sizer = new wxBoxSizer(wxVERTICAL);
    win->SetSizer(sizer);
    // Get the child web view
    wxWebView* childWebView = features->GetChildWebView();
    // Place the child web view into the window
    childWebView->Create(win, wxID_ANY);
    sizer->Add(childWebView, 1, wxEXPAND);
}
```