### PR TITLE
Fix undefined behavior in wxImage::Paste with wxIMAGE_ALPHA_BLEND_COM…

### DIFF
--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -1743,10 +1743,11 @@ wxImage::Paste(const wxImage & image, int x, int y,
                         alpha_target_data[i] = (unsigned char)((result_alpha * 255) + 0.5f);
                         for (int c = 3 * i; c < 3 * (i + 1); c++)
                         {
-                            target_data[c] =
-                                (unsigned char)(((source_data[c] * source_alpha +
-                                    target_data[c] * light_left) /
-                                result_alpha) + 0.5f);
+                            float target_value =
+                                ((source_data[c] * source_alpha + target_data[c] * light_left) /
+                                result_alpha) + 0.5f;
+                            target_data[c] = wxFinite(target_value) ? (unsigned char)target_value
+                                                                    : 0;
                         }
                     }
                 }


### PR DESCRIPTION
…POSE

The wxImage::Paste method, when used with wxIMAGE_ALPHA_BLEND_COMPOSE, converts floating point values, which might not be finite, to unsigned char using a simple cast. According to the C++ standard this is an undefined behaviour:

  When a finite value of real floating type is converted to an integer
  type other than _Bool, the fractional part is discarded (i.e., the
  value is truncated toward zero). If the value of the integral part
  cannot be represented by the integer type, the behavior is undefined.

This causes the failure of the "Paste semitransparent image over transparent image" test on a few architectures, including RISC-V.

This commits fixes that by assigning 0 if the value is not finite, to match the x86 behavior.

Fixes: #23791