### PR TITLE
Fix regression in destroying wxArtProvider objects

### DIFF
--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -502,3 +502,13 @@ TEST_CASE("BitmapBundle::GetConsensusSize", "[bmpbundle]")
     // Integer scaling factors should be preferred.
     CHECK( bundles.GetConsensusSize(1.5) == 16 );
 }
+
+// This test is not really related to wxBitmapBundle, but is just here because
+// this file already uses wxArtProvider and we don't have any tests for it
+// specifically right now.
+TEST_CASE("wxArtProvider::Delete", "[artprov]")
+{
+    auto* artprov = new wxArtProvider{};
+    wxArtProvider::Push(artprov);
+    delete artprov;
+}


### PR DESCRIPTION
Don't delete the art provider object in Remove() as this contradicted its contract and do restore the call to Remove() from wxArtProvider dtor as it's actually documented to work.

This fixes a regression due to the changes of 4a294caacd (Stop using macro-based wxList in wxArtProvider code, 2023-04-11).

Closes #23513.