### PR TITLE
Fix CMake build issues after enabling manifest from rc file

### DIFF
--- a/.github/workflows/ci_msw.yml
+++ b/.github/workflows/ci_msw.yml
@@ -13,7 +13,6 @@ on:
       - '.github/workflows/ci_mac.yml'
       - '.github/workflows/ci_msw_cross.yml'
       - '.github/workflows/docs_update.yml'
-      - 'build/cmake/**'
       - 'build/tools/appveyor*.bat'
       - 'distrib/**'
       - 'docs/**'
@@ -25,7 +24,6 @@ on:
       - 'src/osx/**'
       - '*.md'
       - '*.yml'
-      - 'CMakeLists.txt'
   pull_request:
     branches:
       - master
@@ -37,7 +35,6 @@ on:
       - '.github/workflows/ci_mac.yml'
       - '.github/workflows/ci_msw_cross.yml'
       - '.github/workflows/docs_update.yml'
-      - 'build/cmake/**'
       - 'build/tools/appveyor*.bat'
       - 'distrib/**'
       - 'docs/**'
@@ -49,7 +46,6 @@ on:
       - 'src/osx/**'
       - '*.md'
       - '*.yml'
-      - 'CMakeLists.txt'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -801,7 +801,11 @@ function(wx_add name group)
         add_executable(${target_name} ${exe_type} ${src_files})
 
         if (DEFINED wxUSE_DPI_AWARE_MANIFEST_VALUE)
-            set_target_properties(${target_name} PROPERTIES LINK_FLAGS "/MANIFEST:NO")
+            if(MSVC)
+                # Manifest is included via .rc file.
+                # Disable the default manifest added by CMake to prevent dupicate manifest error.
+                set_target_properties(${target_name} PROPERTIES LINK_FLAGS "/MANIFEST:NO")
+            endif()
             target_compile_definitions(${target_name} PRIVATE wxUSE_DPI_AWARE_MANIFEST=${wxUSE_DPI_AWARE_MANIFEST_VALUE})
         endif()
     endif()

--- a/samples/minimal/CMakeLists.txt
+++ b/samples/minimal/CMakeLists.txt
@@ -46,7 +46,7 @@ set(SRC_FILES
     )
 
 if(WIN32)
-    # Include a RC file for windows
+    # Include a RC file for windows, for icon and manifest
     list(APPEND SRC_FILES ../sample.rc)
 elseif(APPLE)
     # Add an icon for the apple .app file
@@ -58,7 +58,10 @@ add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE ${SRC_FILES})
 # Link required libraries to the executable
 target_link_libraries(${PROJECT_NAME} ${wxWidgets_LIBRARIES})
 
-if(APPLE)
+if(MSVC)
+    # Prevent duplicate manifest, it is already added via sample.rc
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/MANIFEST:NO")
+elseif(APPLE)
     set_target_properties(${PROJECT_NAME} PROPERTIES
         RESOURCE "../../src/osx/carbon/wxmac.icns"
         MACOSX_BUNDLE_ICON_FILE wxmac.icns


### PR DESCRIPTION
This should fix the CMake CI build errors.

Note that `test[_gui].vcxproj` also seems to need a similar fix as https://github.com/wxWidgets/wxWidgets/commit/f6255e456b4d83f09168a2731c32da44a1f73ff8 to fix all CI build errors.