### PR TITLE
Enable wxWebView in ASAN Unix CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
             use_xvfb: true
           - name: Ubuntu 22.04 wxGTK with ASAN
             runner: ubuntu-22.04
-            configure_flags: --disable-compat30 --disable-sys-libs --disable-webview
+            configure_flags: --disable-compat30 --disable-sys-libs
             skip_samples: true
             use_asan: true
             use_xvfb: true
@@ -276,6 +276,17 @@ jobs:
 
       - name: Building
         run: |
+          if [ ${{ matrix.use_asan }} ]; then
+            # This is a horrible hack needed to prevent ASAN from being used
+            # for the WebKit extension shared library: this wouldn't work
+            # because this library is loaded in a separate WebKit process not
+            # using ASAN. This should really be fixed at makefile level, but
+            # for now just work around the problem here by manually building
+            # this library without ASAN: get the compile and link commands
+            # (the only ones that should contain ASAN flags) and filter these
+            # flags out from them before running them.
+            /bin/sh -xc "`make -n install_webkit2_ext | sed -n -e 's/-fsanitize=address//gp'`"
+          fi
           make -k $wxBUILD_ARGS "CXXFLAGS=$wxMAKEFILE_ERROR_CXXFLAGS"
 
       - name: Building tests


### PR DESCRIPTION
Work around the problem which was previously hidden by 07dfc18cc0 (Disable wxWebView in ASAN CI build, 2021-01-31) by building the webkit extension shared library without ASAN.

This should ideally be handled at the build system level, but this seems difficult to do, so use this hack for now -- it at least ensures that wxWebView unit tests are tested with ASAN too.