### PR TITLE
Fixing up implicit copy constructor warnings by using wxDECLARE_DYNAM…

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -98,7 +98,7 @@ private:
     int m_toolId;
 
 private:
-    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxAuiToolBarEvent);
+    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxAuiToolBarEvent);
 };
 
 

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -79,7 +79,7 @@ private:
 
 #ifndef SWIG
 private:
-    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxAuiNotebookEvent);
+    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxAuiNotebookEvent);
 #endif
 };
 

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -673,7 +673,7 @@ public:
 
 #ifndef SWIG
 private:
-    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxAuiManagerEvent);
+    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxAuiManagerEvent);
 #endif
 };
 

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -3522,7 +3522,7 @@ struct WXDLLIMPEXP_BASE wxEventTableEntry : public wxEventTableEntryBase
     const int& m_eventType;
 
 private:
-    wxDECLARE_NO_ASSIGN_CLASS(wxEventTableEntry);
+    wxDECLARE_NO_ASSIGN_DEF_COPY(wxEventTableEntry);
 };
 
 // an entry used in dynamic event table managed by wxEvtHandler::Connect()

--- a/include/wx/osx/core/cfdictionary.h
+++ b/include/wx/osx/core/cfdictionary.h
@@ -58,6 +58,14 @@ public:
      */
     wxCFDictionaryRefCommon(const wxCFDictionaryRefCommon&) = default;
 
+    /*! @method     operator=
+        @abstract   Assigns the other ref's pointer to us when the otherRef is the same type.
+        @param otherRef The other ref holder to copy.
+        @discussion The incoming pointer is retained, the original pointer is released, and this object
+                    is made to point to the new pointer.
+    */
+    wxCFDictionaryRefCommon& operator=(const wxCFDictionaryRefCommon&) = default;
+
     wxCFTypeRef GetValue(const void* key)
     {
         CFTypeRef val = CFDictionaryGetValue(this->m_ptr, key);

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -272,7 +272,7 @@ private:
     // Minimal and maximal values accepted (inclusive).
     ValueType m_min, m_max;
 
-    wxDECLARE_NO_ASSIGN_CLASS(wxNumValidator);
+    wxDECLARE_NO_ASSIGN_DEF_COPY(wxNumValidator);
 };
 
 } // namespace wxPrivate
@@ -318,7 +318,7 @@ protected:
     virtual bool IsCharOk(const wxString& val, int pos, wxChar ch) const override;
 
 private:
-    wxDECLARE_NO_ASSIGN_CLASS(wxIntegerValidatorBase);
+    wxDECLARE_NO_ASSIGN_DEF_COPY(wxIntegerValidatorBase);
 };
 
 // Validator for integer numbers. It can actually work with any integer type
@@ -381,7 +381,7 @@ public:
     }
 
 private:
-    wxDECLARE_NO_ASSIGN_CLASS(wxIntegerValidator);
+    wxDECLARE_NO_ASSIGN_DEF_COPY(wxIntegerValidator);
 };
 
 // Helper function for creating integer validators which allows to avoid
@@ -442,7 +442,7 @@ private:
     // Factor applied for the displayed the value.
     double m_factor;
 
-    wxDECLARE_NO_ASSIGN_CLASS(wxFloatingPointValidatorBase);
+    wxDECLARE_NO_ASSIGN_DEF_COPY(wxFloatingPointValidatorBase);
 };
 
 // Validator for floating point numbers. It can be used with float, double or


### PR DESCRIPTION
…IC_CLASS_NO_ASSIGN_DEF_COPY/wxDECLARE_NO_ASSIGN_DEF_COPY.

See #23625

Attaching original build logs and build logs with the fix.
[build_with_fix.log](https://github.com/wxWidgets/wxWidgets/files/11702089/build_with_fix.log)
[build.log](https://github.com/wxWidgets/wxWidgets/files/11702090/build.log)
