### PR TITLE
Updated wxwin.m4 macro regex to detect x.x.x[...] versions

### DIFF
--- a/wxwin.m4
+++ b/wxwin.m4
@@ -222,11 +222,11 @@ AC_DEFUN([WX_CONFIG_CHECK],
 
     WX_VERSION=`$WX_CONFIG_WITH_ARGS --version 2>/dev/null`
     wx_config_major_version=`echo $WX_VERSION | \
-           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
+           sed -r 's/^([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+)(.*)$/\1/'`
     wx_config_minor_version=`echo $WX_VERSION | \
-           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
+           sed -r 's/^([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+)(.*)$/\2/'`
     wx_config_micro_version=`echo $WX_VERSION | \
-           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
+           sed -r 's/^([[0-9]]+)\.([[0-9]]+)\.([[0-9]]+)(.*)$/\3/'`
 
     wx_requested_major_version=`echo $min_wx_version | \
            sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`


### PR DESCRIPTION
Hello,

Is it possible to add the possibility to detect wxWidgets versions like `3.2.2.1`?

There are problems compiling [xCHM](https://github.com/rzvncj/xCHM/pull/27) on Gentoo GNU/Linux with `wxGTK-3.2.2.1` installed: https://bugs.gentoo.org/895982

The current `wxwin.m4` macro fails to detect `x.x.x[...]` versions:
```
echo "3.2.2.1" | sed 's/\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1/'
```
This PR simply adds a capture group to glob the `[...]` part in `x.x.x[...]`:
```
echo "3.2.2.1" | sed -r 's/^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$/\1/'
```
Thanks.