### PR TITLE
Create the IE emulation key in the Windows registry if it does not exist

### DIFF
--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -995,7 +995,8 @@ bool wxWebViewIE::MSWSetEmulationLevel(wxWebViewIE_EmulationLevel level)
         wxT("\\FeatureControl\\FEATURE_BROWSER_EMULATION");
 
     wxRegKey key(wxRegKey::HKCU, IE_EMULATION_KEY);
-    if ( !key.Exists() )
+    // Check the existence of the key and create it if it does not exist
+    if ( !key.Exists() || !key.Create() )
     {
         wxLogWarning(_("Failed to find web view emulation level in the registry"));
         return false;

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -996,7 +996,7 @@ bool wxWebViewIE::MSWSetEmulationLevel(wxWebViewIE_EmulationLevel level)
 
     wxRegKey key(wxRegKey::HKCU, IE_EMULATION_KEY);
     // Check the existence of the key and create it if it does not exist
-    if ( !key.Exists() || !key.Create() )
+    if ( !key.Exists() && !key.Create() )
     {
         wxLogWarning(_("Failed to find web view emulation level in the registry"));
         return false;


### PR DESCRIPTION
The related folder of the IE registry key (FEATURE_BROWSER_EMULATION) should be created if it does not exist. Otherwise some of IE features may not work depending on the level set.