### PR TITLE
Removal of unjustified undeclared selector warnings

### DIFF
--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -446,10 +446,13 @@ void wxFileDialog::SetupExtraControls(WXWindow nativeWindow)
     {
         [accView removeFromSuperview];
         [panel setAccessoryView:accView];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
         if ([panel respondsToSelector:@selector(setAccessoryViewDisclosed)])
         {
             [(id)panel setAccessoryViewDisclosed:YES];
         }
+#pragma clang diagnostic pop
     }
     else
     {

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -1598,10 +1598,13 @@ public:
         {
             eventsMask &= ~wxTOUCH_PAN_GESTURES;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
             m_panGestureRecognizer =
             [[NSPanGestureRecognizer alloc] initWithTarget:m_view action: @selector(handlePanGesture:)];
             if ( !class_respondsToSelector(cls, @selector(handlePanGesture:)) )
                 class_addMethod(cls, @selector(handlePanGesture:), (IMP) wxOSX_panGestureEvent, "v@:@" );
+#pragma clang diagnostic pop
             [m_view addGestureRecognizer:m_panGestureRecognizer];
         }
         else
@@ -1613,6 +1616,8 @@ public:
         {
             eventsMask &= ~wxTOUCH_ZOOM_GESTURE;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
             m_magnificationGestureRecognizer =
             [[NSMagnificationGestureRecognizer alloc] initWithTarget:m_view action: @selector(handleZoomGesture:)];
             if ( !class_respondsToSelector(cls, @selector(handleZoomGesture:)) )


### PR DESCRIPTION
Selectors may exist in case panel is an NSOpenPanel, respectively selectors are created when they do not exist.