### PR TITLE
Fix `wxSearchCtrl` base class

### DIFF
--- a/include/wx/srchctrl.h
+++ b/include/wx/srchctrl.h
@@ -31,7 +31,7 @@
     private:
         // implement this to return the HWND of the EDIT control
         // can return nullptr here as this TextEntry is just a proxy
-        virtual WXHWND GetEditHWND() const override  { return nullptr; }
+        virtual WXHWND GetEditHWND() const override  { wxFAIL_MSG("unreachable"); return nullptr; }
 #endif
     };
 #elif defined(__WXMAC__)

--- a/include/wx/srchctrl.h
+++ b/include/wx/srchctrl.h
@@ -27,7 +27,7 @@
         : public wxCompositeWindow< wxNavigationEnabled<wxControl> >,
           public wxTextEntry
     {
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     private:
         // implement this to return the HWND of the EDIT control
         // can return nullptr here as this TextEntry is just a proxy

--- a/include/wx/srchctrl.h
+++ b/include/wx/srchctrl.h
@@ -25,8 +25,14 @@
 
     class WXDLLIMPEXP_CORE wxSearchCtrlBaseBaseClass
         : public wxCompositeWindow< wxNavigationEnabled<wxControl> >,
-          public wxTextEntryBase
+          public wxTextEntry
     {
+#if defined(__WXMSW__)
+    private:
+        // implement this to return the HWND of the EDIT control
+        // can return nullptr here as this TextEntry is just a proxy
+        virtual WXHWND GetEditHWND() const override  { return nullptr; }
+#endif
     };
 #elif defined(__WXMAC__)
     // search control was introduced in Mac OS X 10.3 Panther

--- a/interface/wx/srchctrl.h
+++ b/interface/wx/srchctrl.h
@@ -15,9 +15,9 @@
     generically for all the other platforms.
 
     Please note that this class provides many wxTextCtrl-like methods, but does
-    _not_ necessarily derive from wxTextCtrl in all ports (although it does in
-    the generic version). Only the methods defined in wxTextEntry interface
-    class are guaranteed to be available under all platforms.
+    _not_ necessarily derive from wxTextCtrl in all ports (it actually only does
+    so in the MacOSX version currently). Only the methods defined in the wxTextEntry
+    interface class are guaranteed to be available under all platforms.
 
     @beginStyleTable
     @style{wxTE_PROCESS_TAB}

--- a/tests/controls/searchctrltest.cpp
+++ b/tests/controls/searchctrltest.cpp
@@ -32,6 +32,29 @@ public:
         delete m_search;
     }
 
+    void CheckStringSelection(const char *sel)
+    {
+        wxTextEntry * const entry = m_search;
+        CHECK( sel == entry->GetStringSelection() );
+    }
+
+    void AssertSelection(int from, int to, const char *sel)
+    {
+        wxTextEntry * const entry = m_search;
+
+        CHECK( entry->HasSelection() );
+
+        long fromReal,
+             toReal;
+        entry->GetSelection(&fromReal, &toReal);
+        CHECK( from == fromReal );
+        CHECK( to == toReal );
+
+        CHECK( from == entry->GetInsertionPoint() );
+
+        CheckStringSelection(sel);
+    }
+
 protected:
     wxSearchCtrl* const m_search;
 };
@@ -54,6 +77,42 @@ SEARCH_CTRL_TEST_CASE("wxSearchCtrl::ChangeValue", "[wxSearchCtrl][text]")
 
     m_search->ChangeValue("foo");
     CHECK( m_search->GetValue() == "foo" );
+}
+
+SEARCH_CTRL_TEST_CASE("wxSearchCtrl::SetValue", "[wxSearchCtrl][set_value]")
+{
+  CHECK( m_search->IsEmpty() );
+
+  m_search->SetValue("foo");
+  CHECK( m_search->GetValue() == "foo" );
+
+  m_search->SetValue("");
+  CHECK( m_search->IsEmpty() );
+
+  m_search->SetValue("hi");
+  CHECK( "hi" ==  m_search->GetValue() );
+
+  m_search->SetValue("bye");
+  CHECK( "bye" == m_search->GetValue() );
+}
+
+SEARCH_CTRL_TEST_CASE("wxSearchCtrl::Selection", "[wxSearchCtrl][selection]")
+{
+  wxTextEntry * const entry = m_search;
+
+  entry->SetValue("0123456789");
+
+  entry->SetSelection(2, 4);
+  AssertSelection(2, 4, "23"); // not "234"!
+
+  entry->SetSelection(3, -1);
+  AssertSelection(3, 10, "3456789");
+
+  entry->SelectAll();
+  AssertSelection(0, 10, "0123456789");
+
+  entry->SetSelection(0, 0);
+  CHECK( !entry->HasSelection() );
 }
 
 #endif // wxUSE_SEARCHCTRL

--- a/tests/controls/searchctrltest.cpp
+++ b/tests/controls/searchctrltest.cpp
@@ -77,6 +77,9 @@ SEARCH_CTRL_TEST_CASE("wxSearchCtrl::ChangeValue", "[wxSearchCtrl][text]")
 
     m_search->ChangeValue("foo");
     CHECK( m_search->GetValue() == "foo" );
+
+    m_search->Clear();
+    CHECK( m_search->GetValue() == "" );
 }
 
 SEARCH_CTRL_TEST_CASE("wxSearchCtrl::SetValue", "[wxSearchCtrl][set_value]")

--- a/tests/controls/searchctrltest.cpp
+++ b/tests/controls/searchctrltest.cpp
@@ -84,6 +84,9 @@ SEARCH_CTRL_TEST_CASE("wxSearchCtrl::ChangeValue", "[wxSearchCtrl][text]")
 
 SEARCH_CTRL_TEST_CASE("wxSearchCtrl::SetValue", "[wxSearchCtrl][set_value]")
 {
+#if defined(__WXGTK__) && !defined(__WXGTK3__)
+  m_search->Clear();
+#endif
   CHECK( m_search->IsEmpty() );
 
   m_search->SetValue("foo");


### PR DESCRIPTION
This fixes #23686.
Syncs up all wxSearchCtrl implementations to properly derive from wxTextEntry.
Corrects a mistake in the wxSearchCtrl documentation.