### PR TITLE
Turn wxCAPTION on automatically if it's required by other styles

### DIFF
--- a/interface/wx/dialog.h
+++ b/interface/wx/dialog.h
@@ -92,7 +92,10 @@ enum wxDialogLayoutAdaptationMode
 
     @beginStyleTable
     @style{wxCAPTION}
-           Puts a caption on the dialog box.
+           Shows the title bar, containing the window title, for this window.
+           Note that this style is implicitly enabled by wxMINIMIZE_BOX,
+           wxMAXIMIZE_BOX and wxCLOSE_BOX on most systems as the corresponding
+           buttons couldn't be shown if the window had no title bar at all.
     @style{wxDEFAULT_DIALOG_STYLE}
            Equivalent to a combination of wxCAPTION, wxCLOSE_BOX and
            wxSYSTEM_MENU (the last one is not used under Unix).
@@ -101,11 +104,14 @@ enum wxDialogLayoutAdaptationMode
     @style{wxSYSTEM_MENU}
            Display a system menu.
     @style{wxCLOSE_BOX}
-           Displays a close box on the frame.
+           Displays a close box on the frame. This style implicitly enables
+           wxCAPTION too.
     @style{wxMAXIMIZE_BOX}
-           Displays a maximize box on the dialog.
+           Displays a maximize box on the dialog.  This style implicitly enables
+           wxCAPTION too.
     @style{wxMINIMIZE_BOX}
-           Displays a minimize box on the dialog.
+           Displays a minimize box on the dialog. This style implicitly enables
+           wxCAPTION too.
     @style{wxTHICK_FRAME}
            Display a thick frame around the window.
     @style{wxSTAY_ON_TOP}

--- a/interface/wx/frame.h
+++ b/interface/wx/frame.h
@@ -61,29 +61,31 @@
     @style{wxICONIZE}
            Display the frame iconized (minimized). Windows only.
     @style{wxCAPTION}
-           Puts a caption on the frame. Notice that this flag is required by
-           wxMINIMIZE_BOX, wxMAXIMIZE_BOX and wxCLOSE_BOX on most systems as
-           the corresponding buttons cannot be shown if the window has no title
-           bar at all. I.e. if wxCAPTION is not specified those styles would be
-           simply ignored.
+           Shows the title bar, containing the window title, for this window.
+           Note that this style is implicitly enabled by wxMINIMIZE_BOX,
+           wxMAXIMIZE_BOX and wxCLOSE_BOX on most systems as the corresponding
+           buttons couldn't be shown if the window had no title bar at all.
     @style{wxMINIMIZE}
            Identical to wxICONIZE. Windows only.
     @style{wxMINIMIZE_BOX}
-           Displays a minimize box on the frame.
+           Displays a minimize box on the frame. This style implicitly enables
+           wxCAPTION too.
     @style{wxMAXIMIZE}
            Displays the frame maximized. Windows and GTK+ only.
     @style{wxMAXIMIZE_BOX}
            Displays a maximize box on the frame. Notice that under wxGTK
            wxRESIZE_BORDER must be used as well or this style is ignored.
+           This style implicitly enables wxCAPTION too.
     @style{wxCLOSE_BOX}
-           Displays a close box on the frame.
+           Displays a close box on the frame. This style implicitly enables
+           wxCAPTION too.
     @style{wxSTAY_ON_TOP}
            Stay on top of all other windows, see also wxFRAME_FLOAT_ON_PARENT.
     @style{wxSYSTEM_MENU}
            Displays a system menu containing the list of various windows
            commands in the window title bar. Unlike wxMINIMIZE_BOX,
-           wxMAXIMIZE_BOX and wxCLOSE_BOX styles this style can be used without
-           wxCAPTION, at least under Windows, and makes the system menu
+           wxMAXIMIZE_BOX and wxCLOSE_BOX styles this style doesn't turn on
+           wxCAPTION under MSW and if it's not specified, makes the system menu
            available without showing it on screen in this case. However it is
            recommended to only use it together with wxCAPTION for consistent
            behaviour under all platforms.

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -130,7 +130,9 @@ WXDWORD wxTopLevelWindowMSW::MSWGetStyle(long style, WXDWORD *exflags) const
     else
         msflags |= WS_POPUP;
 
-    if ( style & wxCAPTION )
+    // We need to use WS_CAPTION to show any of the minimize/maximize/close
+    // buttons, so enable it if any of these styles is specified.
+    if ( style & (wxCAPTION | wxMINIMIZE_BOX | wxMAXIMIZE_BOX | wxCLOSE_BOX) )
         msflags |= WS_CAPTION;
     else
         msflags |= WS_POPUP;


### PR DESCRIPTION
The documentation used to warn that wxXXX_BOX styles were ignored unless wxCAPTION was also specified, but this was actually wrong, at least for wxOSX, which instead enabled wxCAPTION too if any of the BOX flags was given.

And this behaviour seems more useful, as it's not really obvious why the boxes are not shown otherwise, so make wxMSW behave like this too and update the documentation.

---

See [this question](https://stackoverflow.com/questions/76344236/custom-dialog-derived-from-wxdialog-does-not-have-close-button-and-cannot-be-mov/).