### PR TITLE
Fixed constant changes in the progress dialog size if the message keeps changging

### DIFF
--- a/include/wx/generic/progdlgg.h
+++ b/include/wx/generic/progdlgg.h
@@ -182,6 +182,8 @@ private:
     wxGauge *m_gauge;
     // the message displayed
     wxStaticText *m_msg;
+    // the message width in pixels. If the new width is greater, the dialog grows
+    unsigned m_msgWidth;
     // displayed elapsed, estimated, remaining time
     wxStaticText *m_elapsed,
                  *m_estimated,

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -82,6 +82,7 @@ void wxGenericProgressDialog::Init()
 
     m_gauge = nullptr;
     m_msg = nullptr;
+    m_msgWidth = 0;
     m_elapsed =
     m_estimated =
     m_remaining = nullptr;
@@ -778,15 +779,17 @@ void wxGenericProgressDialog::UpdateMessage(const wxString &newmsg)
 {
     if ( !newmsg.empty() && newmsg != m_msg->GetLabel() )
     {
-        const wxSize sizeOld = m_msg->GetSize();
-
         m_msg->SetLabel(newmsg);
 
-        if ( m_msg->GetSize().x > sizeOld.x )
+        const unsigned newWidth = m_msg->GetSize().x;
+
+        // Prevent shrinking the dialog when the message becomes shorter
+        if ( newWidth > m_msgWidth )
         {
             // Resize the dialog to fit its new, longer contents instead of
             // just truncating it.
             Fit();
+	    m_msgWidth = newWidth;
         }
 
         // allow the window to repaint:


### PR DESCRIPTION
This PR fixes an undesired side effect of https://github.com/wxWidgets/wxWidgets/commit/4101849b4d0a4e1291e45cd990611eb9408c68a1:

According to the commit message, the author did not want the progress dialog to change in it's size when the message was becoming shorter.

But the original code

```
const wxSize sizeOld = m_msg->GetSize();

        m_msg->SetLabel(newmsg);

        if ( m_msg->GetSize().x > sizeOld.x )
```

had wrong behavior if the message at first was long (L3), then bacame short (L1) and then became middle (L2), L1 < L2 < L3. In this case the size was changing from L3 to L2, because the code compared the new width (L2) with the previous one (L1) instead of with the maximal (L3).

The attached test shows a wrong behavior without this patch and a right behavior with this patch: 
[WxProgressDialogTest.zip](https://github.com/wxWidgets/wxWidgets/files/12137149/WxProgressDialogTest.zip)

