### PR TITLE
Update wxMemoryInputStream::Peek to set last read count.

### DIFF
--- a/src/common/mstream.cpp
+++ b/src/common/mstream.cpp
@@ -112,10 +112,12 @@ char wxMemoryInputStream::Peek()
     if ( pos == m_length )
     {
         m_lasterror = wxSTREAM_READ_ERROR;
+        m_lastcount = 0;
 
         return 0;
     }
 
+    m_lastcount = 1;
     return buf[pos];
 }
 

--- a/tests/streams/bstream.h
+++ b/tests/streams/bstream.h
@@ -253,9 +253,17 @@ protected:
         while (stream_in.IsOk())
         {
             char peekChar = stream_in.Peek();
+            size_t peekLastRead = stream_in.LastRead();
+
             char getChar = stream_in.GetC();
+
+            // Peek and GetC should retrieve the same 0 or 1 characters.
+            CPPUNIT_ASSERT_EQUAL(peekLastRead, stream_in.LastRead());
+
             if (stream_in.LastRead() == 1)
+            {
                 CPPUNIT_ASSERT_EQUAL(getChar, peekChar);
+            }
         }
     }
 


### PR DESCRIPTION
Fix for #23757 

This updates the implementation of `wxMemoryInputStream::Peek` to set the last read count to 1 if it successfully retrieved a byte from the stream, or 0 if it did not. This change is to align the memory stream's behavior with that of the other stream types - `wxFileInputStream`, `wxFFileInputStream`, or `wxStringInputStream` for a few examples.