### PR TITLE
Replace gtk_combo_box_text_insert_text with direct model insertion

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -251,6 +251,10 @@ All (GUI):
   using names for the months in short date format (#23310).
 - Fix wx-config output when using NanoSVG library (#23373).
 
+wxGTK:
+
+- Dramatically optimize adding many items to wxChoice (Ian McInerney, #23443).
+
 wxMSW:
 
 - Fix setting locale for wxLANGUAGE_UKRAINIAN (Ulrich Telle, #23210).

--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -141,11 +141,13 @@ bool wxChoice::GTKHandleFocusOut()
 
 void wxChoice::GTKInsertComboBoxTextItem( unsigned int n, const wxString& text )
 {
-#ifdef __WXGTK3__
-    gtk_combo_box_text_insert_text(GTK_COMBO_BOX_TEXT(m_widget), n, wxGTK_CONV(text));
-#else
-    gtk_combo_box_insert_text( GTK_COMBO_BOX( m_widget ), n, wxGTK_CONV( text ) );
-#endif
+    GtkComboBox* combobox = GTK_COMBO_BOX( m_widget );
+    GtkTreeModel *model = gtk_combo_box_get_model( combobox );
+    GtkListStore *store = GTK_LIST_STORE( model );
+    GtkTreeIter iter;
+
+    gtk_list_store_insert_with_values(store, &iter, n, m_stringCellIndex,
+                                      wxGTK_CONV(text).data(), -1);
 }
 
 int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
@@ -161,6 +163,8 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
 
     int n = wxNOT_FOUND;
 
+    gtk_widget_freeze_child_notify(m_widget);
+
     for ( int i = 0; i < count; ++i )
     {
         n = pos + i;
@@ -174,6 +178,9 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
         m_clientData.Insert( NULL, n );
         AssignNewItemClientData(n, clientData, i, type);
     }
+
+    gtk_widget_thaw_child_notify(m_widget);
+
 
     InvalidateBestSize();
 


### PR DESCRIPTION
There is a lot of overhead in the gtk_combo_box_text_insert_text function, so adding a lot of items to a choicebox can be an expensive operation when it is used. Instead directly access the underlying data model and add the items to it.

Experiments show that for adding 10000 items to a wxChoice, the amount of time spent in wxChoice::DoInsertItems for each method are:
    gtk_combo_box_text_insert_text: 6.75s
    gtk_list_store_insert_with_values: 438.2ms

(cherry picked from commit 983608c0f24bae47d7ef164a10e00baba6c66438)

See #23443.