### PR TITLE
Fix comment about wxWebResponse::IsOk()'s return type

### DIFF
--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -280,7 +280,7 @@ public:
 
         Before sending a request or after a failed request this will return
         an invalid response object, i.e. such that wxWebResponse::IsOk()
-        returns @NULL.
+        returns @c false.
     */
     wxWebResponse GetResponse() const;
 


### PR DESCRIPTION
`wxWebResponse::IsOk()` returns a boolean, not a pointer.