### PR TITLE
Add `windowToUse` argument to wxXRC `GetPosition()` too

### DIFF
--- a/include/wx/xrc/xmlres.h
+++ b/include/wx/xrc/xmlres.h
@@ -566,7 +566,8 @@ public:
                    wxWindow *windowToUse = nullptr) override;
 
     // Gets the position (may be in dialog units).
-    wxPoint GetPosition(const wxString& param = wxT("pos")) override;
+    wxPoint GetPosition(const wxString& param = wxT("pos"),
+                        wxWindow *windowToUse = nullptr) override;
 
     // Gets a dimension (may be in dialog units).
     wxCoord GetDimension(const wxString& param, wxCoord defaultv = 0,

--- a/include/wx/xrc/xmlreshandler.h
+++ b/include/wx/xrc/xmlreshandler.h
@@ -79,7 +79,8 @@ public:
                                const wxColour& defaultv = wxNullColour) = 0;
     virtual wxSize GetSize(const wxString& param = wxT("size"),
                            wxWindow *windowToUse = nullptr) = 0;
-    virtual wxPoint GetPosition(const wxString& param = wxT("pos")) = 0;
+    virtual wxPoint GetPosition(const wxString& param = wxT("pos"),
+                                wxWindow *windowToUse = nullptr) = 0;
     virtual wxCoord GetDimension(const wxString& param, wxCoord defaultv = 0,
                                  wxWindow *windowToUse = nullptr) = 0;
     virtual wxSize GetPairInts(const wxString& param) = 0;
@@ -309,9 +310,10 @@ protected:
     {
         return GetImpl()->GetSize(param, windowToUse);
     }
-    wxPoint GetPosition(const wxString& param = wxT("pos"))
+    wxPoint GetPosition(const wxString& param = wxT("pos"),
+                        wxWindow *windowToUse = nullptr)
     {
-        return GetImpl()->GetPosition(param);
+        return GetImpl()->GetPosition(param, windowToUse);
     }
     wxCoord GetDimension(const wxString& param, wxCoord defaultv = 0,
                          wxWindow *windowToUse = nullptr)

--- a/interface/wx/xrc/xmlres.h
+++ b/interface/wx/xrc/xmlres.h
@@ -809,8 +809,10 @@ protected:
 
     /**
         Gets the position (may be in dialog units).
+
+        The @a windowToUse argument is only available since wxWidgets 3.3.0.
     */
-    wxPoint GetPosition(const wxString& param = "pos");
+    wxPoint GetPosition(const wxString& param = "pos", wxWindow* windowToUse = nullptr);
 
     /**
         Gets the size (may be in dialog units).

--- a/interface/wx/xrc/xmlres.h
+++ b/interface/wx/xrc/xmlres.h
@@ -668,7 +668,7 @@ protected:
         Gets a dimension (may be in dialog units).
     */
     wxCoord GetDimension(const wxString& param, wxCoord defaultv = 0,
-                         wxWindow* windowToUse = 0);
+                         wxWindow* windowToUse = nullptr);
 
     /**
         Gets a direction.
@@ -815,7 +815,7 @@ protected:
     /**
         Gets the size (may be in dialog units).
     */
-    wxSize GetSize(const wxString& param = "size", wxWindow* windowToUse = 0);
+    wxSize GetSize(const wxString& param = "size", wxWindow* windowToUse = nullptr);
 
     /**
         Gets style flags from text in form "flag | flag2| flag3 |..."

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -2385,9 +2385,10 @@ wxSize wxXmlResourceHandlerImpl::GetSize(const wxString& param,
 
 
 
-wxPoint wxXmlResourceHandlerImpl::GetPosition(const wxString& param)
+wxPoint wxXmlResourceHandlerImpl::GetPosition(const wxString& param,
+                                              wxWindow *windowToUse)
 {
-    return ParseValueInPixels(this, param, wxDefaultPosition);
+    return ParseValueInPixels(this, param, wxDefaultPosition, windowToUse);
 }
 
 


### PR DESCRIPTION
Make it consistent with `GetSize()` etc.

AFAICS this function is not supposed to be overridden in the user code, it's only virtual due to the separation between `wxXmlResourceHandlerImplBase` and `wxXmlResourceHandlerImpl` itself, so this shouldn't break any existing code. But please let me know if I'm wrong.