### PR TITLE
Fix regression in code using pointers to `wxAuiToolBar` elements

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -254,7 +254,7 @@ private:
     int m_alignment;             // sizer alignment flag, defaults to wxCENTER, may be wxEXPAND or any other
 };
 
-using wxAuiToolBarItemArray = wxBaseArray<wxAuiToolBarItem>;
+using wxAuiToolBarItemArray = wxBaseObjectArray<wxAuiToolBarItem>;
 
 
 

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -271,12 +271,25 @@ private:
 // _WX_DECLARE_OBJARRAY: an array for pointers to type T with owning semantics
 // ----------------------------------------------------------------------------
 
+// Trivial default implementation of the traits used by wxBaseObjectArray.
+// It can only be used if the class T is complete.
+template <typename T>
+class wxDefaultBaseObjectArrayTraits
+{
+public:
+    static T* Clone(const T& value) { return new T{value}; }
+    static void Free(T* p) { delete p; }
+};
+
 // This class must be able to be declared with incomplete types, so it doesn't
 // actually use type T in its definition, and relies on a helper template
 // parameter, which is declared by WX_DECLARE_OBJARRAY() and defined by
 // WX_DEFINE_OBJARRAY(), for providing a way to create and destroy objects of
 // type T
-template <typename T, typename Traits>
+//
+// If the class T happens to be complete, Traits can be left unspecified and a
+// trivial implementation using copy ctor directly is used.
+template <typename T, typename Traits = wxDefaultBaseObjectArrayTraits<T>>
 class wxBaseObjectArray : private wxBaseArray<T*>
 {
     typedef wxBaseArray<T*> base;

--- a/tests/controls/auitest.cpp
+++ b/tests/controls/auitest.cpp
@@ -21,9 +21,12 @@
 
 #include "wx/panel.h"
 
+#include "wx/aui/auibar.h"
 #include "wx/aui/auibook.h"
 
 #include "asserthelper.h"
+
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // test fixtures
@@ -163,6 +166,17 @@ TEST_CASE_METHOD(AuiNotebookTestCase, "wxAuiNotebook::FindPage", "[aui]")
     CHECK( nb->FindPage(p1) == 0 );
     CHECK( nb->FindPage(p2) == 1 );
     CHECK( nb->FindPage(p3) == wxNOT_FOUND );
+}
+
+TEST_CASE("wxAuiToolBar::Items", "[aui][toolbar]")
+{
+    std::unique_ptr<wxAuiToolBar> tbar{new wxAuiToolBar(wxTheApp->GetTopWindow())};
+
+    // Check that adding more toolbar elements doesn't invalidate the existing
+    // pointers.
+    auto first = tbar->AddLabel(wxID_ANY, "first");
+    tbar->AddLabel(wxID_ANY, "second");
+    CHECK( first->GetLabel() == "first" );
 }
 
 #endif


### PR DESCRIPTION
This fixes #23514 by mostly reverting the change of bc23b1f4f0 (Use wxBaseArray instead of object array for wxAuiToolBarItemArray, 2023-04-11).