### PR TITLE
Misc WebKit2 fixes

### DIFF
--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -631,7 +631,7 @@ wxgtk_initialize_web_extensions(WebKitWebContext *context,
 
             for ( size_t n = 0; n < WXSIZEOF(directories); ++n )
             {
-                if ( !TrySetWebExtensionsDirectory(context, directories[n]) )
+                if ( TrySetWebExtensionsDirectory(context, directories[n]) )
                     break;
             }
         }

--- a/tests/controls/webtest.cpp
+++ b/tests/controls/webtest.cpp
@@ -232,9 +232,11 @@ TEST_CASE_METHOD(WebViewTestCase, "WebView", "[wxWebView]")
         // With WebKit SelectAll() sends a request to perform the selection to
         // another process via proxy and there doesn't seem to be any way to
         // wait until this request is actually handled, so loop here for some a
-        // bit before giving up.
-        for ( wxStopWatch sw; !m_browser->HasSelection() && sw.Time() < 50; )
-            wxMilliSleep(1);
+        // bit before giving up.  Avoid calling HasSelection() right away
+        // without wxYielding a bit because this seems to cause the extension
+        // to hang with webkit 2.40.0+.
+        for ( wxStopWatch sw; sw.Time() < 50; )
+            wxYield();
 #endif // wxUSE_WEBVIEW_WEBKIT2
 
         CHECK(m_browser->HasSelection());


### PR DESCRIPTION
This is a couple of fixes for issues I encountered while working on enabling GUI tests on Fedora.

Both are backport candidates; the WebKit2 test failure is something I noticed on Fedora with 3.2 a month or two ago.