### PR TITLE
Update wx_setup.props to be more comprehensive

### DIFF
--- a/build/msw/wx_setup.props
+++ b/build/msw/wx_setup.props
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_PropertySheetDisplayName>wxWidgets Setup Options</_PropertySheetDisplayName>
@@ -34,40 +34,31 @@
   <PropertyGroup Label="UserMacros" Condition="'$(Platform)'=='Itanium'">
     <wxArchSuffix>_ia64</wxArchSuffix>
   </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="('$(Configuration)'=='Debug' or '$(Configuration)'=='DLL Debug')">
+  <PropertyGroup Label="UserMacros" Condition="$(Configuration.ToUpper().Contains('DEBUG'))">
     <wxSuffixDebug>d</wxSuffixDebug>
   </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="('$(Configuration)'=='Release' or '$(Configuration)'=='DLL Release')">
+  <PropertyGroup Label="UserMacros" Condition="$(Configuration.ToUpper().Contains('RELEASE'))">
     <wxSuffixDebug>
     </wxSuffixDebug>
   </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='DLL Debug'">
-    <wxSuffixDebug>d</wxSuffixDebug>
-  </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'!='Debug' and '$(Configuration)'!='DLL Debug'">
+  <PropertyGroup Label="UserMacros" Condition="!$(Configuration.ToUpper().Contains('DEBUG'))">
     <wxSuffixDebug>
     </wxSuffixDebug>
   </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='DLL Debug' or '$(Configuration)'=='DLL Release'">
+  <PropertyGroup Label="UserMacros" Condition="$(Configuration.ToUpper().Contains('DLL'))">
     <wxLibTypeSuffix>dll</wxLibTypeSuffix>
   </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'!='DLL Debug' and '$(Configuration)'!='DLL Release'">
+  <PropertyGroup Label="UserMacros" Condition="!$(Configuration.ToUpper().Contains('DLL'))">
     <wxLibTypeSuffix>lib</wxLibTypeSuffix>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros">
     <wxOutDirName>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxLibTypeSuffix)$(wxCfg)</wxOutDirName>
     <wxOutDir>..\..\lib\$(wxOutDirName)\</wxOutDir>
   </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='DLL Debug'">
+  <PropertyGroup Label="UserMacros" Condition="$(Configuration.ToUpper().Contains('DLL'))">
     <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)dll\</wxIntRootDir>
   </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='DLL Release'">
-    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)dll\</wxIntRootDir>
-  </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='Debug'">
-    <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)\</wxIntRootDir>
-  </PropertyGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='Release'">
+  <PropertyGroup Label="UserMacros" Condition="!$(Configuration.ToUpper().Contains('DLL'))">
     <wxIntRootDir>$(wxCompilerPrefix)$(wxArchSuffix)_$(wxToolkitPrefix)u$(wxSuffixDebug)\</wxIntRootDir>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros">
@@ -81,7 +72,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions Condition="'$(PlatformToolset)' == 'v140_xp'">/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="('$(Configuration)'=='Release' or '$(Configuration)'=='DLL Release') and '$(VisualStudioVersion)' >= '14.0'">/Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="$(Configuration.ToUpper().Contains('RELEASE')) and '$(VisualStudioVersion)' >= '14.0'">/Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;shell32.lib;shlwapi.lib;ole32.lib;oleaut32.lib;uuid.lib;advapi32.lib;version.lib;comctl32.lib;rpcrt4.lib;ws2_32.lib;wininet.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
I have descriptive names for my different build configurations in VS2022, and the original `wx_setup.props` wouldn't recognize them.  Proposed solution is based on this forum post: https://forums.wxwidgets.org/viewtopic.php?t=47314