### PR TITLE
Fix position of label window in wxStaticBox after DPI change

### DIFF
--- a/include/wx/msw/statbox.h
+++ b/include/wx/msw/statbox.h
@@ -97,6 +97,8 @@ protected:
 
     void OnPaint(wxPaintEvent& event);
 
+    virtual void MSWBeforeDPIChangedEvent(const wxDPIChangedEvent& event) override;
+
 private:
     void PositionLabelWindow();
 

--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -366,6 +366,11 @@ WXLRESULT wxStaticBox::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lPar
     return wxControl::MSWWindowProc(nMsg, wParam, lParam);
 }
 
+void wxStaticBox::MSWBeforeDPIChangedEvent(const wxDPIChangedEvent& WXUNUSED(event))
+{
+    PositionLabelWindow();
+}
+
 // ----------------------------------------------------------------------------
 // static box drawing
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #23740

This should be backported to 3.2, but that doesn't have `MSWBeforeDPIChangedEvent`. So it should bind to `wxEVT_DPI_CHANGED` instead:

```diff
 include/wx/msw/statbox.h | 2 ++
 src/msw/statbox.cpp      | 7 +++++++
 2 files changed, 9 insertions(+)

diff --git a/include/wx/msw/statbox.h b/include/wx/msw/statbox.h
index 2280cb17d9..f815abd3fc 100644
--- a/include/wx/msw/statbox.h
+++ b/include/wx/msw/statbox.h
@@ -97,6 +97,8 @@ protected:
 
     void OnPaint(wxPaintEvent& event);
 
+    void OnDPIChanged(wxDPIChangedEvent& evt);
+
 private:
     void PositionLabelWindow();
 
diff --git a/src/msw/statbox.cpp b/src/msw/statbox.cpp
index 161d438f39..92b0f5011a 100644
--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -93,6 +93,8 @@ bool wxStaticBox::Create(wxWindow *parent,
     if ( ShouldUseCustomPaint() )
         UseCustomPaint();
 
+    Bind(wxEVT_DPI_CHANGED, &wxStaticBox::OnDPIChanged, this);
+
     return true;
 }
 
@@ -366,6 +368,11 @@ WXLRESULT wxStaticBox::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lPar
     return wxControl::MSWWindowProc(nMsg, wParam, lParam);
 }
 
+void wxStaticBox::OnDPIChanged(wxDPIChangedEvent& WXUNUSED(event))
+{
+    PositionLabelWindow();
+}
+
 // ----------------------------------------------------------------------------
 // static box drawing
 // ----------------------------------------------------------------------------
```