### PR TITLE
Fix compilation errors when wxUSE_INTL or wxUSE_RADIOBTN is off.

### DIFF
--- a/include/wx/filedlgcustomize.h
+++ b/include/wx/filedlgcustomize.h
@@ -15,7 +15,9 @@
 class wxFileDialogCustomControlImpl;
 class wxFileDialogButtonImpl;
 class wxFileDialogCheckBoxImpl;
+#if wxUSE_RADIOBTN
 class wxFileDialogRadioButtonImpl;
+#endif
 class wxFileDialogChoiceImpl;
 class wxFileDialogTextCtrlImpl;
 class wxFileDialogStaticTextImpl;
@@ -92,6 +94,7 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxFileDialogCheckBox);
 };
 
+#if wxUSE_RADIOBTN
 // A class representing a custom radio button.
 class WXDLLIMPEXP_CORE wxFileDialogRadioButton : public wxFileDialogCustomControl
 {
@@ -110,6 +113,7 @@ private:
 
     wxDECLARE_NO_COPY_CLASS(wxFileDialogRadioButton);
 };
+#endif // wxUSE_RADIOBTN
 
 // A class representing a custom combobox button.
 class WXDLLIMPEXP_CORE wxFileDialogChoice : public wxFileDialogCustomControl
@@ -170,7 +174,9 @@ class WXDLLIMPEXP_CORE wxFileDialogCustomize
 public:
     wxFileDialogButton* AddButton(const wxString& label);
     wxFileDialogCheckBox* AddCheckBox(const wxString& label);
+#if wxUSE_RADIOBTN
     wxFileDialogRadioButton* AddRadioButton(const wxString& label);
+#endif
     wxFileDialogChoice* AddChoice(size_t n, const wxString* strings);
     wxFileDialogTextCtrl* AddTextCtrl(const wxString& label = wxString());
     wxFileDialogStaticText* AddStaticText(const wxString& label);

--- a/include/wx/private/filedlgcustomize.h
+++ b/include/wx/private/filedlgcustomize.h
@@ -38,12 +38,14 @@ public:
     virtual void SetValue(bool value) = 0;
 };
 
+#if wxUSE_RADIOBTN
 class wxFileDialogRadioButtonImpl : public wxFileDialogCustomControlImpl
 {
 public:
     virtual bool GetValue() = 0;
     virtual void SetValue(bool value) = 0;
 };
+#endif // wxUSE_RADIOBTN
 
 class wxFileDialogChoiceImpl : public wxFileDialogCustomControlImpl
 {
@@ -74,7 +76,9 @@ class wxFileDialogCustomizeImpl
 public:
     virtual wxFileDialogButtonImpl* AddButton(const wxString& label) = 0;
     virtual wxFileDialogCheckBoxImpl* AddCheckBox(const wxString& label) = 0;
+#if wxUSE_RADIOBTN
     virtual wxFileDialogRadioButtonImpl* AddRadioButton(const wxString& label) = 0;
+#endif
     virtual wxFileDialogChoiceImpl* AddChoice(size_t n, const wxString* strings) = 0;
     virtual wxFileDialogTextCtrlImpl* AddTextCtrl(const wxString& label) = 0;
     virtual wxFileDialogStaticTextImpl* AddStaticText(const wxString& label) = 0;

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -781,10 +781,12 @@ wxString wxDateTime::GetMonthName(Month month,
                                   const NameForm& form)
 {
     wxCHECK_MSG(month != Inv_Month, wxEmptyString, wxT("invalid month"));
+#if wxUSE_INTL
     wxString name = wxUILocale::GetCurrent().GetMonthName(month, form);
-    if (name.empty())
-        name = GetEnglishMonthName(month, form);
-    return name;
+    if (!name.empty())
+        return name;
+#endif // wxUSE_INTL
+    return GetEnglishMonthName(month, form);
 }
 
 /* static */
@@ -812,10 +814,12 @@ wxString wxDateTime::GetWeekDayName(WeekDay wday,
                                     const NameForm& form)
 {
     wxCHECK_MSG(wday != Inv_WeekDay, wxEmptyString, wxT("invalid weekday"));
+#if wxUSE_INTL
     wxString name = wxUILocale::GetCurrent().GetWeekDayName(wday, form);
-    if (name.empty())
-        name = GetEnglishWeekDayName(wday, form);
-    return name;
+    if (!name.empty())
+        return name;
+#endif // wxUSE_INTL
+    return GetEnglishWeekDayName(wday, form);
 }
 
 /* static */

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -320,13 +320,15 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
 
     wxString format = formatp;
 #ifdef __WXOSX__
+#if wxUSE_INTL
     if ( format.Contains("%c") )
         format.Replace("%c", wxUILocale::GetCurrent().GetInfo(wxLOCALE_DATE_TIME_FMT));
     if ( format.Contains("%x") )
         format.Replace("%x", wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT));
     if ( format.Contains("%X") )
         format.Replace("%X", wxUILocale::GetCurrent().GetInfo(wxLOCALE_TIME_FMT));
-#endif
+#endif // wxUSE_INTL
+#endif // __WXOSX__
     // we have to use our own implementation if the date is out of range of
     // strftime()
 #ifdef wxHAS_STRFTIME

--- a/src/common/fldlgcmn.cpp
+++ b/src/common/fldlgcmn.cpp
@@ -145,6 +145,7 @@ void wxFileDialogCheckBox::SetValue(bool value)
     GetImpl()->SetValue(value);
 }
 
+#if wxUSE_RADIOBTN
 wxFileDialogRadioButton::wxFileDialogRadioButton(wxFileDialogRadioButtonImpl* impl)
     : wxFileDialogCustomControl(impl)
 {
@@ -172,6 +173,7 @@ void wxFileDialogRadioButton::SetValue(bool value)
 {
     GetImpl()->SetValue(value);
 }
+#endif // wxUSE_RADIOBTN
 
 wxFileDialogChoice::wxFileDialogChoice(wxFileDialogChoiceImpl* impl)
     : wxFileDialogCustomControl(impl)
@@ -280,11 +282,13 @@ wxFileDialogCustomize::AddCheckBox(const wxString& label)
     return StoreAndReturn(new wxFileDialogCheckBox(m_impl->AddCheckBox(label)));
 }
 
+#if wxUSE_RADIOBTN
 wxFileDialogRadioButton*
 wxFileDialogCustomize::AddRadioButton(const wxString& label)
 {
     return StoreAndReturn(new wxFileDialogRadioButton(m_impl->AddRadioButton(label)));
 }
+#endif // wxUSE_RADIOBTN
 
 wxFileDialogChoice*
 wxFileDialogCustomize::AddChoice(size_t n, const wxString* strings)
@@ -444,6 +448,7 @@ private:
     wxEvtHandler* m_handler;
 };
 
+#if wxUSE_RADIOBTN
 class RadioButtonImpl : public ControlImplBase<wxFileDialogRadioButtonImpl>
 {
 public:
@@ -495,6 +500,7 @@ private:
 
     wxEvtHandler* m_handler;
 };
+#endif // wxUSE_RADIOBTN
 
 class ChoiceImpl : public ControlImplBase<wxFileDialogChoiceImpl>
 {
@@ -648,6 +654,7 @@ public:
         return AddToLayoutAndReturn<CheckBoxImpl>(label);
     }
 
+#if wxUSE_RADIOBTN
     wxFileDialogRadioButtonImpl* AddRadioButton(const wxString& label) override
     {
         RadioButtonImpl* const impl = AddToLayoutAndReturn<RadioButtonImpl>(label);
@@ -661,6 +668,7 @@ public:
 
         return impl;
     }
+#endif // wxUSE_RADIOBTN
 
     wxFileDialogChoiceImpl* AddChoice(size_t n, const wxString* strings) override
     {

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -326,6 +326,7 @@ public:
     }
 };
 
+#if wxUSE_RADIOBTN
 class wxFileDialogRadioButtonImplFDC
     : public wxFileDialogImplFDC<wxFileDialogRadioButtonImpl>
 {
@@ -366,6 +367,7 @@ public:
 private:
     const DWORD m_item;
 };
+#endif // wxUSE_RADIOBTN
 
 class wxFileDialogChoiceImplFDC
     : public wxFileDialogImplFDC<wxFileDialogChoiceImpl>
@@ -534,6 +536,7 @@ public:
         return new wxFileDialogCheckBoxImplFDC(m_fdc, m_lastId);
     }
 
+#if wxUSE_RADIOBTN
     wxFileDialogRadioButtonImpl* AddRadioButton(const wxString& label) override
     {
         HRESULT hr;
@@ -568,6 +571,7 @@ public:
 
         return impl;
     }
+#endif // wxUSE_RADIOBTN
 
     wxFileDialogChoiceImpl* AddChoice(size_t n, const wxString* strings) override
     {

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -505,8 +505,8 @@ static wxMenu *CreateAppleMenu()
     if ( wxApp::s_macPreferencesMenuItemId != wxID_NONE )
     {
         appleMenu->Append( wxApp::s_macPreferencesMenuItemId,
-                           wxGETTEXT_IN_CONTEXT("macOS menu item", "Preferences...")
-                           + "\tCtrl+," );
+                           wxString::Format("%s\tCtrl+,",
+                                            wxGETTEXT_IN_CONTEXT("macOS menu item", "Preferences...")) );
         appleMenu->AppendSeparator();
     }
 
@@ -523,7 +523,8 @@ static wxMenu *CreateAppleMenu()
         hideLabel = wxGETTEXT_IN_CONTEXT("macOS menu item", "Hide Application");
     appleMenu->Append( wxID_OSX_HIDE, hideLabel + "\tCtrl+H" );
     appleMenu->Append( wxID_OSX_HIDEOTHERS,
-                       wxGETTEXT_IN_CONTEXT("macOS menu item", "Hide Others")+"\tAlt+Ctrl+H" );
+                       wxString::Format("%s\tAlt+Ctrl+H",
+                                        wxGETTEXT_IN_CONTEXT("macOS menu item", "Hide Others")) );
     appleMenu->Append( wxID_OSX_SHOWALL,
                        wxGETTEXT_IN_CONTEXT("macOS menu item", "Show All") );
     appleMenu->AppendSeparator();


### PR DESCRIPTION
I noticed [the latest changes of `datetime.cpp`](https://github.com/wxWidgets/wxWidgets/commit/5b424ea181400f1898fd297f97e544d055191a82) won't work with `wxUSE_INTL=0`.
This PR will fix the issue and some compilation errors I found.

- Fixed compilation errors when `wxUSE_INTL` is off.
- Fixed compilation erros for wxFileDialog when `wxUSE_RADIOBTN` is off.