### PR TITLE
Remove outdated parts from build system

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -371,11 +371,7 @@ if(wxUSE_GUI)
         endif()
     endif()
      if(MSVC) # match setup.h
-        if(MSVC_VERSION LESS 1600)
-            wx_option_force_value(wxUSE_GRAPHICS_DIRECT2D OFF)
-        else()
-            wx_option_force_value(wxUSE_GRAPHICS_DIRECT2D ${wxUSE_GRAPHICS_CONTEXT})
-        endif()
+        wx_option_force_value(wxUSE_GRAPHICS_DIRECT2D ${wxUSE_GRAPHICS_CONTEXT})
      endif()
 
     # WXQT checks

--- a/build/cmake/main.cmake
+++ b/build/cmake/main.cmake
@@ -57,14 +57,7 @@ include(build/cmake/install.cmake)
 # Determine minimum required OS at runtime
 set(wxREQUIRED_OS_DESC "${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}")
 if(MSVC OR MINGW OR CYGWIN)
-    # Determine based on used toolkit
-    if(MINGW OR CYGWIN OR (MSVC_VERSION LESS 1700) OR (CMAKE_VS_PLATFORM_TOOLSET MATCHES "_xp$") )
-        # Visual Studio < 2012 and MinGW always create XP compatible binaries
-        # XP Toolset is required since VS 2012
-        set(wxREQUIRED_OS_DESC "Windows XP / Windows Server 2003")
-    else()
-        set(wxREQUIRED_OS_DESC "Windows Vista / Windows Server 2008")
-    endif()
+    set(wxREQUIRED_OS_DESC "Windows 7 / Windows Server 2008")
     if(wxPLATFORM_ARCH)
         wx_string_append(wxREQUIRED_OS_DESC " (${wxPLATFORM_ARCH} Edition)")
     endif()

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -43,18 +43,18 @@ if(MSVC)
     mark_as_advanced(wxBUILD_MSVC_MULTIPROC)
 endif()
 
-if(NOT MSVC OR MSVC_VERSION GREATER 1800)
-    # support setting the C++ standard, present it an option to the user
-    if(DEFINED CMAKE_CXX_STANDARD)
-        set(wxCXX_STANDARD_DEFAULT ${CMAKE_CXX_STANDARD})
-    elseif(APPLE)
-        set(wxCXX_STANDARD_DEFAULT 11)
-    else()
-        set(wxCXX_STANDARD_DEFAULT COMPILER_DEFAULT)
-    endif()
-    wx_option(wxBUILD_CXX_STANDARD "C++ standard used to build wxWidgets targets"
-              ${wxCXX_STANDARD_DEFAULT} STRINGS COMPILER_DEFAULT 11 14 17 20)
+
+# support setting the C++ standard, present it an option to the user
+if(DEFINED CMAKE_CXX_STANDARD)
+    set(wxCXX_STANDARD_DEFAULT ${CMAKE_CXX_STANDARD})
+elseif(APPLE)
+    set(wxCXX_STANDARD_DEFAULT 11)
+else()
+    set(wxCXX_STANDARD_DEFAULT COMPILER_DEFAULT)
 endif()
+wx_option(wxBUILD_CXX_STANDARD "C++ standard used to build wxWidgets targets"
+          ${wxCXX_STANDARD_DEFAULT} STRINGS COMPILER_DEFAULT 11 14 17 20)
+
 
 if(UNIX)
     wx_option(wxBUILD_LARGEFILE_SUPPORT "support for large files")
@@ -462,13 +462,12 @@ wx_option(wxUSE_ICO_CUR "use Windows ICO and CUR formats")
 # ---------------------------------------------------------------------------
 
 if(WIN32)
-    if(MSVC_VERSION GREATER 1600 AND NOT CMAKE_VS_PLATFORM_TOOLSET MATCHES "_xp$")
+    if(MSVC)
         set(wxUSE_WINRT_DEFAULT ON)
     else()
         set(wxUSE_WINRT_DEFAULT OFF)
     endif()
-    if(MSVC_VERSION GREATER 1800 AND NOT CMAKE_VS_PLATFORM_TOOLSET MATCHES "_xp$" AND
-        EXISTS "${wxSOURCE_DIR}/3rdparty/webview2")
+    if(EXISTS "${wxSOURCE_DIR}/3rdparty/webview2")
         set(wxUSE_WEBVIEW_EDGE_DEFAULT ON)
     else()
         set(wxUSE_WEBVIEW_EDGE_DEFAULT OFF)
@@ -484,7 +483,7 @@ if(WIN32)
     wx_option(wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW "use PS printing in wxMSW (Win32 only)")
     wx_option(wxUSE_TASKBARICON_BALLOONS "enable wxTaskBarIcon::ShowBalloon() method (Win32 only)")
     wx_option(wxUSE_UXTHEME "enable support for Windows XP themed look (Win32 only)")
-    wx_option(wxUSE_WEBVIEW_EDGE "use wxWebView Edge (Chromium) backend (Windows 7+ only)" ${wxUSE_WEBVIEW_EDGE_DEFAULT})
+    wx_option(wxUSE_WEBVIEW_EDGE "use wxWebView Edge (Chromium) backend (Windows only)" ${wxUSE_WEBVIEW_EDGE_DEFAULT})
     wx_option(wxUSE_WEBVIEW_EDGE_STATIC "use wxWebView Edge with static loader" OFF)
     wx_option(wxUSE_WEBVIEW_IE "use wxWebView IE backend (Win32 only)")
     wx_option(wxUSE_WINRT "enable WinRT support" ${wxUSE_WINRT_DEFAULT})

--- a/include/wx/msw/setup_inc.h
+++ b/include/wx/msw/setup_inc.h
@@ -17,15 +17,13 @@
 //
 // Default is 1.
 //
-// Recommended setting: 1 if you need to support XP, as Direct2D is not
-// available there.
+// Recommended setting: 1, GDI+ is always available.
 #define wxUSE_GRAPHICS_GDIPLUS wxUSE_GRAPHICS_CONTEXT
 
 // Enable support for Direct2D-based implementation of wxGraphicsContext.
 //
-// Default is 1 for compilers which support it, i.e. MSVS currently. If you
-// use another compiler and installed the necessary SDK components manually,
-// you need to change this setting.
+// Default is 1 for MSVS. mingw-64 supports Direct2D as well, but if you use it,
+// you need to change this setting manually.
 //
 // Recommended setting: 1 for faster and better quality graphics.
 #if defined(_MSC_VER)


### PR DESCRIPTION
I am ashamed to admit that I forgot how to update setup.h files nor I could find any information about this in the contributor docs. IIRC, only one file should be updated and the rest is somehow regenerated? So for now, I updated only  `wx/msw/setup_inc.h` and have no idea how to continue. 

I also considered adding `23` to `wxBUILD_CXX_STANDARD` but I decided against it (for now?), even if the latest MSVS and GCC 13.2 build with it just fine.