### PR TITLE
Document that RUNTIME_LIBS works only when building with MSVC

### DIFF
--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -345,9 +345,8 @@ The full list of the build settings follows:
 
 * `RUNTIME_LIBS=static`
 
-  Links static version of C and C++ runtime libraries into the executable, so
-  that the program does not depend on DLLs provided with the compiler (e.g.
-  Visual C++'s msvcrt.dll).
+  (VC++ only.) Links static version of C and C++ runtime libraries into the
+  executable, so that the program does not depend on DLLs provided with the compiler.
   Caution: Do not use static runtime libraries when building DLL (SHARED=1)!
 
 * `DEBUG_FLAG=0`


### PR DESCRIPTION
I considered also mentioning that the same effect can be achieved for GCC (no idea about clang) by passing `LDFLAGS="-static"`, but that is probably outside the document scope.