### PR TITLE
Fixes for `wxListCtrl` drawing under Windows 11 in dark mode

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -1007,6 +1007,7 @@ enum wxWinVersion
     wxWinVersion_8_1 = 0x603,
 
     wxWinVersion_10 = 0x1000,
+    wxWinVersion_11 = 0x1001,
 
     // Any version we can't recognize will be later than the last currently
     // known one, so give it a value greater than any in the known range.

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1095,6 +1095,10 @@ int wxIsWindowsServer()
     return -1;
 }
 
+// Windows 11 uses the same version as Windows 10 but its build numbers start
+// from 22000, which provides a way to test for it.
+static const int FIRST_WINDOWS11_BUILD = 22000;
+
 } // anonymous namespace
 
 wxString wxGetOsDescription()
@@ -1158,7 +1162,7 @@ wxString wxGetOsDescription()
                     break;
 
                 case 10:
-                    if (info.dwBuildNumber >= 22000)
+                    if (info.dwBuildNumber >= FIRST_WINDOWS11_BUILD)
                         str = wxIsWindowsServer() == 1
                             ? "Windows Server 2022"
                             : "Windows 11";
@@ -1269,8 +1273,9 @@ bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
 wxWinVersion wxGetWinVersion()
 {
     int verMaj,
-        verMin;
-    switch ( wxGetOsVersion(&verMaj, &verMin) )
+        verMin,
+        build;
+    switch ( wxGetOsVersion(&verMaj, &verMin, &build) )
     {
         case wxOS_WINDOWS_NT:
             switch ( verMaj )
@@ -1305,7 +1310,8 @@ wxWinVersion wxGetWinVersion()
                     break;
 
                 case 10:
-                    return wxWinVersion_10;
+                    return build >= FIRST_WINDOWS11_BUILD ? wxWinVersion_11
+                                                          : wxWinVersion_10;
             }
             break;
         default:


### PR DESCRIPTION
Also fix using `wxListCtrl` with `WS_EX_COMPOSITED` as a (very nice) side effect.