### PR TITLE
Fixes for wxControl::GTKGetEntryMargins, wxTextCtrl::DoGetSizeFromTextSize, wxTreeTextCtrl on wxGTK

### DIFF
--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -436,22 +436,21 @@ wxTreeTextCtrl::wxTreeTextCtrl(wxGenericTreeCtrl *owner,
     wxRect rect;
     m_owner->GetBoundingRect(m_itemEdited, rect, true);
 
-    // corrects position and size for better appearance
-#ifdef __WXMSW__
-    rect.x -= 5;
-#elif defined(__WXGTK__)
-    rect.x -= 5;
-#endif // platforms
-
     const wxSize textSize = rect.GetSize();
     wxSize fullSize = GetSizeFromTextSize(textSize);
+
+    // Ensure that the text field covers tree item.
+    fullSize.x = wxMax(fullSize.x, textSize.x + 5);
+
+    // Correct position for better appearance.
+#ifdef __WXMSW__
+    rect.x -= 5;
+#else
+    rect.x -= (fullSize.x - textSize.x) / 2;
+#endif
+
     if ( fullSize.y > textSize.y )
-    {
-        // It's ok to extend the rect to the right horizontally, which happens
-        // when we just change its size without changing its position below,
-        // but when extending it vertically, we need to keep it centered.
-        rect.y -= (fullSize.y - textSize.y + 1) / 2;
-    }
+        rect.y -= (fullSize.y - textSize.y) / 2;
 
     // Also check that the control fits into the parent window.
     const int totalWidth = m_owner->GetClientSize().x;

--- a/src/gtk/control.cpp
+++ b/src/gtk/control.cpp
@@ -366,12 +366,17 @@ wxSize wxControl::GTKGetPreferredSize(GtkWidget* widget) const
 wxSize wxControl::GTKGetEntryMargins(GtkEntry* entry) const
 {
     wxSize size;
-    gtk_entry_get_layout_offsets(entry, &size.x, &size.y);
 
 #ifdef __WXGTK3__
-    GtkBorder border;
     GtkStyleContext* sc = gtk_widget_get_style_context(GTK_WIDGET(entry));
-    gtk_style_context_get_padding(sc, gtk_style_context_get_state(sc), &border);
+    GtkStateFlags    state = gtk_style_context_get_state(sc);
+
+    GtkBorder padding, border;
+    gtk_style_context_get_padding(sc, state, &padding);
+    gtk_style_context_get_border(sc, state, &border);
+
+    size.x += padding.left + padding.right + border.left + border.right;
+    size.y += padding.top + padding.bottom + border.top + border.bottom;
 #else
     if (gtk_entry_get_has_frame(entry))
     {
@@ -402,10 +407,10 @@ wxSize wxControl::GTKGetEntryMargins(GtkEntry* entry) const
         }
     }
 #endif // GTK+ 2.10+
-#endif
 
     size.x += border.left + border.right;
     size.y += border.top  + border.bottom;
+#endif
 
     return size;
 }

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -2138,29 +2138,11 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
 
     if ( IsSingleLine() )
     {
-        if ( HasFlag(wxBORDER_NONE) )
-        {
-#ifdef __WXGTK3__
-            tsize.IncBy(9, 0);
-#else
-            tsize.IncBy(4, 0);
-#endif // GTK3
-        }
-        else
-        {
-            // default height
-            tsize.y = GTKGetPreferredSize(m_widget).y;
-#ifdef __WXGTK3__
-            // Add the margins we have previously set.
-            tsize.IncBy( GTKGetEntryMargins(GetEntry()) );
-#else
-            // For GTK 2 these margins are too big, so hard code something more
-            // reasonable, this is not great but should be fine considering
-            // that it's very unlikely that GTK 2 is going to evolve, making
-            // this inappropriate.
-            tsize.IncBy(20, 0);
-#endif
-        }
+        // Default height
+        tsize.y = GTKGetPreferredSize(m_widget).y;
+
+        // Add padding + border size
+        tsize.x += GTKGetEntryMargins(GetEntry()).x;
     }
 
     //multiline


### PR DESCRIPTION
See https://github.com/wxWidgets/wxWidgets/issues/23610, https://github.com/wxWidgets/wxWidgets/issues/23001. 

**Only tested on Linux Mint 21.1 XFCE**

treectrl sample:
| GTK2, 96dpi, Yaru  | GTK2, 96dpi, Adwaita | GTK2, 96dpi, Mint-Y |
| ------------- | ------------- |----|
| ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/4a0db11b-c7e6-42ac-a17d-821ce956ae56) | ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/e780f04e-7c07-4607-aa38-8eba8c3e3015)  | ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/281530fa-5477-4fb7-b65a-00ab8e58b39f) |

| GTK3, 96dpi, Yaru  | GTK3, 96dpi, Adwaita | GTK3, 96dpi, Mint-Y |
| ------------- | ------------- |----|
| ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/c50f45e7-32a2-4549-973b-0badf5d4dc51) | ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/5e5eaaa0-d2e8-45e4-b03e-48aa5f8740c4) | ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/2c20fcf6-d788-49dd-b3d3-6165a04bbcf0) |

| GTK2, 150dpi, Yaru  | GTK2, 150dpi, Adwaita | GTK2, 150dpi, Mint-Y |
| ------------- | ------------- |----|
| ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/e3a6a984-215a-4164-ad16-6eaee00a000d) | ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/aaced38f-944b-4f81-a36b-6e8b646b2e40) | ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/a6b7d401-86b9-458c-bf23-4b0c30e14a75) |

| GTK3, 150dpi, Yaru  | GTK3, 150dpi, Adwaita | GTK3, 150dpi, Mint-Y |
| ------------- | ------------- |----|
| ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/cd3c8f23-c140-4288-964c-ad38b6c8b5dc) | ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/6a5f2669-b374-442b-bf35-3c5a3524b11b) | ![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/05d26ff7-9a84-4a24-b64a-085a2d91b55d) |

---

KiCad 7.0.5, wxWidgets 3.2.2.1 without patches, restore to page via ChangeSelection:

![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/e7e110b8-9709-4510-8e66-5ac279fd34ec)

Manual switch to the page:

![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/8cd1d55a-662d-46bd-9845-de7bfa9ecb6e)

---

With patches, Mint-Y

![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/412ec978-c5fb-447e-9539-209801889575)

With patches, Adwaita:

![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/b14f7ecb-99a7-4f69-bef5-9c2ea66a083e)
