### PR TITLE
Non-wx thread memory leak

### DIFF
--- a/include/wx/private/threadinfo.h
+++ b/include/wx/private/threadinfo.h
@@ -52,13 +52,6 @@ public:
     wxLocaleUntranslatedStrings untranslatedStrings;
 #endif
 
-#if wxUSE_THREADS
-    // Cleans up storage for the current thread. Should be called when a thread
-    // is being destroyed. If it's not called, the only bad thing that happens
-    // is that the memory is deallocated later, on process termination.
-    static void ThreadCleanUp();
-#endif
-
 private:
     wxThreadSpecificInfo() : logger(NULL), loggingDisabled(false) {}
 };

--- a/src/common/threadinfo.cpp
+++ b/src/common/threadinfo.cpp
@@ -10,86 +10,14 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
-
-#include "wx/private/threadinfo.h"
-
 #if wxUSE_THREADS
 
-#include "wx/tls.h"
-#include "wx/thread.h"
-#include "wx/sharedptr.h"
-#include "wx/vector.h"
+// The threaded version for wxThreadSpecificInfo::Get() is defined in platform specific
+// thread files: src/msw/thread.cpp or src/unix/threadpsx.cpp
 
-namespace
-{
+#else
 
-// All thread info objects are stored in a global list so that they are
-// freed when global objects are destroyed and no memory leaks are reported.
-
-// Notice that we must be using accessor functions instead of simple global
-// variables here as this code could be executed during global initialization
-// time, i.e. before any globals in this module were initialzied.
-inline wxCriticalSection& GetAllThreadInfosCS()
-{
-    static wxCriticalSection s_csAllThreadInfos;
-
-    return s_csAllThreadInfos;
-}
-
-typedef wxVector< wxSharedPtr<wxThreadSpecificInfo> > wxAllThreadInfos;
-inline wxAllThreadInfos& GetAllThreadInfos()
-{
-    static wxAllThreadInfos s_allThreadInfos;
-
-    return s_allThreadInfos;
-}
-
-// Pointer to the current thread's instance
-inline wxTLS_TYPE_REF(wxThreadSpecificInfo*) GetThisThreadInfo()
-{
-    static wxTLS_TYPE(wxThreadSpecificInfo*) s_thisThreadInfo;
-
-    return s_thisThreadInfo;
-}
-
-#define wxTHIS_THREAD_INFO wxTLS_VALUE(GetThisThreadInfo())
-
-} // anonymous namespace
-
-
-wxThreadSpecificInfo& wxThreadSpecificInfo::Get()
-{
-    if ( !wxTHIS_THREAD_INFO )
-    {
-        wxTHIS_THREAD_INFO = new wxThreadSpecificInfo;
-        wxCriticalSectionLocker lock(GetAllThreadInfosCS());
-        GetAllThreadInfos().push_back(
-                wxSharedPtr<wxThreadSpecificInfo>(wxTHIS_THREAD_INFO));
-    }
-    return *wxTHIS_THREAD_INFO;
-}
-
-void wxThreadSpecificInfo::ThreadCleanUp()
-{
-    if ( !wxTHIS_THREAD_INFO )
-        return; // nothing to do, not used by this thread at all
-
-    // find this thread's instance in GetAllThreadInfos() and destroy it
-    wxCriticalSectionLocker lock(GetAllThreadInfosCS());
-    for ( wxAllThreadInfos::iterator i = GetAllThreadInfos().begin();
-          i != GetAllThreadInfos().end();
-          ++i )
-    {
-        if ( i->get() == wxTHIS_THREAD_INFO )
-        {
-            GetAllThreadInfos().erase(i);
-            wxTHIS_THREAD_INFO = NULL;
-            break;
-        }
-    }
-}
-
-#else // !wxUSE_THREADS
+#include "wx/private/threadinfo.h"
 
 wxThreadSpecificInfo& wxThreadSpecificInfo::Get()
 {

--- a/src/msw/thread.cpp
+++ b/src/msw/thread.cpp
@@ -122,6 +122,101 @@ static bool gs_waitingForThread = false;
 // Windows implementation of thread and related classes
 // ============================================================================
 
+// Create a wrapper class for storing wxThreadSpecificInfo
+// using FLS or TLS api. Preferably we want to use FLS
+// since it supports freeing the created objects automatically
+// on thread exit. However, this is only supported from
+// Windows Vista and newer, so TLS is used as a fallback.
+// Note that with TLS we need to clean up the objects
+// manually in wxThreadInternal::WinThreadStart, and
+// if the running thread is not a wxThread, the objects
+// will not be freed until program exit. As mentioned,
+// this will only affect Windows XP.
+class wxThreadSpecificInfoTLS {
+private:
+    typedef DWORD(WINAPI *AllocCallback_t)(void (WINAPI*)(void*));
+    AllocCallback_t AllocCallback;
+    typedef DWORD(WINAPI *Alloc_t)();
+    Alloc_t Alloc;
+    typedef BOOL(WINAPI *Free_t)(DWORD);
+    Free_t Free;
+    typedef void* (WINAPI *GetValue_t)(DWORD);
+    GetValue_t GetValue;
+    typedef BOOL(WINAPI *SetValue_t)(DWORD, void*);
+    SetValue_t SetValue;
+    DWORD m_idx;
+
+    static void WINAPI DeleteThreadSpecificInfo(void* ptr)
+    {
+        delete static_cast<wxThreadSpecificInfo*>(ptr);
+    }
+
+    static const wxThreadSpecificInfoTLS& Instance() {
+        static wxThreadSpecificInfoTLS s_instance;
+        return s_instance;
+    }
+
+    wxThreadSpecificInfoTLS():
+        AllocCallback(reinterpret_cast<AllocCallback_t>(GetProcAddress(GetModuleHandle(_T("kernel32.dll")), "FlsAlloc"))),
+        Alloc(NULL),
+        Free(reinterpret_cast<Free_t>(GetProcAddress(GetModuleHandle(_T("kernel32.dll")), "FlsFree"))),
+        GetValue(reinterpret_cast<GetValue_t>(GetProcAddress(GetModuleHandle(_T("kernel32.dll")), "FlsGetValue"))),
+        SetValue(reinterpret_cast<SetValue_t>(GetProcAddress(GetModuleHandle(_T("kernel32.dll")), "FlsSetValue")))
+    {
+        if (AllocCallback && Free && GetValue && SetValue)
+        {
+            // FLS API was available, so use it to free objects automatically
+            m_idx = AllocCallback(&DeleteThreadSpecificInfo);
+        }
+        else
+        {
+            // FLS API was not available (Windows XP?), so use TLS as fallback
+            AllocCallback = NULL;
+            Alloc = reinterpret_cast<Alloc_t>(TlsAlloc);
+            Free = reinterpret_cast<Free_t>(TlsFree);
+            GetValue = reinterpret_cast<GetValue_t>(TlsGetValue);
+            SetValue = reinterpret_cast<SetValue_t>(TlsSetValue);
+            m_idx = Alloc();
+        }
+    }
+
+public:
+    static wxThreadSpecificInfo* Get()
+    {
+        return static_cast<wxThreadSpecificInfo*>(Instance().GetValue(Instance().m_idx));
+    }
+
+    // wxThreadSpecificInfo will try to delete info when thread ends
+    static bool Set(wxThreadSpecificInfo* info)
+    {
+        return Instance().SetValue(Instance().m_idx, info);
+    }
+
+    static void CleanUp() {
+        if (!Instance().AllocCallback) {
+            // FLS API was not available, which means that objects will not be freed automatically.
+            delete Get();
+            Set(NULL);
+        }
+    }
+};
+
+wxThreadSpecificInfo& wxThreadSpecificInfo::Get()
+{
+    wxThreadSpecificInfo* info = wxThreadSpecificInfoTLS::Get();
+    if (!info)
+    {
+        info = new wxThreadSpecificInfo;
+        if (!wxThreadSpecificInfoTLS::Set(info))
+        {
+            // Will probably crash, but going to leak memory otherwise
+            delete info;
+            info = NULL;
+        }
+    }
+    return *info;
+}
+
 // ----------------------------------------------------------------------------
 // wxCriticalSection
 // ----------------------------------------------------------------------------
@@ -585,9 +680,11 @@ THREAD_RETVAL THREAD_CALLCONV wxThreadInternal::WinThreadStart(void *param)
     if ( isDetached )
         thread->m_internal->LetDie();
 
-    // Do this as the very last thing to ensure that thread-specific info is
+    // Do this as the very last thing to ensure that thread specific info is
     // not recreated any longer.
-    wxThreadSpecificInfo::ThreadCleanUp();
+    // CleanUp is necessary only if the wxThreadSpecificInfoTLS cannot
+    // perform the cleanup automatically. That is, with Windows XP or older.
+    wxThreadSpecificInfoTLS::CleanUp();
 
     return rc;
 }

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -27,7 +27,6 @@
 
 #include "wx/thread.h"
 #include "wx/except.h"
-#include "wx/scopeguard.h"
 
 #include "wx/private/threadinfo.h"
 
@@ -858,11 +857,6 @@ void *wxPthreadStart(void *ptr)
 
 void *wxThreadInternal::PthreadStart(wxThread *thread)
 {
-    // Ensure that we clean up thread-specific data before exiting the thread
-    // and do it as late as possible as wxLog calls can recreate it and may
-    // happen until the very end.
-    wxON_BLOCK_EXIT0(wxThreadSpecificInfo::ThreadCleanUp);
-
     wxThreadInternal *pthread = thread->m_internal;
 
     wxLogTrace(TRACE_THREADS, wxT("Thread %p started."), THR_ID(pthread));
@@ -2030,6 +2024,47 @@ void wxMutexGuiLeaveImpl()
 }
 
 #endif
+
+wxThreadSpecificInfo& wxThreadSpecificInfo::Get()
+{
+    // Since wxTlsValue only allows POD types, we need to use FLS API directly instead
+    // to free the allocated object automatically on thread exit.
+    class wxThreadSpecificInfoTLS
+    {
+        static void DeleteThreadSpecificInfo(void *ptr)
+        {
+            delete static_cast<wxThreadSpecificInfo*>(ptr);
+        }
+        pthread_key_t m_key;
+    public:
+        wxThreadSpecificInfoTLS()
+        {
+            pthread_key_create(&m_key, &DeleteThreadSpecificInfo);
+        }
+        ~wxThreadSpecificInfoTLS()
+        {
+            pthread_key_delete(m_key);
+        }
+        wxThreadSpecificInfo& Get() const
+        {
+            wxThreadSpecificInfo* info = static_cast<wxThreadSpecificInfo*>(pthread_getspecific(m_key));
+            if (!info)
+            {
+                info = new wxThreadSpecificInfo;
+                if (0 != pthread_setspecific(m_key, info))
+                   {
+                    // Will probably crash, but going to leak memory otherwise
+                    delete info;
+                    info = NULL;
+                }
+            }
+            return *info;
+        }
+    };
+
+    static const wxThreadSpecificInfoTLS sc_info;
+    return sc_info.Get();
+}
 
 // ----------------------------------------------------------------------------
 // include common implementation code


### PR DESCRIPTION
Using certain parts of wx from a thread other than wxThread results in a memory leak.

For example, using wxSemaphore causes wxLogTrace calls that create a wxThreadSpecificInfo object that then never gets freed. This was tested using wxGTK 3.2.2.1:
```cpp
#include <wx/wx.h>

#include <future>

int main(int argc, char **argv) {
	wxInitializer initializer;
	wxSemaphore sema;
	for (;;) {
		std::async(std::launch::async, [&sema]() { sema.Post(); });
		sema.Wait();
	}
	return 0;
}
```

This commit tries to work around the problem by only creating the wxThreadSpecificInfo from wxThreads, and otherwise reverting to using common log objects.

Notably in master this would probably be a trivial thing to work around by just creating the wxThreadSpecificInfo thread_local, but I wanted a workaround for 3.2.

Another place which this will affect is wxTranslations::GetUntranslatedString. I switched it to use a common critical section protected hashmap, which should work just find in my understanding. Although I am not 100% sure if the hash map created by WX_DECLARE_HASH_SET keeps the addresses of its items intact when inserting new items. std::unordered_set should be safe and I am assuming this works the same way.