### PR TITLE
Avoid using destroyed HWND in `wxComboPopupWindow`

### DIFF
--- a/include/wx/combo.h
+++ b/include/wx/combo.h
@@ -442,6 +442,9 @@ public:
     // common code to be called on popup hide/dismiss
     void OnPopupDismiss(bool generateEvent);
 
+    // called if popup is destroyed not by wxComboCtrl itself
+    void OnPopupDestroy();
+
     // PopupShown states
     enum
     {

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -749,6 +749,9 @@ private:
     // common part of all ctors
     void Init();
 
+    // common part of UnsubclassWin() and DissociateHandle()
+    WXHWND DoDetachHWND();
+
     // the (non-virtual) handlers for the events
     bool HandleMove(int x, int y);
     bool HandleMoving(wxRect& rect);

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -346,6 +346,46 @@ protected:
     virtual void OnDismiss() override;
 #endif
 
+#ifdef __WXMSW__
+    virtual bool MSWHandleMessage(WXLRESULT *result,
+                                  WXUINT message,
+                                  WXWPARAM wParam,
+                                  WXLPARAM lParam) override
+    {
+        // This is a workaround for a MSW-specific problem: popup windows are
+        // created with the TLW and not the combobox itself as their parent and
+        // so if the TLW gets destroyed, they're destroyed together with it,
+        // but the associated wxComboCtrl may survive if it gets reparented to
+        // something else, which is exactly what happens when it's used inside
+        // a wxAUI pane. And if this wxComboCtrl is opened again later, it
+        // tries to use the existing popup whose HWND had been destroyed, which
+        // doesn't work at all.
+        //
+        // To prevent this from happening, we delete the popup if this happens
+        // to force recreating it later.
+        if ( message == WM_DESTROY && !m_isBeingDeleted )
+        {
+            m_combo->OnPopupDestroy();
+
+            // We can't delete it immediately because this object is used after
+            // this function returns, so do it slightly later.
+            wxWindow* const self = this;
+            m_combo->CallAfter([self]()
+            {
+                // Before really deleting it, reset the HWND which had been
+                // already destroyed, to prevent us from trying to destroy it
+                // again (which would just fail with an error).
+                self->DissociateHandle();
+
+                delete self;
+            });
+        }
+
+        return wxComboPopupWindowBase::MSWHandleMessage(result, message,
+                                                        wParam, lParam);
+    }
+#endif // __WXMSW__
+
 private:
     // This is the same as our parent, but has the right type, so that we can
     // avoid using casts later.
@@ -2360,6 +2400,14 @@ void wxComboCtrlBase::HidePopup(bool generateEvent)
     m_winPopup->Hide();
 
     OnPopupDismiss(generateEvent);
+}
+
+void wxComboCtrlBase::OnPopupDestroy()
+{
+    m_winPopup = nullptr;
+
+    delete m_popupInterface;
+    m_popupInterface = nullptr;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -982,7 +982,6 @@ void wxOwnerDrawnComboBox::DoSetPopupControl(wxComboPopup* popup)
     if ( !GetVListBoxComboPopup()->GetCount() )
     {
         GetVListBoxComboPopup()->Populate(m_initChs);
-        m_initChs.Clear();
     }
 }
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -541,8 +541,7 @@ void wxListCtrl::DeleteEditControl()
 {
     if ( m_textCtrl )
     {
-        m_textCtrl->UnsubclassWin();
-        m_textCtrl->SetHWND(0);
+        m_textCtrl->DissociateHandle();
         wxDELETE(m_textCtrl);
     }
 }

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -2008,16 +2008,10 @@ void wxTreeCtrl::DeleteTextCtrl()
 {
     if ( m_textCtrl )
     {
-        // the HWND corresponding to this control is deleted by the tree
-        // control itself and we don't know when exactly this happens, so check
-        // if the window still exists before calling UnsubclassWin()
-        if ( !::IsWindow(GetHwndOf(m_textCtrl)) )
-        {
-            m_textCtrl->SetHWND(0);
-        }
-
-        m_textCtrl->UnsubclassWin();
-        m_textCtrl->SetHWND(0);
+        // the HWND corresponding to this control is destroyed by the tree
+        // control itself, so call DissociateHandle() to prevent the dtor from
+        // destroying the window again
+        m_textCtrl->DissociateHandle();
         wxDELETE(m_textCtrl);
 
         m_idEdited.Unset();


### PR DESCRIPTION
Destroy `wxComboPopupWindow` itself if its HWND got destroyed under it as it happened when it was used inside AUI floating pane.