### PR TITLE
Fix deleting taskbar icon in wxMSW wxNotificationMessage

### DIFF
--- a/include/wx/private/notifmsg.h
+++ b/include/wx/private/notifmsg.h
@@ -14,8 +14,7 @@ class wxNotificationMessageImpl
 {
 public:
     wxNotificationMessageImpl(wxNotificationMessageBase* notification):
-        m_notification(notification),
-        m_active(false)
+        m_notification(notification)
     {
 
     }
@@ -38,20 +37,9 @@ public:
 
     virtual bool AddAction(wxWindowID actionid, const wxString &label) = 0;
 
-    virtual void Detach()
-    {
-        if (m_active)
-            m_notification = nullptr;
-        else
-            delete this;
-    }
-
     bool ProcessNotificationEvent(wxEvent& event)
     {
-        if (m_notification)
-            return m_notification->ProcessEvent(event);
-        else
-            return false;
+        return m_notification->ProcessEvent(event);
     }
 
     wxNotificationMessageBase* GetNotification() const
@@ -61,16 +49,6 @@ public:
 
 protected:
     wxNotificationMessageBase* m_notification;
-    bool m_active;
-
-    void SetActive(bool active)
-    {
-        m_active = active;
-
-        // Delete the implementation if the notification is detached
-        if (!m_notification && !active)
-            delete this;
-    }
 };
 
 #endif // _WX_PRIVATE_NOTIFMSG_H_

--- a/src/common/notifmsgcmn.cpp
+++ b/src/common/notifmsgcmn.cpp
@@ -35,7 +35,7 @@ wxDEFINE_EVENT( wxEVT_NOTIFICATION_MESSAGE_ACTION, wxCommandEvent );
 
 wxNotificationMessageBase::~wxNotificationMessageBase()
 {
-    m_impl->Detach();
+    delete m_impl;
 }
 
 bool wxNotificationMessageBase::Show(int timeout)

--- a/src/generic/notifmsgg.cpp
+++ b/src/generic/notifmsgg.cpp
@@ -470,7 +470,6 @@ bool wxGenericNotificationMessageImpl::Show(int timeout)
         timeout = GetDefaultTimeout();
     }
 
-    SetActive(true);
     m_window->Set(timeout);
 
     m_window->ShowWithEffect(wxSHOW_EFFECT_BLEND);
@@ -484,8 +483,6 @@ bool wxGenericNotificationMessageImpl::Close()
         return false;
 
     m_window->Hide();
-
-    SetActive(false);
 
     return true;
 }


### PR DESCRIPTION
Previously, the taskbar icon could remain shown in the taskbar after wxNotificationMessage was destroyed, as wxEVT_TASKBAR_BALLOON_TIMEOUT handler was called on an already dead object.

Weirdly enough this didn't result in the crashes, but it definitely didn't work correctly neither.

Fix this by binding a separate handler for this event, not using the wxNotificationMessage object at all, which is responsible for destroying the icon when it times out.

This also seems to make it completely unnecessary to have a separate m_active flag in wxNotificationMessageImpl, as we can now just delete the "impl" object too directly when the main object itself is deleted.

---

@TcT2k Please let me know if I'm missing something here, but to me the hack with `m_active` just seems unnecessary -- and it is definitely insufficient, as the commit message above explains. With this change I don't get stray taskbar icons in my own applications any longer after testing this for a couple of days.