### PR TITLE
dynamiclib test: Add more glibc versions

### DIFF
--- a/tests/misc/dynamiclib.cpp
+++ b/tests/misc/dynamiclib.cpp
@@ -43,7 +43,7 @@ TEST_CASE("DynamicLibrary::Load", "[dynlib]")
         "/usr/lib",
     };
 
-    static const char* const candidateVersions[] = { "6", "7", };
+    static const char* const candidateVersions[] = { "6", "7", "6.1", "0.3", "0.1" };
 
     wxString LIB_NAME;
     wxArrayString allMatches;


### PR DESCRIPTION
alpha and ia64 use libc.so.6.1, GNU/kFreeBSD uses libc.so.0.1, and GNU/Hurd uses libc.so.0.3