### PR TITLE
Refactor and improve command line arguments handling during initialization

### DIFF
--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -44,6 +44,11 @@ struct WXDLLIMPEXP_BASE wxInitData
     void MSWInitialize();
 
     wchar_t** argvMSW = nullptr;
+#else // !__WINDOWS__
+    // Under other platforms we typically need the original, non-Unicode
+    // command line version, so we keep it too. Unlike argv that we allocate,
+    // this pointer doesn't need to be freed.
+    char** argvA = nullptr;
 #endif // __WINDOWS__
 
     wxDECLARE_NO_COPY_CLASS(wxInitData);

--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -1,0 +1,45 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/init.h
+// Purpose:     Private initialization-related data.
+// Author:      Vadim Zeitlin
+// Created:     2023-09-02
+// Copyright:   (c) 2023 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_INIT_H_
+#define _WX_PRIVATE_INIT_H_
+
+// ----------------------------------------------------------------------------
+// Initialization data contains parameters we get from the OS entry function.
+// ----------------------------------------------------------------------------
+
+struct WXDLLIMPEXP_BASE wxInitData
+{
+    wxInitData() = default;
+
+    // Get the single global object.
+    static wxInitData& Get();
+
+    // Initialize from ANSI command line arguments.
+    void Initialize(int argc, char** argv);
+
+    // This function is used instead of the dtor because the global object can
+    // be initialized multiple times.
+    void Free();
+
+
+    // We always have argc and (Unicode) argv, they're filled by Initialize().
+    int argc = 0;
+    wchar_t** argv = nullptr;
+
+    // We also need to keep their original copies as they can be modified
+    // during initialization (e.g. GTK removes GTK-specific parameters from
+    // it), but we must free the originally allocated array at the end.
+    int argcOrig = 0;
+    wchar_t** argvOrig = nullptr;
+
+    wxDECLARE_NO_COPY_CLASS(wxInitData);
+};
+
+#endif // _WX_PRIVATE_INIT_H_

--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -29,7 +29,8 @@ struct WXDLLIMPEXP_BASE wxInitData
     void Free();
 
 
-    // We always have argc and (Unicode) argv, they're filled by Initialize().
+    // We always have argc and (Unicode) argv, they're filled by Initialize()
+    // and argv as well as its elements are owned by us, see Free().
     int argc = 0;
     wchar_t** argv = nullptr;
 
@@ -37,6 +38,12 @@ struct WXDLLIMPEXP_BASE wxInitData
     // Initialize from the implicitly available Unicode command line.
     void MSWInitialize();
 
+    // This pointer is non-null only if MSWInitialize() was called. In this
+    // case, argv is also set to it and, because this pointer needs to be freed
+    // using MSW-specific function, argv must not be freed at all.
+    //
+    // It's also possible to use Initialize(), even under Windows, in which
+    // case this pointer remains null and argv must be freed as usual.
     wchar_t** argvMSW = nullptr;
 #else // !__WINDOWS__
     // Under other platforms we typically need the original, non-Unicode

--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -33,12 +33,6 @@ struct WXDLLIMPEXP_BASE wxInitData
     int argc = 0;
     wchar_t** argv = nullptr;
 
-    // We also need to keep their original copies as they can be modified
-    // during initialization (e.g. GTK removes GTK-specific parameters from
-    // it), but we must free the originally allocated array at the end.
-    int argcOrig = 0;
-    wchar_t** argvOrig = nullptr;
-
 #ifdef __WINDOWS__
     // Initialize from the implicitly available Unicode command line.
     void MSWInitialize();

--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -39,6 +39,13 @@ struct WXDLLIMPEXP_BASE wxInitData
     int argcOrig = 0;
     wchar_t** argvOrig = nullptr;
 
+#ifdef __WINDOWS__
+    // Initialize from the implicitly available Unicode command line.
+    void MSWInitialize();
+
+    wchar_t** argvMSW = nullptr;
+#endif // __WINDOWS__
+
     wxDECLARE_NO_COPY_CLASS(wxInitData);
 };
 

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -154,6 +154,10 @@ void wxInitData::Initialize(int argcIn, char **argvIn)
 {
     wxASSERT_MSG( !argc && !argv, "initializing twice?" );
 
+#ifndef __WINDOWS__
+    argvA = argvIn;
+#endif
+
     argvOrig = new wchar_t *[argcIn + 1];
     argv = new wchar_t *[argcIn + 1];
 

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -502,6 +502,7 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
         {
             while ( strcmp(wxConvUTF8.cWX2MB(argv_[i]), argvA[i]) != 0 )
             {
+                free(argv_[i]);
                 memmove(argv_ + i, argv_ + i + 1, (argc_ - i)*sizeof(*argv_));
             }
         }

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -24,6 +24,8 @@
 #include "wx/fontmap.h"
 #include "wx/msgout.h"
 
+#include "wx/private/init.h"
+
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/log.h"
 #include "wx/gtk/private/threads.h"
@@ -472,19 +474,6 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
 
     bool init_result;
 
-    int i;
-
-    // gtk_init() wants UTF-8, not wchar_t, so convert
-    char **argvGTK = new char *[argc_ + 1];
-    for ( i = 0; i < argc_; i++ )
-    {
-        argvGTK[i] = wxStrdupA(wxConvUTF8.cWX2MB(argv_[i]));
-    }
-
-    argvGTK[argc_] = nullptr;
-
-    int argcGTK = argc_;
-
     // Prevent gtk_init_check() from changing the locale automatically for
     // consistency with the other ports that don't do it. If necessary,
     // wxApp::SetCLocale() may be explicitly called.
@@ -501,15 +490,17 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
 #if defined(__WXGTK4__)
     init_result = gtk_init_check() != 0;
 #else
-    init_result = gtk_init_check( &argcGTK, &argvGTK ) != 0;
-#endif
+    auto argvA = wxInitData::Get().argvA;
+
+    int argcGTK = argc_;
+    init_result = gtk_init_check( &argcGTK, &argvA ) != 0;
 
     if ( argcGTK != argc_ )
     {
         // we have to drop the parameters which were consumed by GTK+
-        for ( i = 0; i < argcGTK; i++ )
+        for ( int i = 0; i < argcGTK; i++ )
         {
-            while ( strcmp(wxConvUTF8.cWX2MB(argv_[i]), argvGTK[i]) != 0 )
+            while ( strcmp(wxConvUTF8.cWX2MB(argv_[i]), argvA[i]) != 0 )
             {
                 memmove(argv_ + i, argv_ + i + 1, (argc_ - i)*sizeof(*argv_));
             }
@@ -517,20 +508,12 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
 
         argc_ = argcGTK;
         argv_[argc_] = nullptr;
+
+        this->argc = argc_;
+        this->argv.Init(argc_, argv_);
     }
     //else: gtk_init() didn't modify our parameters
-
-    // free our copy
-    for ( i = 0; i < argcGTK; i++ )
-    {
-        free(argvGTK[i]);
-    }
-
-    delete [] argvGTK;
-
-    // update internal arg[cv] as GTK+ may have removed processed options:
-    this->argc = argc_;
-    this->argv.Init(argc_, argv_);
+#endif
 
     if ( !init_result )
     {


### PR DESCRIPTION
The real goal of this PR is to make `argvA` to the code that will need it, such as CEF initialization functions, but it also improves the existing code by simplifying it for both wxMSW and wxGTK.