### PR TITLE
Update maximum supported compiler versions in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ This version of wxWidgets supports the following primary platforms:
 All C++11 compilers are supported including but not limited to:
 
 - Microsoft Visual C++ 2015 or later (up to 2022).
-- g++ 4.8 or later (up to 12), including MinGW/MinGW-64/TDM under Windows.
-- Clang (up to 14).
+- g++ 4.8 or later (up to 13), including MinGW/MinGW-64/TDM under Windows.
+- Clang (up to 16).
 
 Please use [3.2 branch](https://github.com/wxWidgets/wxWidgets/tree/3.2) if
 you must use wxWidgets with a C++98 compiler or support Windows XP.


### PR DESCRIPTION
TBH, I am not sure if this information is useful, I would not expect wxWidgets build break with newer ("unsupported") compiler versions and prefer listing just the minimal supported version (clang is missing it).

Moreover, the readme has: "All C++11 compilers are supported including but not limited to:" I think there are no other compilers besides the three listed (Borland and Intel do not have their own anymore), are they?

~~And now I notice the commit text wrong, with an extra "Update" in it. :(~~