### PR TITLE
Explain git submodules in gtk install instructions

### DIFF
--- a/docs/gtk/install.md
+++ b/docs/gtk/install.md
@@ -11,7 +11,8 @@ The simplest case                      {#gtk_simple}
 -------------------
 
 If you compile wxWidgets on Linux for the first time and don't like to read
-install instructions just do the following in wxWidgets directory:
+install instructions just [obtain the complete source code](https://github.com/wxWidgets/wxWidgets/blob/master/README-GIT.md)
+and then do the following in wxWidgets directory:
 
     $ mkdir buildgtk
     $ cd buildgtk


### PR DESCRIPTION
These instructions are supposed to be easy to follow. But they don't work unless you already know how to manage git submodules, and already have all the git submodules in place at the correct versions. 

So the simple instructions on how to achieve that from scratch should be included