### PR TITLE
Remove redundant "const" from wxItemId conversion operator

### DIFF
--- a/include/wx/itemid.h
+++ b/include/wx/itemid.h
@@ -33,7 +33,7 @@ public:
 
     bool IsOk() const { return m_pItem != nullptr; }
     Type GetID() const { return m_pItem; }
-    operator const Type() const { return m_pItem; }
+    operator Type() const { return m_pItem; }
 
     // This is used for implementation purposes only.
     Type operator->() const { return m_pItem; }


### PR DESCRIPTION
This "const" is ignored and just results in a warning from MSVS 17.6.

Closes #23590.
