### PR TITLE
CYGWIN: Tests: add test case for Intl

### DIFF
--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -188,6 +188,10 @@ void IntlTestCase::DateTimeFmtFrench()
     static const char *FRENCH_DATE_FMT = "%d.%m.%Y";
     static const char *FRENCH_LONG_DATE_FMT = "%a %e %b %Y";
     static const char *FRENCH_DATE_TIME_FMT = "%a %e %b %X %Y";
+#elif defined(__CYGWIN__)
+    static const char *FRENCH_DATE_FMT = "%d/%m/%Y";
+    static const char *FRENCH_LONG_DATE_FMT = "%a %e %b %Y";
+    static const char *FRENCH_DATE_TIME_FMT = "%a %e %b %Y %H:%M:%S";
 #else
     static const char *FRENCH_DATE_FMT = "%d/%m/%Y";
     static const char *FRENCH_LONG_DATE_FMT = "%A %d %B %Y";


### PR DESCRIPTION
While running the `test_base` on CYGWIN, this message will be printed on the console:

```
-------------------------------------------------------------------------------
/cygdrive/c/Users/carlo/Documents/GitHub/wxWidgets/tests/intl/intltest.cpp:44
...............................................................................

/cygdrive/c/Users/carlo/Documents/GitHub/wxWidgets/tests/intl/intltest.cpp:199: FAILED:
  REQUIRE( FRENCH_LONG_DATE_FMT == NormalizeFormat(wxLocale::GetInfo(wxLOCALE_LONG_DATE_FMT)) )
with expansion:
  "%A %d %B %Y" == "%a %e %b %Y"
with message:
  French long date
```

It looks like that NEWLIB needs its own signatures for letting these test to be passed.
This patch adds the right test case for CYGWIN, for letting the execution of the test.