### PR TITLE
Fix typo in wxColourDialog documentation

### DIFF
--- a/interface/wx/colordlg.h
+++ b/interface/wx/colordlg.h
@@ -27,7 +27,7 @@
 
         wxColourData data;
         data.SetColour(initialColourToUse);
-        wxColourData dlg(this, &data);
+        wxColourDialog dlg(this, &data);
         dlg.Bind(wxEVT_COLOUR_CHANGED, [](wxColourDialogEvent& event) {
                     Redraw(event.GetColour());
                  });


### PR DESCRIPTION
The code example in wxColourDialog documentation used a wrong type to create wxColourDialog instance.

Closes #23793.

Should be backported to 3.2.