### PR TITLE
Replace gtk_combo_box_text_insert_text with direct model insertion

### DIFF
--- a/include/wx/gtk/bmpcbox.h
+++ b/include/wx/gtk/bmpcbox.h
@@ -130,7 +130,6 @@ protected:
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const override;
 
     virtual void GTKCreateComboBoxWidget() override;
-    virtual void GTKInsertComboBoxTextItem( unsigned int n, const wxString& text ) override;
 
     virtual wxSize DoGetBestSize() const override;
 

--- a/include/wx/gtk/choice.h
+++ b/include/wx/gtk/choice.h
@@ -105,10 +105,6 @@ protected:
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const override;
     virtual void DoApplyWidgetStyle(GtkRcStyle *style) override;
 
-    // in derived classes, implement this to insert list store entry
-    // with all items default except text
-    virtual void GTKInsertComboBoxTextItem( unsigned int n, const wxString& text );
-
 private:
     void Init();
 

--- a/src/gtk/bmpcbox.cpp
+++ b/src/gtk/bmpcbox.cpp
@@ -285,20 +285,6 @@ int wxBitmapComboBox::Insert(const wxString& item, const wxBitmapBundle& bitmap,
     return n;
 }
 
-void wxBitmapComboBox::GTKInsertComboBoxTextItem( unsigned int n, const wxString& text )
-{
-    GtkComboBox* combobox = GTK_COMBO_BOX( m_widget );
-    GtkTreeModel *model = gtk_combo_box_get_model( combobox );
-    GtkListStore *store = GTK_LIST_STORE( model );
-    GtkTreeIter iter;
-
-    gtk_list_store_insert( store, &iter, n );
-
-    wxGtkValue value( G_TYPE_STRING );
-    g_value_set_string( value, text.utf8_str() );
-    gtk_list_store_set_value( store, &iter, m_stringCellIndex, value );
-}
-
 // ----------------------------------------------------------------------------
 // wxTextEntry interface override
 // ----------------------------------------------------------------------------

--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -139,17 +139,6 @@ bool wxChoice::GTKHandleFocusOut()
     return wxChoiceBase::GTKHandleFocusOut();
 }
 
-void wxChoice::GTKInsertComboBoxTextItem( unsigned int n, const wxString& text )
-{
-    GtkComboBox* combobox = GTK_COMBO_BOX( m_widget );
-    GtkTreeModel *model = gtk_combo_box_get_model( combobox );
-    GtkListStore *store = GTK_LIST_STORE( model );
-    GtkTreeIter iter;
-
-    gtk_list_store_insert_with_values(store, &iter, n, m_stringCellIndex,
-                                      text.utf8_str().data(), -1);
-}
-
 int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
                             unsigned int pos,
                             void **clientData, wxClientDataType type)
@@ -163,6 +152,10 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
 
     int n = wxNOT_FOUND;
 
+    GtkTreeIter iter;
+    GtkTreeModel *model = gtk_combo_box_get_model( GTK_COMBO_BOX( m_widget ) );
+    GtkListStore *store = GTK_LIST_STORE( model );
+
     gtk_widget_freeze_child_notify(m_widget);
 
     for ( int i = 0; i < count; ++i )
@@ -173,7 +166,8 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
         if (m_strings)
             n = m_strings->Add(items[i]);
 
-        GTKInsertComboBoxTextItem( n, items[i] );
+        gtk_list_store_insert_with_values(store, &iter, n, m_stringCellIndex,
+                                          items[i].utf8_str().data(), -1);
 
         m_clientData.Insert( nullptr, n );
         AssignNewItemClientData(n, clientData, i, type);

--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -141,11 +141,13 @@ bool wxChoice::GTKHandleFocusOut()
 
 void wxChoice::GTKInsertComboBoxTextItem( unsigned int n, const wxString& text )
 {
-#ifdef __WXGTK3__
-    gtk_combo_box_text_insert_text(GTK_COMBO_BOX_TEXT(m_widget), n, text.utf8_str());
-#else
-    gtk_combo_box_insert_text( GTK_COMBO_BOX( m_widget ), n,  text.utf8_str() );
-#endif
+    GtkComboBox* combobox = GTK_COMBO_BOX( m_widget );
+    GtkTreeModel *model = gtk_combo_box_get_model( combobox );
+    GtkListStore *store = GTK_LIST_STORE( model );
+    GtkTreeIter iter;
+
+    gtk_list_store_insert_with_values(store, &iter, n, m_stringCellIndex,
+                                      text.utf8_str().data(), -1);
 }
 
 int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
@@ -161,6 +163,8 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
 
     int n = wxNOT_FOUND;
 
+    gtk_widget_freeze_child_notify(m_widget);
+
     for ( int i = 0; i < count; ++i )
     {
         n = pos + i;
@@ -174,6 +178,9 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
         m_clientData.Insert( nullptr, n );
         AssignNewItemClientData(n, clientData, i, type);
     }
+
+    gtk_widget_thaw_child_notify(m_widget);
+
 
     InvalidateBestSize();
 


### PR DESCRIPTION
There is a lot of overhead in the `gtk_combo_box_text_insert_text` function, so adding a lot of items to a choicebox can be an expensive operation when it is used. We have encountered this in KiCad when trying to use a wxChoiceBox as a font chooser on systems that have a lot of fonts installed (https://gitlab.com/kicad/code/kicad/-/issues/14277).

I traced back some of the slow performance on creation of the wxChoiceBox to the method that was being used to add the items to the combobox. Experiments showed that adding 10000 items to the choicebox takes 6.75s in the current implementation using `gtk_combo_box_text_insert_text`. The other way of adding items is to directly access the underlying data model using `gtk_list_store_insert_with_values`. Using the data model access, experiments showed the time needed to add 10000 items dropped to 438.2ms.

It turns out, that was already the method used in `wxBitmapComboBox`, so this actually collapses that down into the base `wxChoice` class, removing the overriden function from `wxBitmapComboBox`. I tried using the same 2-step insertion pattern from `wxBitmapComboBox` (calling `gtk_list_store_insert` followed by `gtk_list_store_set_value`, but it turns out this is just as slow as the original method, and using the 1-step method by calling `gtk_list_store_insert_with_values` was much faster).

I have split this into two separate commits. The first is ABI-compatible, so it would be good to backport it to 3.2. The second removes the now redundant function from `wxBitmapComboBox`, so it changes the ABI (but leaves the API). I would have preferred to just collapse out `GTKInsertComboBoxTextItem` entirely so each item didn't have to query for the model, but that would remove that from the API, and it could theoretically be being overriden by user's in their own implementations currently.

This doesn't completely solve the performance issues for the large choicebox though, there is still a large performance hit when computing the text size and showing the menu, but that needs to be handled separately (and I haven't quite figured out the best way to do that yet).


These experiments can be seen using the minimal sample with this diff:

```
diff --git a/samples/minimal/minimal.cpp b/samples/minimal/minimal.cpp
index 501caf9096..428f3db1b5 100644
--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -144,6 +144,9 @@ MyFrame::MyFrame(const wxString& title)
     // set the frame icon
     SetIcon(wxICON(sample));
 
+    wxBoxSizer* main_sizer = new wxBoxSizer(wxVERTICAL);
+    SetSizer(main_sizer);
+
 #if wxUSE_MENUBAR
     // create a menu bar
     wxMenu *fileMenu = new wxMenu;
@@ -162,12 +165,13 @@ MyFrame::MyFrame(const wxString& title)
     // ... and attach this menu bar to the frame
     SetMenuBar(menuBar);
 #else // !wxUSE_MENUBAR
+
     // If menus are not available add a button to access the about box
     wxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
     wxButton* aboutBtn = new wxButton(this, wxID_ANY, "About...");
     aboutBtn->Bind(wxEVT_BUTTON, &MyFrame::OnAbout, this);
     sizer->Add(aboutBtn, wxSizerFlags().Center());
-    SetSizer(sizer);
+    main_sizer->Add(sizer);
 #endif // wxUSE_MENUBAR/!wxUSE_MENUBAR
 
 #if wxUSE_STATUSBAR
@@ -175,6 +179,18 @@ MyFrame::MyFrame(const wxString& title)
     CreateStatusBar(2);
     SetStatusText("Welcome to wxWidgets!");
 #endif // wxUSE_STATUSBAR
+
+    wxArrayString labels;
+
+    for( int i=0; i < 10001; i++)
+    {
+        labels.Add( wxString::Format( "Item %d", i ) );
+    }
+
+    wxChoice* choice = new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, labels);
+    main_sizer->Add(choice);
+
+    Layout();
 }

```

The flamegraph from the original implementation is:

![Choicebox_Original](https://user-images.githubusercontent.com/2262453/231467939-f26ff8e6-1615-41a6-b9df-ffa6ac773f50.png)

The flamegraph from the proposed implementation is (note the different scale on the time axis):
![Choicebox_SingleStage](https://user-images.githubusercontent.com/2262453/231467969-ebcaac2b-ce7f-4fa1-979e-ba8caabf6bb0.png)
