### PR TITLE
Corrected typo in samples/notebook/notebook.cpp

### DIFF
--- a/samples/notebook/notebook.cpp
+++ b/samples/notebook/notebook.cpp
@@ -326,7 +326,7 @@ MyFrame::MyFrame()
     menuType->AppendRadioItem(ID_BOOK_TREEBOOK,   "&Treebook\tCtrl-4");
 #endif
 #if wxUSE_TOOLBOOK
-    menuType->AppendRadioItem(ID_BOOK_TOOLBOOK,   "T&oolbook\tCtrl-5");
+    menuType->AppendRadioItem(ID_BOOK_TOOLBOOK,   "&Toolbook\tCtrl-5");
 #endif
 #if wxUSE_AUI
     menuType->AppendRadioItem(ID_BOOK_AUINOTEBOOK,   "&AuiNotebook\tCtrl-6");


### PR DESCRIPTION
Hi, there is a small error in `notebook.cpp` (`"T&oolbook"` instead of `"&Toolbook"`).
