### PR TITLE
Add boolean operator to wxPGGlobalVars

### DIFF
--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -113,6 +113,8 @@ class WXDLLIMPEXP_PROPGRID wxPGGlobalVarsPtr
 {
 public:
     wxPGGlobalVarsClass* operator->() const;
+    bool operator!() const;
+    explicit operator bool() const;
 };
 
 extern WXDLLIMPEXP_DATA_PROPGRID(wxPGGlobalVarsPtr) wxPGGlobalVars;

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -171,6 +171,16 @@ wxPGGlobalVarsClass* wxPGGlobalVarsPtr::operator->() const
     return g_PGGlobalVars;
 }
 
+bool wxPGGlobalVarsPtr::operator!() const
+{
+    return !g_PGGlobalVars;
+}
+
+wxPGGlobalVarsPtr::operator bool() const
+{
+    return !!g_PGGlobalVars;
+}
+
 wxPGGlobalVarsClass::wxPGGlobalVarsClass()
     : m_fontFamilyChoices(nullptr)
     , m_defaultRenderer(new wxPGDefaultRenderer())


### PR DESCRIPTION
This is just a minor tweak, but the old API for `wxPGGlobalVars` allowed for users to directly test the variable and find if it was null, so recreate that API with the new system to preserve compatibility.