### PR TITLE
Add a hack to fix link problem with wxScrolledCanvas in wx DLL

### DIFF
--- a/include/wx/scrolwin.h
+++ b/include/wx/scrolwin.h
@@ -500,4 +500,17 @@ public:
 
 typedef wxScrolled<wxWindow> wxScrolledCanvas;
 
+namespace wxPrivate
+{
+
+// This class is specifically DLL-exported, even though it's trivial, in order
+// to ensure that there is only a single copy of wxScrolledCanvas in the wx DLL.
+class WXDLLIMPEXP_CORE wxScrolledCanvasDummySubclass : public wxScrolledCanvas
+{
+public:
+    wxScrolledCanvasDummySubclass();
+};
+
+} // namespace wxPrivate
+
 #endif // _WX_SCROLWIN_H_BASE_

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -1532,3 +1532,10 @@ WXLRESULT wxScrolledT_Helper::FilterMSWWindowProc(WXUINT nMsg, WXLRESULT rc)
 // NB: skipping wxScrolled<T> in wxRTTI information because being a template,
 //     it doesn't and can't implement wxRTTI support
 wxIMPLEMENT_DYNAMIC_CLASS(wxScrolledWindow, wxPanel);
+
+namespace wxPrivate
+{
+
+wxScrolledCanvasDummySubclass::wxScrolledCanvasDummySubclass() = default;
+
+}


### PR DESCRIPTION
When using MSVC, wxScrolledCanvas could be instantiated multiple times
when including wx/scrolwin.h directly and when including wx/grid.h,
which declares a class deriving from wxScrolledCanvas, later.

Fix this by defining a dummy class deriving from wxScrolledCanvas in the
same header, as this is enough to convince MSVC to generate the
definition of wxScrolledCanvas itself in the DLL instead of doing it
inline.

Closes #23774.
