### PR TITLE
AuiTabBook's close button size for HiDPI

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -223,6 +223,7 @@ protected:
     void OnChar(wxKeyEvent& event);
     void OnCaptureLost(wxMouseCaptureLostEvent& evt);
     void OnSysColourChanged(wxSysColourChangedEvent& event);
+    void OnDpiChanged(wxDPIChangedEvent& event);
 
 protected:
 

--- a/include/wx/aui/tabart.h
+++ b/include/wx/aui/tabart.h
@@ -113,6 +113,7 @@ public:
 
     // Provide opportunity for subclasses to recalculate colours
     virtual void UpdateColoursFromSystem() {}
+    virtual void UpdateDpi() {}
 };
 
 

--- a/include/wx/aui/tabartmsw.h
+++ b/include/wx/aui/tabartmsw.h
@@ -74,6 +74,8 @@ public:
         const wxAuiNotebookPageArray& pages,
         const wxSize& requiredBmpSize) override;
 
+    void UpdateDpi() override;
+
 private:
     bool m_themed;
     wxSize m_closeBtnSize;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1003,6 +1003,7 @@ wxBEGIN_EVENT_TABLE(wxAuiTabCtrl, wxControl)
     EVT_CHAR(wxAuiTabCtrl::OnChar)
     EVT_MOUSE_CAPTURE_LOST(wxAuiTabCtrl::OnCaptureLost)
     EVT_SYS_COLOUR_CHANGED(wxAuiTabCtrl::OnSysColourChanged)
+    EVT_DPI_CHANGED(wxAuiTabCtrl::OnDpiChanged)
 wxEND_EVENT_TABLE()
 
 
@@ -1503,6 +1504,12 @@ void wxAuiTabCtrl::OnChar(wxKeyEvent& event)
     }
     else
         event.Skip();
+}
+
+void wxAuiTabCtrl::OnDpiChanged(wxDPIChangedEvent& event)
+{
+    m_art->UpdateDpi();
+    event.Skip();
 }
 
 // wxTabFrame is an interesting case.  It's important that all child pages

--- a/src/aui/tabartmsw.cpp
+++ b/src/aui/tabartmsw.cpp
@@ -458,5 +458,9 @@ bool wxAuiMSWTabArt::IsThemed() const
         !(m_flags & wxAUI_NB_BOTTOM); // Native theme does not support bottom tabs
 }
 
+void wxAuiMSWTabArt::UpdateDpi()
+{
+    m_closeBtnSize = wxDefaultSize;
+}
 
 #endif // wxUSE_AUI && wxUSE_UXTHEME && !defined(__WXUNIVERSAL__)


### PR DESCRIPTION
When Application runs on many monitor that have different DPI, AuiTabBook draw close button as incorrect  size. so when DPI is changed, it force to calling InitSize as resetting close button's size.