### PR TITLE
Fix `wxSocketImpl::RecvDgram()` when caller requests fewer bytes than are present in datagram

### DIFF
--- a/build/cmake/tests/base/CMakeLists.txt
+++ b/build/cmake/tests/base/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_SRC
     misc/module.cpp
     misc/pathlist.cpp
     misc/typeinfotest.cpp
+    net/dgramsocket.cpp
     net/ipc.cpp
     net/socket.cpp
     net/webrequest.cpp

--- a/include/wx/socket.h
+++ b/include/wx/socket.h
@@ -74,7 +74,8 @@ enum wxSocketError
     wxSOCKET_WOULDBLOCK,
     wxSOCKET_TIMEDOUT,
     wxSOCKET_MEMERR,
-    wxSOCKET_OPTERR
+    wxSOCKET_OPTERR,
+    wxSOCKET_MSGSIZE
 };
 
 // socket options/flags bit masks

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -689,7 +689,12 @@ int wxSocketImpl::RecvDgram(void *buffer, int size)
                                   0, &from.addr, &fromlen) );
 
     if ( ret == SOCKET_ERROR )
-        return SOCKET_ERROR;
+    {
+        if ( GetLastError() == wxSOCKET_MSGSIZE )
+            ret = size;
+        else
+            return SOCKET_ERROR;
+    }
 
     m_peer = wxSockAddressImpl(from.addr, fromlen);
     if ( !m_peer.IsOk() )

--- a/src/msw/sockmsw.cpp
+++ b/src/msw/sockmsw.cpp
@@ -298,6 +298,9 @@ wxSocketError wxSocketImplMSW::GetLastError() const
         case WSAEWOULDBLOCK:
             return wxSOCKET_WOULDBLOCK;
 
+        case WSAEMSGSIZE:
+            return wxSOCKET_MSGSIZE;
+
         default:
             return wxSOCKET_IOERR;
     }

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -745,6 +745,9 @@ test_pathlist.o: $(srcdir)/misc/pathlist.cpp $(TEST_ODEP)
 test_typeinfotest.o: $(srcdir)/misc/typeinfotest.cpp $(TEST_ODEP)
 	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/misc/typeinfotest.cpp
 
+test_dgramsocket.o: $(srcdir)/net/dgramsocket.cpp $(TEST_ODEP)
+	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/net/dgramsocket.cpp
+
 test_ipc.o: $(srcdir)/net/ipc.cpp $(TEST_ODEP)
 	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/net/ipc.cpp
 

--- a/tests/descrip.mms
+++ b/tests/descrip.mms
@@ -374,6 +374,9 @@ test_pathlist.obj : [.misc]pathlist.cpp
 test_typeinfotest.obj : [.misc]typeinfotest.cpp 
 	$(CXXC) /object=[]$@ $(TEST_CXXFLAGS) [.misc]typeinfotest.cpp
 
+test_dgramsocket.obj : [.net]dgramsocket.cpp 
+	$(CXXC) /object=[]$@ $(TEST_CXXFLAGS) [.net]dgramsocket.cpp
+
 test_ipc.obj : [.net]ipc.cpp 
 	$(CXXC) /object=[]$@ $(TEST_CXXFLAGS) [.net]ipc.cpp
 

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -694,6 +694,9 @@ $(OBJS)\test_pathlist.o: ./misc/pathlist.cpp
 $(OBJS)\test_typeinfotest.o: ./misc/typeinfotest.cpp
 	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
 
+$(OBJS)\test_dgramsocket.o: ./net/dgramsocket.cpp
+	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
+
 $(OBJS)\test_ipc.o: ./net/ipc.cpp
 	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
 

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -987,6 +987,9 @@ $(OBJS)\test_pathlist.obj: .\misc\pathlist.cpp
 $(OBJS)\test_typeinfotest.obj: .\misc\typeinfotest.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\misc\typeinfotest.cpp
 
+$(OBJS)\test_dgramsocket.obj: .\net\dgramsocket.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\net\dgramsocket.cpp
+
 $(OBJS)\test_ipc.obj: .\net\ipc.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\net\ipc.cpp
 

--- a/tests/net/dgramsocket.cpp
+++ b/tests/net/dgramsocket.cpp
@@ -1,0 +1,35 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/net/dgramsocket.cpp
+// Purpose:     wxDatagramSocket unit tests
+// Author:      Brian Nixon
+// Copyright:   (c) 2023 Brian Nixon
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+// For compilers that support precompilation, includes "wx/wx.h".
+// and "wx/cppunit.h"
+#include "testprec.h"
+
+
+#if wxUSE_SOCKETS
+
+#include "wx/socket.h"
+
+TEST_CASE("wxDatagramSocket::SendPeek", "[socket][dgram]")
+{
+    wxIPV4address addr;
+    addr.LocalHost();
+    addr.Service(19898);// Arbitrary port number
+    wxDatagramSocket sock(addr);
+    unsigned int sendbuf[4] = {1, 2, 3, 4};
+    unsigned int recvbuf[1] = {0};
+    sock.SendTo(addr, sendbuf, sizeof(sendbuf));
+    sock.Peek(recvbuf, sizeof(recvbuf));
+    CHECK(!sock.Error());
+    CHECK(recvbuf[0] == sendbuf[0]);
+    sock.Read(recvbuf, sizeof(recvbuf));
+    CHECK(!sock.Error());
+    CHECK(recvbuf[0] == sendbuf[0]);
+}
+
+#endif // wxUSE_SOCKETS

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -69,6 +69,7 @@
             misc/module.cpp
             misc/pathlist.cpp
             misc/typeinfotest.cpp
+            net/dgramsocket.cpp
             net/ipc.cpp
             net/socket.cpp
             net/webrequest.cpp

--- a/tests/test.vcxproj
+++ b/tests/test.vcxproj
@@ -523,6 +523,7 @@
     <ClCompile Include="misc\module.cpp" />
     <ClCompile Include="misc\pathlist.cpp" />
     <ClCompile Include="misc\typeinfotest.cpp" />
+    <ClCompile Include="net\dgramsocket.cpp" />
     <ClCompile Include="net\ipc.cpp" />
     <ClCompile Include="net\socket.cpp" />
     <ClCompile Include="net\webrequest.cpp" />

--- a/tests/test.vcxproj.filters
+++ b/tests/test.vcxproj.filters
@@ -121,6 +121,9 @@
     <ClCompile Include="streams\iostreams.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="net\dgramsocket.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="net\ipc.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
On Windows, when the number of bytes present in a datagram is less than what was requested to read, `recvfrom()` will return `SOCKET_ERROR` (not the short count, as on other platforms) and `WSAGetLastError()` will return `WSAEMSGSIZE`. This patch fixes `wxSocketImpl::RecvDgram()` to handle that case.