### PR TITLE
Support wxDP_DROPDOWN mode for native date pickers on macOS

### DIFF
--- a/include/wx/datectrl.h
+++ b/include/wx/datectrl.h
@@ -28,7 +28,7 @@ enum
     // a spin control-like date picker (not supported in generic version)
     wxDP_SPIN = 1,
 
-    // a combobox-like date picker (not supported in mac version)
+    // a combobox-like date picker (not supported on macOS <10.15.4)
     wxDP_DROPDOWN = 2,
 
     // always show century in the default date display (otherwise it depends on

--- a/interface/wx/datectrl.h
+++ b/interface/wx/datectrl.h
@@ -14,7 +14,7 @@ enum
     /// a spin control-like date picker (not supported in generic version)
     wxDP_SPIN = 1,
 
-    /// a combobox-like date picker (not supported in mac version)
+    /// a combobox-like date picker (not supported on macOS <10.15.4)
     wxDP_DROPDOWN = 2,
 
     /// always show century in the default date display (otherwise it depends on
@@ -45,8 +45,8 @@ enum
            style is not supported by the generic version.
     @style{wxDP_DROPDOWN}
            Creates a control with a month calendar drop-down part from which
-           the user can select a date. This style is not supported in OSX/Cocoa
-           native version.
+           the user can select a date. In OSX/Cocoa native version this
+           style is supported on macOS 10.15.4 and later.
     @style{wxDP_DEFAULT}
            Creates a control with the style that is best supported for the
            current platform (currently wxDP_SPIN under Windows and OSX/Cocoa

--- a/src/osx/cocoa/datetimectrl.mm
+++ b/src/osx/cocoa/datetimectrl.mm
@@ -26,6 +26,7 @@
 
 #include "wx/osx/core/private/datetimectrl.h"
 #include "wx/osx/cocoa/private/date.h"
+#include "wx/osx/private/available.h"
 
 using namespace wxOSXImpl;
 
@@ -164,7 +165,7 @@ wxDateTimeWidgetImpl::CreateDateTimePicker(wxDateTimePickerCtrl* wxpeer,
                                            const wxDateTime& dt,
                                            const wxPoint& pos,
                                            const wxSize& size,
-                                           long WXUNUSED(style),
+                                           long style,
                                            wxDateTimeWidgetKind kind)
 {
     NSRect r = wxOSXGetFrameForControl(wxpeer, pos, size);
@@ -186,6 +187,16 @@ wxDateTimeWidgetImpl::CreateDateTimePicker(wxDateTimePickerCtrl* wxpeer,
     [v setDatePickerElements: elements];
 
     [v setDatePickerStyle: NSTextFieldAndStepperDatePickerStyle];
+
+    if ( style & wxDP_DROPDOWN )
+    {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101504
+        if ( WX_IS_MACOS_AVAILABLE_FULL(10, 15, 4) )
+        {
+            v.presentsCalendarOverlay = YES;
+        }
+#endif
+    }
 
     // Avoid a disabled looking transparent background for the text cells.
     [v setDrawsBackground: YES];


### PR DESCRIPTION
According to Apple's documentation, the presentsCalendarOverlay property is supported in macOS 10.15.4 and later.

This should be safe to cherry-pick to 3.2, too.