### PR TITLE
Fix wxTextCtrl hint showing for wxUniv

### DIFF
--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -783,7 +783,7 @@ wxTextCtrl::~wxTextCtrl()
 
 void wxTextCtrl::DoSetValue(const wxString& value, int flags)
 {
-    if ( value != GetValue() )
+    if ( value != DoGetValue() )
     {
         EventsSuppressor noeventsIf(this, !(flags & SetValue_SendEvent));
 


### PR DESCRIPTION
GetValue use text stored in wxTextEntryHintData so when wxTextCtrl get focus it wasn't remove hint as expected.