### PR TITLE
Restore `wxDocument::{Save,Load}Object()` compatibility with the old non-STL build

### DIFF
--- a/docs/doxygen/mainpages/const_wxusedef.h
+++ b/docs/doxygen/mainpages/const_wxusedef.h
@@ -221,6 +221,7 @@ library:
 @itemdef{wxUSE_STATUSBAR, Use wxStatusBar class.}
 @itemdef{wxUSE_STC, Use wxStyledTextCtrl.}
 @itemdef{wxUSE_STDPATHS, Use wxStandardPaths class.}
+@itemdef{wxUSE_STD_IOSTREAM, Use standard stream classes in addition to or, in wxDocument, instead of, wx streams.}
 @itemdef{wxUSE_STOPWATCH, Use wxStopWatch class.}
 @itemdef{wxUSE_STREAMS, Enable stream classes.}
 @itemdef{wxUSE_SVG, Use wxSVGFileDC class.}

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -272,11 +272,15 @@
 // disabled, wx streams are used instead.
 //
 // Notice that enabling this does not replace wx streams with std streams
-// everywhere, in a lot of places wx streams are used no matter what.
+// everywhere, in a lot of places wx streams are used no matter what and in
+// other places this option enables the use of standard streams in _addition_
+// to the wx ones. The only exception is wxDocument which defines functions
+// working with standard streams only when this option is on, and only
+// functions working with wx streams when it's off.
 //
 // Default is 1.
 //
-// Recommended setting: 1.
+// Recommended setting: 1, there should be no reason to disable it.
 #define wxUSE_STD_IOSTREAM  1
 
 // ----------------------------------------------------------------------------

--- a/include/wx/docview.h
+++ b/include/wx/docview.h
@@ -99,8 +99,8 @@ public:
     virtual bool Revert();
 
 #if wxUSE_STD_IOSTREAM
-    virtual wxSTD ostream& SaveObject(wxSTD ostream& stream);
-    virtual wxSTD istream& LoadObject(wxSTD istream& stream);
+    virtual std::ostream& SaveObject(std::ostream& stream);
+    virtual std::istream& LoadObject(std::istream& stream);
 #else
     virtual wxOutputStream& SaveObject(wxOutputStream& stream);
     virtual wxInputStream& LoadObject(wxInputStream& stream);
@@ -972,9 +972,9 @@ private:
 // converts from/to a stream to/from a temporary file.
 #if wxUSE_STD_IOSTREAM
 bool WXDLLIMPEXP_CORE
-wxTransferFileToStream(const wxString& filename, wxSTD ostream& stream);
+wxTransferFileToStream(const wxString& filename, std::ostream& stream);
 bool WXDLLIMPEXP_CORE
-wxTransferStreamToFile(wxSTD istream& stream, const wxString& filename);
+wxTransferStreamToFile(std::istream& stream, const wxString& filename);
 #else
 bool WXDLLIMPEXP_CORE
 wxTransferFileToStream(const wxString& filename, wxOutputStream& stream);

--- a/include/wx/gtk/setup.h
+++ b/include/wx/gtk/setup.h
@@ -273,11 +273,15 @@
 // disabled, wx streams are used instead.
 //
 // Notice that enabling this does not replace wx streams with std streams
-// everywhere, in a lot of places wx streams are used no matter what.
+// everywhere, in a lot of places wx streams are used no matter what and in
+// other places this option enables the use of standard streams in _addition_
+// to the wx ones. The only exception is wxDocument which defines functions
+// working with standard streams only when this option is on, and only
+// functions working with wx streams when it's off.
 //
 // Default is 1.
 //
-// Recommended setting: 1.
+// Recommended setting: 1, there should be no reason to disable it.
 #define wxUSE_STD_IOSTREAM  1
 
 // ----------------------------------------------------------------------------

--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -704,7 +704,7 @@ class WXDLLIMPEXP_BASE wxLogStream : public wxLog,
 {
 public:
     // redirect log output to an ostream
-    wxLogStream(wxSTD ostream *ostr = (wxSTD ostream *) nullptr,
+    wxLogStream(std::ostream *ostr = (std::ostream *) nullptr,
                 const wxMBConv& conv = wxConvWhateverWorks);
 
 protected:
@@ -712,7 +712,7 @@ protected:
     virtual void DoLogText(const wxString& msg) override;
 
     // using ptr here to avoid including <iostream.h> from this file
-    wxSTD ostream *m_ostr;
+    std::ostream *m_ostr;
 
     wxDECLARE_NO_COPY_CLASS(wxLogStream);
 };

--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -326,7 +326,7 @@ public:
 #if wxUSE_STD_IOSTREAM
         // input/output
     friend WXDLLIMPEXP_BASE
-    wxSTD ostream& operator<<(wxSTD ostream&, const wxLongLongNative&);
+    std::ostream& operator<<(std::ostream&, const wxLongLongNative&);
 #endif
 
     friend WXDLLIMPEXP_BASE
@@ -545,7 +545,7 @@ public:
 #if wxUSE_STD_IOSTREAM
         // input/output
     friend WXDLLIMPEXP_BASE
-    wxSTD ostream& operator<<(wxSTD ostream&, const wxULongLongNative&);
+    std::ostream& operator<<(std::ostream&, const wxULongLongNative&);
 #endif
 
     friend WXDLLIMPEXP_BASE
@@ -785,7 +785,7 @@ public:
 
 #if wxUSE_STD_IOSTREAM
     friend WXDLLIMPEXP_BASE
-    wxSTD ostream& operator<<(wxSTD ostream&, const wxLongLongWx&);
+    std::ostream& operator<<(std::ostream&, const wxLongLongWx&);
 #endif // wxUSE_STD_IOSTREAM
 
     friend WXDLLIMPEXP_BASE
@@ -1001,7 +1001,7 @@ public:
 
 #if wxUSE_STD_IOSTREAM
     friend WXDLLIMPEXP_BASE
-    wxSTD ostream& operator<<(wxSTD ostream&, const wxULongLongWx&);
+    std::ostream& operator<<(std::ostream&, const wxULongLongWx&);
 #endif // wxUSE_STD_IOSTREAM
 
     friend WXDLLIMPEXP_BASE

--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -125,7 +125,7 @@ public:
     virtual bool Eq(wxVariantData& data) const override;
 
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 
@@ -151,7 +151,7 @@ public:
     virtual bool Eq(wxVariantData& data) const override;
 
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 
@@ -179,7 +179,7 @@ public:
     virtual bool Eq(wxVariantData& data) const override;
 
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 

--- a/include/wx/msw/setup.h
+++ b/include/wx/msw/setup.h
@@ -273,11 +273,15 @@
 // disabled, wx streams are used instead.
 //
 // Notice that enabling this does not replace wx streams with std streams
-// everywhere, in a lot of places wx streams are used no matter what.
+// everywhere, in a lot of places wx streams are used no matter what and in
+// other places this option enables the use of standard streams in _addition_
+// to the wx ones. The only exception is wxDocument which defines functions
+// working with standard streams only when this option is on, and only
+// functions working with wx streams when it's off.
 //
 // Default is 1.
 //
-// Recommended setting: 1.
+// Recommended setting: 1, there should be no reason to disable it.
 #define wxUSE_STD_IOSTREAM  1
 
 // ----------------------------------------------------------------------------

--- a/include/wx/osx/setup.h
+++ b/include/wx/osx/setup.h
@@ -279,11 +279,15 @@
 // disabled, wx streams are used instead.
 //
 // Notice that enabling this does not replace wx streams with std streams
-// everywhere, in a lot of places wx streams are used no matter what.
+// everywhere, in a lot of places wx streams are used no matter what and in
+// other places this option enables the use of standard streams in _addition_
+// to the wx ones. The only exception is wxDocument which defines functions
+// working with standard streams only when this option is on, and only
+// functions working with wx streams when it's off.
 //
 // Default is 1.
 //
-// Recommended setting: 1.
+// Recommended setting: 1, there should be no reason to disable it.
 #define wxUSE_STD_IOSTREAM  1
 
 // ----------------------------------------------------------------------------

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -148,6 +148,8 @@ public:
     virtual void SetAcceleratorTable( const wxAcceleratorTable& accel ) override;
 #endif // wxUSE_ACCEL
 
+    virtual bool EnableTouchEvents(int eventsMask) override;
+
     // wxQt implementation internals:
 
     // Caller maintains ownership of pict - window will NOT delete it
@@ -222,8 +224,6 @@ protected:
     // overridden in wxFrame to use its central widget rather than the frame
     // itself.
     virtual QWidget* QtGetParentWidget() const { return GetHandle(); }
-
-    virtual bool EnableTouchEvents(int eventsMask) override;
 
     QWidget *m_qtWindow;
 

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -269,11 +269,15 @@
 // disabled, wx streams are used instead.
 //
 // Notice that enabling this does not replace wx streams with std streams
-// everywhere, in a lot of places wx streams are used no matter what.
+// everywhere, in a lot of places wx streams are used no matter what and in
+// other places this option enables the use of standard streams in _addition_
+// to the wx ones. The only exception is wxDocument which defines functions
+// working with standard streams only when this option is on, and only
+// functions working with wx streams when it's off.
 //
 // Default is 1.
 //
-// Recommended setting: 1.
+// Recommended setting: 1, there should be no reason to disable it.
 #define wxUSE_STD_IOSTREAM  1
 
 // ----------------------------------------------------------------------------

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -4113,18 +4113,18 @@ namespace std
 
 #include "wx/iosfwrap.h"
 
-WXDLLIMPEXP_BASE wxSTD ostream& operator<<(wxSTD ostream&, const wxString&);
-WXDLLIMPEXP_BASE wxSTD ostream& operator<<(wxSTD ostream&, const wxCStrData&);
+WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxString&);
+WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxCStrData&);
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-WXDLLIMPEXP_BASE wxSTD ostream& operator<<(wxSTD ostream&, const wxScopedCharBuffer&);
+WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxScopedCharBuffer&);
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-WXDLLIMPEXP_BASE wxSTD ostream& operator<<(wxSTD ostream&, const wxScopedWCharBuffer&);
+WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxScopedWCharBuffer&);
 
 #if defined(HAVE_WOSTREAM)
 
-WXDLLIMPEXP_BASE wxSTD wostream& operator<<(wxSTD wostream&, const wxString&);
-WXDLLIMPEXP_BASE wxSTD wostream& operator<<(wxSTD wostream&, const wxCStrData&);
-WXDLLIMPEXP_BASE wxSTD wostream& operator<<(wxSTD wostream&, const wxScopedWCharBuffer&);
+WXDLLIMPEXP_BASE std::wostream& operator<<(std::wostream&, const wxString&);
+WXDLLIMPEXP_BASE std::wostream& operator<<(std::wostream&, const wxCStrData&);
+WXDLLIMPEXP_BASE std::wostream& operator<<(std::wostream&, const wxScopedWCharBuffer&);
 
 #endif  // defined(HAVE_WOSTREAM)
 

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -742,7 +742,7 @@ private:
 
 class WXDLLIMPEXP_CORE wxTextCtrlBase : public wxControl,
 #if wxHAS_TEXT_WINDOW_STREAM
-                                   public wxSTD streambuf,
+                                   public std::streambuf,
 #endif
                                    public wxTextAreaBase,
                                    public wxTextEntry
@@ -965,12 +965,12 @@ private:
 
 public:
     wxStreamToTextRedirector(wxTextCtrl *text)
-        : m_ostr(wxSTD cout)
+        : m_ostr(std::cout)
     {
         Init(text);
     }
 
-    wxStreamToTextRedirector(wxTextCtrl *text, wxSTD ostream *ostr)
+    wxStreamToTextRedirector(wxTextCtrl *text, std::ostream *ostr)
         : m_ostr(*ostr)
     {
         Init(text);
@@ -983,10 +983,10 @@ public:
 
 private:
     // the stream we're redirecting
-    wxSTD ostream&   m_ostr;
+    std::ostream&   m_ostr;
 
     // the old streambuf (before we changed it)
-    wxSTD streambuf *m_sbufOld;
+    std::streambuf *m_sbufOld;
 };
 
 #endif // wxHAS_TEXT_WINDOW_STREAM

--- a/include/wx/univ/setup.h
+++ b/include/wx/univ/setup.h
@@ -272,11 +272,15 @@
 // disabled, wx streams are used instead.
 //
 // Notice that enabling this does not replace wx streams with std streams
-// everywhere, in a lot of places wx streams are used no matter what.
+// everywhere, in a lot of places wx streams are used no matter what and in
+// other places this option enables the use of standard streams in _addition_
+// to the wx ones. The only exception is wxDocument which defines functions
+// working with standard streams only when this option is on, and only
+// functions working with wx streams when it's off.
 //
 // Default is 1.
 //
-// Recommended setting: 1.
+// Recommended setting: 1, there should be no reason to disable it.
 #define wxUSE_STD_IOSTREAM  1
 
 // ----------------------------------------------------------------------------

--- a/include/wx/variant.h
+++ b/include/wx/variant.h
@@ -63,11 +63,11 @@ public:
     virtual bool Eq(wxVariantData& data) const = 0;
 
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& WXUNUSED(str)) const { return false; }
+    virtual bool Write(std::ostream& WXUNUSED(str)) const { return false; }
 #endif
     virtual bool Write(wxString& WXUNUSED(str)) const { return false; }
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& WXUNUSED(str)) { return false; }
+    virtual bool Read(std::istream& WXUNUSED(str)) { return false; }
 #endif
     virtual bool Read(wxString& WXUNUSED(str)) { return false; }
     // What type is it? Return a string name.

--- a/include/wx/variantbase.h
+++ b/include/wx/variantbase.h
@@ -67,8 +67,8 @@ public:
     { }
 
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& WXUNUSED(str)) const { return false; }
-    virtual bool Read(wxSTD istream& WXUNUSED(str)) { return false; }
+    virtual bool Write(std::ostream& WXUNUSED(str)) const { return false; }
+    virtual bool Read(std::istream& WXUNUSED(str)) { return false; }
 #endif
     virtual bool Write(wxString& WXUNUSED(str)) const { return false; }
     virtual bool Read(wxString& WXUNUSED(str)) { return false; }

--- a/interface/wx/docview.h
+++ b/interface/wx/docview.h
@@ -1430,18 +1430,36 @@ public:
     */
     virtual bool IsModified() const;
 
-    ///@{
     /**
-        Override this function and call it from your own LoadObject() before
-        streaming your own data. LoadObject() is called by the framework
-        automatically when the document contents need to be loaded.
+        Override this function to load the object data from the provided stream.
 
-        @note This version of LoadObject() may not exist depending on how
-              wxWidgets was configured.
+        LoadObject() is called by the framework automatically when the document
+        contents need to be loaded by default.
+
+        Note that if @a stream is in the failed state when this function
+        returns, i.e. its `failbit` is set, it indicates that loading the
+        object failed and an error is given. As `failbit` may be set by trying
+        to read after reaching the end of the stream, you may need to call
+        `stream.clear()` to reset it if necessary.
+
+        @note This overload of LoadObject() is not available if
+            `wxUSE_STD_IOSTREAM` is set to 0 (which is done by
+            `--disable-std_iostreams` option when using configure).
     */
-    virtual istream& LoadObject(istream& stream);
+    virtual std::istream& LoadObject(std::istream& stream);
+
+    /**
+        Override this function to load the object data from the provided stream.
+
+        @overload
+
+        @note This overload of LoadObject() is only available if
+            `wxUSE_STD_IOSTREAM` is set to 0 (which is done by
+            `--disable-std_iostreams` option when using configure). Otherwise,
+            i.e. in the default build of the library, only the overload taking
+            `std::istream` exists.
+     */
     virtual wxInputStream& LoadObject(wxInputStream& stream);
-    ///@}
 
     /**
         Call with @true to mark the document as modified since the last save,
@@ -1587,18 +1605,30 @@ public:
     */
     virtual bool Revert();
 
-    ///@{
     /**
-        Override this function and call it from your own SaveObject() before
-        streaming your own data. SaveObject() is called by the framework
-        automatically when the document contents need to be saved.
+        Override this function to save the object data into the provided stream.
 
-        @note This version of SaveObject() may not exist depending on how
-              wxWidgets was configured.
+        SaveObject() is called by the framework automatically when the document
+        contents need to be saved by default.
+
+        @note This overload of SaveObject() is not available if
+            `wxUSE_STD_IOSTREAM` is set to 0 (which is done by
+            `--disable-std_iostreams` option when using configure).
     */
-    virtual ostream& SaveObject(ostream& stream);
+    virtual std::ostream& SaveObject(std::ostream& stream);
+
+    /**
+        Override this function to load the object data from the provided stream.
+
+        @overload
+
+        @note This overload of SaveObject() is only available if
+            `wxUSE_STD_IOSTREAM` is set to 0 (which is done by
+            `--disable-std_iostreams` option when using configure). Otherwise,
+            i.e. in the default build of the library, only the overload taking
+            `std::ostream` exists.
+     */
     virtual wxOutputStream& SaveObject(wxOutputStream& stream);
-    ///@}
 
     /**
         Sets the command processor to be used for this document. The document

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -790,8 +790,9 @@ public:
 
     This class can be used to redirect the log messages to a C++ stream.
 
-    Please note that this class is only available if wxWidgets was compiled with
-    the standard iostream library support (@c wxUSE_STD_IOSTREAM must be on).
+    @note
+        This class is not available if `wxUSE_STD_IOSTREAM` is set to 0 (which
+        is done by `--disable-std_iostreams` option when using configure).
 
     @library{wxbase}
     @category{logging}

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1850,12 +1850,8 @@ public:
     ostream object to a wxTextCtrl instead.
 
     @note
-        Some compilers and/or build configurations don't support multiply
-        inheriting wxTextCtrl from @c std::streambuf in which case this class is
-        not compiled in.
-        You also must have @c wxUSE_STD_IOSTREAM option on (i.e. set to 1) in your
-        @c setup.h to be able to use it. Under Unix, specify @c \--enable-std_iostreams
-        switch when running configure for this.
+        This class is not available if `wxUSE_STD_IOSTREAM` is set to 0 (which
+        is done by `--disable-std_iostreams` option when using configure).
 
     Example of usage:
 

--- a/samples/docview/doc.h
+++ b/samples/docview/doc.h
@@ -21,11 +21,11 @@
 // somewhat complicates its code but is necessary in order to support building
 // it under all platforms and in all build configurations
 //
-// In your own code you would normally use std::stream classes only and so
-// wouldn't need these typedefs
+// In your own code you would normally use one set of the stream classes only
+// and so wouldn't need these typedefs and preprocessor conditions.
 #if wxUSE_STD_IOSTREAM
-    typedef wxSTD istream DocumentIstream;
-    typedef wxSTD ostream DocumentOstream;
+    typedef std::istream DocumentIstream;
+    typedef std::ostream DocumentOstream;
 #else // !wxUSE_STD_IOSTREAM
     typedef wxInputStream DocumentIstream;
     typedef wxOutputStream DocumentOstream;

--- a/samples/typetest/typetest.cpp
+++ b/samples/typetest/typetest.cpp
@@ -115,7 +115,7 @@ void MyApp::DoStreamDemo(wxCommandEvent& WXUNUSED(event))
 
     textCtrl.WriteText( "Writing to ofstream and wxFileOutputStream:\n" );
 
-    wxSTD ofstream std_file_output( "test_std.dat" );
+    std::ofstream std_file_output( "test_std.dat" );
     wxFileOutputStream file_output( file_name );
     wxBufferedOutputStream buf_output( file_output );
     wxTextOutputStream text_output( buf_output );
@@ -155,7 +155,7 @@ void MyApp::DoStreamDemo(wxCommandEvent& WXUNUSED(event))
 
     textCtrl.WriteText( "\nReading from ifstream:\n" );
 
-    wxSTD ifstream std_file_input( "test_std.dat" );
+    std::ifstream std_file_input( "test_std.dat" );
 
     std_file_input >> si;
     tmp.Printf( "Signed int: %d\n", si );

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -1060,7 +1060,7 @@ void TextWidgetsPage::OnStreamRedirector(wxCommandEvent& WXUNUSED(event))
 #if wxHAS_TEXT_WINDOW_STREAM
     wxStreamToTextRedirector redirect(m_text);
     wxString str( "Outputed to cout, appears in wxTextCtrl!" );
-    wxSTD cout << str << wxSTD endl;
+    std::cout << str << std::endl;
 #else
     wxMessageBox("This wxWidgets build does not support wxStreamToTextRedirector");
 #endif

--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -434,7 +434,7 @@ bool wxDocument::OnOpenDocument(const wxString& file)
 }
 
 #if wxUSE_STD_IOSTREAM
-wxSTD istream& wxDocument::LoadObject(wxSTD istream& stream)
+std::istream& wxDocument::LoadObject(std::istream& stream)
 #else
 wxInputStream& wxDocument::LoadObject(wxInputStream& stream)
 #endif
@@ -443,7 +443,7 @@ wxInputStream& wxDocument::LoadObject(wxInputStream& stream)
 }
 
 #if wxUSE_STD_IOSTREAM
-wxSTD ostream& wxDocument::SaveObject(wxSTD ostream& stream)
+std::ostream& wxDocument::SaveObject(std::ostream& stream)
 #else
 wxOutputStream& wxDocument::SaveObject(wxOutputStream& stream)
 #endif
@@ -670,7 +670,7 @@ void wxDocument::OnChangeFilename(bool notifyViews)
 bool wxDocument::DoSaveDocument(const wxString& file)
 {
 #if wxUSE_STD_IOSTREAM
-    wxSTD ofstream store(file.mb_str(), wxSTD ios::binary);
+    std::ofstream store(file.mb_str(), std::ios::binary);
     if ( !store )
 #else
     wxFileOutputStream store(file);
@@ -693,7 +693,7 @@ bool wxDocument::DoSaveDocument(const wxString& file)
 bool wxDocument::DoOpenDocument(const wxString& file)
 {
 #if wxUSE_STD_IOSTREAM
-    wxSTD ifstream store(file.mb_str(), wxSTD ios::binary);
+    std::ifstream store(file.mb_str(), std::ios::binary);
     if ( !store )
 #else
     wxFileInputStream store(file);
@@ -2247,7 +2247,7 @@ void wxDocPrintout::GetPageInfo(int *minPage, int *maxPage,
 
 #if wxUSE_STD_IOSTREAM
 
-bool wxTransferFileToStream(const wxString& filename, wxSTD ostream& stream)
+bool wxTransferFileToStream(const wxString& filename, std::ostream& stream)
 {
 #if wxUSE_FFILE
     wxFFile file(filename, wxT("rb"));
@@ -2274,7 +2274,7 @@ bool wxTransferFileToStream(const wxString& filename, wxSTD ostream& stream)
     return true;
 }
 
-bool wxTransferStreamToFile(wxSTD istream& stream, const wxString& filename)
+bool wxTransferStreamToFile(std::istream& stream, const wxString& filename)
 {
 #if wxUSE_FFILE
     wxFFile file(filename, wxT("wb"));

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -50,7 +50,8 @@
 #include <stdlib.h>
 
 #if defined(__WINDOWS__)
-    #include "wx/msw/private.h" // includes windows.h
+    // This header includes <windows.h> and declares wxMSWFormatMessage().
+    #include "wx/msw/private.h"
 #endif
 
 #undef wxLOG_COMPONENT

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -891,11 +891,11 @@ void wxLogStderr::DoLogText(const wxString& msg)
 
 #if wxUSE_STD_IOSTREAM
 #include "wx/ioswrap.h"
-wxLogStream::wxLogStream(wxSTD ostream *ostr, const wxMBConv& conv)
+wxLogStream::wxLogStream(std::ostream *ostr, const wxMBConv& conv)
     : wxMessageOutputWithConv(conv)
 {
     if ( ostr == nullptr )
-        m_ostr = &wxSTD cerr;
+        m_ostr = &std::cerr;
     else
         m_ostr = ostr;
 }

--- a/src/common/longlong.cpp
+++ b/src/common/longlong.cpp
@@ -1224,13 +1224,13 @@ void *wxULongLongWx::asArray() const
 
 // input/output
 WXDLLIMPEXP_BASE
-wxSTD ostream& operator<< (wxSTD ostream& o, const wxLongLong& ll)
+std::ostream& operator<< (std::ostream& o, const wxLongLong& ll)
 {
     return o << ll.ToString();
 }
 
 WXDLLIMPEXP_BASE
-wxSTD ostream& operator<< (wxSTD ostream& o, const wxULongLong& ll)
+std::ostream& operator<< (std::ostream& o, const wxULongLong& ll)
 {
     return o << ll.ToString();
 }

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -156,7 +156,7 @@ static wxStrCacheStatsDumper s_showCacheStats;
 
 #include <iostream>
 
-wxSTD ostream& operator<<(wxSTD ostream& os, const wxCStrData& str)
+std::ostream& operator<<(std::ostream& os, const wxCStrData& str)
 {
 #if !wxUSE_UNICODE_UTF8
     return os << wxConvWhateverWorks.cWX2MB(str);
@@ -165,17 +165,17 @@ wxSTD ostream& operator<<(wxSTD ostream& os, const wxCStrData& str)
 #endif
 }
 
-wxSTD ostream& operator<<(wxSTD ostream& os, const wxString& str)
+std::ostream& operator<<(std::ostream& os, const wxString& str)
 {
     return os << str.c_str();
 }
 
-wxSTD ostream& operator<<(wxSTD ostream& os, const wxScopedCharBuffer& str)
+std::ostream& operator<<(std::ostream& os, const wxScopedCharBuffer& str)
 {
     return os << str.data();
 }
 
-wxSTD ostream& operator<<(wxSTD ostream& os, const wxScopedWCharBuffer& str)
+std::ostream& operator<<(std::ostream& os, const wxScopedWCharBuffer& str)
 {
     // There is no way to write wide character data to std::ostream directly,
     // but we need to define this operator for compatibility, as we provided it
@@ -186,17 +186,17 @@ wxSTD ostream& operator<<(wxSTD ostream& os, const wxScopedWCharBuffer& str)
 
 #if defined(HAVE_WOSTREAM)
 
-wxSTD wostream& operator<<(wxSTD wostream& wos, const wxString& str)
+std::wostream& operator<<(std::wostream& wos, const wxString& str)
 {
     return wos << str.wc_str();
 }
 
-wxSTD wostream& operator<<(wxSTD wostream& wos, const wxCStrData& str)
+std::wostream& operator<<(std::wostream& wos, const wxCStrData& str)
 {
     return wos << str.AsWChar();
 }
 
-wxSTD wostream& operator<<(wxSTD wostream& wos, const wxScopedWCharBuffer& str)
+std::wostream& operator<<(std::wostream& wos, const wxScopedWCharBuffer& str)
 {
     return wos << str.data();
 }

--- a/src/common/variant.cpp
+++ b/src/common/variant.cpp
@@ -241,8 +241,8 @@ public:
     virtual bool Read(wxString& str) override;
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Read(std::istream& str) override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
 #if wxUSE_STREAMS
     virtual bool Read(wxInputStream& str);
@@ -286,7 +286,7 @@ bool wxVariantDataLong::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataLong::Write(wxSTD ostream& str) const
+bool wxVariantDataLong::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -302,7 +302,7 @@ bool wxVariantDataLong::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataLong::Read(wxSTD istream& str)
+bool wxVariantDataLong::Read(std::istream& str)
 {
     str >> m_value;
     return true;
@@ -408,11 +408,11 @@ public:
     virtual bool Eq(wxVariantData& data) const override;
     virtual bool Read(wxString& str) override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
+    virtual bool Read(std::istream& str) override;
 #endif
 #if wxUSE_STREAMS
     virtual bool Read(wxInputStream& str);
@@ -439,7 +439,7 @@ bool wxVariantDoubleData::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDoubleData::Write(wxSTD ostream& str) const
+bool wxVariantDoubleData::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -455,7 +455,7 @@ bool wxVariantDoubleData::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDoubleData::Read(wxSTD istream& str)
+bool wxVariantDoubleData::Read(std::istream& str)
 {
     str >> m_value;
     return true;
@@ -547,12 +547,12 @@ public:
 
     virtual bool Eq(wxVariantData& data) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
     virtual bool Read(wxString& str) override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
+    virtual bool Read(std::istream& str) override;
 #endif
 #if wxUSE_STREAMS
     virtual bool Read(wxInputStream& str);
@@ -579,7 +579,7 @@ bool wxVariantDataBool::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataBool::Write(wxSTD ostream& str) const
+bool wxVariantDataBool::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -595,7 +595,7 @@ bool wxVariantDataBool::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataBool::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataBool::Read(std::istream& WXUNUSED(str))
 {
     wxFAIL_MSG(wxT("Unimplemented"));
 //    str >> (long) m_value;
@@ -690,8 +690,8 @@ public:
 
     virtual bool Eq(wxVariantData& data) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Read(std::istream& str) override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Read(wxString& str) override;
     virtual bool Write(wxString& str) const override;
@@ -719,7 +719,7 @@ bool wxVariantDataChar::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataChar::Write(wxSTD ostream& str) const
+bool wxVariantDataChar::Write(std::ostream& str) const
 {
     str << wxString(m_value);
     return true;
@@ -733,7 +733,7 @@ bool wxVariantDataChar::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataChar::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataChar::Read(std::istream& WXUNUSED(str))
 {
     wxFAIL_MSG(wxT("Unimplemented"));
 
@@ -843,12 +843,12 @@ public:
 
     virtual bool Eq(wxVariantData& data) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Read(wxString& str) override;
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& WXUNUSED(str)) override { return false; }
+    virtual bool Read(std::istream& WXUNUSED(str)) override { return false; }
 #endif
 #if wxUSE_STREAMS
     virtual bool Read(wxInputStream& str);
@@ -894,7 +894,7 @@ bool wxVariantDataString::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataString::Write(wxSTD ostream& str) const
+bool wxVariantDataString::Write(std::ostream& str) const
 {
     str << (const char*) m_value.mb_str();
     return true;
@@ -1036,11 +1036,11 @@ public:
 
     virtual bool Eq(wxVariantData& data) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
+    virtual bool Read(std::istream& str) override;
 #endif
     virtual bool Read(wxString& str) override;
     virtual wxString GetType() const override ;
@@ -1087,7 +1087,7 @@ wxClassInfo* wxVariantDataWxObjectPtr::GetValueClassInfo()
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataWxObjectPtr::Write(wxSTD ostream& str) const
+bool wxVariantDataWxObjectPtr::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -1103,7 +1103,7 @@ bool wxVariantDataWxObjectPtr::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataWxObjectPtr::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataWxObjectPtr::Read(std::istream& WXUNUSED(str))
 {
     // Not implemented
     return false;
@@ -1160,11 +1160,11 @@ public:
 
     virtual bool Eq(wxVariantData& data) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
+    virtual bool Read(std::istream& str) override;
 #endif
     virtual bool Read(wxString& str) override;
     virtual wxString GetType() const override { return wxT("void*"); }
@@ -1187,7 +1187,7 @@ bool wxVariantDataVoidPtr::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataVoidPtr::Write(wxSTD ostream& str) const
+bool wxVariantDataVoidPtr::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -1203,7 +1203,7 @@ bool wxVariantDataVoidPtr::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataVoidPtr::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataVoidPtr::Read(std::istream& WXUNUSED(str))
 {
     // Not implemented
     return false;
@@ -1275,11 +1275,11 @@ public:
 
     virtual bool Eq(wxVariantData& data) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
+    virtual bool Read(std::istream& str) override;
 #endif
     virtual bool Read(wxString& str) override;
     virtual wxString GetType() const override { return wxT("datetime"); }
@@ -1303,7 +1303,7 @@ bool wxVariantDataDateTime::Eq(wxVariantData& data) const
 
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataDateTime::Write(wxSTD ostream& str) const
+bool wxVariantDataDateTime::Write(std::ostream& str) const
 {
     wxString value;
     Write( value );
@@ -1324,7 +1324,7 @@ bool wxVariantDataDateTime::Write(wxString& str) const
 
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataDateTime::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataDateTime::Read(std::istream& WXUNUSED(str))
 {
     // Not implemented
     return false;
@@ -1408,11 +1408,11 @@ public:
 
     virtual bool Eq(wxVariantData& data) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
+    virtual bool Read(std::istream& str) override;
 #endif
     virtual bool Read(wxString& str) override;
     virtual wxString GetType() const override { return wxT("arrstring"); }
@@ -1435,7 +1435,7 @@ bool wxVariantDataArrayString::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataArrayString::Write(wxSTD ostream& WXUNUSED(str)) const
+bool wxVariantDataArrayString::Write(std::ostream& WXUNUSED(str)) const
 {
     // Not implemented
     return false;
@@ -1458,7 +1458,7 @@ bool wxVariantDataArrayString::Write(wxString& str) const
 
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataArrayString::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataArrayString::Read(std::istream& WXUNUSED(str))
 {
     // Not implemented
     return false;
@@ -1539,8 +1539,8 @@ public:
     virtual bool Read(wxString& str) override;
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Read(std::istream& str) override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
 #if wxUSE_STREAMS
     virtual bool Read(wxInputStream& str);
@@ -1607,7 +1607,7 @@ bool wxVariantDataLongLong::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataLongLong::Write(wxSTD ostream& str) const
+bool wxVariantDataLongLong::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -1627,7 +1627,7 @@ bool wxVariantDataLongLong::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataLongLong::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataLongLong::Read(std::istream& WXUNUSED(str))
 {
     wxFAIL_MSG(wxS("Unimplemented"));
     return false;
@@ -1738,8 +1738,8 @@ public:
     virtual bool Read(wxString& str) override;
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Read(std::istream& str) override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
 #if wxUSE_STREAMS
     virtual bool Read(wxInputStream& str);
@@ -1807,7 +1807,7 @@ bool wxVariantDataULongLong::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataULongLong::Write(wxSTD ostream& str) const
+bool wxVariantDataULongLong::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -1827,7 +1827,7 @@ bool wxVariantDataULongLong::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataULongLong::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataULongLong::Read(std::istream& WXUNUSED(str))
 {
     wxFAIL_MSG(wxS("Unimplemented"));
     return false;
@@ -1934,11 +1934,11 @@ public:
 
     virtual bool Eq(wxVariantData& data) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Write(wxSTD ostream& str) const override;
+    virtual bool Write(std::ostream& str) const override;
 #endif
     virtual bool Write(wxString& str) const override;
 #if wxUSE_STD_IOSTREAM
-    virtual bool Read(wxSTD istream& str) override;
+    virtual bool Read(std::istream& str) override;
 #endif
     virtual bool Read(wxString& str) override;
     virtual wxString GetType() const override { return wxT("list"); }
@@ -2048,7 +2048,7 @@ bool wxVariantDataList::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataList::Write(wxSTD ostream& str) const
+bool wxVariantDataList::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -2075,7 +2075,7 @@ bool wxVariantDataList::Write(wxString& str) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataList::Read(wxSTD istream& WXUNUSED(str))
+bool wxVariantDataList::Read(std::istream& WXUNUSED(str))
 {
     wxFAIL_MSG(wxT("Unimplemented"));
     // TODO

--- a/src/msw/ole/oleutils.cpp
+++ b/src/msw/ole/oleutils.cpp
@@ -127,7 +127,7 @@ bool wxVariantDataCurrency::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataCurrency::Write(wxSTD ostream& str) const
+bool wxVariantDataCurrency::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -180,7 +180,7 @@ bool wxVariantDataErrorCode::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataErrorCode::Write(wxSTD ostream& str) const
+bool wxVariantDataErrorCode::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);
@@ -228,7 +228,7 @@ bool wxVariantDataSafeArray::Eq(wxVariantData& data) const
 }
 
 #if wxUSE_STD_IOSTREAM
-bool wxVariantDataSafeArray::Write(wxSTD ostream& str) const
+bool wxVariantDataSafeArray::Write(std::ostream& str) const
 {
     wxString s;
     Write(s);

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -33,10 +33,6 @@
     #include <stat.h>
 #endif
 
-#if wxUSE_STD_IOSTREAM
-    #include <fstream>
-#endif
-
 #include "wx/filefn.h"
 #include "wx/sysopt.h"
 #include "wx/thread.h"

--- a/src/osx/iphone/textctrl.mm
+++ b/src/osx/iphone/textctrl.mm
@@ -33,10 +33,6 @@
     #include <stat.h>
 #endif
 
-#if wxUSE_STD_IOSTREAM
-    #include <fstream>
-#endif
-
 #include "wx/filefn.h"
 #include "wx/sysopt.h"
 #include "wx/thread.h"

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -33,10 +33,6 @@
     #include <stat.h>
 #endif
 
-#if wxUSE_STD_IOSTREAM
-    #include <fstream>
-#endif
-
 #include "wx/filefn.h"
 #include "wx/sysopt.h"
 #include "wx/thread.h"

--- a/src/osx/textentry_osx.cpp
+++ b/src/osx/textentry_osx.cpp
@@ -33,10 +33,6 @@
     #include <stat.h>
 #endif
 
-#if wxUSE_STD_IOSTREAM
-    #include <fstream>
-#endif
-
 #include "wx/filefn.h"
 #include "wx/sysopt.h"
 #include "wx/thread.h"

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -335,7 +335,7 @@ void TextCtrlTestCase::StreamInput()
 
 void TextCtrlTestCase::Redirector()
 {
-#if wxHAS_TEXT_WINDOW_STREAM && wxUSE_STD_IOSTREAM
+#if wxHAS_TEXT_WINDOW_STREAM
 
     wxStreamToTextRedirector redirect(m_text);
 


### PR DESCRIPTION
See #23479.