### PR TITLE
Minor changes related to `wxUSE_STL`

### DIFF
--- a/include/wx/archive.h
+++ b/include/wx/archive.h
@@ -164,7 +164,6 @@ private:
 // An input iterator that can be used to transfer an archive's catalog to
 // a container.
 
-#if wxUSE_STL || defined WX_TEST_ARCHIVE_ITERATOR
 #include <iterator>
 #include <utility>
 
@@ -296,8 +295,6 @@ typedef wxArchiveIterator<wxArchiveInputStream> wxArchiveIter;
 typedef wxArchiveIterator<wxArchiveInputStream,
         std::pair<wxString, wxArchiveEntry*> >  wxArchivePairIter;
 
-#endif // wxUSE_STL || defined WX_TEST_ARCHIVE_ITERATOR
-
 
 /////////////////////////////////////////////////////////////////////////////
 // wxArchiveClassFactory
@@ -314,10 +311,8 @@ public:
     typedef wxArchiveInputStream  instream_type;
     typedef wxArchiveOutputStream outstream_type;
     typedef wxArchiveNotifier     notifier_type;
-#if wxUSE_STL || defined WX_TEST_ARCHIVE_ITERATOR
     typedef wxArchiveIter         iter_type;
     typedef wxArchivePairIter     pairiter_type;
-#endif
 
     virtual ~wxArchiveClassFactory() { }
 

--- a/include/wx/tarstrm.h
+++ b/include/wx/tarstrm.h
@@ -289,11 +289,9 @@ private:
 /////////////////////////////////////////////////////////////////////////////
 // Iterators
 
-#if wxUSE_STL || defined WX_TEST_ARCHIVE_ITERATOR
 typedef wxArchiveIterator<wxTarInputStream> wxTarIter;
 typedef wxArchiveIterator<wxTarInputStream,
          std::pair<wxString, wxTarEntry*> > wxTarPairIter;
-#endif
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -306,10 +304,8 @@ public:
     typedef wxTarInputStream  instream_type;
     typedef wxTarOutputStream outstream_type;
     typedef wxTarNotifier     notifier_type;
-#if wxUSE_STL || defined WX_TEST_ARCHIVE_ITERATOR
     typedef wxTarIter         iter_type;
     typedef wxTarPairIter     pairiter_type;
-#endif
 
     wxTarClassFactory();
 

--- a/include/wx/zipstrm.h
+++ b/include/wx/zipstrm.h
@@ -458,11 +458,9 @@ private:
 /////////////////////////////////////////////////////////////////////////////
 // Iterators
 
-#if wxUSE_STL || defined WX_TEST_ARCHIVE_ITERATOR
 typedef wxArchiveIterator<wxZipInputStream> wxZipIter;
 typedef wxArchiveIterator<wxZipInputStream,
          std::pair<wxString, wxZipEntry*> > wxZipPairIter;
-#endif
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -475,10 +473,8 @@ public:
     typedef wxZipInputStream  instream_type;
     typedef wxZipOutputStream outstream_type;
     typedef wxZipNotifier     notifier_type;
-#if wxUSE_STL || defined WX_TEST_ARCHIVE_ITERATOR
     typedef wxZipIter         iter_type;
     typedef wxZipPairIter     pairiter_type;
-#endif
 
     wxZipClassFactory();
 

--- a/interface/wx/archive.h
+++ b/interface/wx/archive.h
@@ -497,9 +497,7 @@ public:
     @class wxArchiveIterator
 
     An input iterator template class that can be used to transfer an archive's
-    catalogue to a container. It is only available if wxUSE_STL is set to 1
-    in setup.h, and the uses for it outlined below require a compiler which
-    supports member templates.
+    catalogue to a container.
 
     @code
     template<class Arc, class T = typename Arc::entry_type*>

--- a/interface/wx/list.h
+++ b/interface/wx/list.h
@@ -9,7 +9,9 @@
     The wxList<T> class provides linked list functionality.
 
     This class has been rewritten to be type safe and to provide the full API of
-    the STL std::list container and should be used like it.
+    the STL std::list container and should be used like it if you use it at
+    all, which is not recommended in the new code.
+
     The exception is that wxList<T> actually stores pointers and therefore its
     iterators return pointers and not references to the actual objects in the list
     (see example below) and @e value_type is defined as @e T*.
@@ -28,7 +30,7 @@
     that originated from the old wxList class and which can still be used alternatively
     for the same class.
 
-    Note that if you compile wxWidgets in STL mode (@c wxUSE_STL defined as 1)
+    Note that if you use @ref overview_container_std of wxWidgets,
     then wxList<T> will actually derive from @c std::list and just add a legacy
     compatibility layer for the old wxList class.
 

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -48,9 +48,7 @@
     #include <exception>        // for std::current_exception()
     #include <utility>          // for std::swap()
 
-    #if wxUSE_STL
-        #include <typeinfo>
-    #endif
+    #include <typeinfo>
 #endif // wxUSE_EXCEPTIONS
 
 #if !defined(__WINDOWS__)
@@ -668,7 +666,6 @@ void wxAppConsoleBase::OnUnhandledException()
     {
         throw;
     }
-#if wxUSE_STL
     catch ( std::exception& e )
     {
 #ifdef wxNO_RTTI
@@ -678,7 +675,6 @@ void wxAppConsoleBase::OnUnhandledException()
                     typeid(e).name(), e.what());
 #endif
     }
-#endif // wxUSE_STL
     catch ( ... )
     {
         what = "unknown exception";

--- a/tests/archive/archivetest.h
+++ b/tests/archive/archivetest.h
@@ -9,8 +9,6 @@
 #ifndef WX_ARCHIVETEST_INCLUDED
 #define WX_ARCHIVETEST_INCLUDED 1
 
-#define WX_TEST_ARCHIVE_ITERATOR
-
 #include "wx/archive.h"
 #include "wx/wfstream.h"
 

--- a/tests/benchmarks/htmlparser/htmlpars.cpp
+++ b/tests/benchmarks/htmlparser/htmlpars.cpp
@@ -367,12 +367,7 @@ void wx28HtmlParser::PopTagHandler()
     wxList::compatibility_iterator first;
 
     if ( !m_HandlersStack ||
-#if wxUSE_STL
-         !(first = m_HandlersStack->GetFirst())
-#else // !wxUSE_STL
-         ((first = m_HandlersStack->GetFirst()) == nullptr)
-#endif // wxUSE_STL/!wxUSE_STL
-        )
+         !(first = m_HandlersStack->GetFirst()) )
     {
         wxLogWarning(_("Warning: attempt to remove HTML tag handler from empty stack."));
         return;


### PR DESCRIPTION
Basically stop using it where it's not really needed.

This shouldn't result in any real changes or compatibility breakage.