### PR TITLE
Document already existing wxPrintPreview::GetZoom function

### DIFF
--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -375,6 +375,11 @@ public:
     virtual wxPrintout* GetPrintoutForPrinting() const;
 
     /**
+        Gets the current percentage zoom level of the preview canvas.
+    */
+    virtual int wxPrintPreview::GetZoom() const;
+
+    /**
         Returns @true if the wxPrintPreview is valid, @false otherwise.
 
         It could return @false if there was a problem initializing the printer


### PR DESCRIPTION
This base function was added over 16 years ago but never documented.

It would be nice to backport this to 3.2 as well so that it gets documented there. A search of a 3.2 library on my Fedora machine shows the symbol is exported in the library already:
```
$ nm --dynamic libwx_gtk3u_core-3.2.so | grep PrintPreview | grep GetZoom
0000000000520150 T _ZNK14wxPrintPreview7GetZoomEv@@WXU_3.2
00000000005164d0 T _ZNK18wxPrintPreviewBase7GetZoomEv@@WXU_3.2
```