### PR TITLE
Remove mentions of no longer supported MSVS versions

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -526,10 +526,6 @@ public:
             more than 2 arguments, you can use the CallAfter<T>(const T& fn)
             overload that can call any functor.
 
-         @note This method is not available with Visual C++ before version 8
-               (Visual Studio 2005) as earlier versions of the compiler don't
-               have the required support for C++ templates to implement it.
-
          @since 2.9.5
      */
     template<typename T, typename T1, ...>

--- a/interface/wx/xlocale.h
+++ b/interface/wx/xlocale.h
@@ -31,8 +31,7 @@
     This class is fully implemented only under the platforms where xlocale POSIX
     API or equivalent is available. Currently the xlocale API is available under
     most of the recent Unix systems (including Linux, various BSD and macOS) and
-    Microsoft Visual C++ standard library provides a similar API starting from
-    version 8 (Visual Studio 2005).
+    Microsoft Visual C++ standard library provides a similar API.
 
     If neither POSIX API nor Microsoft proprietary equivalent are available, this
     class is still available but works in degraded mode: the only supported locale


### PR DESCRIPTION
The oldest supported MSVS version for wxWidgets 3.3 is 2015, so remove mentions of limitations of older MSVS versions.