### PR TITLE
add delays to make UIActionSimulator work on MacOS Ventura (13.4.1)

### DIFF
--- a/src/osx/uiaction_osx.cpp
+++ b/src/osx/uiaction_osx.cpp
@@ -154,6 +154,8 @@ bool wxUIActionSimulatorOSXImpl::MouseDown(int button)
     wxCFEventLoop* loop = dynamic_cast<wxCFEventLoop*>(wxEventLoop::GetActive());
     if (loop)
         loop->SetShouldWaitForEvent(true);
+
+    ::usleep(useconds_t(10 * 1000));
     
     return true;
 }
@@ -177,6 +179,8 @@ bool wxUIActionSimulatorOSXImpl::MouseMove(long x, long y)
     wxCFEventLoop* loop = dynamic_cast<wxCFEventLoop*>(wxEventLoop::GetActive());
     if (loop)
         loop->SetShouldWaitForEvent(true);
+
+    ::usleep(useconds_t(10 * 1000));
     
     return true;
 }
@@ -195,6 +199,8 @@ bool wxUIActionSimulatorOSXImpl::MouseUp(int button)
     wxCFEventLoop* loop = dynamic_cast<wxCFEventLoop*>(wxEventLoop::GetActive());
     if (loop)
         loop->SetShouldWaitForEvent(true);
+
+    ::usleep(useconds_t(10 * 1000));
     
     return true;
 }
@@ -224,6 +230,8 @@ bool wxUIActionSimulatorOSXImpl::MouseDblClick(int button)
     wxCFEventLoop* loop = dynamic_cast<wxCFEventLoop*>(wxEventLoop::GetActive());
     if (loop)
         loop->SetShouldWaitForEvent(true);
+
+    ::usleep(useconds_t(10 * 1000));
     
     return true;
 }
@@ -264,6 +272,9 @@ bool wxUIActionSimulatorOSXImpl::MouseDragDrop(long x1, long y1, long x2, long y
     if (loop)
         loop->SetShouldWaitForEvent(true);
     
+
+    ::usleep(useconds_t(10 * 1000));
+
     return true;
 }
 
@@ -281,6 +292,8 @@ wxUIActionSimulatorOSXImpl::DoKey(int keycode, int WXUNUSED(modifiers), bool isD
     wxCFEventLoop* loop = dynamic_cast<wxCFEventLoop*>(wxEventLoop::GetActive());
     if (loop)
         loop->SetShouldWaitForEvent(true);
+
+    ::usleep(useconds_t(10 * 1000));
 
     return true;
 }

--- a/src/osx/uiaction_osx.cpp
+++ b/src/osx/uiaction_osx.cpp
@@ -140,7 +140,7 @@ private:
     // give the system some time to process (it seems to need it)
     void wait_for_events()
     {
-    	::usleep(delay_);
+       ::usleep(delay_);
     }
 
     wxDECLARE_NO_COPY_CLASS(wxUIActionSimulatorOSXImpl);

--- a/src/osx/uiaction_osx.cpp
+++ b/src/osx/uiaction_osx.cpp
@@ -135,6 +135,14 @@ private:
     // This class has no public ctors, use Get() instead.
     wxUIActionSimulatorOSXImpl() { }
 
+    const useconds_t delay_ = 10 * 1000;
+
+    // give the system some time to process (it seems to need it)
+    void wait_for_events()
+    {
+    	::usleep(delay_);
+    }
+
     wxDECLARE_NO_COPY_CLASS(wxUIActionSimulatorOSXImpl);
 };
 
@@ -155,7 +163,7 @@ bool wxUIActionSimulatorOSXImpl::MouseDown(int button)
     if (loop)
         loop->SetShouldWaitForEvent(true);
 
-    ::usleep(useconds_t(10 * 1000));
+    wait_for_events();
     
     return true;
 }
@@ -180,7 +188,7 @@ bool wxUIActionSimulatorOSXImpl::MouseMove(long x, long y)
     if (loop)
         loop->SetShouldWaitForEvent(true);
 
-    ::usleep(useconds_t(10 * 1000));
+    wait_for_events();
     
     return true;
 }
@@ -200,7 +208,7 @@ bool wxUIActionSimulatorOSXImpl::MouseUp(int button)
     if (loop)
         loop->SetShouldWaitForEvent(true);
 
-    ::usleep(useconds_t(10 * 1000));
+    wait_for_events();
     
     return true;
 }
@@ -231,7 +239,7 @@ bool wxUIActionSimulatorOSXImpl::MouseDblClick(int button)
     if (loop)
         loop->SetShouldWaitForEvent(true);
 
-    ::usleep(useconds_t(10 * 1000));
+    wait_for_events();
     
     return true;
 }
@@ -273,7 +281,7 @@ bool wxUIActionSimulatorOSXImpl::MouseDragDrop(long x1, long y1, long x2, long y
         loop->SetShouldWaitForEvent(true);
     
 
-    ::usleep(useconds_t(10 * 1000));
+    wait_for_events();
 
     return true;
 }
@@ -293,7 +301,7 @@ wxUIActionSimulatorOSXImpl::DoKey(int keycode, int WXUNUSED(modifiers), bool isD
     if (loop)
         loop->SetShouldWaitForEvent(true);
 
-    ::usleep(useconds_t(10 * 1000));
+    wait_for_events();
 
     return true;
 }


### PR DESCRIPTION
On my MacOS Ventura 13.4.1 system wxUIActionSimulator did not work (in tests like Button::Click). 
Based on suggestions from internet search results I added (short) delays after posting events and that seems to do the trick well enough. After these changes the failing tests work again.
I know this is not the prettiest solution but looking at the internet search results it is probably the best I am able to get as it seems a LOT of people have trouble with this functionality on MacOS and none seem to have a better solution.