### PR TITLE
Implement wxRB_SINGLE support in wxGTK (backport to 3.2)

### DIFF
--- a/include/wx/gtk/radiobut.h
+++ b/include/wx/gtk/radiobut.h
@@ -28,6 +28,7 @@ public:
     {
         Create( parent, id, label, pos, size, style, validator, name );
     }
+    ~wxRadioButton();
 
     bool Create( wxWindow *parent,
                  wxWindowID id,

--- a/interface/wx/radiobut.h
+++ b/interface/wx/radiobut.h
@@ -33,7 +33,10 @@
            When this style is used, no other radio buttons will be turned off
            automatically when this button is turned on and such behaviour will
            need to be implemented manually, in the event handler for this
-           button.
+           button. This style is currently only supported in wxMSW and wxGTK
+           (since version 3.2.x). In the other ports it can be specified, but
+           single radio buttons can't be turned off, making them not very
+           useful.
     @endStyleTable
 
     @beginEventEmissionTable{wxCommandEvent}


### PR DESCRIPTION
Create hidden radio button in wxGTK when using wxRB_SINGLE, as this lets us deactivate the shown button by activating the hidden one. GTK does not allow deactivating radio buttons by calling them with gtk_toggle_button_set_active( ..., FALSE), so we need to work around it like this.

Also update the documentation to mention that this works in wxGTK now.

See #17022, #23652, and #23677.

---

Feedback regarding where I placed the destructor and data would be good as the file seems to have some sort of organisation structure with comments and I don't know what the convention is regarding that. I'm also not sure if using snake_case for `hidden_rbs` is right, I just copied the convention from `src/motif/timer.cpp`.