### PR TITLE
Add support for `WXLOG_TIME_FORMAT` and docs improvements

### DIFF
--- a/docs/doxygen/overviews/envvars.h
+++ b/docs/doxygen/overviews/envvars.h
@@ -13,6 +13,14 @@ This section describes all environment variables that affect execution of
 wxWidgets programs.
 
 @beginDefList
+@itemdef{WXLOG_TIME_FORMAT,
+         If set, the contents of this variable is set as the initial timestamp
+         used for logging, i.e. passed to wxLog::SetTimestamp(), on program
+         startup. For example, this can be used to enable milliseconds in the
+         timestamps by setting `WXLOG_TIME_FORMAT=%H:%M:%S.%l` or it could also
+         be used to use ISO 8601 timestamp format instead of the default
+         locale-dependent format. This variable is only used since wxWidgets
+         3.3.0.}
 @itemdef{WXTRACE,
         This variable can be set to a comma-separated list of trace masks used in
         wxLogTrace calls; wxLog::AddTraceMask is called for every mask

--- a/docs/doxygen/overviews/envvars.h
+++ b/docs/doxygen/overviews/envvars.h
@@ -14,10 +14,10 @@ wxWidgets programs.
 
 @beginDefList
 @itemdef{WXTRACE,
-        (Debug build only.)
         This variable can be set to a comma-separated list of trace masks used in
         wxLogTrace calls; wxLog::AddTraceMask is called for every mask
-        in the list during wxWidgets initialization.}
+        in the list during wxWidgets initialization. It only has an effect if
+        debug logging is enabled, see wxLogTrace().}
 @itemdef{WXPREFIX,
         (Unix only.)
         Overrides installation prefix. Normally, the prefix

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -512,6 +512,11 @@ public:
         formatter and custom formatters may ignore this format. You can also
         define a custom wxLogFormatter to customize the time stamp handling
         beyond changing its format.
+
+        In addition to calling this function explicitly, it can also be called
+        implicitly by wxWidgets if `WXLOG_TIME_FORMAT` environment variable is
+        set, see @ref overview_envvars "overview of the environment variables"
+        affecting wxWidgets programs.
     */
     static void SetTimestamp(const wxString& format);
 

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -494,6 +494,11 @@ public:
 
         Notice that the current time stamp is only used by the default log
         formatter and custom formatters may ignore this format.
+
+        The default time stamp is `%X`, i.e. locale-dependent time
+        representation.
+
+        @see SetTimestamp()
     */
     static const wxString& GetTimestamp();
 

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -1448,10 +1448,12 @@ void wxVLogError(const char* formatString, va_list argPtr);
     do the same thing for log messages of any level, and not just the tracing
     ones.
 
-    Like wxLogDebug(), trace functions only do something in debug builds and
-    expand to nothing in the release one. The reason for making it a separate
-    function is that usually there are a lot of trace messages, so it might
-    make sense to separate them from other debug messages.
+    Like wxLogDebug(), trace functions are disabled at compile time if
+    wxWidgets is compiled without debugging support, i.e. with `wxDEBUG_LEVEL`
+    set to 0 see @ref overview_debugging "Debugging overview" for more details).
+    The reason for having a separate function for tracing messages is that
+    usually there are a lot of them and so it may be useful to separate them
+    from the other debug messages.
 
     Trace messages can be separated into different categories; these functions in facts
     only log the message if the given @a mask is currently enabled in wxLog.
@@ -1510,9 +1512,13 @@ void wxVLogTrace(wxTraceMask mask, const char* formatString, va_list argPtr);
 /** @addtogroup group_funcmacro_log */
 ///@{
 /**
-    The right functions for debug output. They only do something in debug mode
-    (when the preprocessor symbol @c \__WXDEBUG__ is defined) and expand to
-    nothing in release mode (otherwise).
+    The function to use for debugging output.
+
+    In addition to not producing any output if the current log level is not
+    high enough, just as all the other logging function, this function does
+    nothing at all, and is not even present in the final executable code, if
+    wxWidgets was compiled without debugging support, i.e. `wxDEBUG_LEVEL` is 0
+    (see @ref overview_debugging "Debugging overview" for more details).
 
     @header{wx/log.h}
 */

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -1240,6 +1240,10 @@ static void LINKAGEMODE SetTraceMasks()
         while ( tkn.HasMoreTokens() )
             wxLog::AddTraceMask(tkn.GetNextToken());
     }
+
+    wxString ts;
+    if ( wxGetEnv("WXLOG_TIME_FORMAT", &ts) )
+        wxLog::SetTimestamp(ts);
 #endif // wxUSE_LOG
 }
 


### PR DESCRIPTION
Any objections to adding this? I find it convenient to customize logging (notably of the trace messages) of the existing applications without having to modify them.