### PR TITLE
BUG FIX - File history's menu items not correctly formatted when loaded

### DIFF
--- a/src/common/filehistorycmn.cpp
+++ b/src/common/filehistorycmn.cpp
@@ -271,6 +271,7 @@ void wxFileHistoryBase::Load(const wxConfigBase& config)
     }
 
     AddFilesToMenu();
+    DoRefreshLabels();
 }
 
 void wxFileHistoryBase::Save(wxConfigBase& config)


### PR DESCRIPTION
Formatting function is not called. Add DoRefreshLabels().