### PR TITLE
Fix /tmp permissions in Cirrus CI environment

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,6 +39,7 @@ task:
 
     case "${osname}" in
       Linux)
+        chmod 1777 /tmp
         WX_EXTRA_PACKAGES="$WX_EXTRA_PACKAGES \
               g++ libexpat1-dev libjpeg-dev libpng-dev libtiff-dev make zlib1g-dev"
         ;;


### PR DESCRIPTION
For some reason /tmp is not world-writable any more and running apt-get
(even as root) fails. Fix this by ensuring the directory has the correct
permissions.
