### PR TITLE
wxWindowsPrintNativeData InitializeDevMode fix

### DIFF
--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -425,9 +425,8 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
     {
         // ensure that we have a printer object here, otherwise we are unable to determine m_devMode
         WinPrinter fallbackPrinter;
-        if (!printer) {
+        if (!printer)
             printer = &fallbackPrinter;
-        }
 
         // Open printer
         if ( printer && printer->Open( printerName ) == TRUE )

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -473,7 +473,7 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
         }
     }
 
-    if ( !m_devMode && printerName.IsEmpty())
+    if ( !m_devMode && printerName.IsEmpty() )
     {
         // Use PRINTDLG as a way of creating a DEVMODE object
         PRINTDLG pd;

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -429,7 +429,7 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
             printer = &fallbackPrinter;
 
         // Open printer
-        if ( printer && printer->Open( printerName ) == TRUE )
+        if ( printer->Open( printerName ) == TRUE )
         {
             DWORD dwNeeded, dwRet;
 

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -423,6 +423,12 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
     // this replaces the PrintDlg function which creates the DEVMODE filled only with data from default printer.
     if ( !m_devMode && !printerName.IsEmpty() )
     {
+        // ensure that we have a printer object here, otherwise we are unable to determine m_devMode
+        WinPrinter fallbackPrinter;
+        if (!printer) {
+            printer = &fallbackPrinter;
+        }
+
         // Open printer
         if ( printer && printer->Open( printerName ) == TRUE )
         {
@@ -468,7 +474,7 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
         }
     }
 
-    if ( !m_devMode )
+    if ( !m_devMode && printerName.IsEmpty())
     {
         // Use PRINTDLG as a way of creating a DEVMODE object
         PRINTDLG pd;


### PR DESCRIPTION
Use a temporary WinPrinter if not specified via unction call in order to not fall back to the default printer code.

Do not use PRINTDLG if a printerName is specified because this returns the default printer which is not necessarily the printer we want. Therefore we have to ensure, that the code above is used and therefore we use a temporary printer if not specified.