### PR TITLE
[EGL] Fail early if EGL version is less than 1.5

### DIFF
--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -370,14 +370,16 @@ EGLDisplay wxGLCanvasEGL::GetDisplay()
     typedef EGLDisplay (*GetPlatformDisplayFunc)(EGLenum platform,
                                                  void* native_display,
                                                  const EGLAttrib* attrib_list);
+    // Static initializers ensure these are only computed once.
+    static const bool s_EGLHasPlatformDisplay(
+        wxGLCanvasBase::IsExtensionInList(
+            eglQueryString(nullptr, EGL_EXTENSIONS),
+            "EGL_EXT_platform_base"));
 
-    // Static initializer ensures this is only computed once.
     static const GetPlatformDisplayFunc s_eglGetPlatformDisplay(
         []() -> GetPlatformDisplayFunc
         {
-            if ( !wxGLCanvasBase::IsExtensionInList(
-                eglQueryString(nullptr, EGL_EXTENSIONS),
-                "EGL_EXT_platform_base") )
+            if ( !s_EGLHasPlatformDisplay )
             {
                 return nullptr;
             }


### PR DESCRIPTION
* Add an explicit error message indicating why the `wxGLCanvas` failed to initialize on systems where the EGL runtime version is older than 1.5.
* Change `wxGLCanvasEGL::GetDisplay()` to use `eglGetDisplay()` rather than `eglGetPlatformDisplay()` when the latter is not available. This is necessary because this has to be called before EGL is initialized, which is the point where we can know the EGL runtime version. `eglGetPlatformDisplay()` is only available on EGL 1.5 and greater.

Bug: #22325

TEST=Tested the OpenGL samples on Wayland with EGL 1.5. Hard-coded the EGL version number to an older version to ensure the samples were failing with the expected error message.