### PR TITLE
Add wxString::wc_string() for consistency

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1265,6 +1265,7 @@ public:
   #if wxUSE_UNICODE_WCHAR
     #define wxStringToStdWstringRetType const std::wstring&
     const std::wstring& ToStdWstring() const { return m_impl; }
+    const std::wstring& wc_string() const { return m_impl; }
   #else // wxUSE_UNICODE_UTF8
     // wxStringImpl is either not std::string or needs conversion
     #define wxStringToStdWstringRetType std::wstring
@@ -1272,6 +1273,10 @@ public:
     {
         wxScopedWCharBuffer buf(wc_str());
         return std::wstring(buf.data(), buf.length());
+    }
+    std::wstring wc_string() const
+    {
+        return ToStdWstring();
     }
   #endif
 

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -113,7 +113,8 @@
         no data loss, use @c wxConvUTF8 conversion or wxString::utf8_string().
         - Wide C string using implicit conversion or wxString::wc_str()
         explicitly.
-        - Standard @c std::wstring using wxString::ToStdWstring().
+        - Standard @c std::wstring using wxString::ToStdWstring() or its
+        synonym wxString::wc_string().
 
 
     As above, defining `wxNO_IMPLICIT_WXSTRING_ENCODING` when compiling
@@ -479,7 +480,7 @@ public:
     /**
        Constructs a string from @a str.
 
-       @see ToStdWstring()
+       @see ToStdWstring(), wc_string()
     */
     wxString(const std::wstring& str);
 
@@ -720,6 +721,21 @@ public:
     const wxWX2WCbuf wc_str() const;
 
     /**
+        Returns the strings contents as a wide character string.
+
+        This is a somewhat more readable synonym for ToStdWstring().
+
+        The return type of this function is actually `const std::wstring&` in
+        wxWidgets builds using `wxUSE_UNICODE_WCHAR==1` (which is the default),
+        i.e. in this build there is no copying of string contents, however a
+        temporary copy of the string is returned in `wxUSE_UNICODE_UTF8==1`
+        build.
+
+        @since 3.3.0
+     */
+    std::wstring wc_string() const;
+
+    /**
         Returns an object with string data that is implicitly convertible to
         @c char* pointer. Note that changes to the returned buffer may or may
         not be lost (depending on the build) and so this function is only usable for
@@ -798,7 +814,15 @@ public:
         Unlike ToStdString(), there is no danger of data loss when using this
         function.
 
+        Note that the return type of this function is actually `const
+        std::wstring&` in wxWidgets builds using `wxUSE_UNICODE_WCHAR==1`
+        (which is the default), i.e. in this build there is no copying of
+        string contents, however a temporary copy of the string is returned in
+        `wxUSE_UNICODE_UTF8==1` build.
+
         @since 2.9.1
+
+        @see wc_string()
     */
     std::wstring ToStdWstring() const;
 

--- a/tests/strings/stdstrings.cpp
+++ b/tests/strings/stdstrings.cpp
@@ -628,6 +628,8 @@ TEST_CASE("StdString::Conversion", "[stdstring]")
 #endif
     CHECK( s6 == L"hello" );
 
+    CHECK( s4.wc_string() == L"hello" );
+
 #if wxUSE_STD_STRING_CONV_IN_WXSTRING
 #if !defined(wxNO_UNSAFE_WXSTRING_CONV)
     std::string s7(s4);


### PR DESCRIPTION
We have utf8_str() and utf8_string(), but no similar equivalent for wc_str(), so add one too, it seems nicer to use than ToStdWstring().

---

It seems a bit ridiculuous to add even more redundant functions, but OTOH I really want to recommend people to use `utf8_string()` and `wc_string()` rather than `utf8_string()` and `ToStdWstring()`.