### PR TITLE
Fix typo and formatting in wxWebResponse docs

### DIFF
--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -582,15 +582,15 @@ public:
     /**
         Get the length of returned data if available.
 
-        Returns the value specified in the @c Content-Length: response header
-        of @c -1 if not available.
+        Returns the value specified in the @c Content-Length response header
+        or @c -1 if not available.
      */
     wxFileOffset GetContentLength() const;
 
     /**
         Returns the MIME type of the response (if available).
 
-        This is just the MIME type part (e.g. "text/html") of the value returned
+        This is just the MIME type part (e.g., "text/html") of the value returned
         by GetContentType().
     */
     wxString GetMimeType() const;
@@ -598,12 +598,12 @@ public:
     /**
         Returns the content type of the response (if available).
 
-        This is the full value of the "Content-Type" header of the response,
-        e.g. a value such as "text/html; charset=utf-8".
+        This is the full value of the @c Content-Type header of the response,
+        (e.g., a value such as "text/html; charset=utf-8").
 
         @since 3.3.0
     */
-    wxString GetContentType() const
+    wxString GetContentType() const;
 
     /**
         Returns the status code returned by the server.


### PR DESCRIPTION
Fix typo, missing semicolon, missing commas, and stray colon; use consistent formatting.