### PR TITLE
Use Python 3.8 for httpbin in AppVeyor CI builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,12 +85,13 @@ before_test:
     pip.exe --disable-pip-version-check install httpbin
     Start-Job -Name wx_httpbin { python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
     Start-Sleep -Seconds 5
-    curl.exe -s http://127.0.0.1:5000/ip > $null
+    curl.exe --silent --show-error http://127.0.0.1:5000/ip > $null
     if ($lastExitCode -eq "0") {
         $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
     }
     else {
-        Write-Error "Disabling wxWebRequest tests as launching httpbin failed."
+        Write-Error "Disabling wxWebRequest tests as launching httpbin failed, log follows:"
+        Get-Content c:\projects\wxwidgets\httpbin.log
         $env:WX_TEST_WEBREQUEST_URL="0"
     }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,7 +81,7 @@ build_script: c:\projects\wxwidgets\build\tools\appveyor.bat
 before_test:
 - ps: |
     Write-Output "Getting and launching httpbin."
-    $env:PATH = "C:\Python35;C:\Python35\Scripts;" + $env:PATH
+    $env:PATH = "C:\Python38;C:\Python38\Scripts;" + $env:PATH
     pip.exe --disable-pip-version-check install httpbin
     Start-Job -Name wx_httpbin { python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
     Start-Sleep -Seconds 5


### PR DESCRIPTION
Installing httpbin using PYthon 3.5 fails with strange build errors, try using 3.8 instead.