### PR TITLE
Only include Scintilla libraries in wx-config --libs if needed

### DIFF
--- a/configure
+++ b/configure
@@ -643,6 +643,7 @@ WXCONFIG_LDFLAGS_GUI
 WXCONFIG_LDFLAGS
 WX_LDFLAGS
 WXCONFIG_RPATH
+WXCONFIG_STC_LIBS
 WXCONFIG_LIBS
 WXCONFIG_CXXFLAGS
 WX_CXXFLAGS
@@ -40615,6 +40616,10 @@ $as_echo "$as_me: WARNING: GStreamer not available... disabling wxMediaCtrl" >&2
 fi
 
 
+for lib in scintilla lexilla; do
+    WXCONFIG_STC_LIBS="$WXCONFIG_STC_LIBS -lwx${lib}${WX_LIB_FLAVOUR}-${WX_RELEASE}${HOST_SUFFIX}"
+done
+
 if test "$wxUSE_MSW" = 1 ; then
     EXTRALIBS_STC="-limm32"
 fi
@@ -40928,9 +40933,6 @@ case "$wxUSE_REGEX" in
         WXCONFIG_LIBS="$PCRE_LINK $WXCONFIG_LIBS"
         ;;
 esac
-if test "$wxUSE_STC" = "yes" ; then
-    wxconfig_3rdparty="scintilla lexilla $wxconfig_3rdparty"
-fi
 case "$wxUSE_EXPAT" in
     builtin)
         wxconfig_3rdparty="expat $wxconfig_3rdparty"
@@ -43374,6 +43376,7 @@ OBJCFLAGS="$OBJCFLAGS $CFLAGS_VISIBILITY"
 OBJCXXFLAGS="$OBJCXXFLAGS $CXXFLAGS_VISIBILITY"
 
 SAMPLES_SUBDIRS="`echo $SAMPLES_SUBDIRS | tr -s ' ' | tr ' ' '\n' | sort | uniq | tr '\n' ' '| tr -d '\r'`"
+
 
 
 

--- a/configure.in
+++ b/configure.in
@@ -7299,6 +7299,10 @@ dnl ---------------------------------------------------------------------------
 dnl wxStyledTextCtrl
 dnl ---------------------------------------------------------------------------
 
+for lib in scintilla lexilla; do
+    WXCONFIG_STC_LIBS="$WXCONFIG_STC_LIBS -lwx${lib}${WX_LIB_FLAVOUR}-${WX_RELEASE}${HOST_SUFFIX}"
+done
+
 if test "$wxUSE_MSW" = 1 ; then
     EXTRALIBS_STC="-limm32"
 fi
@@ -7608,9 +7612,6 @@ case "$wxUSE_REGEX" in
         WXCONFIG_LIBS="$PCRE_LINK $WXCONFIG_LIBS"
         ;;
 esac
-if test "$wxUSE_STC" = "yes" ; then
-    wxconfig_3rdparty="scintilla lexilla $wxconfig_3rdparty"
-fi
 case "$wxUSE_EXPAT" in
     builtin)
         wxconfig_3rdparty="expat $wxconfig_3rdparty"
@@ -7947,6 +7948,7 @@ AC_SUBST(WX_CXXFLAGS)
 AC_SUBST(WXCONFIG_CXXFLAGS)
 
 AC_SUBST(WXCONFIG_LIBS)
+AC_SUBST(WXCONFIG_STC_LIBS)
 AC_SUBST(WXCONFIG_RPATH)
 AC_SUBST(WX_LDFLAGS)
 AC_SUBST(WXCONFIG_LDFLAGS)

--- a/wx-config.in
+++ b/wx-config.in
@@ -1033,7 +1033,7 @@ ldlibs_gl="@OPENGL_LIBS@"
 ldlibs_html="@EXTRALIBS_HTML@"
 ldlibs_media="@EXTRALIBS_MEDIA@"
 ldlibs_xml="@EXTRALIBS_XML@"
-ldlibs_stc="@EXTRALIBS_STC@"
+ldlibs_stc="@WXCONFIG_STC_LIBS@ @EXTRALIBS_STC@"
 ldlibs_webview="@EXTRALIBS_WEBVIEW@"
 
 


### PR DESCRIPTION
Don't always output -lscintilla and -llexilla in wx-config --libs, as
they are not needed unless linking with wxstc library is requested but
204bc3c887 (Fix linking of wxscintilla in static monolithic build,
2017-12-06) added them unconditionally.

Improve this by putting them in a separate WXCONFIG_STC_LIBS instead of
WXCONFIG_LIBS used for all libraries (even wxbase, which is wrong on its
own).

Also see #23643.
