### PR TITLE
Samples darkmode

### DIFF
--- a/samples/caret/caret.cpp
+++ b/samples/caret/caret.cpp
@@ -306,7 +306,7 @@ MyCanvas::MyCanvas( wxWindow *parent )
 {
     m_text = nullptr;
 
-    SetBackgroundColour(*wxWHITE);
+    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
 
     SetFontSize(12);
 

--- a/samples/image/canvas.cpp
+++ b/samples/image/canvas.cpp
@@ -401,6 +401,7 @@ void MyCanvas::OnPaint( wxPaintEvent &WXUNUSED(event) )
     wxPaintDC dc( this );
     PrepareDC( dc );
 
+    dc.SetTextForeground(*wxBLACK);
     dc.DrawText( "Loaded image", 30, 10 );
     if (my_square.IsOk())
         dc.DrawBitmap( my_square, 30, 30 );

--- a/samples/joytest/joytest.cpp
+++ b/samples/joytest/joytest.cpp
@@ -193,7 +193,7 @@ void MyCanvas::OnPaint(wxPaintEvent& WXUNUSED(evt))
     else if (m_stick->GetButtonState(3))
         dc.SetPen(*wxYELLOW_PEN);
     else
-        dc.SetPen(*wxBLACK_PEN);
+        dc.SetPen(*wxCYAN_PEN);
 
     dc.DrawLine(FromDIP(m_pos), FromDIP(pt));
 

--- a/samples/ownerdrw/ownerdrw.cpp
+++ b/samples/ownerdrw/ownerdrw.cpp
@@ -297,7 +297,7 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
     for ( ui = 0; ui < WXSIZEOF(aszChoices); ui += 2 )
     {
 #if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
-        m_pListBox->GetItem(ui)->SetBackgroundColour(wxColor(200, 200, 200));
+        m_pListBox->GetItem(ui)->SetBackgroundColour(*wxBLUE);
 #endif
     }
 
@@ -344,6 +344,11 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
         if ( ui == 4 )
         {
             pListBox->GetItem(ui)->SetBackgroundColour(wxColor(0, 0, 0));
+        }
+        else
+        if ( ui == 5 ) // black on dark gray is barely visible
+        {
+            pListBox->GetItem(ui)->SetBackgroundColour(*wxYELLOW);
         }
     }
 

--- a/samples/ownerdrw/ownerdrw.cpp
+++ b/samples/ownerdrw/ownerdrw.cpp
@@ -345,8 +345,7 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
         {
             pListBox->GetItem(ui)->SetBackgroundColour(wxColor(0, 0, 0));
         }
-        else
-        if ( ui == 5 ) // black on dark gray is barely visible
+        else if ( ui == 5 ) // black on dark grey is barely visible
         {
             pListBox->GetItem(ui)->SetBackgroundColour(*wxYELLOW);
         }

--- a/samples/popup/popup.cpp
+++ b/samples/popup/popup.cpp
@@ -109,8 +109,13 @@ SimpleTransientPopup::SimpleTransientPopup( wxWindow *parent, bool scrolled )
                                               wxBORDER_NONE |
                                               wxPU_CONTAINS_CONTROLS )
 {
+    wxColour colour(*wxLIGHT_GREY);
+
+    if ( wxSystemSettings::GetAppearance().IsDark() )
+        colour.Set(90, 90, 90); // dark grey
+
     m_panel = new wxScrolledWindow( this, wxID_ANY );
-    m_panel->SetBackgroundColour( *wxLIGHT_GREY );
+    m_panel->SetBackgroundColour(colour);
 
     // Keep this code to verify if mouse events work, they're required if
     // you're making a control like a combobox where the items are highlighted
@@ -216,6 +221,9 @@ void SimpleTransientPopup::OnMouse(wxMouseEvent &event)
     rect.SetWidth(1000000);
     wxColour colour(*wxLIGHT_GREY);
 
+    if ( wxSystemSettings::GetAppearance().IsDark() )
+        colour.Set(90, 90, 90); // dark grey
+    
     if (rect.Contains(event.GetPosition()))
     {
         colour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);

--- a/samples/popup/popup.cpp
+++ b/samples/popup/popup.cpp
@@ -223,7 +223,7 @@ void SimpleTransientPopup::OnMouse(wxMouseEvent &event)
 
     if ( wxSystemSettings::GetAppearance().IsDark() )
         colour.Set(90, 90, 90); // dark grey
-    
+
     if (rect.Contains(event.GetPosition()))
     {
         colour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);

--- a/samples/popup/popup.cpp
+++ b/samples/popup/popup.cpp
@@ -109,10 +109,7 @@ SimpleTransientPopup::SimpleTransientPopup( wxWindow *parent, bool scrolled )
                                               wxBORDER_NONE |
                                               wxPU_CONTAINS_CONTROLS )
 {
-    wxColour colour(*wxLIGHT_GREY);
-
-    if ( wxSystemSettings::GetAppearance().IsDark() )
-        colour.Set(90, 90, 90); // dark grey
+    wxColour colour = wxSystemSettings::SelectLightDark(*wxLIGHT_GREY, wxColour(90, 90, 90));
 
     m_panel = new wxScrolledWindow( this, wxID_ANY );
     m_panel->SetBackgroundColour(colour);
@@ -219,10 +216,7 @@ void SimpleTransientPopup::OnMouse(wxMouseEvent &event)
     wxRect rect(m_mouseText->GetRect());
     rect.SetX(-100000);
     rect.SetWidth(1000000);
-    wxColour colour(*wxLIGHT_GREY);
-
-    if ( wxSystemSettings::GetAppearance().IsDark() )
-        colour.Set(90, 90, 90); // dark grey
+    wxColour colour = wxSystemSettings::SelectLightDark(*wxLIGHT_GREY, wxColour(90, 90, 90));
 
     if (rect.Contains(event.GetPosition()))
     {


### PR DESCRIPTION
Attempt to ensure that there is always a good contrast between the foreground and background colours both in light and dark color system modes. I left alone the samples that may use a white canvas but the drawings are readable (e.g., the font sample).

There may be better solutions for this (and better hard-coded colours), so suggestions are welcome. I thought wx had an API for getting a contrasting colour for a `wxColour` but I failed to find it.

Tested only on Windows 10. I have run into other issues (see my Issues spree) and some where I am not sure whether the issue is with sample or wxWidgets but I think it is enough for now.

EDIT: The PR (and eventual merge commit) title should be "Improve samples appearance in dark mode".