### PR TITLE
Pin httpbin to the previously working 0.7.0 version

### DIFF
--- a/build/tools/httpbin.sh
+++ b/build/tools/httpbin.sh
@@ -13,7 +13,7 @@ httpbin_launch() {
     # working version.
     pip_explicit_deps='Flask==2.0.3 Werkzeug==2.0.3'
 
-    python3 -m pip install $pip_explicit_deps httpbin --user
+    python3 -m pip install $pip_explicit_deps 'httpbin==0.7.0' --user
     python3 -m httpbin.core --port 50500 2>&1 >httpbin.log &
     WX_TEST_WEBREQUEST_URL="http://localhost:50500"
 }


### PR DESCRIPTION
The recently released 0.10.0 doesn't seem to have any actual changes but
has new dependencies which broke the previously working builds.
