### PR TITLE
Improve `wxHyperLinkCtrl` colours management

### DIFF
--- a/include/wx/generic/hyperlink.h
+++ b/include/wx/generic/hyperlink.h
@@ -63,6 +63,10 @@ public:
     // NOTE: also wxWindow::Set/GetLabel, wxWindow::Set/GetBackgroundColour,
     //       wxWindow::Get/SetFont, wxWindow::Get/SetCursor are important !
 
+    // overridden/inherited wxWindow methods
+    virtual wxVisualAttributes GetDefaultAttributes() const override;
+    static wxVisualAttributes
+    GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 
 protected:
     // Helper used by this class itself and native MSW implementation that

--- a/include/wx/msw/hyperlink.h
+++ b/include/wx/msw/hyperlink.h
@@ -52,11 +52,15 @@ public:
 
     virtual void SetLabel(const wxString &label) override;
 
-    // Colours used by the native control can't be changed, but they can be
-    // retrieved.
+    // Native control doesn't change appearance on hover, so we don't support
+    // changing hover colour.
     virtual wxColour GetHoverColour() const override;
+
     virtual wxColour GetNormalColour() const override;
+    virtual void SetNormalColour(const wxColour &colour) override;
+
     virtual wxColour GetVisitedColour() const override;
+    virtual void SetVisitedColour(const wxColour &colour) override;
 
     // overridden/inherited wxWindow methods
     virtual wxVisualAttributes GetDefaultAttributes() const override;
@@ -69,6 +73,9 @@ protected:
 
 private:
     virtual bool MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result) override;
+
+    bool MSWAreCustomColoursEnabled() const;
+    void MSWEnableCustomColours();
 
     wxDECLARE_DYNAMIC_CLASS( wxHyperlinkCtrl );
 };

--- a/include/wx/msw/hyperlink.h
+++ b/include/wx/msw/hyperlink.h
@@ -52,6 +52,17 @@ public:
 
     virtual void SetLabel(const wxString &label) override;
 
+    // Colours used by the native control can't be changed, but they can be
+    // retrieved.
+    virtual wxColour GetHoverColour() const override;
+    virtual wxColour GetNormalColour() const override;
+    virtual wxColour GetVisitedColour() const override;
+
+    // overridden/inherited wxWindow methods
+    virtual wxVisualAttributes GetDefaultAttributes() const override;
+    static wxVisualAttributes
+    GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
+
 protected:
     virtual WXDWORD MSWGetStyle(long style, WXDWORD *exstyle) const override;
     virtual wxSize DoGetBestClientSize() const override;

--- a/interface/wx/hyperlink.h
+++ b/interface/wx/hyperlink.h
@@ -142,6 +142,10 @@ public:
     /**
         Returns the colour used to print the label of the hyperlink when the mouse is
         over the control.
+
+        In native wxMSW version of this control hover colour is always the same
+        as normal colour, i.e. the control doesn't change its appearance when
+        the mouse hovers over it.
     */
     virtual wxColour GetHoverColour() const;
 
@@ -172,6 +176,8 @@ public:
     /**
         Sets the colour used to print the label of the hyperlink when the mouse is over
         the control.
+
+        Changing this colour is not supported in the native wxMSW version.
     */
     virtual void SetHoverColour(const wxColour& colour);
 

--- a/src/generic/hyperlinkg.cpp
+++ b/src/generic/hyperlinkg.cpp
@@ -100,6 +100,17 @@ bool wxGenericHyperlinkCtrl::Create(wxWindow *parent, wxWindowID id,
     return true;
 }
 
+namespace
+{
+
+wxColour GetLinkColour()
+{
+    // see https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3
+    return wxColour(0x00, 0x00, 0xee);
+}
+
+} // anonymous namespace
+
 void wxGenericHyperlinkCtrl::Init()
 {
     m_rollover = false;
@@ -107,7 +118,7 @@ void wxGenericHyperlinkCtrl::Init()
     m_visited = false;
 
     // colours
-    m_normalColour = wxColour(0x00, 0x00, 0xee);
+    m_normalColour = GetLinkColour();
     m_hoverColour = *wxRED;
     m_visitedColour = wxColour("#551a8b");
 }

--- a/src/generic/hyperlinkg.cpp
+++ b/src/generic/hyperlinkg.cpp
@@ -107,7 +107,7 @@ void wxGenericHyperlinkCtrl::Init()
     m_visited = false;
 
     // colours
-    m_normalColour = *wxBLUE;
+    m_normalColour = wxColour(0x00, 0x00, 0xee);
     m_hoverColour = *wxRED;
     m_visitedColour = wxColour("#551a8b");
 }

--- a/src/generic/hyperlinkg.cpp
+++ b/src/generic/hyperlinkg.cpp
@@ -34,6 +34,7 @@
     #include "wx/menu.h"
     #include "wx/log.h"
     #include "wx/dataobj.h"
+    #include "wx/settings.h"
 #endif
 
 #include "wx/clipbrd.h"
@@ -105,8 +106,13 @@ namespace
 
 wxColour GetLinkColour()
 {
+    // There is a standard link colour appropriate for the default "light" mode,
     // see https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3
-    return wxColour(0x00, 0x00, 0xee);
+    // it doesn't stand out enough in dark mode, so choose "light sky blue"
+    // colour for the links in dark mode instead (this is a rather arbitrary
+    // choice, but there doesn't seem to be any standard one).
+    return wxSystemSettings::SelectLightDark(wxColour(0x00, 0x00, 0xee),
+                                             wxColour(0x87, 0xce, 0xfa));
 }
 
 } // anonymous namespace

--- a/src/generic/hyperlinkg.cpp
+++ b/src/generic/hyperlinkg.cpp
@@ -137,6 +137,20 @@ wxSize wxGenericHyperlinkCtrl::DoGetBestClientSize() const
     return dc.GetTextExtent(GetLabel());
 }
 
+wxVisualAttributes wxGenericHyperlinkCtrl::GetDefaultAttributes() const
+{
+    return GetClassDefaultAttributes(GetWindowVariant());
+}
+
+/* static */
+wxVisualAttributes
+wxGenericHyperlinkCtrl::GetClassDefaultAttributes(wxWindowVariant variant)
+{
+    auto attrs = wxHyperlinkCtrlBase::GetClassDefaultAttributes(variant);
+    attrs.colFg = GetLinkColour();
+    return attrs;
+}
+
 
 void wxGenericHyperlinkCtrl::SetNormalColour(const wxColour &colour)
 {

--- a/src/msw/hyperlink.cpp
+++ b/src/msw/hyperlink.cpp
@@ -21,6 +21,7 @@
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/settings.h"
     #include "wx/msw/wrapcctl.h" // include <commctrl.h> "properly"
     #include "wx/msw/private.h"
     #include "wx/msw/missing.h"
@@ -158,6 +159,49 @@ void wxHyperlinkCtrl::SetLabel(const wxString &label)
     m_labelOrig = label;
     wxWindow::SetLabel( GetLabelForSysLink(label, GetURL()) );
     InvalidateBestSize();
+}
+
+wxColour wxHyperlinkCtrl::GetHoverColour() const
+{
+    if ( !HasNativeHyperlinkCtrl() )
+        return wxGenericHyperlinkCtrl::GetHoverColour();
+
+    // Native control doesn't use special colour on hover.
+    return GetNormalColour();
+}
+
+wxColour wxHyperlinkCtrl::GetNormalColour() const
+{
+    if ( !HasNativeHyperlinkCtrl() )
+        return wxGenericHyperlinkCtrl::GetNormalColour();
+
+    return GetClassDefaultAttributes().colFg;
+}
+
+wxColour wxHyperlinkCtrl::GetVisitedColour() const
+{
+    if ( !HasNativeHyperlinkCtrl() )
+        return wxGenericHyperlinkCtrl::GetVisitedColour();
+
+    // Native control doesn't show visited links differently.
+    return GetNormalColour();
+}
+
+wxVisualAttributes wxHyperlinkCtrl::GetDefaultAttributes() const
+{
+    return GetClassDefaultAttributes(GetWindowVariant());
+}
+
+/* static */
+wxVisualAttributes
+wxHyperlinkCtrl::GetClassDefaultAttributes(wxWindowVariant variant)
+{
+    auto attrs = wxGenericHyperlinkCtrl::GetClassDefaultAttributes(variant);
+
+    if ( HasNativeHyperlinkCtrl() )
+        attrs.colFg = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT);
+
+    return attrs;
 }
 
 wxSize wxHyperlinkCtrl::DoGetBestClientSize() const

--- a/src/msw/hyperlink.cpp
+++ b/src/msw/hyperlink.cpp
@@ -108,6 +108,14 @@ bool wxHyperlinkCtrl::Create(wxWindow *parent,
         return false;
     }
 
+    if ( wxSystemSettings::GetAppearance().IsDark() )
+    {
+        // Override the colour used by default by the native control with the
+        // colour appropriate for the dark mode, as the default one doesn't
+        // have enough contrast in it.
+        SetNormalColour(GetClassDefaultAttributes().colFg);
+    }
+
     ConnectMenuHandlers();
 
     return true;
@@ -243,7 +251,7 @@ wxHyperlinkCtrl::GetClassDefaultAttributes(wxWindowVariant variant)
 {
     auto attrs = wxGenericHyperlinkCtrl::GetClassDefaultAttributes(variant);
 
-    if ( HasNativeHyperlinkCtrl() )
+    if ( HasNativeHyperlinkCtrl() && !wxSystemSettings::GetAppearance().IsDark() )
         attrs.colFg = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT);
 
     return attrs;

--- a/tests/asserthelper.cpp
+++ b/tests/asserthelper.cpp
@@ -11,35 +11,9 @@
 
 #include "asserthelper.h"
 
-namespace wxTestPrivate
-{
-
-std::ostream& operator<<(std::ostream& os, const ColourChannel& cc)
-{
-    os.width(2);
-    os.fill('0');
-    os << static_cast<int>(cc.m_value);
-    return os;
-}
-
-}
-
 std::ostream& operator<<(std::ostream& os, const wxColour& c)
 {
-    using wxTestPrivate::ColourChannel;
-
-    os << std::hex << std::noshowbase
-       << "("
-       << ColourChannel(c.Red()) << ", "
-       << ColourChannel(c.Green()) << ", "
-       << ColourChannel(c.Blue());
-
-    if ( const unsigned char a = c.Alpha() )
-    {
-        os << ", " << ColourChannel(a);
-    }
-
-    os << ")";
+    os << c.GetAsString(wxC2S_HTML_SYNTAX);
 
     return os;
 }

--- a/tests/asserthelper.h
+++ b/tests/asserthelper.h
@@ -14,21 +14,6 @@
 #include "wx/gdicmn.h"
 #include "wx/font.h"
 
-namespace wxTestPrivate
-{
-    // by default colour components values are output incorrectly because they
-    // are unsigned chars, define a small helper struct which formats them in
-    // a more useful way
-    struct ColourChannel
-    {
-        ColourChannel(unsigned char value) : m_value(value) { }
-
-        unsigned char m_value;
-    };
-
-    std::ostream& operator<<(std::ostream& os, const ColourChannel& cc);
-} // wxTestPrivate namespace
-
 // Operators used to show the values of the corresponding types when comparing
 // them in the unit tests fails.
 std::ostream& operator<<(std::ostream& os, const wxColour& c);

--- a/tests/controls/hyperlinkctrltest.cpp
+++ b/tests/controls/hyperlinkctrltest.cpp
@@ -20,76 +20,61 @@
 #include "testableframe.h"
 #include "asserthelper.h"
 
-class HyperlinkCtrlTestCase : public CppUnit::TestCase
+class HyperlinkCtrlTestCase
 {
 public:
-    HyperlinkCtrlTestCase() { }
+    HyperlinkCtrlTestCase()
+    {
+        m_hyperlink = new wxHyperlinkCtrl(wxTheApp->GetTopWindow(), wxID_ANY,
+                                         "wxWidgets", "http://wxwidgets.org");
+    }
 
-    void setUp() override;
-    void tearDown() override;
+    ~HyperlinkCtrlTestCase()
+    {
+        delete m_hyperlink;
+    }
 
-private:
-    CPPUNIT_TEST_SUITE( HyperlinkCtrlTestCase );
-        CPPUNIT_TEST( Colour );
-        CPPUNIT_TEST( Url );
-        WXUISIM_TEST( Click );
-    CPPUNIT_TEST_SUITE_END();
-
-    void Colour();
-    void Url();
-    void Click();
-
+protected:
     wxHyperlinkCtrl* m_hyperlink;
 
     wxDECLARE_NO_COPY_CLASS(HyperlinkCtrlTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( HyperlinkCtrlTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( HyperlinkCtrlTestCase, "HyperlinkCtrlTestCase" );
-
-void HyperlinkCtrlTestCase::setUp()
-{
-    m_hyperlink = new wxHyperlinkCtrl(wxTheApp->GetTopWindow(), wxID_ANY,
-                                     "wxWidgets", "http://wxwidgets.org");
-}
-
-void HyperlinkCtrlTestCase::tearDown()
-{
-    wxDELETE(m_hyperlink);
-}
-
-void HyperlinkCtrlTestCase::Colour()
+TEST_CASE_METHOD(HyperlinkCtrlTestCase, "wxHyperlinkCtrl::Colour",
+                 "[hyperlinkctrl]")
 {
 #ifndef __WXGTK__
-    CPPUNIT_ASSERT(m_hyperlink->GetHoverColour().IsOk());
-    CPPUNIT_ASSERT(m_hyperlink->GetNormalColour().IsOk());
-    CPPUNIT_ASSERT(m_hyperlink->GetVisitedColour().IsOk());
+    CHECK(m_hyperlink->GetHoverColour().IsOk());
+    CHECK(m_hyperlink->GetNormalColour().IsOk());
+    CHECK(m_hyperlink->GetVisitedColour().IsOk());
 
     m_hyperlink->SetHoverColour(*wxGREEN);
     m_hyperlink->SetNormalColour(*wxRED);
     m_hyperlink->SetVisitedColour(*wxBLUE);
 
-    CPPUNIT_ASSERT_EQUAL(*wxGREEN, m_hyperlink->GetHoverColour());
-    CPPUNIT_ASSERT_EQUAL(*wxRED, m_hyperlink->GetNormalColour());
-    CPPUNIT_ASSERT_EQUAL(*wxBLUE, m_hyperlink->GetVisitedColour());
+    CHECK( m_hyperlink->GetHoverColour() == *wxGREEN );
+    CHECK( m_hyperlink->GetNormalColour() == *wxRED );
+    CHECK( m_hyperlink->GetVisitedColour() == *wxBLUE );
 #endif
 }
 
-void HyperlinkCtrlTestCase::Url()
+TEST_CASE_METHOD(HyperlinkCtrlTestCase, "wxHyperlinkCtrl::Url",
+                 "[hyperlinkctrl]")
 {
-    CPPUNIT_ASSERT_EQUAL("http://wxwidgets.org", m_hyperlink->GetURL());
+    CHECK( m_hyperlink->GetURL() == "http://wxwidgets.org" );
 
     m_hyperlink->SetURL("http://google.com");
 
-    CPPUNIT_ASSERT_EQUAL("http://google.com", m_hyperlink->GetURL());
+    CHECK( m_hyperlink->GetURL() == "http://google.com" );
 }
 
-void HyperlinkCtrlTestCase::Click()
+TEST_CASE_METHOD(HyperlinkCtrlTestCase, "wxHyperlinkCtrl::Click",
+                 "[hyperlinkctrl]")
 {
 #if wxUSE_UIACTIONSIMULATOR
+    if ( !EnableUITests() )
+        return;
+
     EventCounter hyperlink(m_hyperlink, wxEVT_HYPERLINK);
 
     wxUIActionSimulator sim;
@@ -100,7 +85,7 @@ void HyperlinkCtrlTestCase::Click()
     sim.MouseClick();
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, hyperlink.GetCount());
+    CHECK( hyperlink.GetCount() == 1 );
 #endif
 }
 

--- a/tests/controls/hyperlinkctrltest.cpp
+++ b/tests/controls/hyperlinkctrltest.cpp
@@ -48,12 +48,16 @@ TEST_CASE_METHOD(HyperlinkCtrlTestCase, "wxHyperlinkCtrl::Colour",
     CHECK(m_hyperlink->GetNormalColour().IsOk());
     CHECK(m_hyperlink->GetVisitedColour().IsOk());
 
+    // Changing hover colour doesn't work in wxMSW.
+#ifndef __WXMSW__
     m_hyperlink->SetHoverColour(*wxGREEN);
-    m_hyperlink->SetNormalColour(*wxRED);
-    m_hyperlink->SetVisitedColour(*wxBLUE);
-
     CHECK( m_hyperlink->GetHoverColour() == *wxGREEN );
+#endif // !__WXMSW__
+
+    m_hyperlink->SetNormalColour(*wxRED);
     CHECK( m_hyperlink->GetNormalColour() == *wxRED );
+
+    m_hyperlink->SetVisitedColour(*wxBLUE);
     CHECK( m_hyperlink->GetVisitedColour() == *wxBLUE );
 #endif
 }

--- a/tests/controls/hyperlinkctrltest.cpp
+++ b/tests/controls/hyperlinkctrltest.cpp
@@ -48,11 +48,18 @@ TEST_CASE_METHOD(HyperlinkCtrlTestCase, "wxHyperlinkCtrl::Colour",
     CHECK(m_hyperlink->GetNormalColour().IsOk());
     CHECK(m_hyperlink->GetVisitedColour().IsOk());
 
-    // Changing hover colour doesn't work in wxMSW.
-#ifndef __WXMSW__
+    // Changing hover colour doesn't work in wxMSW and Wine doesn't seem to
+    // implement either LM_SETITEM or LM_GETITEM correctly, so skip this there.
+#ifdef __WXMSW__
+    if ( wxIsRunningUnderWine() )
+    {
+        WARN("Skipping testing wxHyperlinkCtrl colours under Wine.");
+        return;
+    }
+#else // __WXMSW__
     m_hyperlink->SetHoverColour(*wxGREEN);
     CHECK( m_hyperlink->GetHoverColour() == *wxGREEN );
-#endif // !__WXMSW__
+#endif // __WXMSW__/!__WXMSW__
 
     m_hyperlink->SetNormalColour(*wxRED);
     CHECK( m_hyperlink->GetNormalColour() == *wxRED );

--- a/tests/testprec.h
+++ b/tests/testprec.h
@@ -4,7 +4,8 @@
 #include "wx/wxprec.h"
 #include "wx/evtloop.h"
 
-// This needs to be included before catch.hpp to be taken into account.
+// These headers must be included before catch.hpp to be taken into account.
+#include "asserthelper.h"
 #include "testdate.h"
 
 // This needs to be defined before including catch.hpp for PCH support.


### PR DESCRIPTION
The goal here is to use more readable/contrasting colour for the links in dark mode and let the application reuse them via `wxHyperlinkCtrl::GetClassDefaultAttributes()`.

As a side effect, this also implements changing colour of the link in wxMSW, where it previously didn't work at all.

Also some test cleanup related to this.