### PR TITLE
Add support for setting proxy to `wxWebView` implementations that support it

### DIFF
--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -79,6 +79,7 @@ public:
     virtual void EnableAccessToDevTools(bool enable = true) override;
     virtual bool IsAccessToDevToolsEnabled() const override;
     virtual bool SetUserAgent(const wxString& userAgent) override;
+    virtual bool SetProxy(const wxString& proxy) override;
 #endif
 
     void SetZoomType(wxWebViewZoomType) override;

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -94,6 +94,8 @@ public:
     virtual bool SetUserAgent(const wxString& userAgent) override;
     virtual wxString GetUserAgent() const override;
 
+    virtual bool SetProxy(const wxString& proxy) override;
+
     virtual bool RunScript(const wxString& javascript, wxString* output = nullptr) const override;
     virtual void RunScriptAsync(const wxString& javascript, void* clientData = nullptr) const override;
     virtual bool AddScriptMessageHandler(const wxString& name) override;

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -251,6 +251,7 @@ public:
     virtual void Reload(wxWebViewReloadFlags flags = wxWEBVIEW_RELOAD_DEFAULT) = 0;
     virtual bool SetUserAgent(const wxString& userAgent) { wxUnusedVar(userAgent); return false; }
     virtual wxString GetUserAgent() const;
+    virtual bool SetProxy(const wxString& proxy) { wxUnusedVar(proxy); return false; }
 
     // Script
     virtual bool RunScript(const wxString& javascript, wxString* output = nullptr) const;

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -1212,6 +1212,19 @@ public:
     virtual wxString GetUserAgent() const;
 
     /**
+        Set the proxy to use for all requests.
+
+        The @a proxy string must be a valid proxy specification, e.g. @c
+        http://my.local.proxy.corp:8080
+
+        @note Currently this function is only implemented in WebKit2 backend.
+
+        @return @true if proxy was set successfully or @false if it failed,
+            e.g. because this is not supported by the currently used backend.
+     */
+    virtual bool SetProxy(const wxString& proxy);
+
+    /**
         @name Scripting
     */
     /**

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -1217,7 +1217,8 @@ public:
         The @a proxy string must be a valid proxy specification, e.g. @c
         http://my.local.proxy.corp:8080
 
-        @note Currently this function is only implemented in WebKit2 backend.
+        @note Currently this function is only implemented in WebKit2 and Edge
+            backends and must be called before Create() for the latter one.
 
         @return @true if proxy was set successfully or @false if it failed,
             e.g. because this is not supported by the currently used backend.

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -161,6 +161,7 @@ public:
     void OnRunScriptCustom(wxCommandEvent& evt);
     void OnAddUserScript(wxCommandEvent& evt);
     void OnSetCustomUserAgent(wxCommandEvent& evt);
+    void OnSetProxy(wxCommandEvent& evt);
     void OnClearSelection(wxCommandEvent& evt);
     void OnDeleteSelection(wxCommandEvent& evt);
     void OnSelectAll(wxCommandEvent& evt);
@@ -548,6 +549,7 @@ WebFrame::WebFrame(const wxString& url, bool isMain, wxWebViewWindowFeatures* wi
     m_tools_menu->AppendSubMenu(script_menu, _("Run Script"));
     wxMenuItem* addUserScript = m_tools_menu->Append(wxID_ANY, _("Add user script"));
     wxMenuItem* setCustomUserAgent = m_tools_menu->Append(wxID_ANY, _("Set custom user agent"));
+    wxMenuItem* setProxy = m_tools_menu->Append(wxID_ANY, _("Set proxy"));
 
     //Selection menu
     wxMenu* selection = new wxMenu();
@@ -657,6 +659,7 @@ WebFrame::WebFrame(const wxString& url, bool isMain, wxWebViewWindowFeatures* wi
     Bind(wxEVT_MENU, &WebFrame::OnRunScriptAsync, this, m_script_async->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnAddUserScript, this, addUserScript->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnSetCustomUserAgent, this, setCustomUserAgent->GetId());
+    Bind(wxEVT_MENU, &WebFrame::OnSetProxy, this, setProxy->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnClearSelection, this, m_selection_clear->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnDeleteSelection, this, m_selection_delete->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnSelectAll, this, selectall->GetId());
@@ -1372,6 +1375,29 @@ void WebFrame::OnSetCustomUserAgent(wxCommandEvent& WXUNUSED(evt))
 
     if (!m_browser->SetUserAgent(customUserAgent))
         wxLogError("Could not set custom user agent");
+}
+
+void WebFrame::OnSetProxy(wxCommandEvent& WXUNUSED(evt))
+{
+    static wxString s_proxy;
+    if ( s_proxy.empty() )
+        wxGetEnv("http_proxy", &s_proxy);
+
+    const auto proxy = wxGetTextFromUser
+        (
+            "Enter the proxy to use",
+            wxGetTextFromUserPromptStr,
+            s_proxy,
+            this
+        );
+
+    if (proxy.empty())
+        return;
+
+    s_proxy = proxy;
+
+    if (!m_browser->SetProxy(s_proxy))
+        wxLogError("Could not set proxy");
 }
 
 void WebFrame::OnClearSelection(wxCommandEvent& WXUNUSED(evt))

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -423,6 +423,17 @@ WebFrame::WebFrame(const wxString& url, bool isMain, wxWebViewWindowFeatures* wi
 #endif
     // Create the webview
     m_browser = (windowFeatures) ? windowFeatures->GetChildWebView() : wxWebView::New();
+
+#if wxUSE_WEBVIEW_EDGE
+    // With Edge the proxy can only be set before creation, so do it here.
+    if (wxWebView::IsBackendAvailable(wxWebViewBackendEdge))
+    {
+        wxString proxy;
+        if (wxGetEnv("http_proxy", &proxy))
+            m_browser->SetProxy(proxy);
+    }
+#endif // wxUSE_WEBVIEW_EDGE
+
 #ifdef __WXMAC__
     if (m_isMainFrame)
     {

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -424,15 +424,15 @@ WebFrame::WebFrame(const wxString& url, bool isMain, wxWebViewWindowFeatures* wi
     // Create the webview
     m_browser = (windowFeatures) ? windowFeatures->GetChildWebView() : wxWebView::New();
 
-#if wxUSE_WEBVIEW_EDGE
-    // With Edge the proxy can only be set before creation, so do it here.
-    if (wxWebView::IsBackendAvailable(wxWebViewBackendEdge))
+    // With several backends the proxy can only be set before creation, so do
+    // it here if the standard environment variable is defined.
+    wxString proxy;
+    if ( wxGetEnv("http_proxy", &proxy) )
     {
-        wxString proxy;
-        if (wxGetEnv("http_proxy", &proxy))
-            m_browser->SetProxy(proxy);
+        if ( m_browser->SetProxy(proxy) )
+            wxLogMessage("Using proxy \"%s\"", proxy);
+        //else: error message should have been already given by wxWebView itself
     }
-#endif // wxUSE_WEBVIEW_EDGE
 
 #ifdef __WXMAC__
     if (m_isMainFrame)

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -268,6 +268,22 @@ public:
 #endif
     }
 
+    bool SetProxy(const wxString& proxy)
+    {
+#ifdef __VISUALC__
+        m_webViewEnvironmentOptions->put_AdditionalBrowserArguments(
+            wxString::Format("--proxy-server=\"%s\"", proxy).wc_str()
+        );
+        return true;
+#else
+        wxUnusedVar(proxy);
+
+        wxLogError(_("This program was compiled without support for setting Edge proxy."));
+
+        return false;
+#endif
+    }
+
     virtual void* GetNativeConfiguration() const override
     {
         return m_webViewEnvironmentOptions;
@@ -1357,6 +1373,16 @@ wxString wxWebViewEdge::GetUserAgent() const
     return wxString{};
 }
 
+
+bool wxWebViewEdge::SetProxy(const wxString& proxy)
+{
+    wxCHECK_MSG(!m_impl->m_webViewController, false,
+                "Proxy must be set before calling Create()");
+
+    auto configImpl = static_cast<wxWebViewConfigurationImplEdge*>(m_impl->m_config.GetImpl());
+
+    return configImpl->SetProxy(proxy);
+}
 
 void* wxWebViewEdge::GetNativeBackend() const
 {


### PR DESCRIPTION
Unfortunately Mac doesn't, but it's still arguably better to have it only for WebKitGTK and Edge (and Chromium, in another branch soon) than not at all.

The API is intentionally minimal for now.