### PR TITLE
Fix GetMimeType() returning empty

### DIFF
--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -168,7 +168,7 @@ public:
 
     virtual wxString GetMimeType() const;
 
-    virtual wxString GetContentType() const
+    virtual wxString GetContentType() const;
 
     virtual int GetStatus() const = 0;
 

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -168,6 +168,8 @@ public:
 
     virtual wxString GetMimeType() const;
 
+    virtual wxString GetContentType() const
+
     virtual int GetStatus() const = 0;
 
     virtual wxString GetStatusText() const = 0;

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -104,7 +104,7 @@ public:
 
     wxString GetMimeType() const;
 
-    wxString GetContentType() const
+    wxString GetContentType() const;
 
     int GetStatus() const;
 

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -104,6 +104,8 @@ public:
 
     wxString GetMimeType() const;
 
+    wxString GetContentType() const
+
     int GetStatus() const;
 
     wxString GetStatusText() const;

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -598,7 +598,8 @@ public:
     /**
         Returns the content type of the response (if available).
 
-        This can be a value such as "text/html; charset=utf-8".
+        This is the full value of the "Content-Type" header of the response,
+        e.g. a value such as "text/html; charset=utf-8".
 
         @since 3.3.0
     */

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -589,8 +589,17 @@ public:
 
     /**
         Returns the MIME type of the response (if available).
+
+        This can be a value such as "text/html".
     */
     wxString GetMimeType() const;
+
+    /**
+        Returns the content type of the response (if available).
+
+        This can be a value such as "text/html; charset=utf-8".
+    */
+    wxString GetContentType() const
 
     /**
         Returns the status code returned by the server.

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -598,6 +598,8 @@ public:
         Returns the content type of the response (if available).
 
         This can be a value such as "text/html; charset=utf-8".
+
+        @since 3.3.0
     */
     wxString GetContentType() const
 

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -590,7 +590,8 @@ public:
     /**
         Returns the MIME type of the response (if available).
 
-        This can be a value such as "text/html".
+        This is just the MIME type part (e.g. "text/html") of the value returned
+        by GetContentType().
     */
     wxString GetMimeType() const;
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -637,7 +637,7 @@ void wxWebResponseImpl::Init()
 
 wxString wxWebResponseImpl::GetMimeType() const
 {
-    return GetHeader("Mime-Type");
+    return GetHeader("Content-Type");
 }
 
 wxInputStream * wxWebResponseImpl::GetStream() const

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -637,6 +637,14 @@ void wxWebResponseImpl::Init()
 
 wxString wxWebResponseImpl::GetMimeType() const
 {
+    wxString contentType( GetContentType() );
+    const auto separatorPosition = contentType.find(';');
+    return (separatorPosition != wxString::npos) ?
+        contentType.substr(0, separatorPosition) : contentType;
+}
+
+wxString wxWebResponseImpl::GetContentType() const
+{
     return GetHeader("Content-Type");
 }
 
@@ -816,6 +824,13 @@ wxString wxWebResponse::GetMimeType() const
     wxCHECK_IMPL( wxString() );
 
     return m_impl->GetMimeType();
+}
+
+wxString wxWebResponse::GetContentType() const
+{
+    wxCHECK_IMPL( wxString() );
+
+    return m_impl->GetContentType();
 }
 
 int wxWebResponse::GetStatus() const

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -637,10 +637,7 @@ void wxWebResponseImpl::Init()
 
 wxString wxWebResponseImpl::GetMimeType() const
 {
-    wxString contentType( GetContentType() );
-    const auto separatorPosition = contentType.find(';');
-    return (separatorPosition != wxString::npos) ?
-        contentType.substr(0, separatorPosition) : contentType;
+    return GetContentType().BeforeFirst(';');
 }
 
 wxString wxWebResponseImpl::GetContentType() const


### PR DESCRIPTION
I believe it should be "Content-Type" to request the MIME type from a response header, not "Mime-Type".

https://developer.mozilla.org/en-US/docs/web/http/headers/content-type

As an example, currently wxWebResponse::GetMimeType() will return empty string for any page (e.g., "https://www.libreoffice.org/discover/libreoffice/").  With this fix, I will now get "text/html; charset=utf-8" (tested on Windows).