### PR TITLE
fix measure high dpi

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -115,6 +115,8 @@ public:
     virtual bool SetCursor( const wxCursor &cursor ) override;
     virtual bool SetFont( const wxFont &font ) override;
 
+    virtual bool IsTransparentBackgroundSupported(wxString* reason = nullptr) const override;
+
     virtual int GetCharHeight() const override;
     virtual int GetCharWidth() const override;
 

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -2420,12 +2420,12 @@ public:
         problem.
 
 
-        Under wxGTK and wxOSX, you can use ::wxBG_STYLE_TRANSPARENT to obtain
+        Under wxGTK, wxOSX and wxMSW, you can use ::wxBG_STYLE_TRANSPARENT to obtain
         full transparency of the window background. Note that wxGTK supports
         this only since GTK 2.12 with a compositing manager enabled, call
         IsTransparentBackgroundSupported() to check whether this is the case,
         see the example of doing it in @ref page_samples_shaped "the shaped
-        sample".
+        sample". Under wxMSW this is supported since 3.3.0.
 
         Also, in order for @c SetBackgroundStyle(wxBG_STYLE_TRANSPARENT) to
         work, it must be called before Create(). If you're using your own

--- a/src/msw/textmeasure.cpp
+++ b/src/msw/textmeasure.cpp
@@ -69,8 +69,25 @@ void wxTextMeasure::BeginMeasuring()
     // also if we're associated with a window because the window HDC created
     // above has the default font selected into it and not the font of the
     // window.
-    if ( m_font || m_win )
-        m_hfontOld = (HFONT)::SelectObject(m_hdc, GetHfontOf(GetFont()));
+    wxFont font;
+    if ( m_font )
+    {
+        font = *m_font;
+
+        // We also need to adjust this font to the DPI used by the window if
+        // both are given.
+        if ( m_win )
+            font.WXAdjustToPPI(m_win->GetDPI());
+    }
+    else if ( m_win )
+    {
+        // This font doesn't need DPI adjustment.
+        font = m_win->GetFont();
+    }
+    //else: no need to do anything when using wxDC with its default font.
+
+    if ( font.IsOk() )
+        m_hfontOld = (HFONT)::SelectObject(m_hdc, GetHfontOf(font));
 }
 
 void wxTextMeasure::EndMeasuring()

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -874,6 +874,11 @@ bool wxWindowMSW::SetFont(const wxFont& font)
     return true;
 }
 
+bool wxWindowMSW::IsTransparentBackgroundSupported(wxString* WXUNUSED(reason)) const
+{
+    return true;
+}
+
 bool wxWindowMSW::SetCursor(const wxCursor& cursor)
 {
     if ( !wxWindowBase::SetCursor(cursor) )
@@ -1656,6 +1661,12 @@ WXDWORD wxWindowMSW::MSWGetStyle(long flags, WXDWORD *exstyle) const
             *exstyle |= WS_EX_CONTROLPARENT;
         }
 #endif // __WXUNIVERSAL__
+
+        // Set this style when background style is set to transparent. Don't
+        // apply it to toplevel windows, since it will make events (like mouse
+        // clicks) fall through the window.
+        if ( GetBackgroundStyle() == wxBG_STYLE_TRANSPARENT && !IsTopLevel() )
+            *exstyle |= WS_EX_TRANSPARENT;
     }
 
     return style;


### PR DESCRIPTION
- Enable transparent background on Windows
- Fix wxMSW wxWindow::GetTextExtent() with given font in high DPI
