### PR TITLE
Fix wxMSW wxWindow::GetTextExtent() with given font in high DPI

### DIFF
--- a/src/msw/textmeasure.cpp
+++ b/src/msw/textmeasure.cpp
@@ -69,8 +69,25 @@ void wxTextMeasure::BeginMeasuring()
     // also if we're associated with a window because the window HDC created
     // above has the default font selected into it and not the font of the
     // window.
-    if ( m_font || m_win )
-        m_hfontOld = (HFONT)::SelectObject(m_hdc, GetHfontOf(GetFont()));
+    wxFont font;
+    if ( m_font )
+    {
+        font = *m_font;
+
+        // We also need to adjust this font to the DPI used by the window if
+        // both are given.
+        if ( m_win )
+            font.WXAdjustToPPI(m_win->GetDPI());
+    }
+    else if ( m_win )
+    {
+        // This font doesn't need DPI adjustment.
+        font = m_win->GetFont();
+    }
+    //else: no need to do anything when using wxDC with its default font.
+
+    if ( font.IsOk() )
+        m_hfontOld = (HFONT)::SelectObject(m_hdc, GetHfontOf(font));
 }
 
 void wxTextMeasure::EndMeasuring()


### PR DESCRIPTION
This function returned wrong results when using a non-default font in
non-standard DPI because it didn't adjust the font to use the window
DPI, as needs to be done manually in wxMSW before using it.

Fix this now and do the same thing here as we already did in
wxWindow::SetFont() (via WXAdjustFontToOwnPPI()) or in wxDC::SetFont().
