### PR TITLE
Implement wxGTK3 dark mode

### DIFF
--- a/src/common/settcmn.cpp
+++ b/src/common/settcmn.cpp
@@ -69,7 +69,7 @@ void wxSystemSettings::SetScreenType( wxSystemScreenType screen )
 // ----------------------------------------------------------------------------
 
 // wxMSW has its own implementation of these functions.
-#if !defined(__WXMSW__)
+#if !defined(__WXMSW__) && !defined(__WXGTK3__) && !defined(__WXGTK__)
 
 bool wxSystemAppearance::AreAppsDark() const
 {
@@ -81,7 +81,7 @@ bool wxSystemAppearance::IsSystemDark() const
     return IsDark();
 }
 
-#endif // !__WXMSW__
+#endif // !__WXMSW__ && !__WXGTK3__ && !__WXGTK__
 
 #if !defined(__WXOSX__)
 

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -26,6 +26,7 @@
 #ifndef WX_PRECOMP
     #include "wx/frame.h"
     #include "wx/app.h"     // GetAppDisplayName()
+    #include "wx/settings.h"
     #include "wx/icon.h"
     #include "wx/log.h"
 #endif
@@ -895,6 +896,12 @@ bool wxTopLevelWindowGTK::Create( wxWindow *parent,
     // old colours etc.
     g_signal_connect_after(gtk_settings_get_default(), "notify::gtk-theme-name",
         G_CALLBACK(notify_gtk_theme_name), this);
+
+#ifdef __WXGTK3__
+    GtkSettings *settings = gtk_widget_get_settings(GTK_WIDGET(m_widget));
+    g_object_set(settings, "gtk-application-prefer-dark-theme",
+        wxSystemSettings::GetAppearance().IsSystemDark(), nullptr);
+#endif
 
     return true;
 }


### PR DESCRIPTION
Read dark mode state from DBus `org.freedesktop.appearance.color-scheme` and set `GtkSettings` `gtk-application-prefer-dark-theme` property.

### To Do
* ~[ ] Keep DBus connection (`wxDarkModeModule`?)~
  * ~[ ] Listen for `color-scheme` changes~ [libadwaita](https://gitlab.gnome.org/GNOME/libadwaita/-/blob/d7307a4b0da7a47de2cc1e84f23e45d604aa00c7/src/adw-settings-impl-portal.c)
* [x] `IsDark` fallback when DBus is unavailable
* [x] ~Look into GTK2 dark mode~
* [x] Other `wxSystemAppearance` functions?