### PR TITLE
Fix a linker error when wxUSE_PROTOCOL_FILE is off

### DIFF
--- a/src/common/url.cpp
+++ b/src/common/url.cpp
@@ -31,7 +31,9 @@ wxIMPLEMENT_CLASS(wxURL, wxURI);
 wxProtoInfo *wxURL::ms_protocols = nullptr;
 
 // Enforce linking of protocol classes:
+#if wxUSE_PROTOCOL_FILE
 USE_PROTOCOL(wxFileProto)
+#endif
 
 #if wxUSE_PROTOCOL_HTTP
 USE_PROTOCOL(wxHTTP)


### PR DESCRIPTION
Tiny fix for a linker error.
It'll allow us to disable `wxUSE_PROTOCOL_FILE` with `wxUSE_PROTOCOL` enabled.