### PR TITLE
Create hidden radio button in wxGTK when using wxRB_SINGLE

### DIFF
--- a/include/wx/gtk/radiobut.h
+++ b/include/wx/gtk/radiobut.h
@@ -55,6 +55,8 @@ protected:
 
 private:
     typedef wxControl base_type;
+    // Only used by wxRB_SINGLE
+    GtkWidget *m_hidden_radio_button = nullptr;
 
     wxDECLARE_DYNAMIC_CLASS(wxRadioButton);
 };

--- a/interface/wx/radiobut.h
+++ b/interface/wx/radiobut.h
@@ -33,9 +33,9 @@
            When this style is used, no other radio buttons will be turned off
            automatically when this button is turned on and such behaviour will
            need to be implemented manually, in the event handler for this
-           button. This style is currently only supported in wxMSW, in the
-           other ports it can be specified, but single radio buttons can't be
-           turned off, making them not very useful.
+           button. This style is currently only supported in wxMSW and wxGTK,
+           in the other ports it can be specified, but single radio buttons
+           can't be turned off, making them not very useful.
     @endStyleTable
 
     @beginEventEmissionTable{wxCommandEvent}

--- a/src/gtk/radiobut.cpp
+++ b/src/gtk/radiobut.cpp
@@ -92,7 +92,22 @@ bool wxRadioButton::Create( wxWindow *parent,
         }
     }
 
-    m_widget = gtk_radio_button_new_with_label( radioButtonGroup, label.utf8_str() );
+    // GTK does not allow a radio button to be inactive if it is the only radio
+    // button in its group, so we need to work around this by creating a second
+    // hidden radio button.
+    if (HasFlag(wxRB_SINGLE))
+    {
+        m_hidden_radio_button = gtk_radio_button_new( nullptr );
+        m_widget = gtk_radio_button_new_with_label_from_widget( GTK_RADIO_BUTTON(m_hidden_radio_button), label.utf8_str() );
+        // Since this is the second button in the group, we need to ensure it
+        // is active by default and not the first hidden one.
+        gtk_toggle_button_set_active( GTK_TOGGLE_BUTTON(m_widget), TRUE );
+    }
+    else
+    {
+        m_widget = gtk_radio_button_new_with_label( radioButtonGroup, label.utf8_str() );
+    }
+
     g_object_ref(m_widget);
 
     SetLabel(label);
@@ -133,9 +148,8 @@ void wxRadioButton::SetValue( bool val )
     }
     else
     {
-        // should give an assert
-        // RL - No it shouldn't.  A wxGenericValidator might try to set it
-        //      as FALSE.  Failing silently is probably TRTTD here.
+        if (HasFlag(wxRB_SINGLE))
+            gtk_toggle_button_set_active( GTK_TOGGLE_BUTTON(m_hidden_radio_button), TRUE );
     }
 
     g_signal_handlers_unblock_by_func(


### PR DESCRIPTION
This lets us deactivate the shown button by activating the hidden one. GTK does not allow deactivating radio buttons by calling them with `gtk_toggle_button_set_active ( ..., FALSE )`, so we need to work around it like this.

Tested with GTK 3.24.38.

Closes https://github.com/wxWidgets/wxWidgets/issues/23652
Related https://github.com/wxWidgets/wxWidgets/issues/17022