### PR TITLE
Explain how to specifiy download paths before starting a wxWebRequest

### DIFF
--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -63,6 +63,15 @@
         // Start the request
         request.Start();
     @endcode
+    
+    The location of where files are downloaded can also be defined prior to any request
+    by passing unique IDs to `wxWebSession::GetDefault().CreateRequest()` and processing
+    them in your @c wxEVT_WEBREQUEST_STATE handler. For example, create a map of IDs with
+    their respective download paths prior to creating any requests. For each call to
+    `wxWebSession::GetDefault().CreateRequest()`, pass in the webpath to download and an ID
+    from your map. Then, in your @c wxEVT_WEBREQUEST_STATE handler, get the ID from the
+    @c wxWebRequestEvent object and look it up from your ID map. Here, you can access the
+    download path that you assigned to this ID and proceed to save the file to that location.
 
     @section apple_http macOS and iOS App Transport Security
 

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -63,7 +63,7 @@
         // Start the request
         request.Start();
     @endcode
-    
+
     The location of where files are downloaded can also be defined prior to any request
     by passing unique IDs to `wxWebSession::GetDefault().CreateRequest()` and processing
     them in your @c wxEVT_WEBREQUEST_STATE handler. For example, create a map of IDs with


### PR DESCRIPTION
Adding an overview paragraph explaining how to use wxWebRequest's and wxWebEvent's IDs together to specify a request's download path before starting it. The sample shows how to interactively prompt for local paths once a file downloads, but I was wanting to download a file to a specific location without user prompting. The technique described here worked for me.

If accepted, this could close #22986.