### PR TITLE
Fix problems with refreshing "+" button for `wxTreeCtrl` items in wxMSW

### DIFF
--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -166,6 +166,16 @@ wxTreeView_GetItemRect(HWND hwnd,
                         (LPARAM)&param) == TRUE;
 }
 
+inline void
+wxTreeView_RefreshItem(HWND hwnd,
+                       HTREEITEM hItem)
+{
+    TVGetItemRectParam param;
+
+    wxTreeView_GetItemRect(hwnd, hItem, param, FALSE);
+    ::InvalidateRect(hwnd, &param.rect, FALSE);
+}
+
 } // anonymous namespace
 
 // wrappers for TreeView_GetItem/TreeView_SetItem
@@ -1547,10 +1557,7 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
 
     if ( refreshFirstChild )
     {
-        TVGetItemRectParam param2;
-
-        wxTreeView_GetItemRect(GetHwnd(), HITEM(parent), param2, FALSE);
-        ::InvalidateRect(GetHwnd(), &param2.rect, FALSE);
+        wxTreeView_RefreshItem(GetHwnd(), HITEM(parent));
     }
 
     // associate the application tree item with Win32 tree item handle

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -1703,6 +1703,10 @@ void wxTreeCtrl::DeleteChildren(const wxTreeItemId& item)
     {
         Delete(children[n]);
     }
+
+    // Refresh update the "+" button which otherwise can remain displayed.
+    if ( !IsHiddenRoot(item) )
+        wxTreeView_RefreshItem(GetHwnd(), HITEM(item));
 }
 
 void wxTreeCtrl::DeleteAllItems()

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -1533,10 +1533,24 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
     tvIns.item.lParam = (LPARAM)param;
     tvIns.item.mask = mask;
 
+    // Without this, the tree doesn't show a "+" button when we add the first
+    // child, at least after removing the children previously (see #23718).
+    const bool refreshFirstChild =
+            !IsHiddenRoot(parent) &&
+                !TreeView_GetChild(GetHwnd(), HITEM(parent));
+
     HTREEITEM id = TreeView_InsertItem(GetHwnd(), &tvIns);
     if ( id == 0 )
     {
         wxLogLastError(wxT("TreeView_InsertItem"));
+    }
+
+    if ( refreshFirstChild )
+    {
+        TVGetItemRectParam param2;
+
+        wxTreeView_GetItemRect(GetHwnd(), HITEM(parent), param2, FALSE);
+        ::InvalidateRect(GetHwnd(), &param2.rect, FALSE);
     }
 
     // associate the application tree item with Win32 tree item handle


### PR DESCRIPTION
This addresses #23718 and another similar problem.