### PR TITLE
Fix/workaround for wxLocale breaking Unicode string formatting

### DIFF
--- a/include/wx/private/localeset.h
+++ b/include/wx/private/localeset.h
@@ -46,4 +46,22 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxCLocaleSetter);
 };
 
+// This function must be called on program startup and after changing
+// locale to ensure LC_CTYPE is set correctly under macOS (it does nothing
+// under the other platforms currently).
+inline void wxEnsureLocaleIsCompatibleWithCRT()
+{
+#if defined(__WXOSX__)
+    // In OS X and iOS, wchar_t CRT functions convert to char* and fail under
+    // some locales. The safest fix is to set LC_CTYPE to UTF-8 to ensure that
+    // they can handle any input.
+    //
+    // Note that this must be done for any app, Cocoa or console, whether or
+    // not it uses wxLocale.
+    //
+    // See https://stackoverflow.com/questions/11713745/why-does-the-printf-family-of-functions-care-about-locale
+    setlocale(LC_CTYPE, "UTF-8");
+#endif // defined(__WXOSX__)
+}
+
 #endif // _WX_PRIVATE_LOCALESET_H_

--- a/include/wx/private/localeset.h
+++ b/include/wx/private/localeset.h
@@ -51,7 +51,7 @@ private:
 // under the other platforms currently).
 inline void wxEnsureLocaleIsCompatibleWithCRT()
 {
-#if defined(__WXOSX__)
+#if defined(__DARWIN__)
     // In OS X and iOS, wchar_t CRT functions convert to char* and fail under
     // some locales. The safest fix is to set LC_CTYPE to UTF-8 to ensure that
     // they can handle any input.
@@ -61,7 +61,7 @@ inline void wxEnsureLocaleIsCompatibleWithCRT()
     //
     // See https://stackoverflow.com/questions/11713745/why-does-the-printf-family-of-functions-care-about-locale
     setlocale(LC_CTYPE, "UTF-8");
-#endif // defined(__WXOSX__)
+#endif // defined(__DARWIN__)
 }
 
 #endif // _WX_PRIVATE_LOCALESET_H_

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -23,7 +23,6 @@
     #include "wx/app.h"
     #include "wx/filefn.h"
     #include "wx/log.h"
-    #include "wx/intl.h"
     #include "wx/module.h"
 #endif
 
@@ -50,9 +49,7 @@
     #endif // wxCrtSetDbgFlag
 #endif // __WINDOWS__
 
-#if defined(__WXOSX__)
-    #include <locale.h>
-#endif
+#include "wx/private/localeset.h"
 
 #include <memory>
 
@@ -217,17 +214,9 @@ static void FreeConvertedArgs()
 // initialization which is always done (not customizable) before wxApp creation
 static bool DoCommonPreInit()
 {
-#if defined(__WXOSX__)
-    // In OS X and iOS, wchar_t CRT functions convert to char* and fail under
-    // some locales. The safest fix is to set LC_CTYPE to UTF-8 to ensure that
-    // they can handle any input.
-    //
-    // Note that this must be done for any app, Cocoa or console, whether or
-    // not it uses wxLocale.
-    //
-    // See https://stackoverflow.com/questions/11713745/why-does-the-printf-family-of-functions-care-about-locale
-    setlocale(LC_CTYPE, "UTF-8");
-#endif // defined(__WXOSX__)
+    // This is necessary even for the default locale, see comments in this
+    // function.
+    wxEnsureLocaleIsCompatibleWithCRT();
 
 #if wxUSE_LOG
     // Reset logging in case we were cleaned up and are being reinitialized.

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -52,6 +52,7 @@
 #include "wx/hashset.h"
 #include "wx/uilocale.h"
 
+#include "wx/private/localeset.h"
 #include "wx/private/uilocale.h"
 
 #ifdef __WIN32__
@@ -396,11 +397,8 @@ bool wxLocale::DoCommonPostInit(bool success,
             t->AddStdCatalog();
     }
 
-#if defined(__WXOSX__)
-    // LC_CTYPE is set in DoCommonPreInit() (see init.cpp). Set it again here,
-    // in case its value was changed/lost during wxLocale initialization.
-    setlocale(LC_CTYPE, "UTF-8");
-#endif // defined(__WXOSX__)
+    // Do this again here in case LC_CTYPE was changed by setlocale().
+    wxEnsureLocaleIsCompatibleWithCRT();
 
     return success;
 }

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -396,6 +396,12 @@ bool wxLocale::DoCommonPostInit(bool success,
             t->AddStdCatalog();
     }
 
+#if defined(__WXOSX__)
+    // LC_CTYPE is set in DoCommonPreInit() (see init.cpp). Set it again here,
+    // in case its value was changed/lost during wxLocale initialization.
+    setlocale(LC_CTYPE, "UTF-8");
+#endif // defined(__WXOSX__)
+
     return success;
 }
 

--- a/tests/strings/strings.cpp
+++ b/tests/strings/strings.cpp
@@ -106,6 +106,15 @@ TEST_CASE("StringFormatUnicode", "[wxString]")
     wxString expected(fmt);
     expected.Replace("%i", "1");
     CHECK( s == expected );
+
+    // Repeat exactly the same after creating a wxLocale
+    // object, and ensure formatting Unicode strings still works.
+    wxLocale l(wxLANGUAGE_DEFAULT);
+
+    wxString s2 = wxString::Format(fmt, 1, 1);
+    wxString expected2(fmt);
+    expected2.Replace("%i", "1");
+    CHECK( s2 == expected2 );
 }
 
 TEST_CASE("StringConstructors", "[wxString]")


### PR DESCRIPTION
Also attempt to test whether wxLocale breaks formatting Unicode strings.
See #23450.