### PR TITLE
Make GetTextObject() in GTK text controls protected instead of private

### DIFF
--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -186,7 +186,7 @@ protected:
     void GTKSetWrapMode();
     void GTKSetJustification();
 
-    // get the underlying text buffer for multi-line controls, or NULL otherwise
+    // get the underlying text buffer for multi-line controls, or null otherwise
     GtkTextBuffer *GTKGetTextBuffer() { return IsMultiLine() ? m_buffer : nullptr; }
 
 private:

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -186,6 +186,15 @@ protected:
     void GTKSetWrapMode();
     void GTKSetJustification();
 
+    // returns either m_text or m_buffer depending on whether the control is
+    // single- or multi-line; convenient for the GTK+ functions which work with
+    // both
+    void *GetTextObject() const override
+    {
+        return IsMultiLine() ? static_cast<void *>(m_buffer)
+                             : static_cast<void *>(m_text);
+    }
+
 private:
     void Init();
 
@@ -201,16 +210,6 @@ private:
     // current position); returns wxFONTENCODING_SYSTEM if we have no specific
     // encoding
     wxFontEncoding GetTextEncoding() const;
-
-    // returns either m_text or m_buffer depending on whether the control is
-    // single- or multi-line; convenient for the GTK+ functions which work with
-    // both
-    void *GetTextObject() const override
-    {
-        return IsMultiLine() ? static_cast<void *>(m_buffer)
-                             : static_cast<void *>(m_text);
-    }
-
 
     // the widget used for single line controls
     GtkWidget  *m_text;

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -11,6 +11,8 @@
 #define _WX_GTK_TEXTCTRL_H_
 
 typedef struct _GtkTextMark GtkTextMark;
+typedef struct _GTKGetTextBuffer GTKGetTextBuffer;
+typedef struct _GTKGetEditable GTKGetEditable;
 
 //-----------------------------------------------------------------------------
 // wxTextCtrl

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -188,6 +188,8 @@ protected:
 
     // get the underlying text buffer for multi-line controls, or null otherwise
     GtkTextBuffer *GTKGetTextBuffer() { return IsMultiLine() ? m_buffer : nullptr; }
+    // get the underlying text control
+    GtkEditable *GTKGetEditable() const { return GetEditable(); }
 
 private:
     void Init();

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -186,14 +186,8 @@ protected:
     void GTKSetWrapMode();
     void GTKSetJustification();
 
-    // returns either m_text or m_buffer depending on whether the control is
-    // single- or multi-line; convenient for the GTK+ functions which work with
-    // both
-    void *GetTextObject() const override
-    {
-        return IsMultiLine() ? static_cast<void *>(m_buffer)
-                             : static_cast<void *>(m_text);
-    }
+    // get the underlying text buffer for multi-line controls, or NULL otherwise
+    GtkTextBuffer *GTKGetTextBuffer() { return IsMultiLine() ? m_buffer : nullptr; }
 
 private:
     void Init();
@@ -210,6 +204,16 @@ private:
     // current position); returns wxFONTENCODING_SYSTEM if we have no specific
     // encoding
     wxFontEncoding GetTextEncoding() const;
+
+    // returns either m_text or m_buffer depending on whether the control is
+    // single- or multi-line; convenient for the GTK+ functions which work with
+    // both
+    void *GetTextObject() const override
+    {
+        return IsMultiLine() ? static_cast<void *>(m_buffer)
+                             : static_cast<void *>(m_text);
+    }
+
 
     // the widget used for single line controls
     GtkWidget  *m_text;

--- a/include/wx/gtk/textentry.h
+++ b/include/wx/gtk/textentry.h
@@ -118,6 +118,11 @@ protected:
     // the dialog containing this control if any.
     bool ClickDefaultButtonIfPossible();
 
+    // This one exists in order to be overridden by wxTextCtrl which uses
+    // either GtkEditable or GtkTextBuffer depending on whether it is single-
+    // or multi-line.
+    virtual void *GetTextObject() const { return GetEntry(); }
+
 private:
     // implement this to return the associated GtkEntry or another widget
     // implementing GtkEditable
@@ -125,12 +130,6 @@ private:
 
     // implement this to return the associated GtkEntry
     virtual GtkEntry *GetEntry() const = 0;
-
-    // This one exists in order to be overridden by wxTextCtrl which uses
-    // either GtkEditable or GtkTextBuffer depending on whether it is single-
-    // or multi-line.
-    virtual void *GetTextObject() const { return GetEntry(); }
-
 
     // Various auto-completion-related stuff, only used if any of AutoComplete()
     // methods are called.

--- a/include/wx/gtk/textentry.h
+++ b/include/wx/gtk/textentry.h
@@ -118,11 +118,6 @@ protected:
     // the dialog containing this control if any.
     bool ClickDefaultButtonIfPossible();
 
-    // This one exists in order to be overridden by wxTextCtrl which uses
-    // either GtkEditable or GtkTextBuffer depending on whether it is single-
-    // or multi-line.
-    virtual void *GetTextObject() const { return GetEntry(); }
-
 private:
     // implement this to return the associated GtkEntry or another widget
     // implementing GtkEditable
@@ -130,6 +125,12 @@ private:
 
     // implement this to return the associated GtkEntry
     virtual GtkEntry *GetEntry() const = 0;
+
+    // This one exists in order to be overridden by wxTextCtrl which uses
+    // either GtkEditable or GtkTextBuffer depending on whether it is single-
+    // or multi-line.
+    virtual void *GetTextObject() const { return GetEntry(); }
+
 
     // Various auto-completion-related stuff, only used if any of AutoComplete()
     // methods are called.

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1791,6 +1791,39 @@ public:
 
     ///@}
 
+    /**
+        @name Gtk-specific functions
+    */
+    ///@{
+
+    /**
+        Gets the underlying text buffer for multi-line controls, or null if single line.
+
+        Having direct access to the `GtkTextBuffer` allows you to edit the content of the text control via GTK’s API (e.g., `gtk_text_buffer_insert_markup()`).
+
+        @onlyfor{wxgtk}
+        @since 3.3
+    */
+    GtkTextBuffer *GTKGetTextBuffer();
+
+    /**
+        Gets the underlying text control that can be uses with GTK’s API.
+
+        @onlyfor{wxgtk}
+        @since 3.3
+    */
+    GtkEditable *GTKGetEditable();
+
+    /**
+        Widgets that use the style's base colour for the BG colour should
+        override this and return true.
+
+        @onlyfor{wxgtk}
+    */
+    virtual bool UseGTKStyleBase() const;
+
+    ///@}
+
     ///@{
     /**
         Operator definitions for appending to a text control.


### PR DESCRIPTION
This allows users to derive from `wxTextCtrl` and be able to access the underlying `GtkTextBuffer`. This is useful in my case as this allows me to write Pango markup directly to the control efficiently.  I was trying to do this earlier:

```
GtkWidget* text_view = gtk_bin_get_child(GTK_BIN(GTK_SCROLLED_WINDOW(GetHandle())));
GtkTextBuffer* buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(text_view) );
do stuff with buffer...
```
and I could do stuff with `buffer`. However, usually my edits get lost because `DoFreeze()` and `DoThaw()` swap the real buffer with an empty temp one. In my situation then, the buffer that `gtk_text_view_get_buffer()` gives me is usually the temp, empty one that eventually gets de-attached.

By exposing `GetTextObject()` as a protected member and using that, all works great as I am now pointing to the real buffer at all times.

I'm leaving this out of the documentation since you should only be using this if you know what you're doing.