### PR TITLE
Fix peeking and reading datagram sockets when caller requests fewer bytes than are present

### DIFF
--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -1152,9 +1152,35 @@ wxSocketBase& wxSocketBase::Peek(void* buffer, wxUint32 nbytes)
     // Peek() should never block
     wxSocketWaitModeChanger changeFlags(this, wxSOCKET_NOWAIT);
 
-    m_lcount = DoRead(buffer, nbytes);
+    // Guard against data loss when reading fewer bytes
+    // than are present in a received datagram
+    void* readbuf;
+    wxUint32 readbytes;
+    const wxUint32 DGRAM_MIN_READ = 65536;  // 64K is enough for UDP
+    std::vector<unsigned char> peekbuf;
+    bool usePeekbuf = !m_impl->m_stream && nbytes < DGRAM_MIN_READ;
+    if ( usePeekbuf )
+    {
+        // Allocate our own buffer
+        peekbuf.reserve(DGRAM_MIN_READ);
+        readbuf = &peekbuf[0];
+        readbytes = DGRAM_MIN_READ;
+    }
+    else
+    {
+        // Use the caller-supplied buffer directly
+        readbuf = buffer;
+        readbytes = nbytes;
+    }
 
-    Pushback(buffer, m_lcount);
+    wxUint32 lcount = DoRead(readbuf, readbytes);
+
+    Pushback(readbuf, lcount);
+
+    if ( usePeekbuf )
+        lcount = GetPushback(buffer, nbytes, true);
+
+    m_lcount = lcount;
 
     return *this;
 }

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -1162,7 +1162,7 @@ wxSocketBase& wxSocketBase::Peek(void* buffer, wxUint32 nbytes)
     if ( usePeekbuf )
     {
         // Allocate our own buffer
-        peekbuf.reserve(DGRAM_MIN_READ);
+        peekbuf.resize(DGRAM_MIN_READ);
         readbuf = &peekbuf[0];
         readbytes = DGRAM_MIN_READ;
     }

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -689,7 +689,15 @@ int wxSocketImpl::RecvDgram(void *buffer, int size)
                                   0, &from.addr, &fromlen) );
 
     if ( ret == SOCKET_ERROR )
-        return SOCKET_ERROR;
+    {
+#ifdef __WINDOWS__
+        if ( WSAGetLastError() == WSAEMSGSIZE )
+            ret = size;
+        else
+#endif // __WINDOWS__
+            return SOCKET_ERROR;
+    }
+
 
     m_peer = wxSockAddressImpl(from.addr, fromlen);
     if ( !m_peer.IsOk() )

--- a/tests/net/socket.cpp
+++ b/tests/net/socket.cpp
@@ -302,4 +302,21 @@ void SocketTestCase::UrlTest()
     CPPUNIT_ASSERT_EQUAL( wxSTREAM_EOF, in->Read(out).GetLastError() );
 }
 
+TEST_CASE("wxDatagramSocket::SendPeek", "[socket][dgram]")
+{
+    wxIPV4address addr;
+    addr.LocalHost();
+    addr.Service(19898);// Arbitrary port number
+    wxDatagramSocket sock(addr);
+    unsigned int sendbuf[4] = {1, 2, 3, 4};
+    unsigned int recvbuf[1] = {0};
+    sock.SendTo(addr, sendbuf, sizeof(sendbuf));
+    sock.Peek(recvbuf, sizeof(recvbuf));
+    CHECK(!sock.Error());
+    CHECK(recvbuf[0] == sendbuf[0]);
+    sock.Read(recvbuf, sizeof(recvbuf));
+    CHECK(!sock.Error());
+    CHECK(recvbuf[0] == sendbuf[0]);
+}
+
 #endif // wxUSE_SOCKETS

--- a/tests/net/socket.cpp
+++ b/tests/net/socket.cpp
@@ -324,4 +324,38 @@ TEST_CASE("wxDatagramSocket::ShortRead", "[socket][dgram]")
     CHECK(recvbuf[0] == sendbuf[0]);
 }
 
+TEST_CASE("wxDatagramSocket::ShortPeek", "[socket][dgram]")
+{
+    // Check that peeking fewer bytes than are present in a datagram
+    // does not lose the rest of the data in that datagram (#23594)
+
+    wxIPV4address addr;
+    addr.LocalHost();
+    addr.Service(27384);// Arbitrary port number
+    wxDatagramSocket sock(addr);
+
+    // Send ourselves 2 datagrams
+    unsigned int sendbuf1[2] = {1, 2};
+    sock.SendTo(addr, sendbuf1, sizeof(sendbuf1));
+    unsigned int sendbuf2[2] = {3, 4};
+    sock.SendTo(addr, sendbuf2, sizeof(sendbuf2));
+
+    long timeout_s = 1;
+    if ( !sock.WaitForRead(timeout_s) )
+        return;
+
+    // Peek the first word
+    unsigned int peekbuf[1] = {0};
+    sock.Peek(peekbuf, sizeof(peekbuf));
+    CHECK(sock.LastCount() == sizeof(peekbuf));
+    CHECK(peekbuf[0] == sendbuf1[0]);
+
+    // Read the whole of the first datagram
+    unsigned int recvbuf[2] = {0};
+    sock.Read(recvbuf, sizeof(recvbuf));
+    CHECK(sock.LastReadCount() == sizeof(recvbuf));
+    CHECK(recvbuf[0] == sendbuf1[0]);
+    CHECK(recvbuf[1] == sendbuf1[1]);
+}
+
 #endif // wxUSE_SOCKETS

--- a/tests/net/socket.cpp
+++ b/tests/net/socket.cpp
@@ -302,20 +302,25 @@ void SocketTestCase::UrlTest()
     CPPUNIT_ASSERT_EQUAL( wxSTREAM_EOF, in->Read(out).GetLastError() );
 }
 
-TEST_CASE("wxDatagramSocket::SendPeek", "[socket][dgram]")
+TEST_CASE("wxDatagramSocket::ShortRead", "[socket][dgram]")
 {
+    // Check that reading fewer bytes than are present in a
+    // datagram does not leave the socket in an error state
+
     wxIPV4address addr;
     addr.LocalHost();
     addr.Service(19898);// Arbitrary port number
     wxDatagramSocket sock(addr);
+
+    // Send ourselves a datagram
     unsigned int sendbuf[4] = {1, 2, 3, 4};
-    unsigned int recvbuf[1] = {0};
     sock.SendTo(addr, sendbuf, sizeof(sendbuf));
-    sock.Peek(recvbuf, sizeof(recvbuf));
-    CHECK(!sock.Error());
-    CHECK(recvbuf[0] == sendbuf[0]);
+
+    // Read less than we know we sent
+    unsigned int recvbuf[1] = {0};
     sock.Read(recvbuf, sizeof(recvbuf));
     CHECK(!sock.Error());
+    CHECK(sock.LastReadCount() == sizeof(recvbuf));
     CHECK(recvbuf[0] == sendbuf[0]);
 }
 


### PR DESCRIPTION
Simpler version of #23598, plus a fix for #23594