### PR TITLE
Fix hang in wxMSW wxFileDialog when using multi-thread COM

### DIFF
--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -33,7 +33,9 @@
 // initialize/cleanup OLE
 // ----------------------------------------------------------------------------
 
-// call OleInitialize() or CoInitialize[Ex]() depending on the platform
+// Simple wrapper for OleInitialize().
+//
+// Avoid using it directly, use wxOleInitializer instead.
 //
 // return true if ok, false otherwise
 inline bool wxOleInitialize()

--- a/include/wx/msw/private/filedialog.h
+++ b/include/wx/msw/private/filedialog.h
@@ -36,6 +36,11 @@ namespace wxMSWImpl
 class wxIFileDialog
 {
 public:
+    // Return true if we can use IFileDialog with an owner: this is
+    // unfortunately not always the case, as IFileDialog requires using
+    // apartment threading model in this case.
+    static bool CanBeUsedWithAnOwner();
+
     // Create the dialog of the specified type.
     //
     // CLSID must be either CLSID_FileOpenDialog or CLSID_FileSaveDialog.

--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -146,6 +146,12 @@ const char wxFileSelectorDefaultWildcardStr[];
     @ref page_samples_dialogs, please check it for more details.
 
 
+    @note New style file dialogs can only be used in wxMSW when the apartment,
+        COM threading model is used. This is the case by default, but if the
+        application initializes COM on its own using multi-threaded model, old
+        style dialogs are used, at least when they must have a parent, as the
+        new style dialog doesn't support this threading model.
+
     @beginStyleTable
     @style{wxFD_DEFAULT_STYLE}
            Equivalent to @c wxFD_OPEN.

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -1233,23 +1233,10 @@ int wxFileDialog::ShowModal()
         canUseIFileDialog = false;
 
     /*
-        We also can't use it if we're in a multi-threaded COM apartment _and_
-        have a parent, as IFileDialog::Show() simply hangs in this case, see
-        #23578.
+        We also can't use it if we have a parent in some cases.
      */
-    if ( hWndParent )
-    {
-        // Call this function just to check in which apartment we are: it will
-        // return S_OK if COINIT_APARTMENTTHREADED had been used for the first
-        // COM initialization and an error if not.
-        const HRESULT hr = ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-
-        if ( hr == RPC_E_CHANGED_MODE )
-            canUseIFileDialog = false;
-
-        // This just undoes the call above, COM remains initialized.
-        ::CoUninitialize();
-    }
+    if ( hWndParent && !wxMSWImpl::wxIFileDialog::CanBeUsedWithAnOwner() )
+        canUseIFileDialog = false;
 
     if ( canUseIFileDialog )
     {


### PR DESCRIPTION
Fall back to old style file dialogs in this case, as IFileDialog just doesn't seem to support this COM threading model, as hinted at in SHBrowseForFolder() documentation.

Also document this limitation.

Closes #23578.