### PR TITLE
Fix wxTreeCtrl::ScrollTo() with hidden root item in wxMSW

### DIFF
--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -1979,7 +1979,18 @@ void wxTreeCtrl::EnsureVisible(const wxTreeItemId& item)
 
 void wxTreeCtrl::ScrollTo(const wxTreeItemId& item)
 {
-    if ( !TreeView_SelectSetFirstVisible(GetHwnd(), HITEM(item)) )
+    HTREEITEM htItem = HITEM(item);
+
+    if ( IsHiddenRoot(item) )
+    {
+        // Calling TreeView_SelectSetFirstVisible() with the invisible root
+        // item would simply crash (#23534), so don't do this. However also
+        // don't just assert and return as this works in the generic version,
+        // so do the same thing as it does here, and scroll to the top item.
+        htItem = TreeView_GetChild(GetHwnd(), htItem);
+    }
+
+    if ( !TreeView_SelectSetFirstVisible(GetHwnd(), htItem) )
     {
         wxLogLastError(wxT("TreeView_SelectSetFirstVisible"));
     }

--- a/tests/controls/treectrltest.cpp
+++ b/tests/controls/treectrltest.cpp
@@ -57,6 +57,7 @@ private:
         CPPUNIT_TEST( Focus );
         CPPUNIT_TEST( Bold );
         CPPUNIT_TEST( Visible );
+        CPPUNIT_TEST( Scroll );
         CPPUNIT_TEST( Sort );
         WXUISIM_TEST( KeyNavigation );
         CPPUNIT_TEST( HasChildren );
@@ -85,6 +86,7 @@ private:
     void Focus();
     void Bold();
     void Visible();
+    void Scroll();
     void Sort();
     void KeyNavigation();
     void HasChildren();
@@ -594,6 +596,13 @@ void TreeCtrlTestCase::Visible()
 
     CPPUNIT_ASSERT(!m_tree->GetNextVisible(m_child2));
     CPPUNIT_ASSERT(!m_tree->GetPrevVisible(m_root));
+}
+
+void TreeCtrlTestCase::Scroll()
+{
+    // This trivial test just checks that calling ScrollTo() with the root item
+    // doesn't crash any longer, as it used to do when the root item was hidden.
+    m_tree->ScrollTo(m_root);
 }
 
 void TreeCtrlTestCase::Sort()


### PR DESCRIPTION
Scroll to the topmost item, as the generic version does, instead of crashing.

Closes #23534.