### PR TITLE
Fix weekday/month name localization in generic wxCalendarCtrl on macOS

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -583,5 +583,7 @@ private:
 
 #endif // wxUSE_GUI
 
+wxString wxOSXEmulateStrftime(const wxString& format, const tm* tm);
+
 #endif
     // _WX_PRIVATE_COCOA_H_

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -81,6 +81,10 @@
     #include <locale.h>
 #endif
 
+#ifdef __DARWIN__
+    #include "wx/osx/cocoa/private.h"
+#endif
+
 #include "wx/datetime.h"
 
 // ----------------------------------------------------------------------------
@@ -782,7 +786,11 @@ wxString wxDateTime::GetMonthName(wxDateTime::Month month,
     wxInitTm(tm);
     tm.tm_mon = month;
 
+#ifdef __DARWIN__
+    return wxOSXEmulateStrftime(flags == Name_Abbr ? wxS("%b") : wxS("%B"), &tm);
+#else
     return wxCallStrftime(flags == Name_Abbr ? wxS("%b") : wxS("%B"), &tm);
+#endif
 #else // !wxHAS_STRFTIME
     return GetEnglishMonthName(month, flags);
 #endif // wxHAS_STRFTIME/!wxHAS_STRFTIME
@@ -830,7 +838,11 @@ wxString wxDateTime::GetWeekDayName(wxDateTime::WeekDay wday,
     (void)mktime(&tm);
 
     // ... and call strftime()
+#ifdef __DARWIN__
+    return wxOSXEmulateStrftime(flags == Name_Abbr ? wxS("%a") : wxS("%A"), &tm);
+#else
     return wxCallStrftime(flags == Name_Abbr ? wxS("%a") : wxS("%A"), &tm);
+#endif
 #else // !wxHAS_STRFTIME
     return GetEnglishWeekDayName(wday, flags);
 #endif // wxHAS_STRFTIME/!wxHAS_STRFTIME


### PR DESCRIPTION
wxDateTime::GetWeekDayName()/GetMonthName() relied on strftime() to acquire localized strings for weekday/month names, but since the C locale is no longer set by wxUILocale on macOS, and/or setting the locale the old way may fail, the names were returned in English.

Instead we can emulate the necessary functionality of strftime() by implementing it through NSDateFormatter and get properly localized names.

Fixes #23191

***
This is one possible way to fix the situation, one that doesn't involve touching `wxUILocale` at all.