### PR TITLE
Fix typo in clipboard header files

### DIFF
--- a/include/wx/clipbrd.h
+++ b/include/wx/clipbrd.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////
 // Name:        wx/clipbrd.h
-// Purpose:     wxClipboad class and clipboard functions
+// Purpose:     wxClipboard class and clipboard functions
 // Author:      Vadim Zeitlin
 // Modified by:
 // Created:     19.10.99

--- a/include/wx/msw/clipbrd.h
+++ b/include/wx/msw/clipbrd.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////
 // Name:        wx/msw/clipbrd.h
-// Purpose:     wxClipboad class and clipboard functions for MSW
+// Purpose:     wxClipboard class and clipboard functions for MSW
 // Author:      Julian Smart
 // Modified by:
 // Created:     01/02/97


### PR DESCRIPTION
Sorry for not noticing this when making the previous changes in clipboard files.

I promise I am going to take a break from reporting issues and creating PRs.