### PR TITLE
Invalidate the current cell coords when inside table changed in wxGrid::SetTable

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2911,6 +2911,7 @@ wxGrid::SetTable(wxGridTableBase *table,
     }
 
     InvalidateBestSize();
+    m_currentCellCoords = wxGridNoCellCoords;
 
     return m_created;
 }


### PR DESCRIPTION
Fix #23751 

In case of table inside grid has been changed, the function call of IsVisible should be cautious of the index validation.