### PR TITLE
Show high resolution bitmaps in wxBusyInfo if available

### DIFF
--- a/include/wx/busyinfo.h
+++ b/include/wx/busyinfo.h
@@ -13,8 +13,8 @@
 
 #if wxUSE_BUSYINFO
 
+#include "wx/bmpbndl.h"
 #include "wx/colour.h"
-#include "wx/icon.h"
 
 class WXDLLIMPEXP_FWD_CORE wxWindow;
 
@@ -38,7 +38,7 @@ public:
     wxBusyInfoFlags& Parent(wxWindow* parent)
         { m_parent = parent; return *this; }
 
-    wxBusyInfoFlags& Icon(const wxIcon& icon)
+    wxBusyInfoFlags& Icon(const wxBitmapBundle& icon)
         { m_icon = icon; return *this; }
     wxBusyInfoFlags& Title(const wxString& title)
         { m_title = title; return *this; }
@@ -58,7 +58,7 @@ public:
 private:
     wxWindow* m_parent;
 
-    wxIcon m_icon;
+    wxBitmapBundle m_icon;
     wxString m_title,
              m_text,
              m_label;

--- a/interface/wx/busyinfo.h
+++ b/interface/wx/busyinfo.h
@@ -40,8 +40,9 @@
             (
                 wxBusyInfoFlags()
                     .Parent(this)
-                    .Icon(wxArtProvider::GetIcon(wxART_PRINT,
-                                                 wxART_OTHER, wxSize(128, 128)))
+                    .Icon(wxArtProvider::GetBitmapBundle(wxART_PRINT,
+                                                         wxART_OTHER,
+                                                         wxSize(128, 128)))
                     .Title("<b>Printing your document</b>")
                     .Text("Please wait...")
                     .Foreground(*wxWHITE)
@@ -173,8 +174,14 @@ public:
     /// Sets the parent for wxBusyInfo.
     wxBusyInfoFlags& Parent(wxWindow* parent);
 
-    /// Sets the icon to show in wxBusyInfo.
-    wxBusyInfoFlags& Icon(const wxIcon& icon);
+    /**
+        Sets the icon to show in wxBusyInfo.
+
+        @a icon can contain multiple versions of the bitmap in different
+        resolutions since wxWidgets 3.3.0, in the earlier versions this
+        parameter was just a single wxIcon.
+     */
+    wxBusyInfoFlags& Icon(const wxBitmapBundle& icon);
 
     /**
         Sets the title, shown prominently in wxBusyInfo window.

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3532,8 +3532,9 @@ void MyFrame::ShowRichBusyInfo(wxCommandEvent& WXUNUSED(event))
         (
             wxBusyInfoFlags()
                 .Parent(this)
-                .Icon(wxArtProvider::GetIcon(wxART_PRINT,
-                                             wxART_OTHER, wxSize(128, 128)))
+                .Icon(wxArtProvider::GetBitmapBundle(wxART_PRINT,
+                                                     wxART_OTHER,
+                                                     wxSize(128, 128)))
                 .Title("<b>Printing your document</b>")
                 .Text("Please wait...")
                 .Foreground(*wxWHITE)


### PR DESCRIPTION
Instead of always scaling the single bitmap passed to it, allow passing
wxBitmapBundle and select the bitmap most appropriate for the current
resolution from it.
