### PR TITLE
Fix using system libtiff installed in non-standard location

### DIFF
--- a/configure
+++ b/configure
@@ -25977,7 +25977,7 @@ else
 $as_echo "yes" >&6; }
 
                 TIFF_LINK=$LIBTIFF_LIBS
-                CFLAGS="$LIBTIFF_CFLAGS $CFLAGS"
+                CXXFLAGS="$LIBTIFF_CFLAGS $CXXFLAGS"
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -2480,12 +2480,10 @@ if test "$wxUSE_LIBTIFF" != "no" ; then
     AC_DEFINE(wxUSE_LIBTIFF)
 
     if test "$wxUSE_LIBTIFF" = "sys" -o "$wxUSE_LIBTIFF" = "yes" ; then
-        dnl First try using pkg-config as it's the most reliable way to detect
-        dnl libtiff.
         PKG_CHECK_MODULES(LIBTIFF, [libtiff-4],
             [
                 TIFF_LINK=$LIBTIFF_LIBS
-                CFLAGS="$LIBTIFF_CFLAGS $CFLAGS"
+                CXXFLAGS="$LIBTIFF_CFLAGS $CXXFLAGS"
             ],
             [
                 AC_MSG_RESULT([not found via pkg-config])


### PR DESCRIPTION
Add the required CFLAGS (such as the path to libtiff headers if they are
not in one of the system directories) to CXXFLAGS, not CFLAGS, as we're
using libtiff from C++ code.

This fixes a problem introduced in b9fe8ca10c (Try to use pkg-config for
detecting libtiff in configure, 2018-12-12).

Closes #23702.
