### PR TITLE
Fix wxHyperlinkCtrl interface documentation

### DIFF
--- a/interface/wx/hyperlink.h
+++ b/interface/wx/hyperlink.h
@@ -164,7 +164,7 @@ public:
         Returns @true if the hyperlink has already been clicked by the user at least
         one time.
     */
-    virtual bool GetVisited() const = 0;
+    virtual bool GetVisited() const;
 
     /**
         Returns the colour used to print the label when the mouse is not over the
@@ -195,7 +195,7 @@ public:
     /**
         Marks the hyperlink as visited (see wxHyperlinkCtrl::SetVisitedColour).
     */
-    virtual void SetVisited(bool visited = true) = 0;
+    virtual void SetVisited(bool visited = true);
 
     /**
         Sets the colour used to print the label when the mouse is not over the control


### PR DESCRIPTION
The interface docs for wxHyperlinkCtrl incorrectly declare GetVisited/SetVisited as pure virtual which they are not.
