### PR TITLE
Fix memory leak in the art provider sample

### DIFF
--- a/samples/artprov/artbrows.cpp
+++ b/samples/artprov/artbrows.cpp
@@ -196,11 +196,7 @@ wxArtBrowserDialog::wxArtBrowserDialog(wxWindow *parent)
 
 wxArtBrowserDialog::~wxArtBrowserDialog()
 {
-    const int itemCount = m_list->GetItemCount();
-
-    // item data are set by the ART_ICON macro
-    for ( int i = 0; i < itemCount; ++i )
-        delete reinterpret_cast<wxString*>(m_list->GetItemData(i));
+    DeleteListItemData();
 }
 
 wxSize wxArtBrowserDialog::GetSelectedBitmapSize() const
@@ -209,6 +205,14 @@ wxSize wxArtBrowserDialog::GetSelectedBitmapSize() const
   return wxSize(size, size);
 }
 
+void wxArtBrowserDialog::DeleteListItemData()
+{
+    const int itemCount = m_list->GetItemCount();
+
+    // item data are set by the ART_ICON macro
+    for ( int i = 0; i < itemCount; ++i )
+        delete reinterpret_cast<wxString*>(m_list->GetItemData(i));
+}
 
 void wxArtBrowserDialog::SetArtClient(const wxArtClient& client)
 {
@@ -221,6 +225,7 @@ void wxArtBrowserDialog::SetArtClient(const wxArtClient& client)
     long sel = m_list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_FOCUSED);
     if (sel < 0) sel = 0;
 
+    DeleteListItemData();
     m_list->DeleteAllItems();
     FillBitmaps(img, m_list, index, client, wxSize(16, 16));
     m_list->AssignImageList(img, wxIMAGE_LIST_SMALL);

--- a/samples/artprov/artbrows.h
+++ b/samples/artprov/artbrows.h
@@ -34,6 +34,8 @@ private:
 
     wxSize GetSelectedBitmapSize() const;
 
+    void DeleteListItemData();
+
     wxListCtrl *m_list;
     wxStaticBitmap *m_canvas;
     wxStaticText *m_text;


### PR DESCRIPTION
The list client data must be destroyed not only when closing the resource browser dialog (see 754f75c) but also whenever the art client is changed.

Closes #23417