### PR TITLE
Backport all changes from PR #23556 to 3.2

### DIFF
--- a/include/wx/private/uilocale.h
+++ b/include/wx/private/uilocale.h
@@ -68,6 +68,14 @@ public:
     // The entries contain platform-dependent identifiers.
     static wxVector<wxString> GetPreferredUILanguages();
 
+    // Helper function used by GetMonthName/GetWeekDayName(): returns 0 if flags is
+    // wxDateTime::Name_Full and 1 if it is wxDateTime::Name_Abbr
+    // or -1 if the flags is incorrect (and asserts in this case)
+    //
+    // the return value of this function is used as an index into 2D array
+    // containing full names in its first row and abbreviated ones in the 2nd one
+    static int ArrayIndexFromFlag(wxDateTime::NameFlags flags);
+
     // Use this locale in the UI.
     //
     // This is not implemented for all platforms, notably not for Mac where the
@@ -80,6 +88,8 @@ public:
     virtual wxLocaleIdent GetLocaleId() const = 0;
     virtual wxString GetInfo(wxLocaleInfo index, wxLocaleCategory cat) const = 0;
     virtual wxString GetLocalizedName(wxLocaleName name, wxLocaleForm form) const = 0;
+    virtual wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const = 0;
+    virtual wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const = 0;
     virtual wxLayoutDirection GetLayoutDirection() const = 0;
     virtual int CompareStrings(const wxString& lhs, const wxString& rhs,
                                int flags) const = 0;

--- a/include/wx/private/uilocale.h
+++ b/include/wx/private/uilocale.h
@@ -88,11 +88,11 @@ public:
     virtual wxLocaleIdent GetLocaleId() const = 0;
     virtual wxString GetInfo(wxLocaleInfo index, wxLocaleCategory cat) const = 0;
     virtual wxString GetLocalizedName(wxLocaleName name, wxLocaleForm form) const = 0;
-    virtual wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const = 0;
-    virtual wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const = 0;
     virtual wxLayoutDirection GetLayoutDirection() const = 0;
     virtual int CompareStrings(const wxString& lhs, const wxString& rhs,
                                int flags) const = 0;
+    virtual wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const = 0;
+    virtual wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const = 0;
 
     virtual ~wxUILocaleImpl() { }
 };

--- a/include/wx/uilocale.h
+++ b/include/wx/uilocale.h
@@ -148,6 +148,14 @@ public:
     // Query the locale for the specified localized name.
     wxString GetLocalizedName(wxLocaleName name, wxLocaleForm form) const;
 
+    // Query the layout direction of the current locale.
+    wxLayoutDirection GetLayoutDirection() const;
+
+    // Compares two strings in the order defined by this locale.
+    int CompareStrings(const wxString& lhs, const wxString& rhs,
+                       int flags = wxCompare_CaseSensitive) const;
+
+#if wxABI_VERSION >= 30203
     // Get the full (default) or abbreviated localized month name
     // returns empty string on error
     wxString GetMonthName(wxDateTime::Month month,
@@ -157,13 +165,7 @@ public:
     // returns empty string on error
     wxString GetWeekDayName(wxDateTime::WeekDay weekday,
                             wxDateTime::NameFlags flags = wxDateTime::Name_Full) const;
-
-    // Query the layout direction of the current locale.
-    wxLayoutDirection GetLayoutDirection() const;
-
-    // Compares two strings in the order defined by this locale.
-    int CompareStrings(const wxString& lhs, const wxString& rhs,
-                       int flags = wxCompare_CaseSensitive) const;
+#endif // wxABI_VERSION >= 3.2.3
 
     // Note that this class is not supposed to be used polymorphically, hence
     // its dtor is not virtual.

--- a/include/wx/uilocale.h
+++ b/include/wx/uilocale.h
@@ -14,6 +14,7 @@
 
 #if wxUSE_INTL
 
+#include "wx/datetime.h"
 #include "wx/localedefs.h"
 #include "wx/string.h"
 #include "wx/vector.h"
@@ -146,6 +147,16 @@ public:
 
     // Query the locale for the specified localized name.
     wxString GetLocalizedName(wxLocaleName name, wxLocaleForm form) const;
+
+    // Get the full (default) or abbreviated localized month name
+    // returns empty string on error
+    wxString GetMonthName(wxDateTime::Month month,
+                          wxDateTime::NameFlags flags = wxDateTime::Name_Full) const;
+
+    // Get the full (default) or abbreviated localized weekday name
+    // returns empty string on error
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday,
+                            wxDateTime::NameFlags flags = wxDateTime::Name_Full) const;
 
     // Query the layout direction of the current locale.
     wxLayoutDirection GetLayoutDirection() const;

--- a/interface/wx/uilocale.h
+++ b/interface/wx/uilocale.h
@@ -209,9 +209,9 @@ public:
             Either wxDateTime::Name_Full (default) or wxDateTime::Name_Abbr.
 
         @see GetWeekDayName()
-        @since 3.3.0
+        @since 3.2.3
     */
-    wxString GetMonthName(wxDateTime::Month month, wxDateTime::flags = wxDateTime::Name_Full);
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags = wxDateTime::Name_Full);
 
     /**
         Gets the full (default) or abbreviated name of the given week day.
@@ -225,6 +225,7 @@ public:
             Either wxDateTime::Name_Full (default) or wxDateTime::Name_Abbr.
 
         @see GetMonthName()
+        @since 3.2.3
     */
     wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags = wxDateTime::Name_Full);
 

--- a/interface/wx/uilocale.h
+++ b/interface/wx/uilocale.h
@@ -198,6 +198,37 @@ public:
     wxString GetLocalizedName(wxLocaleName name, wxLocaleForm form) const;
 
     /**
+        Gets the full (default) or abbreviated name of the given month.
+
+        This function returns the name in the current locale, use
+        wxDateTime::GetEnglishMonthName() to get the untranslated name if necessary.
+
+        @param month
+            One of wxDateTime::Jan, ..., wxDateTime::Dec values.
+        @param flags
+            Either wxDateTime::Name_Full (default) or wxDateTime::Name_Abbr.
+
+        @see GetWeekDayName()
+        @since 3.3.0
+    */
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::flags = wxDateTime::Name_Full);
+
+    /**
+        Gets the full (default) or abbreviated name of the given week day.
+
+        This function returns the name in the current locale, use
+        wxDateTime::GetEnglishWeekDayName() to get the untranslated name if necessary.
+
+        @param weekday
+            One of wxDateTime::Sun, ..., wxDateTime::Sat values.
+        @param flags
+            Either wxDateTime::Name_Full (default) or wxDateTime::Name_Abbr.
+
+        @see GetMonthName()
+    */
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags = wxDateTime::Name_Full);
+
+    /**
         Query the layout direction of the current locale.
 
         @return

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -82,6 +82,7 @@
 #endif
 
 #include "wx/datetime.h"
+#include "wx/uilocale.h"
 
 // ----------------------------------------------------------------------------
 // wxXTI
@@ -773,19 +774,11 @@ wxString wxDateTime::GetEnglishMonthName(Month month, NameFlags flags)
 wxString wxDateTime::GetMonthName(wxDateTime::Month month,
                                   wxDateTime::NameFlags flags)
 {
-#ifdef wxHAS_STRFTIME
-    wxCHECK_MSG( month != Inv_Month, wxEmptyString, wxT("invalid month") );
-
-    // notice that we must set all the fields to avoid confusing libc (GNU one
-    // gets confused to a crash if we don't do this)
-    tm tm;
-    wxInitTm(tm);
-    tm.tm_mon = month;
-
-    return wxCallStrftime(flags == Name_Abbr ? wxS("%b") : wxS("%B"), &tm);
-#else // !wxHAS_STRFTIME
-    return GetEnglishMonthName(month, flags);
-#endif // wxHAS_STRFTIME/!wxHAS_STRFTIME
+    wxCHECK_MSG(month != Inv_Month, wxEmptyString, wxT("invalid month"));
+    wxString name = wxUILocale::GetCurrent().GetMonthName(month, flags);
+    if (name.empty())
+        name = GetEnglishMonthName(month, flags);
+    return name;
 }
 
 /* static */
@@ -811,29 +804,11 @@ wxString wxDateTime::GetEnglishWeekDayName(WeekDay wday, NameFlags flags)
 wxString wxDateTime::GetWeekDayName(wxDateTime::WeekDay wday,
                                     wxDateTime::NameFlags flags)
 {
-#ifdef wxHAS_STRFTIME
-    wxCHECK_MSG( wday != Inv_WeekDay, wxEmptyString, wxT("invalid weekday") );
-
-    // take some arbitrary Sunday (but notice that the day should be such that
-    // after adding wday to it below we still have a valid date, e.g. don't
-    // take 28 here!)
-    tm tm;
-    wxInitTm(tm);
-    tm.tm_mday = 21;
-    tm.tm_mon = Nov;
-    tm.tm_year = 99;
-
-    // and offset it by the number of days needed to get the correct wday
-    tm.tm_mday += wday;
-
-    // call mktime() to normalize it...
-    (void)mktime(&tm);
-
-    // ... and call strftime()
-    return wxCallStrftime(flags == Name_Abbr ? wxS("%a") : wxS("%A"), &tm);
-#else // !wxHAS_STRFTIME
-    return GetEnglishWeekDayName(wday, flags);
-#endif // wxHAS_STRFTIME/!wxHAS_STRFTIME
+    wxCHECK_MSG(wday != Inv_WeekDay, wxEmptyString, wxT("invalid weekday"));
+    wxString name = wxUILocale::GetCurrent().GetWeekDayName(wday, flags);
+    if (name.empty())
+        name = GetEnglishWeekDayName(wday, flags);
+    return name;
 }
 
 /* static */

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -63,7 +63,6 @@ inline bool IsDefaultCLocale(const wxString& locale)
 
 } // anonymous namespace
 
-
 // ----------------------------------------------------------------------------
 // global variables
 // ----------------------------------------------------------------------------
@@ -109,6 +108,13 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
 
     wxLocaleIdent locId;
 
+    // 0. Check for special locale identifiers "C" and "POSIX"
+    if (IsDefaultCLocale(tag))
+    {
+        locId.Language(tag);
+        return locId;
+    }
+
     // 1. Handle platform-dependent cases
 
     // 1a. Check for modifier in POSIX tag
@@ -152,8 +158,11 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
     //
     // Make sure we don't extract the region identifier erroneously as a sortorder identifier
     {
-        wxString tagTemp = tagMain.BeforeFirst('_', &tagRest);
-        if (tagRest.length() > 4 && locId.m_modifier.empty() && locId.m_charset.empty())
+        wxString tagTemp = tagMain.BeforeLast('_', &tagRest);
+        if (!tagTemp.empty() &&
+                tagRest.length() > 4 &&
+                    locId.m_modifier.empty() &&
+                        locId.m_charset.empty())
         {
             // Windows sortorder found
             locId.SortOrder(tagRest);
@@ -526,7 +535,14 @@ wxUILocale::wxUILocale(const wxLocaleIdent& localeId)
         return;
     }
 
-    m_impl = wxUILocaleImpl::CreateForLocale(localeId);
+    if (IsDefaultCLocale(localeId.GetLanguage()))
+    {
+        m_impl = wxUILocaleImpl::CreateStdC();
+    }
+    else
+    {
+        m_impl = wxUILocaleImpl::CreateForLocale(localeId);
+    }
 }
 
 wxUILocale::wxUILocale(const wxUILocale& loc)
@@ -583,6 +599,22 @@ wxString wxUILocale::GetLocalizedName(wxLocaleName name, wxLocaleForm form) cons
         return wxString();
 
     return m_impl->GetLocalizedName(name, form);
+}
+
+wxString wxUILocale::GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const
+{
+    if (!m_impl)
+        return wxString();
+
+    return m_impl->GetMonthName(month, flags);
+}
+
+wxString wxUILocale::GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const
+{
+    if (!m_impl)
+        return wxString();
+
+    return m_impl->GetWeekDayName(weekday, flags);
 }
 
 wxLayoutDirection wxUILocale::GetLayoutDirection() const
@@ -870,6 +902,23 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxLocaleIdent& locId)
     }
 
     return infoRet;
+}
+
+int wxUILocaleImpl::ArrayIndexFromFlag(wxDateTime::NameFlags flags)
+{
+    switch (flags)
+    {
+        case wxDateTime::Name_Full:
+            return 0;
+
+        case wxDateTime::Name_Abbr:
+            return 1;
+
+        default:
+            wxFAIL_MSG("unknown wxDateTime::NameFlags value");
+    }
+
+    return -1;
 }
 
 #endif // wxUSE_INTL

--- a/src/msw/uilocale.cpp
+++ b/src/msw/uilocale.cpp
@@ -210,6 +210,17 @@ public:
         return str;
     }
 
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const wxOVERRIDE
+    {
+        return wxDateTime::GetEnglishMonthName(month, flags);
+    }
+
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const wxOVERRIDE
+
+    {
+        return wxDateTime::GetEnglishWeekDayName(weekday, flags);
+    }
+
     wxLayoutDirection GetLayoutDirection() const wxOVERRIDE
     {
         return wxLayout_Default;
@@ -339,6 +350,52 @@ public:
         }
 
         return str;
+    }
+
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const wxOVERRIDE
+    {
+        static LCTYPE monthNameIndex[2][12] =
+        {
+            { LOCALE_SMONTHNAME1,  LOCALE_SMONTHNAME2,  LOCALE_SMONTHNAME3,
+              LOCALE_SMONTHNAME4,  LOCALE_SMONTHNAME5,  LOCALE_SMONTHNAME6,
+              LOCALE_SMONTHNAME7,  LOCALE_SMONTHNAME8,  LOCALE_SMONTHNAME9,
+              LOCALE_SMONTHNAME10, LOCALE_SMONTHNAME11, LOCALE_SMONTHNAME12 },
+            { LOCALE_SABBREVMONTHNAME1,  LOCALE_SABBREVMONTHNAME2,  LOCALE_SABBREVMONTHNAME3,
+              LOCALE_SABBREVMONTHNAME4,  LOCALE_SABBREVMONTHNAME5,  LOCALE_SABBREVMONTHNAME6,
+              LOCALE_SABBREVMONTHNAME7,  LOCALE_SABBREVMONTHNAME8,  LOCALE_SABBREVMONTHNAME9,
+              LOCALE_SABBREVMONTHNAME10, LOCALE_SABBREVMONTHNAME11, LOCALE_SABBREVMONTHNAME12 }
+        };
+
+        const int idx = ArrayIndexFromFlag(flags);
+        if (idx == -1)
+            return wxString();
+
+        // Return names in standalone context
+        // Note: Windows versions below 7 don't support LOCALE_RETURN_GENITIVE_NAMES
+        LCTYPE lctype = monthNameIndex[idx][month] /*| LOCALE_RETURN_GENITIVE_NAMES*/;
+
+        return DoGetInfo(lctype);
+    }
+
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const wxOVERRIDE
+    {
+        static LCTYPE weekdayNameIndex[2][12] =
+        {
+            { LOCALE_SDAYNAME7, LOCALE_SDAYNAME1, LOCALE_SDAYNAME2, LOCALE_SDAYNAME3,
+              LOCALE_SDAYNAME4, LOCALE_SDAYNAME5, LOCALE_SDAYNAME6 },
+            { LOCALE_SABBREVDAYNAME7, LOCALE_SABBREVDAYNAME1, LOCALE_SABBREVDAYNAME2, LOCALE_SABBREVDAYNAME3,
+              LOCALE_SABBREVDAYNAME4, LOCALE_SABBREVDAYNAME5, LOCALE_SABBREVDAYNAME6 }
+        };
+
+        const int idx = ArrayIndexFromFlag(flags);
+        if (idx == -1)
+            return wxString();
+
+        // Return names in standalone context
+        // Note: Windows versions below 7 don't support LOCALE_RETURN_GENITIVE_NAMES
+        LCTYPE lctype = weekdayNameIndex[idx][weekday] /*| LOCALE_RETURN_GENITIVE_NAMES*/;
+
+        return DoGetInfo(lctype);
     }
 
     wxLayoutDirection GetLayoutDirection() const wxOVERRIDE
@@ -689,6 +746,52 @@ public:
         }
 
         return str;
+    }
+
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const wxOVERRIDE
+    {
+        static LCTYPE monthNameIndex[2][12] =
+        {
+            { LOCALE_SMONTHNAME1,  LOCALE_SMONTHNAME2,  LOCALE_SMONTHNAME3,
+              LOCALE_SMONTHNAME4,  LOCALE_SMONTHNAME5,  LOCALE_SMONTHNAME6,
+              LOCALE_SMONTHNAME7,  LOCALE_SMONTHNAME8,  LOCALE_SMONTHNAME9,
+              LOCALE_SMONTHNAME10, LOCALE_SMONTHNAME11, LOCALE_SMONTHNAME12 },
+            { LOCALE_SABBREVMONTHNAME1,  LOCALE_SABBREVMONTHNAME2,  LOCALE_SABBREVMONTHNAME3,
+              LOCALE_SABBREVMONTHNAME4,  LOCALE_SABBREVMONTHNAME5,  LOCALE_SABBREVMONTHNAME6,
+              LOCALE_SABBREVMONTHNAME7,  LOCALE_SABBREVMONTHNAME8,  LOCALE_SABBREVMONTHNAME9,
+              LOCALE_SABBREVMONTHNAME10, LOCALE_SABBREVMONTHNAME11, LOCALE_SABBREVMONTHNAME12 }
+        };
+
+        const int idx = ArrayIndexFromFlag(flags);
+        if (idx == -1)
+            return wxString();
+
+        // Return names in formatting context
+        // Drop OR with LOCALE_RETURN_GENITIVE_NAMES, if standalone context is wanted
+        LCTYPE lctype = monthNameIndex[idx][month] | LOCALE_RETURN_GENITIVE_NAMES;
+
+        return DoGetInfo(lctype);
+    }
+
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const wxOVERRIDE
+    {
+        static LCTYPE weekdayNameIndex[2][12] =
+        {
+            { LOCALE_SDAYNAME7, LOCALE_SDAYNAME1, LOCALE_SDAYNAME2, LOCALE_SDAYNAME3,
+              LOCALE_SDAYNAME4, LOCALE_SDAYNAME5, LOCALE_SDAYNAME6 },
+            { LOCALE_SABBREVDAYNAME7, LOCALE_SABBREVDAYNAME1, LOCALE_SABBREVDAYNAME2, LOCALE_SABBREVDAYNAME3,
+              LOCALE_SABBREVDAYNAME4, LOCALE_SABBREVDAYNAME5, LOCALE_SABBREVDAYNAME6 }
+        };
+
+        const int idx = ArrayIndexFromFlag(flags);
+        if (idx == -1)
+            return wxString();
+
+        // Return names in formatting context
+        // Drop OR with LOCALE_RETURN_GENITIVE_NAMES, if standalone context is wanted
+        LCTYPE lctype = weekdayNameIndex[idx][weekday] | LOCALE_RETURN_GENITIVE_NAMES;
+
+        return DoGetInfo(lctype);
     }
 
     wxLayoutDirection GetLayoutDirection() const wxOVERRIDE

--- a/src/osx/core/uilocale.mm
+++ b/src/osx/core/uilocale.mm
@@ -20,6 +20,7 @@
 
 #if wxUSE_INTL
 
+#include "wx/log.h"
 #include "wx/uilocale.h"
 #include "wx/private/uilocale.h"
 
@@ -29,6 +30,7 @@
 #import <Foundation/NSArray.h>
 #import <Foundation/NSString.h>
 #import <Foundation/NSLocale.h>
+#import <Foundation/NSDateFormatter.h>
 
 extern wxString
 wxGetInfoFromCFLocale(CFLocaleRef cfloc, wxLocaleInfo index, wxLocaleCategory cat);
@@ -86,13 +88,50 @@ public:
         // Surprisingly, localeWithLocaleIdentifier: always succeeds, even for
         // completely invalid strings, so we need to check if the name is
         // actually in the list of the supported locales ourselves.
-        static wxCFRef<CFArrayRef>
-            all((CFArrayRef)[[NSLocale availableLocaleIdentifiers] retain]);
+        bool isAvailable = false;
+        for ( id nsLocId in [NSLocale availableLocaleIdentifiers] )
+        {
+            // We can't simply compare the names here because the list returned
+            // by NSLocale is incomplete and doesn't contain all synonyms, e.g.
+            // it only contains "zh_Hant_TW" but not "zh_TW" itself, so we need
+            // to do our own matching.
+            auto strId = wxCFStringRef::AsString(nsLocId);
+
+            const auto availId = wxLocaleIdent::FromTag(strId);
+            if ( availId.IsEmpty() )
+            {
+                wxLogDebug("Failed to parse locale identifier \"%s\"", strId);
+                continue;
+            }
+
+            // The following conditions have to be checked:
+            //   - The language must always match.
+            //   - The script must match, if it given, otherwise the region must
+            //     match (even though it might be empty).
+            //   - If script and region are both given, they must both match.
+            if ( availId.GetLanguage() == locId.GetLanguage() )
+            {
+                if ( !locId.GetScript().empty() )
+                {
+                    isAvailable = availId.GetScript() == locId.GetScript();
+                    if ( isAvailable && !locId.GetRegion().empty() )
+                    {
+                        isAvailable = availId.GetRegion() == locId.GetRegion();
+                    }
+                }
+                else
+                {
+                    isAvailable = availId.GetRegion() == locId.GetRegion();
+                }
+            }
+            if ( isAvailable )
+                break;
+        }
+
+        if ( !isAvailable )
+            return nullptr;
 
         wxCFStringRef cfName(locId.GetName());
-        if ( ![(NSArray*)all.get() containsObject: cfName.AsNSString()] )
-            return NULL;
-
         auto nsloc = [NSLocale localeWithLocaleIdentifier: cfName.AsNSString()];
         if ( !nsloc )
             return NULL;
@@ -105,6 +144,9 @@ public:
     wxLocaleIdent GetLocaleId() const wxOVERRIDE;
     wxString GetInfo(wxLocaleInfo index, wxLocaleCategory cat) const wxOVERRIDE;
     wxString GetLocalizedName(wxLocaleName name, wxLocaleForm form) const wxOVERRIDE;
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const wxOVERRIDE;
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const wxOVERRIDE;
+
     wxLayoutDirection GetLayoutDirection() const wxOVERRIDE;
     int CompareStrings(const wxString& lhs, const wxString& rhs,
                        int flags) const wxOVERRIDE;
@@ -134,7 +176,7 @@ wxUILocaleImplCF::GetName() const
     wxString name = wxCFStringRef::AsString([m_nsloc localeIdentifier]);
 
     // Check for the special case of the "empty" system locale, see CreateStdC()
-    if ( name.empty() )
+    if ( name.empty() || name.IsSameAs("en_US_POSIX") )
         name = "C";
 
     return name;
@@ -185,6 +227,52 @@ wxUILocaleImplCF::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
     return wxCFStringRef::AsString(str);
 }
 
+wxString
+wxUILocaleImplCF::GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const
+{
+    NSDateFormatter* df = [NSDateFormatter new];
+    df.locale = m_nsloc;
+
+    NSArray* monthNames = NULL;
+
+    switch ( flags )
+    {
+        case wxDateTime::Name_Abbr:
+            monthNames = [df shortMonthSymbols];
+            break;
+        case wxDateTime::Name_Full:
+        default:
+            monthNames = [df monthSymbols];
+            break;
+    }
+
+    NSString* monthName = [monthNames objectAtIndex:(month)];
+    return wxCFStringRef::AsString(monthName);
+}
+
+wxString
+wxUILocaleImplCF::GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const
+{
+    NSDateFormatter* df = [NSDateFormatter new];
+    df.locale = m_nsloc;
+
+    NSArray* weekdayNames = NULL;
+
+    switch ( flags )
+    {
+        case wxDateTime::Name_Abbr:
+            weekdayNames = [df shortWeekdaySymbols];
+            break;
+        case wxDateTime::Name_Full:
+        default:
+            weekdayNames = [df weekdaySymbols];
+            break;
+    }
+
+    NSString* weekdayName = [weekdayNames objectAtIndex:(weekday)];
+    return wxCFStringRef::AsString(weekdayName);
+}
+
 wxLayoutDirection
 wxUILocaleImplCF::GetLayoutDirection() const
 {
@@ -204,7 +292,7 @@ wxUILocaleImpl* wxUILocaleImpl::CreateStdC()
     // wouldn't be much better as we'd still need a hack for it in GetName()
     // because the locale names are always converted to lower case, while we
     // really want to return "C" rather than "c" as the name of this one.
-    return new wxUILocaleImplCF([NSLocale systemLocale]);
+    return new wxUILocaleImplCF([NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]);
 }
 
 /* static */

--- a/src/osx/core/uilocale.mm
+++ b/src/osx/core/uilocale.mm
@@ -129,7 +129,7 @@ public:
         }
 
         if ( !isAvailable )
-            return nullptr;
+            return NULL;
 
         wxCFStringRef cfName(locId.GetName());
         auto nsloc = [NSLocale localeWithLocaleIdentifier: cfName.AsNSString()];

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -179,6 +179,8 @@ public:
     wxLocaleIdent GetLocaleId() const wxOVERRIDE;
     wxString GetInfo(wxLocaleInfo index, wxLocaleCategory cat) const wxOVERRIDE;
     wxString GetLocalizedName(wxLocaleName name, wxLocaleForm form) const wxOVERRIDE;
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const wxOVERRIDE;
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const wxOVERRIDE;
     wxLayoutDirection GetLayoutDirection() const wxOVERRIDE;
 
     int CompareStrings(const wxString& lhs, const wxString& rhs,
@@ -188,6 +190,7 @@ private:
 #ifdef HAVE_LANGINFO_H
     // Call nl_langinfo_l() if available, or nl_langinfo() otherwise.
     const char* GetLangInfo(nl_item item) const;
+    const wchar_t* GetLangInfoWide(nl_item item) const;
 
 #ifdef __LINUX__
     // Call GetLangInfo() using either the native or English item depending on
@@ -272,11 +275,11 @@ locale_t TryCreateLocaleWithUTF8(wxLocaleIdent& locId)
 locale_t TryCreateMatchingLocale(wxLocaleIdent& locId)
 {
     locale_t loc = TryCreateLocaleWithUTF8(locId);
-    if ( !loc )
+    if ( !loc && locId.GetRegion().empty() )
     {
-        // Try to find a variant of this locale available on this system: first
-        // of all, using just the language, without the territory, typically
-        // does _not_ work under Linux, so try adding one if we don't have it.
+        // Try to find a variant of this locale available on this system: as
+        // using just the language, without the territory, typically does _not_
+        // work under Linux, we try adding one if we don't have it.
         const wxString lang = locId.GetLanguage();
 
         const wxLanguageInfos& infos = wxGetLanguageInfos();
@@ -532,6 +535,20 @@ wxUILocaleImplUnix::GetLangInfo(nl_item item) const
     return nl_langinfo(item);
 }
 
+const wchar_t*
+wxUILocaleImplUnix::GetLangInfoWide(nl_item item) const
+{
+#ifdef HAVE_LOCALE_T
+    // We assume that we have nl_langinfo_l() if we have locale_t.
+    if ( m_locale )
+        return (wchar_t*) nl_langinfo_l(item, m_locale);
+#else
+    TempLocaleSetter setThisLocale(LC_CTYPE, m_locId.GetName());
+#endif // HAVE_LOCALE_T
+
+    return (wchar_t*) nl_langinfo(item);
+}
+
 #ifdef __LINUX__
 wxString
 wxUILocaleImplUnix::GetFormOfLangInfo(wxLocaleForm form,
@@ -691,6 +708,98 @@ wxUILocaleImplUnix::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
     }
 #endif // HAVE_LANGINFO_H && __LINUX__/!HAVE_LANGINFO_H || !__LINUX__
     return str;
+}
+
+wxString
+wxUILocaleImplUnix::GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const
+{
+#if defined(HAVE_LANGINFO_H)
+#if defined(__LINUX__) && defined(__GLIBC__)
+    static int monthNameIndex[2][12] =
+    {
+        // Formatting context
+        { _NL_WMON_1,  _NL_WMON_2,  _NL_WMON_3,
+          _NL_WMON_4,  _NL_WMON_5,  _NL_WMON_6,
+          _NL_WMON_7,  _NL_WMON_8,  _NL_WMON_9,
+          _NL_WMON_10, _NL_WMON_11, _NL_WMON_12 },
+        { _NL_WABMON_1,  _NL_WABMON_2,  _NL_WABMON_3,
+          _NL_WABMON_4,  _NL_WABMON_5,  _NL_WABMON_6,
+          _NL_WABMON_7,  _NL_WABMON_8,  _NL_WABMON_9,
+          _NL_WABMON_10, _NL_WABMON_11, _NL_WABMON_12 },
+    };
+
+    int idx = ArrayIndexFromFlag(flags);
+    if (idx == -1)
+        return wxString();
+
+    return wxString(GetLangInfoWide(monthNameIndex[idx][month]));
+#else // !__LINUX__ || !__GLIBC__
+    // If system is not Linux-like or does not have GLIBC, fall back
+    // to LC_TIME symbols that should be defined according to POSIX.
+    static int monthNameIndex[2][12] =
+    {
+        // Formatting context
+        { MON_1,  MON_2,  MON_3,
+          MON_4,  MON_5,  MON_6,
+          MON_7,  MON_8,  MON_9,
+          MON_10, MON_11, MON_12 },
+        { ABMON_1,  ABMON_2,  ABMON_3,
+          ABMON_4,  ABMON_5,  ABMON_6,
+          ABMON_7,  ABMON_8,  ABMON_9,
+          ABMON_10, ABMON_11, ABMON_12 }
+    };
+
+    int idx = ArrayIndexFromFlag(flags);
+    if (idx == -1)
+        return wxString();
+
+    return wxString(GetLangInfo(monthNameIndex[idx][month]), wxCSConv(GetCodeSet()));
+#endif //  __LINUX__ && __GLIBC__ / !__LINUX__ || !__GLIBC__
+#else // !HAVE_LANGINFO_H
+    // If HAVE_LANGINFO_H is not available, fall back to English names.
+    return wxDateTime::GetEnglishMonthName(month, flags);
+#endif // HAVE_LANGINFO_H && __LINUX__/!HAVE_LANGINFO_H || !__LINUX__
+}
+
+wxString
+wxUILocaleImplUnix::GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const
+{
+#if defined(HAVE_LANGINFO_H)
+#if defined(__LINUX__) && defined(__GLIBC__)
+    static int weekdayNameIndex[2][12] =
+    {
+        { _NL_WDAY_1, _NL_WDAY_2, _NL_WDAY_3,
+          _NL_WDAY_4, _NL_WDAY_5, _NL_WDAY_6, _NL_WDAY_7 },
+        { _NL_WABDAY_1, _NL_WABDAY_2, _NL_WABDAY_3,
+          _NL_WABDAY_4, _NL_WABDAY_5, _NL_WABDAY_6, _NL_WABDAY_7 }
+    };
+
+    const int idx = ArrayIndexFromFlag(flags);
+    if (idx == -1)
+        return wxString();
+
+    return wxString(GetLangInfoWide(weekdayNameIndex[idx][weekday]));
+#else // !__LINUX__ || !__GLIBC__
+    // If system is not Linux-like or does not have GLIBC, fall back
+    // to LC_TIME symbols that should be defined according to POSIX.
+    static int weekdayNameIndex[2][12] =
+    {
+        { DAY_1, DAY_2, DAY_3,
+          DAY_4, DAY_5, DAY_6, DAY_7 },
+        { ABDAY_1, ABDAY_2, ABDAY_3,
+          ABDAY_4, ABDAY_5, ABDAY_6, ABDAY_7 }
+    };
+
+    const int idx = ArrayIndexFromFlag(flags);
+    if (idx == -1)
+        return wxString();
+
+    return wxString(GetLangInfo(weekdayNameIndex[idx][weekday]), wxCSConv(GetCodeSet()));
+#endif //  __LINUX__ && __GLIBC__ / !__LINUX__ || !__GLIBC__
+#else // !HAVE_LANGINFO_H
+    // If HAVE_LANGINFO_H is not available, fall back to English names.
+    return wxDateTime::GetEnglishWeekDayName(weekday, flags);
+#endif // HAVE_LANGINFO_H / !HAVE_LANGINFO_H
 }
 
 wxLayoutDirection

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -275,7 +275,7 @@ locale_t TryCreateLocaleWithUTF8(wxLocaleIdent& locId)
 locale_t TryCreateMatchingLocale(wxLocaleIdent& locId)
 {
     locale_t loc = TryCreateLocaleWithUTF8(locId);
-    if ( !loc && locId.GetRegion().empty() )
+    if ( !loc )
     {
         // Try to find a variant of this locale available on this system: as
         // using just the language, without the territory, typically does _not_

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -439,7 +439,15 @@ TEST_CASE("wxUILocale::FromTag", "[.]")
     REQUIRE( !locId.IsEmpty() );
 
     const wxUILocale loc(locId);
-    WARN("Locale \"" << tag << "\" supported: " << loc.IsSupported() );
+    WARN("Locale \"" << tag << "\":\n"
+         "language:\t" << locId.GetLanguage() << "\n"
+         "region:\t" << locId.GetRegion() << "\n"
+         "script:\t" << locId.GetScript() << "\n"
+         "charset:\t" << locId.GetCharset() << "\n"
+         "modifier:\t" << locId.GetModifier() << "\n"
+         "extension:\t" << locId.GetExtension() << "\n"
+         "sort order:\t" << locId.GetSortorder() << "\n"
+         "supported:\t" << (loc.IsSupported() ? "yes" : "no"));
 }
 
 namespace


### PR DESCRIPTION
For month and weekday names only the variants for the date/time formatting context are returned. This is wrong for standalone month names like in the generic calendar control. However, in the prior implementation that was also the case.