### PR TITLE
Fix scrollbar creation for Mac windows not using standard peer

### DIFF
--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -342,7 +342,7 @@ protected:
     virtual bool        MacIsChildOfClientArea( const wxWindow* child ) const ;
 
     bool                MacHasScrollBarCorner() const;
-    void                MacCreateScrollBars( long style ) ;
+    void                MacCreateScrollBars( ) ;
     void                MacRepositionScrollBars() ;
 
     // implement the base class pure virtuals

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -390,19 +390,6 @@ bool wxWindowMac::Create(wxWindowMac *parent,
         MacPostControlCreate(pos, size) ;
     }
 
-#ifndef __WXUNIVERSAL__
-    // Don't give scrollbars to wxControls unless they ask for them
-    if ( (! IsKindOf(CLASSINFO(wxControl))
-#if wxUSE_STATUSBAR
-        && ! IsKindOf(CLASSINFO(wxStatusBar))
-#endif
-        )
-         || (IsKindOf(CLASSINFO(wxControl)) && ((style & wxHSCROLL) || (style & wxVSCROLL))))
-    {
-        MacCreateScrollBars( style ) ;
-    }
-#endif
-
     wxWindowCreateEvent event((wxWindow*)this);
     GetEventHandler()->AddPendingEvent(event);
 
@@ -430,6 +417,20 @@ void wxWindowMac::MacPostControlCreate(const wxPoint& pos,
     {
         SetPosition(pos);
     }
+
+#ifndef __WXUNIVERSAL__
+    // Don't give scrollbars to wxControls unless they ask for them
+    if ( (! IsKindOf(CLASSINFO(wxControl))
+#if wxUSE_STATUSBAR
+        && ! IsKindOf(CLASSINFO(wxStatusBar))
+#endif
+        )
+         || (IsKindOf(CLASSINFO(wxControl)) && (HasFlag(wxHSCROLL) || HasFlag(wxVSCROLL))))
+    {
+        MacCreateScrollBars( ) ;
+    }
+#endif
+
 }
 
 void wxWindowMac::DoSetWindowVariant( wxWindowVariant variant )
@@ -2044,12 +2045,12 @@ bool wxWindowMac::MacHasScrollBarCorner() const
     return false;
 }
 
-void wxWindowMac::MacCreateScrollBars( long style )
+void wxWindowMac::MacCreateScrollBars()
 {
 #if wxUSE_SCROLLBAR
     wxASSERT_MSG( m_vScrollBar == nullptr && m_hScrollBar == nullptr , wxT("attempt to create window twice") ) ;
 
-    if ( style & ( wxVSCROLL | wxHSCROLL ) )
+    if ( HasFlag( wxVSCROLL | wxHSCROLL ) )
     {
         int scrlsize = MAC_SCROLLBAR_SIZE ;
         if ( GetWindowVariant() == wxWINDOW_VARIANT_SMALL || GetWindowVariant() == wxWINDOW_VARIANT_MINI )
@@ -2067,13 +2068,13 @@ void wxWindowMac::MacCreateScrollBars( long style )
         wxSize hSize(width - adjust, scrlsize) ;
 
         // we have to set the min size to a smaller value, otherwise they cannot get smaller (InitialSize sets MinSize)
-        if ( style & wxVSCROLL )
+        if ( HasFlag(wxVSCROLL) )
         {
             m_vScrollBar = new wxScrollBar((wxWindow*)this, wxID_ANY, vPoint, vSize , wxVERTICAL);
             m_vScrollBar->SetMinSize( wxDefaultSize );
         }
 
-        if ( style  & wxHSCROLL )
+        if ( HasFlag(wxHSCROLL) )
         {
             m_hScrollBar = new wxScrollBar((wxWindow*)this, wxID_ANY, hPoint, hSize , wxHORIZONTAL);
             m_hScrollBar->SetMinSize( wxDefaultSize );


### PR DESCRIPTION
This avoids crash if wxVSCROLL or wxHSCROLL is used with wxGLCanvas which calls wxWindow::Create() after calling DontCreatePeer() because the Create() tries to use the not (yet) existent peer in MacCreateScrollBars().

Avoid this problem by moving the call to MacCreateScrollBars() to MacPostControlCreate(), which doesn't change anything for the windows that do not call DontCreatePeer(), but ensures that the peer already exists by the time MacPostControlCreate() is called for those that do.

Closes #23536.