### PR TITLE
Avoid debug warnings when defocusing menu bar in wxGTK

### DIFF
--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2997,7 +2997,15 @@ void wxWindowGTK::PostCreation()
 
     // focus handling
 
-    if (!GTK_IS_WINDOW(m_widget))
+    // Check for GTKNeedsParent() || IsTopLevel() is a hack: it catches the
+    // case of wxMenuBar, which isn't supposed to generate any focus events,
+    // and which is the only non-TLW which returns false from this function.
+    //
+    // The TLW check overlaps with !GTK_IS_WINDOW() check, but it's not 100%
+    // obvious if GTK_IS_WINDOW() and wxWindow::IsTopLevel() are really exactly
+    // equivalent, so for now ensure we don't change the existing check which
+    // only used !GTK_IS_WINDOW().
+    if (!GTK_IS_WINDOW(m_widget) && (GTKNeedsParent() || IsTopLevel()))
     {
         if (m_focusWidget == nullptr)
             m_focusWidget = m_widget;


### PR DESCRIPTION
At least under Wayland, removing focus from the menu consistently
results in "window lost focus even though it didn't have it" debug
messages because wxMenuBar never gets any focus-in signals but does get
focus-out one.

Avoid this by just not connecting handlers for these signals at all, as
we don't need them for wxMenuBar which isn't supposed to generate any
focus events anyhow.
