### PR TITLE
Enable transparent background on Windows

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -115,6 +115,8 @@ public:
     virtual bool SetCursor( const wxCursor &cursor ) override;
     virtual bool SetFont( const wxFont &font ) override;
 
+    virtual bool IsTransparentBackgroundSupported(wxString* reason = nullptr) const override;
+
     virtual int GetCharHeight() const override;
     virtual int GetCharWidth() const override;
 

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -2420,12 +2420,12 @@ public:
         problem.
 
 
-        Under wxGTK and wxOSX, you can use ::wxBG_STYLE_TRANSPARENT to obtain
+        Under wxGTK, wxOSX and wxMSW, you can use ::wxBG_STYLE_TRANSPARENT to obtain
         full transparency of the window background. Note that wxGTK supports
         this only since GTK 2.12 with a compositing manager enabled, call
         IsTransparentBackgroundSupported() to check whether this is the case,
         see the example of doing it in @ref page_samples_shaped "the shaped
-        sample".
+        sample". Under wxMSW this is supported since 3.3.0.
 
         Also, in order for @c SetBackgroundStyle(wxBG_STYLE_TRANSPARENT) to
         work, it must be called before Create(). If you're using your own

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -874,6 +874,11 @@ bool wxWindowMSW::SetFont(const wxFont& font)
     return true;
 }
 
+bool wxWindowMSW::IsTransparentBackgroundSupported(wxString* WXUNUSED(reason)) const
+{
+    return true;
+}
+
 bool wxWindowMSW::SetCursor(const wxCursor& cursor)
 {
     if ( !wxWindowBase::SetCursor(cursor) )
@@ -1656,6 +1661,12 @@ WXDWORD wxWindowMSW::MSWGetStyle(long flags, WXDWORD *exstyle) const
             *exstyle |= WS_EX_CONTROLPARENT;
         }
 #endif // __WXUNIVERSAL__
+
+        // Set this style when background style is set to transparent. Don't
+        // apply it to toplevel windows, since it will make events (like mouse
+        // clicks) fall through the window.
+        if ( GetBackgroundStyle() == wxBG_STYLE_TRANSPARENT && !IsTopLevel() )
+            *exstyle |= WS_EX_TRANSPARENT;
     }
 
     return style;


### PR DESCRIPTION
When the `wxWindow` background style is set to `wxBG_STYLE_TRANSPARENT`, set the `WS_EX_TRANSPARENT` style flag.

Closes #23412