### PR TITLE
Test non-Unicode wxMSW build in CI workflow

### DIFF
--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -244,6 +244,13 @@ jobs:
           # Wine WinHTTP implementations seems buggy, there are many errors.
           excluded_tests+=('~[webrequest]')
 
+          case "$wxCONFIGURE_FLAGS" in
+            *--disable-unicode*)
+              # Regex tests require Unicode, skip them in this build.
+              excluded_tests+=('~wxRegEx::*' '~regex::*')
+              ;;
+          esac
+
           $wxTEST_RUNNER ./test.exe "${excluded_tests[@]}"
 
       - name: Run GUI tests

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -74,6 +74,7 @@ jobs:
             configure_flags: --enable-stl --disable-compat30
           - name: wxMSW 32 bits
             triplet: i686-w64-mingw32
+            configure_flags: --enable-compat28 --disable-unicode
     env:
       wxCONFIGURE_FLAGS: ${{ matrix.configure_flags }}
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -257,6 +257,7 @@ wxGTK:
 
 wxMSW:
 
+- Fix (deprecated) build without Unicode support broken in 3.2.2 (#23516).
 - Fix setting locale for wxLANGUAGE_UKRAINIAN (Ulrich Telle, #23210).
 - Don't reset custom wxToolBar background on system colour change (#23386).
 - Fix wxUILocale::GetPreferredUILanguages() under < 10 (Brian Nixon, #23416).

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -770,7 +770,7 @@ typedef short int WXTYPE;
 /*
     Similar macros but for gcc-specific warnings.
  */
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #   define wxGCC_ONLY_WARNING_SUPPRESS(x) wxGCC_WARNING_SUPPRESS(x)
 #   define wxGCC_ONLY_WARNING_RESTORE(x) wxGCC_WARNING_RESTORE(x)
 #else

--- a/include/wx/tbarbase.h
+++ b/include/wx/tbarbase.h
@@ -503,7 +503,7 @@ public:
     wxToolBarToolBase *AddTool(int toolid,
                                const wxBitmap& bitmap,
                                const wxBitmap& bmpDisabled,
-                               bool toggle = false,
+                               bool toggle,
                                wxObject *clientData = NULL,
                                const wxString& shortHelpString = wxEmptyString,
                                const wxString& longHelpString = wxEmptyString)

--- a/include/wx/vscroll.h
+++ b/include/wx/vscroll.h
@@ -618,7 +618,7 @@ protected:
     // OnGetLineHeight instead (backwards compatible name)
     // note that we don't need to forward OnGetUnitSize() as it is already
     // forwarded to OnGetRowHeight() in wxVarVScrollHelper
-    virtual wxCoord OnGetRowHeight(size_t n) const;
+    virtual wxCoord OnGetRowHeight(size_t n) const wxOVERRIDE;
 
     // this function doesn't have to be overridden but it may be useful to do
     // it if calculating the lines heights is a relatively expensive operation
@@ -638,7 +638,7 @@ protected:
 
     // forwards the calls from base class pure virtual function to pure virtual
     // OnGetLinesHint instead (backwards compatible name)
-    void OnGetRowsHeightHint(size_t rowMin, size_t rowMax) const;
+    void OnGetRowsHeightHint(size_t rowMin, size_t rowMax) const wxOVERRIDE;
 };
 
 #else // !WXWIN_COMPATIBILITY_2_8

--- a/include/wx/wxcrtvararg.h
+++ b/include/wx/wxcrtvararg.h
@@ -286,6 +286,11 @@ wxGCC_ONLY_WARNING_RESTORE(format-nonliteral)
         return implA args
 #endif
 
+// In non-Unicode build we get suggestions for using gnu_printf format
+// attribute, but it doesn't work in Unicode build, so don't bother with it and
+// just disable the warning.
+wxGCC_ONLY_WARNING_SUPPRESS(suggest-attribute=format)
+
 inline int
 wxVprintf(const wxString& format, va_list ap)
 {
@@ -299,6 +304,8 @@ wxVfprintf(FILE *f, const wxString& format, va_list ap)
     WX_VARARG_VFOO_IMPL((f, wxFormatString(format), ap),
                         wxCRT_VfprintfW, wxCRT_VfprintfA);
 }
+
+wxGCC_ONLY_WARNING_RESTORE(suggest-attribute=format)
 
 #undef WX_VARARG_VFOO_IMPL
 

--- a/src/msw/main.cpp
+++ b/src/msw/main.cpp
@@ -197,7 +197,7 @@ int wxEntry(int& argc, wxChar **argv)
 WXDLLIMPEXP_BASE void wxMSWCommandLineInit();
 WXDLLIMPEXP_BASE void wxMSWCommandLineCleanup();
 WXDLLIMPEXP_BASE int& wxMSWCommandLineGetArgc();
-WXDLLIMPEXP_BASE wchar_t** wxMSWCommandLineGetArgv();
+WXDLLIMPEXP_BASE wxChar** wxMSWCommandLineGetArgv();
 
 #if wxUSE_BASE
 
@@ -227,11 +227,6 @@ struct wxMSWCommandLineArguments
             argc = 0;
         }
     }
-
-    ~wxMSWCommandLineArguments()
-    {
-        Cleanup();
-    }
 #else // !wxUSE_UNICODE
     void Init()
     {
@@ -256,7 +251,7 @@ struct wxMSWCommandLineArguments
         argv[argc] = NULL;
     }
 
-    ~wxMSWCommandLineArguments()
+    void Cleanup()
     {
         if ( !argc )
             return;
@@ -270,6 +265,11 @@ struct wxMSWCommandLineArguments
         argc = 0;
     }
 #endif // wxUSE_UNICODE/!wxUSE_UNICODE
+
+    ~wxMSWCommandLineArguments()
+    {
+        Cleanup();
+    }
 
     int argc;
     wxChar **argv;
@@ -296,7 +296,7 @@ WXDLLIMPEXP_BASE int& wxMSWCommandLineGetArgc()
     return wxArgs.argc;
 }
 
-WXDLLIMPEXP_BASE wchar_t** wxMSWCommandLineGetArgv()
+WXDLLIMPEXP_BASE wxChar** wxMSWCommandLineGetArgv()
 {
     return wxArgs.argv;
 }

--- a/src/msw/registry.cpp
+++ b/src/msw/registry.cpp
@@ -114,7 +114,7 @@ static wxString GetFullName(const wxRegKey *pKey, const wxString& szValue);
 // Unfortunately this needs to be a macro to ensure that the temporary buffer
 // returned by t_str() in UTF-8 build lives long enough.
 #define RegValueStr(szValue) \
-    ((szValue).empty() ? NULL : static_cast<const wchar_t*>(szValue.t_str()))
+    ((szValue).empty() ? NULL : static_cast<const wxChar*>(szValue.t_str()))
 
 // Return the user-readable name of the given REG_XXX type constant.
 static wxString GetTypeString(DWORD dwType)

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -171,6 +171,9 @@ void ListCtrlTestCase::ColumnCount()
 #if wxUSE_UIACTIONSIMULATOR
 void ListCtrlTestCase::ColumnDrag()
 {
+#if defined(__WXMSW__) && !wxUSE_UNICODE
+    WARN("Skipping test broken in non-Unicode wxMSW build.");
+#else
     EventCounter begindrag(m_list, wxEVT_LIST_COL_BEGIN_DRAG);
     EventCounter dragging(m_list, wxEVT_LIST_COL_DRAGGING);
     EventCounter enddrag(m_list, wxEVT_LIST_COL_END_DRAG);
@@ -202,6 +205,7 @@ void ListCtrlTestCase::ColumnDrag()
     CPPUNIT_ASSERT_EQUAL(1, enddrag.GetCount());
 
     m_list->ClearAll();
+#endif
 }
 
 void ListCtrlTestCase::ColumnClick()

--- a/tests/formatconverter/formatconvertertest.cpp
+++ b/tests/formatconverter/formatconvertertest.cpp
@@ -279,6 +279,7 @@ void FormatConverterTestCase::check(const wxString& input,
                                     const wxString& expectedWcharWindows)
 {
     // all of them are unused in some build configurations
+    wxUnusedVar(input);
     wxUnusedVar(expectedScanf);
     wxUnusedVar(expectedUtf8);
     wxUnusedVar(expectedWcharUnix);

--- a/tests/menu/menu.cpp
+++ b/tests/menu/menu.cpp
@@ -90,7 +90,7 @@ private:
         CPPUNIT_TEST( EnableTop );
         CPPUNIT_TEST( Count );
         CPPUNIT_TEST( Labels );
-#if wxUSE_INTL
+#if wxUSE_INTL && wxUSE_UNICODE
         CPPUNIT_TEST( TranslatedMnemonics );
 #endif // wxUSE_INTL
         CPPUNIT_TEST( RadioItems );
@@ -106,7 +106,7 @@ private:
     void EnableTop();
     void Count();
     void Labels();
-#if wxUSE_INTL
+#if wxUSE_INTL && wxUSE_UNICODE
     void TranslatedMnemonics();
 #endif // wxUSE_INTL
     void RadioItems();
@@ -376,7 +376,7 @@ void MenuTestCase::Labels()
     CPPUNIT_ASSERT_EQUAL( "Foo", wxMenuItem::GetLabelText("&Foo\tCtrl-F") );
 }
 
-#if wxUSE_INTL
+#if wxUSE_INTL && wxUSE_UNICODE
 
 static wxString
 GetTranslatedString(const wxTranslations& trans, const wxString& s)

--- a/tests/strings/vararg.cpp
+++ b/tests/strings/vararg.cpp
@@ -66,10 +66,13 @@ TEST_CASE("StringPrintf", "[wxString][Printf][vararg]")
     wxGCC_WARNING_RESTORE(write-strings)
     wxCLANG_WARNING_RESTORE(c++11-compat-deprecated-writable-strings)
 
-#ifdef __cpp_lib_string_view
+    // It's not clear why this test doesn't work without Unicode support, but
+    // it's not worth spending time on fixing it considering that Unicode-less
+    // build is deprecated anyhow, so just disable it there.
+#if defined(__cpp_lib_string_view) && wxUSE_UNICODE
     CHECK( wxString::Format("%s", std::string_view{"foobar", 3}) == "foo" );
     CHECK( wxString::Format("%s", std::string_view{"bar"}) == "bar" );
-#endif // __cpp_lib_string_view
+#endif // __cpp_lib_string_view && wxUSE_UNICODE
 }
 
 TEST_CASE("CharPrintf", "[wxString][Printf][vararg]")


### PR DESCRIPTION
This build is the one which risks getting broken the most as it's so little used, so we must have a test for it in the CI.

Also enable 2.8 compatibility for it under assumption that people disabling Unicode support must be working with legacy code bases.