### PR TITLE
CYGWIN: Tests: add test case for DynamicLibrary::Load

### DIFF
--- a/tests/misc/dynamiclib.cpp
+++ b/tests/misc/dynamiclib.cpp
@@ -28,6 +28,9 @@ TEST_CASE("DynamicLibrary::Load", "[dynlib]")
 #if defined(__WINDOWS__)
     static const char* const LIB_NAME = "kernel32.dll";
     static const char* const FUNC_NAME = "lstrlenA";
+#elif defined(__CYGWIN__)
+    static const char* const LIB_NAME = "cygwin1.dll";
+    static const char* const FUNC_NAME = "strlen";
 #elif defined(__DARWIN__)
     // Under macOS 12+ we can actually load the libc dylib even though the
     // corresponding file doesn't exist on disk, so we have to handle it


### PR DESCRIPTION
While running the `test_base` on CYGWIN, this message will be printed on the console:

```
-------------------------------------------------------------------------------
DynamicLibrary::Load
-------------------------------------------------------------------------------
/cygdrive/c/Users/carlo/Documents/GitHub/wxWidgets/tests/misc/dynamiclib.cpp:26
...............................................................................

/cygdrive/c/Users/carlo/Documents/GitHub/wxWidgets/tests/misc/dynamiclib.cpp:80: warning:
  Couldn't find libc.so, skipping DynamicLibrary::Load() test.

/cygdrive/c/Users/carlo/Documents/GitHub/wxWidgets/tests/misc/dynamiclib.cpp:84: warning:
  Possible candidates:
  /lib/libc.a
  /usr/lib/libc.a
```

CYGWIN uses NEWLIB as C library and it is compiled into cygwin1.dll.
This patch adds the right test case for CYGWIN, for letting the execution of the test.