### PR TITLE
Inline wxStringFormat Validate in-class

### DIFF
--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -208,12 +208,13 @@ public:
     };
 
 #if wxDEBUG_LEVEL
-    // Validate all format string parameters at once: the vector contains the
-    // format specifiers corresponding to the actually given arguments.
+    // Debugging implementation of Validate that will ralidate all format string
+    // parameters at once: the vector contains the format specifiers
+    // corresponding to the actually given arguments.
     void Validate(const std::vector<int>& argTypes) const;
 #else
-    // Also provide a trivial implementation of Validate() doing nothing in
-    // this case.
+    // Alternately, provide a trivial implementation of Validate() doing nothing
+    // in the non-debug case.
     void Validate(const std::vector<int>& WXUNUSED(argTypes)) const
     {
     }

--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -207,9 +207,17 @@ public:
         Arg_Unknown     = 0x8000     // unrecognized specifier (likely error)
     };
 
+#if wxDEBUG_LEVEL
     // Validate all format string parameters at once: the vector contains the
     // format specifiers corresponding to the actually given arguments.
     void Validate(const std::vector<int>& argTypes) const;
+#else
+    // Also provide a trivial implementation of Validate() doing nothing in
+    // this case.
+    inline void Validate(const std::vector<int>& WXUNUSED(argTypes)) const
+    {
+    }
+#endif // wxDEBUG_LEVEL/!wxDEBUG_LEVEL
 
     // returns the type of format specifier for n-th variadic argument (this is
     // not necessarily n-th format specifier if positional specifiers are used);
@@ -351,13 +359,6 @@ struct wxFormatStringArgumentFinder<wxWCharBuffer>
     #define wxASSERT_ARG_TYPE(fmt, index, expected_mask)                      \
         wxUnusedVar(fmt);                                                     \
         wxUnusedVar(index)
-
-    // Also provide a trivial implementation of Validate() doing nothing in
-    // this case.
-    inline void
-    wxFormatString::Validate(const std::vector<int>& WXUNUSED(argTypes)) const
-    {
-    }
 #endif // wxDEBUG_LEVEL/!wxDEBUG_LEVEL
 
 

--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -214,7 +214,7 @@ public:
 #else
     // Also provide a trivial implementation of Validate() doing nothing in
     // this case.
-    inline void Validate(const std::vector<int>& WXUNUSED(argTypes)) const
+    void Validate(const std::vector<int>& WXUNUSED(argTypes)) const
     {
     }
 #endif // wxDEBUG_LEVEL/!wxDEBUG_LEVEL


### PR DESCRIPTION
https://github.com/wxWidgets/wxWidgets/issues/23568

wxStringFormat's Validate method was being provided an empty, inline implementation where wxDEBUG_LEVEL did not evalue to true, but outside of the class. This resulted in multiple definitions of the method in different compilation units, which MSVS 2019 did not like.

This change moves the inlined definition to the declaration site with the same predicate.