### PR TITLE
Samples mfc update

### DIFF
--- a/include/wx/msw/mfc.h
+++ b/include/wx/msw/mfc.h
@@ -94,6 +94,12 @@ public:
     // Override this to provide messages pre-processing for wxWidgets windows.
     BOOL PreTranslateMessage(MSG *msg) override
     {
+        // As reported in issue #23574, wxGUIEventLoop::PreProcessMessage()
+        // is always returning true, so try BaseApp::PreTranslateMessage()
+        // and hope it doesn't always report true
+        if (BaseApp::PreTranslateMessage(msg))
+            return TRUE;
+
         // Use the current event loop if there is one, or just fall back to the
         // standard one otherwise, but make sure we pre-process messages in any
         // case as otherwise many things would break (e.g. keyboard
@@ -103,10 +109,7 @@ public:
         wxGUIEventLoop evtLoopStd;
         if ( !evtLoop )
             evtLoop = &evtLoopStd;
-        if ( evtLoop->PreProcessMessage(msg) )
-            return TRUE;
-
-        return BaseApp::PreTranslateMessage(msg);
+        return evtLoop->PreProcessMessage(msg);
     }
 
     BOOL OnIdle(LONG lCount) override

--- a/samples/mfc/mfctest.cpp
+++ b/samples/mfc/mfctest.cpp
@@ -297,6 +297,7 @@ wxEND_EVENT_TABLE()
 MyCanvas::MyCanvas(wxWindow *parent, const wxPoint& pos, const wxSize& size)
         : wxScrolledWindow(parent, -1, pos, size)
 {
+    MSWDisableComposited();
 }
 
 // Define the repainting behaviour

--- a/samples/mfc/mfctest.cpp
+++ b/samples/mfc/mfctest.cpp
@@ -177,9 +177,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, char *, int)
 
 CMainWindow::CMainWindow()
 {
-    LoadAccelTable( "MainAccelTable" );
-    Create( nullptr, "Hello Foundation Application",
-        WS_OVERLAPPEDWINDOW, rectDefault, nullptr, "MainMenu" );
+    LoadAccelTable( L"MainAccelTable" );
+    Create( nullptr, L"Hello Foundation Application",
+        WS_OVERLAPPEDWINDOW, rectDefault, nullptr, L"MainMenu" );
 
     // Create a container representing the MFC window in wxWidgets window
     // hierarchy.
@@ -210,7 +210,7 @@ void CMainWindow::OnPaint()
 
 void CMainWindow::OnAbout()
 {
-    CDialog about( "AboutBox", this );
+    CDialog about( L"AboutBox", this );
     about.DoModal();
 }
 

--- a/samples/mfc/mfctest.cpp
+++ b/samples/mfc/mfctest.cpp
@@ -55,6 +55,12 @@
 #ifndef WINVER
     #define WINVER 0x0600
 #endif
+#ifndef _UNICODE
+#    define _UNICODE
+#endif
+#ifndef UNICODE
+#    define UNICODE
+#endif
 
 #include "stdafx.h"
 


### PR DESCRIPTION
In preparation for trying to add wxWidgets to an existing MFC project, I have been examining `samples/mfc`.  It appears to be out-of-date, and I have tried to update it with this PR.

However, I think the last commit (4336e5c3a6284bb4c8dc52faa28e792b38d85821) in this PR should not actually be applied; I argue that it is a work-around to a bug that I don't know how to solve, so I am marking this PR as a draft so it can't be committed.  (Maybe I should have created separate entries for the PR and the bug-report, but the bug can't be demonstrated without the other commits, so I am putting them both here.)

The bug is that keyboard accelerators for MFC windows don't work in `samples/mfc`.  This can be seen by running `samples/mfc` commit 9c75ec6c8822d3d0854214477743fbd9db774eb7 and using the `F1` key on the MFC window.  It should open the About box, but does not.

I can see that `include/wx/msw/mfc.h` `wxMFCApp<T>::PreTranslateMessage()` calls `wxGUIEventLoop::PreProcessMessage()` with the keyboard accelerator message, and that `wxGUIEventLoop::PreProcessMessage()` always reports that it has consumed the keyboard accelerator message.

I can see that `wxGUIEventLoop::PreProcessMessage()` looks for a `wxWindow` associated with the HWND, and can't find one.  That is to be expected since MFC is creating the frame window in this case.  However, when `wxGUIEventLoop` can't find a `wxWindow`, it asks Win32 `::IsDialogMessage()` if it wants to process the keyboard accelerator,  For reasons I do not understand, `::IsDialogMessage()` reports that it did process the keyboard accelerator, and therefore, the MFC never gets to see it.

The workaround commit modifies `samples/mfc` to give MFC a chance to process the keyboard accelerator before calling `wxMFCApp<T>::PreTranslateMessage()` to demonstrate that this re-enables MFC keyboard accelerator handling, but I don't think every wxWidgets+MFC project should be required to do this; I think wxWidgets should take care of the problem. However, I don't know the right way to handle this since I suspect that wxWidgets is sometimes required to forward the keyboard accelerator to `::IsDialogMessage()`, but doing so in this case appears to be the wrong thing to do.