### PR TITLE
Don't clobber std::string_view equality with char *

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1263,7 +1263,7 @@ public:
   #endif
 
 #ifdef wxHAS_STD_STRING_VIEW
-    wxString(std::wstring_view view)
+    explicit wxString(std::wstring_view view)
         { assign(view.data(), view.length()); }
 #endif  // wxHAS_STD_STRING_VIEW
 
@@ -1272,7 +1272,7 @@ public:
       { assign(str.c_str(), str.length()); }
 
     #ifdef wxHAS_STD_STRING_VIEW
-        wxString(std::string_view view)
+        explicit wxString(std::string_view view)
             { assign(view.data(), view.length()); }
     #endif  // wxHAS_STD_STRING_VIEW
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
@@ -1881,6 +1881,29 @@ public:
     // from wxScopedCharBuffer
   wxString& operator=(const wxScopedCharBuffer& s)
     { return assign(s); }
+#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
+
+#if wxUSE_UNICODE_WCHAR
+  wxString& operator=(const std::wstring& str) { m_impl = str; return *this; }
+  wxString& operator=(std::wstring&& str) noexcept { m_impl = std::move(str); return *this; }
+#else // wxUSE_UNICODE_UTF8
+  wxString& operator=(const std::wstring& str)
+    { return assign(str.c_str(), str.length()); }
+#endif
+
+#ifdef wxHAS_STD_STRING_VIEW
+  wxString& operator=(std::wstring_view view)
+    { return assign(view.data(), view.length()); }
+#endif  // wxHAS_STD_STRING_VIEW
+
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+  wxString& operator=(const std::string& str)
+    { return assign(str.c_str(), str.length()); }
+
+    #ifdef wxHAS_STD_STRING_VIEW
+      wxString& operator=(std::string_view view)
+        { return assign(view.data(), view.length()); }
+    #endif  // wxHAS_STD_STRING_VIEW
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
 
   // string concatenation

--- a/tests/strings/stdstrings.cpp
+++ b/tests/strings/stdstrings.cpp
@@ -690,5 +690,14 @@ TEST_CASE("StdString::View", "[stdstring]")
     std::string_view strViewInvalidUTF(strInvalidUTF);
 
     CHECK( "" == wxString::FromUTF8(strViewInvalidUTF) );
+
+    /* Ensure we don't clobber comparisons on base types */
+    std::string_view view = "abc";
+    const char *str = "abc";
+    CHECK( view == str );
+
+    std::wstring_view wview = L"abc";
+    const wchar_t *wstr = L"abc";
+    CHECK( wview == wstr );
 }
 #endif // wxHAS_STD_STRING_VIEW


### PR DESCRIPTION
Small fix for an annoyance I found when trying to build [SLADE](https://github.com/sirjuddington/SLADE) with wxWidgets 3.3:

Trying to compare a `std::string_view` to a `char *` now fails due to ambiguity with the new `wxString(std::string_view)` constructor.

I suggest making it explicit since I guess that is a pretty common use case.

This sample only builds if the constructor is explicit:

 ```c++
#include <wx/string.h>
#include <string_view>

int main() {
  std::string_view view = "abc";
  const char *str = "abc";
  return view == str;
}
```

This is also consistent with `std::string` from the STL, whose constructor from `std::string_view` is explicit (c.f. https://en.cppreference.com/w/cpp/string/basic_string/basic_string, 10th overload)