### PR TITLE
Remove most occurrences of wxT() from the docs

### DIFF
--- a/docs/doxygen/overviews/mbconvclasses.h
+++ b/docs/doxygen/overviews/mbconvclasses.h
@@ -99,7 +99,7 @@ wxString::FromUTF8().
 Example 3: Input in KOI8-R. Construction of wxCSConv instance on the fly.
 
 @code
-wxString str(input_data, wxCSConv(wxT("koi8-r")));
+wxString str(input_data, wxCSConv("koi8-r"));
 @endcode
 
 Example 4: Printing a wxString to stdout in UTF-8 encoding.

--- a/docs/doxygen/overviews/nonenglish.h
+++ b/docs/doxygen/overviews/nonenglish.h
@@ -112,7 +112,7 @@ English using message catalogs:
 @li Specify the source code language and charset as arguments to
     wxLocale::AddCatalog. For example:
     @code
-    locale.AddCatalog(wxT("myapp"), wxLANGUAGE_GERMAN, wxT("iso-8859-1"));
+    locale.AddCatalog("myapp", wxLANGUAGE_GERMAN, "iso-8859-1");
     @endcode
 
 

--- a/docs/doxygen/overviews/richtextctrl.h
+++ b/docs/doxygen/overviews/richtextctrl.h
@@ -107,12 +107,12 @@ r.BeginAlignment(wxTEXT_ALIGNMENT_CENTRE);
 r.BeginBold();
 
 r.BeginFontSize(14);
-r.WriteText(wxT("Welcome to wxRichTextCtrl, a wxWidgets control for editing and presenting styled text and images"));
+r.WriteText("Welcome to wxRichTextCtrl, a wxWidgets control for editing and presenting styled text and images");
 r.EndFontSize();
 r.Newline();
 
 r.BeginItalic();
-r.WriteText(wxT("by Julian Smart"));
+r.WriteText("by Julian Smart");
 r.EndItalic();
 
 r.EndBold();
@@ -125,75 +125,75 @@ r.EndAlignment();
 r.Newline();
 r.Newline();
 
-r.WriteText(wxT("What can you do with this thing? "));
+r.WriteText("What can you do with this thing? ");
 r.WriteImage(wxBitmap(smiley_xpm));
-r.WriteText(wxT(" Well, you can change text "));
+r.WriteText(" Well, you can change text ");
 
 r.BeginTextColour(wxColour(255, 0, 0));
-r.WriteText(wxT("colour, like this red bit."));
+r.WriteText("colour, like this red bit.");
 r.EndTextColour();
 
 r.BeginTextColour(wxColour(0, 0, 255));
-r.WriteText(wxT(" And this blue bit."));
+r.WriteText(" And this blue bit.");
 r.EndTextColour();
 
-r.WriteText(wxT(" Naturally you can make things "));
+r.WriteText(" Naturally you can make things ");
 r.BeginBold();
-r.WriteText(wxT("bold "));
+r.WriteText("bold ");
 r.EndBold();
 r.BeginItalic();
-r.WriteText(wxT("or italic "));
+r.WriteText("or italic ");
 r.EndItalic();
 r.BeginUnderline();
-r.WriteText(wxT("or underlined."));
+r.WriteText("or underlined.");
 r.EndUnderline();
 
 r.BeginFontSize(14);
-r.WriteText(wxT(" Different font sizes on the same line is allowed, too."));
+r.WriteText(" Different font sizes on the same line is allowed, too.");
 r.EndFontSize();
 
-r.WriteText(wxT(" Next we'll show an indented paragraph."));
+r.WriteText(" Next we'll show an indented paragraph.");
 
 r.BeginLeftIndent(60);
 r.Newline();
 
-r.WriteText(wxT("Indented paragraph."));
+r.WriteText("Indented paragraph.");
 r.EndLeftIndent();
 
 r.Newline();
 
-r.WriteText(wxT("Next, we'll show a first-line indent, achieved using BeginLeftIndent(100, -40)."));
+r.WriteText("Next, we'll show a first-line indent, achieved using BeginLeftIndent(100, -40).");
 
 r.BeginLeftIndent(100, -40);
 r.Newline();
 
-r.WriteText(wxT("It was in January, the most down-trodden month of an Edinburgh winter."));
+r.WriteText("It was in January, the most down-trodden month of an Edinburgh winter.");
 r.EndLeftIndent();
 
 r.Newline();
 
-r.WriteText(wxT("Numbered bullets are possible, again using subindents:"));
+r.WriteText("Numbered bullets are possible, again using subindents:");
 
 r.BeginNumberedBullet(1, 100, 60);
 r.Newline();
 
-r.WriteText(wxT("This is my first item. Note that wxRichTextCtrl doesn't automatically do numbering, but this will be added later."));
+r.WriteText("This is my first item. Note that wxRichTextCtrl doesn't automatically do numbering, but this will be added later.");
 r.EndNumberedBullet();
 
 r.BeginNumberedBullet(2, 100, 60);
 r.Newline();
 
-r.WriteText(wxT("This is my second item."));
+r.WriteText("This is my second item.");
 r.EndNumberedBullet();
 
 r.Newline();
 
-r.WriteText(wxT("The following paragraph is right-indented:"));
+r.WriteText("The following paragraph is right-indented:");
 
 r.BeginRightIndent(200);
 r.Newline();
 
-r.WriteText(wxT("It was in January, the most down-trodden month of an Edinburgh winter. An attractive woman came into the cafe, which is nothing remarkable."));
+r.WriteText("It was in January, the most down-trodden month of an Edinburgh winter. An attractive woman came into the cafe, which is nothing remarkable.");
 r.EndRightIndent();
 
 r.Newline();
@@ -208,17 +208,17 @@ attr.SetFlags(wxTEXT_ATTR_TABS);
 attr.SetTabs(tabs);
 r.SetDefaultStyle(attr);
 
-r.WriteText(wxT("This line contains tabs:\tFirst tab\tSecond tab\tThird tab"));
+r.WriteText("This line contains tabs:\tFirst tab\tSecond tab\tThird tab");
 
 r.Newline();
-r.WriteText(wxT("Other notable features of wxRichTextCtrl include:"));
+r.WriteText("Other notable features of wxRichTextCtrl include:");
 
-r.BeginSymbolBullet(wxT('*'), 100, 60);
+r.BeginSymbolBullet('*', 100, 60);
 r.Newline();
-r.WriteText(wxT("Compatibility with wxTextCtrl API"));
+r.WriteText("Compatibility with wxTextCtrl API");
 r.EndSymbolBullet();
 
-r.WriteText(wxT("Note: this sample content was generated programmatically from within the MyFrame constructor in the demo. The images were loaded from inline XPMs. Enjoy wxRichTextCtrl!"));
+r.WriteText("Note: this sample content was generated programmatically from within the MyFrame constructor in the demo. The images were loaded from inline XPMs. Enjoy wxRichTextCtrl!");
 
 r.EndSuppressUndo();
 @endcode

--- a/docs/doxygen/overviews/validator.h
+++ b/docs/doxygen/overviews/validator.h
@@ -26,7 +26,7 @@ Here is an example of wxTextValidator usage.
 
 @code
 wxTextCtrl *txt1 = new wxTextCtrl(
-    this, -1, wxT(""), wxDefaultPosition, wxDefaultSize, 0,
+    this, -1, "", wxDefaultPosition, wxDefaultSize, 0,
     wxTextValidator(wxFILTER_ALPHA, &g_data.m_string));
 @endcode
 

--- a/docs/doxygen/overviews/xrc.h
+++ b/docs/doxygen/overviews/xrc.h
@@ -493,7 +493,7 @@ wxObject *MyControlXmlHandler::DoCreateResource()
     //                        const wxString &theTitle, const wxFont &titleFont,
     //                        const wxPoint &pos, const wxSize &size,
     //                        long style = MYCONTROL_DEFAULT_STYLE,
-    //                        const wxString &name = wxT("MyControl"));
+    //                        const wxString &name = "MyControl");
     //
     // Then the XRC for your component should look like:
     //
@@ -512,12 +512,12 @@ wxObject *MyControlXmlHandler::DoCreateResource()
     //
     // And the code to read your custom tags from the XRC file is just:
     control->Create(m_parentAsWindow, GetID(),
-                    GetBitmap(wxT("first-bitmap")),
-                    GetPosition(wxT("first-pos")),
-                    GetBitmap(wxT("second-bitmap")),
-                    GetPosition(wxT("second-pos")),
-                    GetText(wxT("the-title")),
-                    GetFont(wxT("title-font")),
+                    GetBitmap("first-bitmap"),
+                    GetPosition("first-pos"),
+                    GetBitmap("second-bitmap"),
+                    GetPosition("second-pos"),
+                    GetText("the-title"),
+                    GetFont("title-font"),
                     GetPosition(), GetSize(), GetStyle(), GetName());
 
     SetupWindow(control);
@@ -529,7 +529,7 @@ bool MyControlXmlHandler::CanHandle(wxXmlNode *node)
 {
     // this function tells XRC system that this handler can parse
     // the <object class="MyControl"> tags
-    return IsOfClass(node, wxT("MyControl"));
+    return IsOfClass(node, "MyControl");
 }
 @endcode
 

--- a/interface/wx/aboutdlg.h
+++ b/interface/wx/aboutdlg.h
@@ -354,7 +354,7 @@ public:
         info.SetName(_("My Program"));
         info.SetVersion(_("1.2.3 Beta"));
         info.SetDescription(_("This program does something great."));
-        info.SetCopyright(wxT("(C) 2007 Me <my@email.addre.ss>"));
+        info.SetCopyright("(C) 2007 Me <my@email.addre.ss>");
 
         wxAboutBox(info);
     }

--- a/interface/wx/archive.h
+++ b/interface/wx/archive.h
@@ -373,7 +373,7 @@ public:
         const wxArchiveClassFactory *factory = wxArchiveClassFactory::GetFirst();
 
         while (factory) {
-            list << factory->GetProtocol() << wxT("\n");
+            list << factory->GetProtocol() << "\n";
             factory = factory->GetNext();
         }
         @endcode
@@ -410,7 +410,7 @@ public:
         const wxChar *const *p;
 
         for (p = factory->GetProtocols(wxSTREAM_FILEEXT); *p; p++)
-            list << *p << wxT("\n");
+            list << *p << "\n";
         @endcode
     */
     virtual const wxChar** GetProtocols(wxStreamProtocolType type = wxSTREAM_PROTOCOL) const = 0;

--- a/interface/wx/chartype.h
+++ b/interface/wx/chartype.h
@@ -9,21 +9,20 @@
 ///@{
 
 /**
-    This macro can be used with character and string literals (in other words,
-    @c 'x' or @c "foo") to automatically convert them to wide strings in Unicode
-    builds of wxWidgets. This macro simply returns the value passed to it
-    without changes in ASCII build. In fact, its definition is:
+    Macro taking a literal string and expanding into a wide string.
+
+    This macro should not be used in the new code any more as it is simply
+    equivalent to using `L` string prefix now, i.e. its simplified definition
+    could be just
 
     @code
-    #ifdef UNICODE
-    #   define wxT(x)  L##x
-    #else // !Unicode
-    #   define wxT(x)  x
-    #endif
+    #define wxT(x)  L##x
     @endcode
 
-    Note that since wxWidgets 2.9.0 you shouldn't use wxT() anymore in your
-    program sources (it was previously required if you wanted to support Unicode).
+    It used to be required when converting literal strings to wxString in
+    wxWidgets versions prior to 2.9.0, and so can be found in a lot of existing
+    code, but can be simply removed in any code using more recent versions of
+    wxWidgets.
 
     @see @ref overview_unicode, wxS()
 

--- a/interface/wx/chartype.h
+++ b/interface/wx/chartype.h
@@ -31,25 +31,11 @@
 #define wxT(string)
 
 /**
-    Compatibility macro which expands to wxT() in wxWidgets 2 only.
+    Obsolete macro which simply expands to its argument.
 
-    This macro can be used in code which needs to compile with both
-    wxWidgets 2 and 3 versions, in places where the wx2 API requires a Unicode string
-    (in Unicode build) but the wx3 API only accepts a standard narrow
-    string, as in e.g. wxCmdLineEntryDesc structure objects initializers.
-
-    Example of use:
-    @code
-    const wxCmdLineEntryDesc cmdLineDesc[] =
-    {
-        { wxCMD_LINE_SWITCH, wxT_2("q"), wxT_2("quiet"),
-          wxT_2("Don't output verbose messages") },
-        wxCMD_LINE_DESC_END
-    };
-    @endcode
-
-    Without @c wxT_2 the code above wouldn't compile with wxWidgets 2, but using @c
-    wxT instead, it wouldn't compile with wxWidgets 3.
+    This macro could be used in the code which needed to compile with both
+    wxWidgets 2 and 3 versions in some rare circumstances. It is still provided
+    for compatibility but serves no purpose any longer.
 
     @see wxT()
 

--- a/interface/wx/html/helpwnd.h
+++ b/interface/wx/html/helpwnd.h
@@ -56,7 +56,7 @@ enum
         m_embeddedHtmlHelp.SetHelpWindow(m_embeddedHelpWindow);
         m_embeddedHelpWindow->Create(this, wxID_ANY, wxDefaultPosition, GetClientSize(),
                                      wxTAB_TRAVERSAL|wxBORDER_NONE, wxHF_DEFAULT_STYLE);
-        m_embeddedHtmlHelp.AddBook(wxFileName(wxT("doc.zip")));
+        m_embeddedHtmlHelp.AddBook(wxFileName("doc.zip"));
     @endcode
 
     You should pass the style wxHF_EMBEDDED to the style parameter of

--- a/interface/wx/richtext/richtextbuffer.h
+++ b/interface/wx/richtext/richtextbuffer.h
@@ -3101,7 +3101,7 @@ public:
     virtual bool ExportXML(wxXmlNode* parent, wxRichTextXMLHandler* handler);
 #endif
 
-    virtual wxString GetXMLNodeName() const { return wxT("paragraphlayout"); }
+    virtual wxString GetXMLNodeName() const { return "paragraphlayout"; }
 
     virtual bool AcceptsFocus() const { return true; }
 
@@ -3692,7 +3692,7 @@ public:
 
     virtual bool Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style);
 
-    virtual wxString GetXMLNodeName() const { return wxT("textbox"); }
+    virtual wxString GetXMLNodeName() const { return "textbox"; }
 
     virtual bool CanEditProperties() const { return true; }
 
@@ -3777,7 +3777,7 @@ public:
 
     virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const;
 
-    virtual wxString GetXMLNodeName() const { return wxT("field"); }
+    virtual wxString GetXMLNodeName() const { return "field"; }
 
     virtual bool CanEditProperties() const;
 
@@ -3800,8 +3800,8 @@ public:
 
 // Accessors
 
-    void SetFieldType(const wxString& fieldType) { GetProperties().SetProperty(wxT("FieldType"), fieldType); }
-    wxString GetFieldType() const { return GetProperties().GetPropertyString(wxT("FieldType")); }
+    void SetFieldType(const wxString& fieldType) { GetProperties().SetProperty("FieldType", fieldType); }
+    wxString GetFieldType() const { return GetProperties().GetPropertyString("FieldType"); }
 
 // Operations
 
@@ -4351,7 +4351,7 @@ public:
 
     virtual void CalculateRange(long start, long& end);
 
-    virtual wxString GetXMLNodeName() const { return wxT("paragraph"); }
+    virtual wxString GetXMLNodeName() const { return "paragraph"; }
 
 // Accessors
 
@@ -4566,7 +4566,7 @@ public:
     virtual bool ExportXML(wxXmlNode* parent, wxRichTextXMLHandler* handler);
 #endif
 
-    virtual wxString GetXMLNodeName() const { return wxT("text"); }
+    virtual wxString GetXMLNodeName() const { return "text"; }
 
 // Accessors
 
@@ -4833,7 +4833,7 @@ public:
     // Images can be floatable (optionally).
     virtual bool IsFloatable() const { return true; }
 
-    virtual wxString GetXMLNodeName() const { return wxT("image"); }
+    virtual wxString GetXMLNodeName() const { return "image"; }
 
 // Accessors
 
@@ -5734,7 +5734,7 @@ public:
 
     virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0);
 
-    virtual wxString GetXMLNodeName() const { return wxT("cell"); }
+    virtual wxString GetXMLNodeName() const { return "cell"; }
 
     virtual bool CanEditProperties() const { return true; }
 
@@ -5832,7 +5832,7 @@ public:
 
     virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0);
 
-    virtual wxString GetXMLNodeName() const { return wxT("table"); }
+    virtual wxString GetXMLNodeName() const { return "table"; }
 
     virtual bool Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style);
 

--- a/interface/wx/spinctrl.h
+++ b/interface/wx/spinctrl.h
@@ -325,7 +325,7 @@ public:
                long style = wxSP_ARROW_KEYS,
                double min = 0, double max = 100,
                double initial = 0, double inc = 1,
-               const wxString& name = wxT("wxSpinCtrlDouble"));
+               const wxString& name = "wxSpinCtrlDouble");
 
     /**
         Creation function called by the spin control constructor.

--- a/interface/wx/stream.h
+++ b/interface/wx/stream.h
@@ -887,7 +887,7 @@ public:
         const wxFilterClassFactory *factory = wxFilterClassFactory::GetFirst();
 
         while (factory) {
-            list << factory->GetProtocol() << wxT("\n");
+            list << factory->GetProtocol() << "\n";
             factory = factory->GetNext();
         }
         @endcode
@@ -917,7 +917,7 @@ public:
         const wxChar *const *p;
 
         for (p = factory->GetProtocols(wxSTREAM_FILEEXT); *p; p++)
-            list << *p << wxT("\n");
+            list << *p << "\n";
         @endcode
     */
     virtual const wxChar * const* GetProtocols(wxStreamProtocolType type = wxSTREAM_PROTOCOL) const = 0;

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -1390,10 +1390,10 @@ public:
         @code
         wxString str;
 
-        str.Printf(wxT("%d %d %d"), 1, 2, 3);
+        str.Printf("%d %d %d", 1, 2, 3);
         // str now contains "1 2 3"
 
-        str.Printf(wxT("%2$d %3$d %1$d"), 1, 2, 3);
+        str.Printf("%2$d %3$d %1$d", 1, 2, 3);
         // str now contains "2 3 1"
         @endcode
 


### PR DESCRIPTION
I have removed `wxT()` in most cases, leaving it only in:
1. Where a string literal is used in `wxChar*` arrays in `wxPropertyGrid` overview (e.g., [here](https://github.com/wxWidgets/wxWidgets/blob/master/docs/doxygen/overviews/propgrid.h#L272)).
2. In `wxIMAGE_OPTION_*` defines.

BTW, I think the current description of `wxT()` may be a bit outdated:
https://github.com/wxWidgets/wxWidgets/blob/d0e892ac09cee8721980e9b56b88e21c9679435f/interface/wx/chartype.h#L17-L23

wxWidgets removed non-UNICODE build option in 3.3 and `wxChar` is always defined as `wchar_t` (i.e., regardless of the underlying `wxString` char type, so even in the UTF-8 build), therefore `wxT()` now always adds `L` (unlike `wxS()` which adds it only if `wxUSE_UNICODE_WCHAR`):
https://github.com/wxWidgets/wxWidgets/blob/d0e892ac09cee8721980e9b56b88e21c9679435f/include/wx/chartype.h#L168-L178

BTW2, is it not high time to deprecate or even remove `wxT_2()` macro, its code comment says "wxT_2 exists only for compatibility with wx 2.x"?