### PR TITLE
Use dl_iterate_phdr() in wxDynamicLibrary::ListLoaded()

### DIFF
--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -565,6 +565,7 @@ check_symbol_exists(dlopen dlfcn.h HAVE_DLOPEN)
 cmake_pop_check_state()
 if(HAVE_DLOPEN)
     check_symbol_exists(dladdr dlfcn.h HAVE_DLADDR)
+    check_symbol_exists(dl_iterate_phdr link.h HAVE_DL_ITERATE_PHDR)
 endif()
 
 if(APPLE)

--- a/configure
+++ b/configure
@@ -35459,6 +35459,18 @@ fi
 fi
 done
 
+
+                for ac_func in dl_iterate_phdr
+do :
+  ac_fn_c_check_func "$LINENO" "dl_iterate_phdr" "ac_cv_func_dl_iterate_phdr"
+if test "x$ac_cv_func_dl_iterate_phdr" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_DL_ITERATE_PHDR 1
+_ACEOF
+
+fi
+done
+
             fi
         fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -4839,7 +4839,7 @@ else
                             ])
             ])
 
-            dnl check also for dlerror()
+            dnl check also for some optional functions which we may use
             if test "$HAVE_DL_FUNCS" = 1; then
                 AC_CHECK_FUNCS(dladdr,
                     AC_DEFINE(HAVE_DLADDR),
@@ -4851,6 +4851,8 @@ else
                             ])
                     ]
                 )
+
+                AC_CHECK_FUNCS(dl_iterate_phdr)
             fi
         fi
 

--- a/interface/wx/dynlib.h
+++ b/interface/wx/dynlib.h
@@ -23,6 +23,10 @@ public:
     /**
         Retrieves the load address and the size of this module.
 
+        Note that under ELF systems (such as Linux) the region defined by the
+        parameters of this function can be discontinuous and contain multiple
+        segments belonging to the module with holes between them.
+
         @param addr
             The pointer to the location to return load address in, may be
             @NULL.
@@ -38,6 +42,8 @@ public:
     /**
         Returns the base name of this module, e.g.\ @c "kernel32.dll" or
         @c "libc-2.3.2.so".
+
+        This name is empty for the main program itself.
     */
     wxString GetName() const;
 
@@ -217,13 +223,20 @@ public:
     bool IsLoaded() const;
 
     /**
-        This static method returns a wxArray containing the details of all
-        modules loaded into the address space of the current project. The array
-        elements are objects of the type: wxDynamicLibraryDetails. The array
-        will be empty if an error occurred.
+        This static method returns a vector-like object containing the details
+        of all modules loaded into the address space of the current project.
 
-        This method is currently implemented only under Win32 and Linux and is
-        useful mostly for diagnostics purposes.
+        The array elements are objects of the type wxDynamicLibraryDetails.
+        Under Unix systems they appear in the order in which they libraries
+        have been loaded, with the module corresponding to the main program
+        itself coming first.
+
+        The returned array will be empty if an error occurred or if the
+        function is not implemented for the current platform.
+
+        This method is currently implemented only under Win32 and Unix systems
+        providing `dl_iterate_phdr()` function (such as Linux) and is useful
+        mostly for diagnostics purposes.
     */
     static wxDynamicLibraryDetailsArray ListLoaded();
 

--- a/setup.h.in
+++ b/setup.h.in
@@ -935,6 +935,9 @@
 /* Define if you have the dladdr function.  */
 #undef HAVE_DLADDR
 
+/* Define if you have the dl_iterate_phdr function.  */
+#undef HAVE_DL_ITERATE_PHDR
+
 /* Define if you have Posix fnctl() function. */
 #undef HAVE_FCNTL
 


### PR DESCRIPTION
This has the advantage of returning libraries in their load order, which
is more useful than the unspecified order that was used before.

It also means that this function now has a chance of working under other
systems such as FreeBSD, which also provides dl_iterate_phdr().
