### PR TITLE
Add wxUILocale::GetMonthName() and GetWeekDayName()

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -247,6 +247,7 @@ All:
 - Fix memory leak when using wx from non-wx threads (Antti Nietosvaara, #23535).
 - Use grep instead of fgrep and egrep in makefiles/scripts (#23537).
 - Use /etc/os-release if lsb_release isn't available (Scott Talbert, #23712).
+- Add wxUILocale::GetMonthName() and GetWeekDayName() (Ulrich Telle, #23556).
 
 All (GUI):
 

--- a/include/wx/private/uilocale.h
+++ b/include/wx/private/uilocale.h
@@ -68,6 +68,14 @@ public:
     // The entries contain platform-dependent identifiers.
     static wxVector<wxString> GetPreferredUILanguages();
 
+    // Helper function used by GetMonthName/GetWeekDayName(): returns 0 if flags is
+    // wxDateTime::Name_Full and 1 if it is wxDateTime::Name_Abbr
+    // or -1 if the flags is incorrect (and asserts in this case)
+    //
+    // the return value of this function is used as an index into 2D array
+    // containing full names in its first row and abbreviated ones in the 2nd one
+    static int ArrayIndexFromFlag(wxDateTime::NameFlags flags);
+
     // Use this locale in the UI.
     //
     // This is not implemented for all platforms, notably not for Mac where the
@@ -83,6 +91,12 @@ public:
     virtual wxLayoutDirection GetLayoutDirection() const = 0;
     virtual int CompareStrings(const wxString& lhs, const wxString& rhs,
                                int flags) const = 0;
+
+    // These functions ought to be (pure) virtual, but aren't for
+    // ABI-compatibility reasons. Instead they are implemented in
+    // platform-specific concrete classes.
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags) const;
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags) const;
 
     virtual ~wxUILocaleImpl() { }
 };

--- a/include/wx/uilocale.h
+++ b/include/wx/uilocale.h
@@ -14,6 +14,7 @@
 
 #if wxUSE_INTL
 
+#include "wx/datetime.h"
 #include "wx/localedefs.h"
 #include "wx/string.h"
 #include "wx/vector.h"
@@ -153,6 +154,18 @@ public:
     // Compares two strings in the order defined by this locale.
     int CompareStrings(const wxString& lhs, const wxString& rhs,
                        int flags = wxCompare_CaseSensitive) const;
+
+#if wxABI_VERSION >= 30203
+    // Get the full (default) or abbreviated localized month name
+    // returns empty string on error
+    wxString GetMonthName(wxDateTime::Month month,
+                          wxDateTime::NameFlags flags = wxDateTime::Name_Full) const;
+
+    // Get the full (default) or abbreviated localized weekday name
+    // returns empty string on error
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday,
+                            wxDateTime::NameFlags flags = wxDateTime::Name_Full) const;
+#endif // wxABI_VERSION >= 3.2.3
 
     // Note that this class is not supposed to be used polymorphically, hence
     // its dtor is not virtual.

--- a/interface/wx/uilocale.h
+++ b/interface/wx/uilocale.h
@@ -198,6 +198,38 @@ public:
     wxString GetLocalizedName(wxLocaleName name, wxLocaleForm form) const;
 
     /**
+        Gets the full (default) or abbreviated name of the given month.
+
+        This function returns the name in the current locale, use
+        wxDateTime::GetEnglishMonthName() to get the untranslated name if necessary.
+
+        @param month
+            One of wxDateTime::Jan, ..., wxDateTime::Dec values.
+        @param flags
+            Either wxDateTime::Name_Full (default) or wxDateTime::Name_Abbr.
+
+        @see GetWeekDayName()
+        @since 3.2.3
+    */
+    wxString GetMonthName(wxDateTime::Month month, wxDateTime::NameFlags flags = wxDateTime::Name_Full);
+
+    /**
+        Gets the full (default) or abbreviated name of the given week day.
+
+        This function returns the name in the current locale, use
+        wxDateTime::GetEnglishWeekDayName() to get the untranslated name if necessary.
+
+        @param weekday
+            One of wxDateTime::Sun, ..., wxDateTime::Sat values.
+        @param flags
+            Either wxDateTime::Name_Full (default) or wxDateTime::Name_Abbr.
+
+        @see GetMonthName()
+        @since 3.2.3
+    */
+    wxString GetWeekDayName(wxDateTime::WeekDay weekday, wxDateTime::NameFlags flags = wxDateTime::Name_Full);
+
+    /**
         Query the layout direction of the current locale.
 
         @return

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -82,6 +82,7 @@
 #endif
 
 #include "wx/datetime.h"
+#include "wx/uilocale.h"
 
 // ----------------------------------------------------------------------------
 // wxXTI
@@ -773,19 +774,11 @@ wxString wxDateTime::GetEnglishMonthName(Month month, NameFlags flags)
 wxString wxDateTime::GetMonthName(wxDateTime::Month month,
                                   wxDateTime::NameFlags flags)
 {
-#ifdef wxHAS_STRFTIME
-    wxCHECK_MSG( month != Inv_Month, wxEmptyString, wxT("invalid month") );
-
-    // notice that we must set all the fields to avoid confusing libc (GNU one
-    // gets confused to a crash if we don't do this)
-    tm tm;
-    wxInitTm(tm);
-    tm.tm_mon = month;
-
-    return wxCallStrftime(flags == Name_Abbr ? wxS("%b") : wxS("%B"), &tm);
-#else // !wxHAS_STRFTIME
-    return GetEnglishMonthName(month, flags);
-#endif // wxHAS_STRFTIME/!wxHAS_STRFTIME
+    wxCHECK_MSG(month != Inv_Month, wxEmptyString, wxT("invalid month"));
+    wxString name = wxUILocale::GetCurrent().GetMonthName(month, flags);
+    if (name.empty())
+        name = GetEnglishMonthName(month, flags);
+    return name;
 }
 
 /* static */
@@ -811,29 +804,11 @@ wxString wxDateTime::GetEnglishWeekDayName(WeekDay wday, NameFlags flags)
 wxString wxDateTime::GetWeekDayName(wxDateTime::WeekDay wday,
                                     wxDateTime::NameFlags flags)
 {
-#ifdef wxHAS_STRFTIME
-    wxCHECK_MSG( wday != Inv_WeekDay, wxEmptyString, wxT("invalid weekday") );
-
-    // take some arbitrary Sunday (but notice that the day should be such that
-    // after adding wday to it below we still have a valid date, e.g. don't
-    // take 28 here!)
-    tm tm;
-    wxInitTm(tm);
-    tm.tm_mday = 21;
-    tm.tm_mon = Nov;
-    tm.tm_year = 99;
-
-    // and offset it by the number of days needed to get the correct wday
-    tm.tm_mday += wday;
-
-    // call mktime() to normalize it...
-    (void)mktime(&tm);
-
-    // ... and call strftime()
-    return wxCallStrftime(flags == Name_Abbr ? wxS("%a") : wxS("%A"), &tm);
-#else // !wxHAS_STRFTIME
-    return GetEnglishWeekDayName(wday, flags);
-#endif // wxHAS_STRFTIME/!wxHAS_STRFTIME
+    wxCHECK_MSG(wday != Inv_WeekDay, wxEmptyString, wxT("invalid weekday"));
+    wxString name = wxUILocale::GetCurrent().GetWeekDayName(wday, flags);
+    if (name.empty())
+        name = GetEnglishWeekDayName(wday, flags);
+    return name;
 }
 
 /* static */

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -439,7 +439,15 @@ TEST_CASE("wxUILocale::FromTag", "[.]")
     REQUIRE( !locId.IsEmpty() );
 
     const wxUILocale loc(locId);
-    WARN("Locale \"" << tag << "\" supported: " << loc.IsSupported() );
+    WARN("Locale \"" << tag << "\":\n"
+         "language:\t" << locId.GetLanguage() << "\n"
+         "region:\t" << locId.GetRegion() << "\n"
+         "script:\t" << locId.GetScript() << "\n"
+         "charset:\t" << locId.GetCharset() << "\n"
+         "modifier:\t" << locId.GetModifier() << "\n"
+         "extension:\t" << locId.GetExtension() << "\n"
+         "sort order:\t" << locId.GetSortorder() << "\n"
+         "supported:\t" << (loc.IsSupported() ? "yes" : "no"));
 }
 
 namespace

--- a/version-script.in
+++ b/version-script.in
@@ -26,6 +26,14 @@
 # build/bakefiles/version.bkl to indicate that new APIs have been added and
 # rebake!
 
+# public symbols added in 3.2.3 (please keep in alphabetical order):
+@WX_VERSION_TAG@.3 {
+    extern "C++" {
+        "wxUILocale::GetMonthName";
+        "wxUILocale::GetWeekDayName";
+    };
+};
+
 # public symbols added in 3.2.2 (please keep in alphabetical order):
 @WX_VERSION_TAG@.2 {
     extern "C++" {


### PR DESCRIPTION
Unlike in master, only the variants for the date/time formatting context are returned to reduce the number of changes in this branch. This is wrong for standalone month names like in the generic calendar control. However, in the prior implementation that was also the case.

Use a horrible hack to avoid adding new virtual functions to wxUILocaleImpl class which, although private, still somehow results in ABI breakage.

See #23556, #23581.

cc @utelle 