### PR TITLE
Fix creating wxRadioBox with no items in wxUniv

### DIFF
--- a/src/univ/radiobox.cpp
+++ b/src/univ/radiobox.cpp
@@ -162,8 +162,9 @@ bool wxRadioBox::Create(wxWindow *parent,
     wxSize actualSize = GetSize();
     DoMoveWindow(actualPos.x, actualPos.y, actualSize.x, actualSize.y);
 
-    // radiobox should already have selection so select at least one item
-    SetSelection(0);
+    // Select first radio button if we have any buttons at all
+    if( n != 0 )
+        SetSelection(0);
 
     return true;
 }


### PR DESCRIPTION
Without changes, in case where radiobox haven't items invalid value is passing to SetSelection.