### PR TITLE
[macOS] BUG FIX - DataviewCtrl's column value can be invalid but checking is not done

### DIFF
--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1602,6 +1602,10 @@ outlineView:(NSOutlineView*)outlineView
     const wxDataViewItem item = wxDataViewItemFromItem([self itemAtRow:row]);
 
     const NSInteger col = [self clickedColumn];
+
+    if ( col == -1)
+      return; // even if row != -1 an invalid column value may occur (e.g. by clicking to the very left or right of the dataview)
+
     wxDataViewColumn* const dvCol = implementation->GetColumn(col);
 
     // Check if we need to activate a custom renderer first.


### PR DESCRIPTION
Although a valid row value has been obtained, the column value can also be invalid. But a check is not done. In those cases the app will crash because of an invalid array index.

Remarks: An invalid column value can be obtained by double-clicking to the far left or right of a table.