### PR TITLE
Fix updating wxFrame client size in wxEVT_DPI_CHANGED handler

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -3129,7 +3129,12 @@ public:
 
     // Scale the value by the ratio between new and old DPIs carried by this
     // event.
+    wxPoint Scale(wxPoint pt) const;
     wxSize Scale(wxSize sz) const;
+    wxRect Scale(wxRect r) const
+    {
+        return wxRect(Scale(r.GetPosition()), Scale(r.GetSize()));
+    }
 
     int ScaleX(int x) const { return Scale(wxSize(x, -1)).x; }
     int ScaleY(int y) const { return Scale(wxSize(-1, y)).y; }

--- a/include/wx/msw/frame.h
+++ b/include/wx/msw/frame.h
@@ -131,6 +131,8 @@ protected:
     virtual void DoGetClientSize(int *width, int *height) const override;
     virtual void DoSetClientSize(int width, int height) override;
 
+    virtual void MSWBeforeDPIChangedEvent(const wxSize& newDPI) override;
+
 #if wxUSE_MENUS_NATIVE
     // perform MSW-specific action when menubar is changed
     virtual void AttachMenuBar(wxMenuBar *menubar) override;

--- a/include/wx/msw/frame.h
+++ b/include/wx/msw/frame.h
@@ -131,7 +131,7 @@ protected:
     virtual void DoGetClientSize(int *width, int *height) const override;
     virtual void DoSetClientSize(int width, int height) override;
 
-    virtual void MSWBeforeDPIChangedEvent(const wxSize& newDPI) override;
+    virtual void MSWBeforeDPIChangedEvent(const wxDPIChangedEvent& event) override;
 
 #if wxUSE_MENUS_NATIVE
     // perform MSW-specific action when menubar is changed

--- a/include/wx/msw/slider.h
+++ b/include/wx/msw/slider.h
@@ -123,8 +123,8 @@ protected:
     WXHBRUSH DoMSWControlColor(WXHDC pDC, wxColour colBg, WXHWND hWnd) override;
 
     virtual void MSWUpdateFontOnDPIChange(const wxSize& newDPI) override;
+    virtual void MSWBeforeDPIChangedEvent(const wxDPIChangedEvent& event) override;
 
-    void OnDPIChanged(wxDPIChangedEvent& event);
 
     // the labels windows, if any
     wxSubwindows  *m_labels;

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -607,8 +607,12 @@ protected:
 
     // Also called from MSWUpdateOnDPIChange() but, unlike the function above,
     // this one is called after updating all the children and just before
-    // generating the wxDPIChangedEvent to be processed by the application.
-    virtual void MSWBeforeDPIChangedEvent(const wxSize& WXUNUSED(newDPI)) { }
+    // letting the application handle the given wxDPIChangedEvent (whose
+    // Scale() functions may be useful for the overridden versions).
+    virtual void
+    MSWBeforeDPIChangedEvent(const wxDPIChangedEvent& WXUNUSED(event))
+    {
+    }
 
     // this allows you to implement standard control borders without
     // repeating the code in different classes that are not derived from

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -605,6 +605,11 @@ protected:
     // controls. The default version updates m_font of this window.
     virtual void MSWUpdateFontOnDPIChange(const wxSize& newDPI);
 
+    // Also called from MSWUpdateOnDPIChange() but, unlike the function above,
+    // this one is called after updating all the children and just before
+    // generating the wxDPIChangedEvent to be processed by the application.
+    virtual void MSWBeforeDPIChangedEvent(const wxSize& WXUNUSED(newDPI)) { }
+
     // this allows you to implement standard control borders without
     // repeating the code in different classes that are not derived from
     // wxControl

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -3475,9 +3475,18 @@ public:
         For example, the returned value will be twice bigger than the original
         one when switching from normal (96) DPI to high (2x, 192) DPI.
 
+        The overloads taking wxPoint and wxRect are only available in wxWidgets
+        3.3.0 and later.
+
         @since 3.1.6
      */
     wxSize Scale(wxSize sz) const;
+
+    /// @overload
+    wxPoint Scale(wxPoint pt) const;
+
+    /// @overload
+    wxRect Scale(wxRect rect) const;
 
     /**
         Rescale horizontal component to match the new DPI.

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -915,6 +915,11 @@ wxHelpEvent::Origin wxHelpEvent::GuessOrigin(Origin origin)
 // wxDPIChangedEvent
 // ----------------------------------------------------------------------------
 
+wxPoint wxDPIChangedEvent::Scale(wxPoint pt) const
+{
+    return wxRescaleCoord(pt).From(m_oldDPI).To(m_newDPI);
+}
+
 wxSize wxDPIChangedEvent::Scale(wxSize sz) const
 {
     return wxRescaleCoord(sz).From(m_oldDPI).To(m_newDPI);

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -947,3 +947,15 @@ wxPoint wxFrame::GetClientAreaOrigin() const
 
     return pt;
 }
+
+void wxFrame::MSWBeforeDPIChangedEvent(const wxSize& WXUNUSED(newDPI))
+{
+#if wxUSE_STATUSBAR
+    // If this frame uses a status bar, we need to adjust its height here
+    // before executing the user-defined wxEVT_DPI_CHANGED handler which may
+    // want to change the client size of the frame (e.g. using wxSizer::Fit()),
+    // because otherwise this wouldn't work correctly because the status bar
+    // would still have its old height, corresponding to the old DPI.
+    PositionStatusBar();
+#endif // wxUSE_STATUSBAR
+}

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -948,7 +948,7 @@ wxPoint wxFrame::GetClientAreaOrigin() const
     return pt;
 }
 
-void wxFrame::MSWBeforeDPIChangedEvent(const wxSize& WXUNUSED(newDPI))
+void wxFrame::MSWBeforeDPIChangedEvent(const wxDPIChangedEvent& WXUNUSED(event))
 {
 #if wxUSE_STATUSBAR
     // If this frame uses a status bar, we need to adjust its height here

--- a/src/msw/slider.cpp
+++ b/src/msw/slider.cpp
@@ -184,8 +184,6 @@ bool wxSlider::Create(wxWindow *parent,
         SetSize(size);
     }
 
-    Bind(wxEVT_DPI_CHANGED, &wxSlider::OnDPIChanged, this);
-
     return true;
 }
 
@@ -649,13 +647,14 @@ void wxSlider::MSWUpdateFontOnDPIChange(const wxSize& newDPI)
     }
 }
 
-void wxSlider::OnDPIChanged(wxDPIChangedEvent& event)
+void wxSlider::MSWBeforeDPIChangedEvent(const wxDPIChangedEvent& event)
 {
+    // We need to update the thumb before processing wxEVT_DPI_CHANGED in the
+    // user code, as it may update the slider size, which wouldn't work
+    // correctly if it still used the old thumb length.
     int thumbLen = GetThumbLength();
 
     SetThumbLength(event.ScaleX(thumbLen));
-
-    event.Skip();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5028,12 +5028,13 @@ wxWindowMSW::MSWUpdateOnDPIChange(const wxSize& oldDPI, const wxSize& newDPI)
         }
     }
 
-    // Another hook to give the derived window a chance to update itself after
-    // updating all the children, but before the user-defined event handler.
-    MSWBeforeDPIChangedEvent(newDPI);
-
     wxDPIChangedEvent event(oldDPI, newDPI);
     event.SetEventObject(this);
+
+    // Another hook to give the derived window a chance to update itself after
+    // updating all the children, but before the user-defined event handler.
+    MSWBeforeDPIChangedEvent(event);
+
     return HandleWindowEvent(event);
 }
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5028,6 +5028,10 @@ wxWindowMSW::MSWUpdateOnDPIChange(const wxSize& oldDPI, const wxSize& newDPI)
         }
     }
 
+    // Another hook to give the derived window a chance to update itself after
+    // updating all the children, but before the user-defined event handler.
+    MSWBeforeDPIChangedEvent(newDPI);
+
     wxDPIChangedEvent event(oldDPI, newDPI);
     event.SetEventObject(this);
     return HandleWindowEvent(event);


### PR DESCRIPTION
This didn't work correctly when switching from higher to lower DPI if the frame had a status bar because this status bar still had its old, bigger height, by the time SetClientSize() was called from the event handler, resulting in the frame size becoming too big.

It notably resulted in having an unwanted gap between the frame contents and the status bar if the event handler called GetSizer()->Fit().

Fix this by calling PositionStatusBar(), which also updates the status bar height to correspond to the new DPI as a side effect, from a new virtual MSWBeforeDPIChangedEvent() function which had to be added to allow wxFrame to customize DPI handling.

Adding this new virtual function just for this isn't great, but the only alternatives seem even worse.

----

@MaartenBent Please let me know if you have any comments/better ideas about how to do it. The TL;DR summary of the commit message above is that we need to somehow call `PositionStatusBar()` before processing `wxDPIChangedEvent` generated in `MSWUpdateOnDPIChange()`.