### PR TITLE
Fix typo in grid.h interface file

### DIFF
--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -4737,7 +4737,7 @@ public:
 
         @since 3.3.0
      */
-    void EnableRowResize(int row)l
+    void EnableRowResize(int row);
 
     /**
         Returns the column ID of the specified column position.


### PR DESCRIPTION
Replace 'l' by ';' (causes corrupted doxygen output)