### PR TITLE
Fix WXWIN_COMPATIBILITY_3_2 check in MSW clipboard code

### DIFF
--- a/include/wx/msw/clipbrd.h
+++ b/include/wx/msw/clipbrd.h
@@ -15,7 +15,7 @@
 
 // Deprecated wxMSW-only function superseded by wxClipboard, don't use them and
 // use that class instead.
-#ifdef WXWIN_COMPATIBILITY_3_2
+#if WXWIN_COMPATIBILITY_3_2
 
 wxDEPRECATED_MSG("Use wxClipboard") WXDLLIMPEXP_CORE bool wxOpenClipboard();
 wxDEPRECATED_MSG("Use wxClipboard") WXDLLIMPEXP_CORE bool wxIsClipboardOpened();

--- a/src/msw/clipbrd.cpp
+++ b/src/msw/clipbrd.cpp
@@ -63,7 +63,7 @@
 static int gs_htmlcfid = 0;
 static int gs_pngcfid = 0;
 
-#ifdef WXWIN_COMPATIBILITY_3_2
+#if WXWIN_COMPATIBILITY_3_2
 
 static bool gs_wxClipboardIsOpen = false;
 


### PR DESCRIPTION
WXWIN_COMPATIBILITY_* checks must use #if, not #ifdef.

Closes #23822.