### PR TITLE
Fix compile errors for wxUIActionSimulator with some features disabled

### DIFF
--- a/src/common/uiactioncmn.cpp
+++ b/src/common/uiactioncmn.cpp
@@ -191,12 +191,20 @@ bool wxUIActionSimulator::Select(const wxString& text)
 #ifdef wxNO_RTTI
     wxItemContainer* container = nullptr;
 
+#if wxUSE_COMBOBOX
     if ( wxComboBox* combo = wxDynamicCast(focus, wxComboBox) )
         container = combo;
-    else if ( wxChoice* choice = wxDynamicCast(focus, wxChoice) )
+#endif // wxUSE_COMBOBOX
+#if wxUSE_CHOICE
+    wxChoice* choice;
+    if ( !container && (choice = wxDynamicCast(focus, wxChoice)) )
         container = choice;
-    else if ( wxListBox* listbox = wxDynamicCast(focus, wxListBox) )
+#endif // wxUSE_CHOICE
+#if wxUSE_LISTBOX
+    wxListBox* listbox;
+    if ( !container && (listbox = wxDynamicCast(focus, wxListBox)) )
         container = listbox;
+#endif // wxUSE_LISTBOX
 #else // !wxNO_RTTI
     wxItemContainer* const container = dynamic_cast<wxItemContainer*>(focus);
 #endif // wxNO_RTTI/!wxNO_RTTI


### PR DESCRIPTION
If you enabled `wxNO_RTTI` and `wxUSE_UIACTIONSIMULATOR`,
The following options will cause compile errors.

- `wxUSE_COMBOBOX=OFF`
- `wxUSE_CHOICE=OFF`
- `wxUSE_LISTBOX=OFF`

This PR will fix the erorrs.