### PR TITLE
Correct color table size calculation for RLE-compressed bitmaps in wxMSW

### DIFF
--- a/include/wx/msw/dib.h
+++ b/include/wx/msw/dib.h
@@ -64,7 +64,7 @@ public:
     bool Load(const wxString& filename);
 
     // dtor is not virtual, this class is not meant to be used polymorphically
-    ~wxDIB();
+    inline ~wxDIB();
 
 
     // operations
@@ -192,10 +192,10 @@ public:
 
 private:
     // common part of all ctors
-    void Init();
+    inline void Init();
 
     // free resources
-    void Free();
+    inline void Free();
 
     // initialize the contents from the provided DDB (Create() must have been
     // already called)
@@ -271,8 +271,6 @@ inline wxDIB::~wxDIB()
     Free();
 }
 
-#endif
-    // wxUSE_WXDIB
+#endif // wxUSE_WXDIB
 
 #endif // _WX_MSW_DIB_H_
-

--- a/src/common/imagbmp.cpp
+++ b/src/common/imagbmp.cpp
@@ -515,8 +515,8 @@ struct BMPDesc
 
 // Read the data in BMP format into the given image.
 //
-// The stream must be positioned at the start of the palette data for the
-// bitmaps using palettes or at the start of the bitmap data otherwise.
+// The stream must be positioned at the start of the bitmap data
+// (i.e., after any palette data)
 bool LoadBMPData(wxImage * image, const BMPDesc& desc,
                  wxInputStream& stream, bool verbose)
 {

--- a/src/msw/clipbrd.cpp
+++ b/src/msw/clipbrd.cpp
@@ -240,6 +240,8 @@ bool wxSetClipboardData(wxDataFormat dataFormat,
                             numColors = 3;
                             break;
                         case BI_RGB:
+                        case BI_RLE8:
+                        case BI_RLE4:
                             numColors = ds.dsBmih.biClrUsed;
                             if ( !numColors )
                             {

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -420,6 +420,8 @@ HBITMAP wxDIB::ConvertToBitmap(const BITMAPINFO *pbmi, HDC hdc, const void *bits
                 break;
 
             case BI_RGB:
+            case BI_RLE8:
+            case BI_RLE4:
                 // biClrUsed has the number of colors but it may be not initialized at
                 // all
                 numColors = pbmih->biClrUsed;


### PR DESCRIPTION
With `BI_RLE8` and `BI_RLE4` it’s the _bits_ that are compressed, not the _color table_, so the same calculation as for `BI_RGB` should be used.

This isn’t documented on MSDN, but it can be checked with many of the bitmaps embedded as resources in Windows system DLLs, which use RLE and otherwise display wrongly after conversion with `wxDIB::ConvertToBitmap()`.