### PR TITLE
Prefer binary packages when installing httpbin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,9 @@ jobs:
               #     be built from source with gcc 4.8 any longer (its build
               #     script uses -Wdate-time option unknown to this compiler).
               #   - xvfb is used for running the GUI tests.
+              #   - httpbin's dependencies can't be built by gcc 4.8 any more.
               apt-get update -qq
-              apt-get install -qq coreutils ${compiler-g++} git make pkg-config python3 python3-cffi python3-pip sudo xvfb
+              apt-get install -qq coreutils ${compiler-g++} git make pkg-config python3 python3-cffi python3-pip python3-httpbin sudo xvfb
               ;;
 
             '')

--- a/build/tools/httpbin.sh
+++ b/build/tools/httpbin.sh
@@ -8,12 +8,19 @@ httpbin_launch() {
 
     echo 'Launching httpbin...'
 
+    # Get Ubuntu codename if it exists
+    if command -v lsb_release > /dev/null; then
+        codename=$(lsb_release --codename --short)
+    fi
+
     # Installing Flask 2.1.0 and its dependency Werkzeug 2.1.0 results
     # in failures when trying to run httpbin, so stick to an older but
     # working version.
     pip_explicit_deps='Flask==2.0.3 Werkzeug==2.0.3'
 
-    python3 -m pip install $pip_explicit_deps httpbin --user
+    if "$codename" != "bionic"; then
+        python3 -m pip install $pip_explicit_deps httpbin --user
+    fi
     python3 -m httpbin.core --port 50500 2>&1 >httpbin.log &
     WX_TEST_WEBREQUEST_URL="http://localhost:50500"
 }


### PR DESCRIPTION
This should hopefully work around the issue of greenlet (dependency of httpbin) failing to compile with gcc 4.8.  Installing binary packages is preferably anyway, as it should be faster.