### PR TITLE
wxBitmap fixes for wxQt

### DIFF
--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -105,6 +105,9 @@ public:
     wxMask(const wxBitmap& bitmap);
     virtual ~wxMask();
 
+    // Construct a mask from QBitmap, takes ownership.
+    wxMask(QBitmap* qtBitmap);
+
     wxBitmap GetBitmap() const;
 
     // Implementation

--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -191,6 +191,24 @@ typedef wxPixelFormat<unsigned char, 24, 0, 1, 2> wxImagePixelFormat;
     typedef wxPixelFormat<unsigned char, 24, 0, 1, 2> wxNativePixelFormat;
 
     #define wxPIXEL_FORMAT_ALPHA 3
+
+    template<>
+    struct wxPixelFormat<void, 1, -1, -1, -1, -1, bool>
+    {
+        // the type which may hold the entire pixel value
+        typedef bool PixelType;
+
+        // size of one pixel in bits
+        static const int BitsPerPixel = 1;
+
+        // size of one pixel in ChannelType units (usually bytes)
+        static const int SizePixel = 1;
+
+        // true if we have an alpha channel (together with the other channels, this
+        // doesn't cover the case of wxImage which stores alpha separately)
+        enum { HasAlpha = false };
+    };
+    typedef wxPixelFormat<void, 1, -1, -1, -1, -1, bool> wxMonoPixelFormat;
 #endif
 
 // the (most common) native format for bitmaps with alpha channel
@@ -678,7 +696,7 @@ struct wxPixelDataOut<wxBitmap>
     // private: -- see comment in the beginning of the file
 
         // the bitmap we're associated with
-        wxBitmap m_bmp;
+        wxBitmap& m_bmp;
 
         // the iterator pointing to the image origin
         Iterator m_pixels;
@@ -695,7 +713,7 @@ struct wxPixelDataOut<wxBitmap>
     };
 };
 
-    #if defined(__WXMSW__)
+    #if defined(__WXMSW__) || defined(__WXQT__)
         template <>
         struct wxPixelDataOut<wxBitmap>::wxPixelDataIn<wxMonoPixelFormat> : public wxPixelDataBase
         {
@@ -722,7 +740,11 @@ struct wxPixelDataOut<wxBitmap>
                 operator bool() const
                 {
                     wxByte mask = static_cast<wxByte>(1 << m_bit);
+                #ifndef __WXQT__
                     return (*m_ptr & mask) != 0;
+                #else
+                    return (*m_ptr & mask) == 0;
+                #endif
                 }
 
             private:
@@ -896,7 +918,7 @@ struct wxPixelDataOut<wxBitmap>
         // private: -- see comment in the beginning of the file
 
             // the bitmap we're associated with
-            wxBitmap m_bmp;
+            wxBitmap& m_bmp;
 
             // the iterator pointing to the image origin
             Iterator m_pixels;
@@ -943,7 +965,7 @@ typedef wxPixelData<wxImage> wxImagePixelData;
 typedef wxPixelData<wxBitmap, wxNativePixelFormat> wxNativePixelData;
 typedef wxPixelData<wxBitmap, wxAlphaPixelFormat> wxAlphaPixelData;
 
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) || defined(__WXQT__)
 typedef wxPixelData<wxBitmap, wxMonoPixelFormat> wxMonoPixelData;
 #endif
 

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -586,7 +586,7 @@ protected:
 #ifdef __WXMAC__
     CGContextRef m_cgContext;
 #endif // __WXMAC__
-    
+
 private:
     cairo_t* m_context;
     cairo_matrix_t m_internalTransform;
@@ -1622,14 +1622,14 @@ wxCairoBitmapData::wxCairoBitmapData( wxGraphicsRenderer* renderer, const wxBitm
     // different format and iterator than if it doesn't...
     const bool isSrcBpp32 = bmp.GetDepth() == 32;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
-    // Under MSW and OSX we can have 32 bpp xRGB bitmaps (without alpha).
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
+    // Under MSW, OSX and Qt we can have 32 bpp xRGB bitmaps (without alpha).
     const bool hasAlpha = bmp.HasAlpha();
 #endif
 
     cairo_format_t bufferFormat =
-    // Under MSW and OSX we can have 32 bpp xRGB bitmaps (without alpha).
-#if defined(__WXMSW__) || defined(__WXOSX__)
+    // Under MSW, OSX and Qt we can have 32 bpp xRGB bitmaps (without alpha).
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         (isSrcBpp32 && hasAlpha) || bmp.GetMask() != nullptr
 #else
         isSrcBpp32 || bmp.GetMask() != nullptr
@@ -1659,11 +1659,11 @@ wxCairoBitmapData::wxCairoBitmapData( wxGraphicsRenderer* renderer, const wxBitm
                     // with alpha in the upper 8 bits, then red, then green, then
                     // blue. The 32-bit quantities are stored native-endian.
                     // Pre-multiplied alpha is used.
-#if defined (__WXMSW__) || defined(__WXOSX__)
+#if defined (__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                     unsigned char alpha = hasAlpha ? p.Alpha() : wxALPHA_OPAQUE;
-                    // MSW and OSX bitmap pixel bits are already premultiplied.
+                    // MSW, OSX and Qt bitmap pixel bits are already premultiplied.
                     *data = (alpha << 24 | p.Red() << 16 | p.Green() << 8 | p.Blue());
-#else // !__WXMSW__ , !__WXOSX__
+#else // !__WXMSW__ , !__WXOSX__ , !__WXQT__
                     // We always have alpha, but we need to premultiply it.
                     unsigned char alpha = p.Alpha();
                     if (alpha == wxALPHA_TRANSPARENT)
@@ -1673,7 +1673,7 @@ wxCairoBitmapData::wxCairoBitmapData( wxGraphicsRenderer* renderer, const wxBitm
                             | Premultiply(alpha, p.Red()) << 16
                             | Premultiply(alpha, p.Green()) << 8
                             | Premultiply(alpha, p.Blue()));
-#endif // __WXMSW__, __WXOSX__ / !__WXMSW__, !__WXOSX__
+#endif // __WXMSW__, __WXOSX__, __WXQT__ / !__WXMSW__, !__WXOSX__, !__WXQT__
                     ++data;
                     ++p;
                 }
@@ -2414,7 +2414,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, cairo_t *context )
 #ifdef __WXMAC__
     m_cgContext = nullptr;
 #endif // __WXMAC__
-    
+
     Init( cairo_reference(context), true );
     m_width = 0;
     m_height = 0;

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -56,15 +56,17 @@ static wxImage ConvertImage( QImage qtImage )
         {
             QRgb colour = line[x];
 
+            if (hasAlpha)
+            {
+                colour = qUnpremultiply(colour);
+                alpha[0] = qAlpha(colour);
+                alpha++;
+            }
+
             data[0] = qRed(colour);
             data[1] = qGreen(colour);
             data[2] = qBlue(colour);
 
-            if (hasAlpha)
-            {
-                alpha[0] = qAlpha(colour);
-                alpha++;
-            }
             data += 3;
         }
     }

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -29,9 +29,9 @@
 
 static wxImage ConvertImage( QImage qtImage )
 {
-    bool hasAlpha = qtImage.hasAlphaChannel();
+    const bool hasAlpha = qtImage.hasAlphaChannel();
 
-    int numPixels = qtImage.height() * qtImage.width();
+    const int numPixels = qtImage.height() * qtImage.width();
 
     //Convert to ARGB32 for scanLine
     qtImage = qtImage.convertToFormat(QImage::Format_ARGB32);
@@ -45,11 +45,11 @@ static wxImage ConvertImage( QImage qtImage )
 
     unsigned char *startAlpha = alpha;
 
-    for (int y = 0; y < qtImage.height(); y++)
+    for (int y = 0; y < qtImage.height(); ++y)
     {
         QRgb *line = (QRgb*)qtImage.scanLine(y);
 
-        for (int x = 0; x < qtImage.width(); x++)
+        for (int x = 0; x < qtImage.width(); ++x)
         {
             QRgb colour = line[x];
 
@@ -73,8 +73,8 @@ static wxImage ConvertImage( QImage qtImage )
 
 static QImage ConvertImage( const wxImage &image )
 {
-    bool hasAlpha = image.HasAlpha();
-    bool hasMask = image.HasMask();
+    const bool hasAlpha = image.HasAlpha();
+    const bool hasMask = image.HasMask();
     QImage qtImage( wxQtConvertSize( image.GetSize() ),
                    ( (hasAlpha || hasMask ) ? QImage::Format_ARGB32 : QImage::Format_RGB32 ) );
 
@@ -90,9 +90,9 @@ static QImage ConvertImage( const wxImage &image )
         maskedColour = ( r << 16 ) + ( g << 8 ) + b;
     }
 
-    for (int y = 0; y < image.GetHeight(); y++)
+    for (int y = 0; y < image.GetHeight(); ++y)
     {
-        for (int x = 0; x < image.GetWidth(); x++)
+        for (int x = 0; x < image.GetWidth(); ++x)
         {
             if (hasAlpha)
             {

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -293,10 +293,67 @@ int wxBitmap::GetDepth() const
 #if wxUSE_IMAGE
 wxImage wxBitmap::ConvertToImage() const
 {
-    QPixmap pixmap(M_PIXDATA);
+    wxImage image;
+
+    wxCHECK_MSG(IsOk(), image, "invalid bitmap");
+
+    image = ConvertImage(M_PIXDATA.toImage());
+
+    // now handle the mask, if we have any
     if ( M_MASK && M_MASK->GetHandle() )
-        pixmap.setMask(*M_MASK->GetHandle());
-    return ConvertImage(pixmap.toImage());
+    {
+        // we hard code the mask colour for now but we could also make an
+        // effort (and waste time) to choose a colour not present in the
+        // image already to avoid having to fudge the pixels below --
+        // whether it's worth to do it is unclear however
+        static const int MASK_RED = 1;
+        static const int MASK_GREEN = 2;
+        static const int MASK_BLUE = 3;
+        static const int MASK_BLUE_REPLACEMENT = 2;
+
+        wxBitmap bmpMask(M_MASK->GetBitmap());
+        wxMonoPixelData dataMask(bmpMask);
+        const int h = dataMask.GetHeight();
+        const int w = dataMask.GetWidth();
+        unsigned char* data = image.GetData();
+
+        wxMonoPixelData::Iterator rowStart(dataMask);
+        for ( int y = 0; y < h; ++y )
+        {
+            // traverse one mask line
+            wxMonoPixelData::Iterator p = rowStart;
+            for ( int x = 0; x < w; ++x )
+            {
+                // should this pixel be transparent?
+                if ( p.Pixel() )
+                {
+                    // no, check that it isn't transparent by accident
+                    if ( (data[0] == MASK_RED) &&
+                            (data[1] == MASK_GREEN) &&
+                                (data[2] == MASK_BLUE) )
+                    {
+                        // we have to fudge the colour a bit to prevent
+                        // this pixel from appearing transparent
+                        data[2] = MASK_BLUE_REPLACEMENT;
+                    }
+
+                    data += 3;
+                }
+                else // yes, transparent pixel
+                {
+                    *data++ = MASK_RED;
+                    *data++ = MASK_GREEN;
+                    *data++ = MASK_BLUE;
+                }
+                ++p;
+            }
+            rowStart.OffsetY(dataMask, 1);
+        }
+
+        image.SetMaskColour(MASK_RED, MASK_GREEN, MASK_BLUE);
+    }
+
+    return image;
 }
 
 #endif // wxUSE_IMAGE

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -74,10 +74,10 @@ static wxImage ConvertImage( QImage qtImage )
         return wxImage(wxQtConvertSize(qtImage.size()), startData);
 }
 
-static QImage ConvertImage( const wxImage &image )
+static QImage ConvertImage( const wxImage &image, wxMask** mask = nullptr  )
 {
     const bool hasAlpha = image.HasAlpha();
-    const bool hasMask = image.HasMask();
+    const bool hasMask = image.HasMask() && mask;
     QImage qtImage( wxQtConvertSize( image.GetSize() ),
                    ( hasAlpha ? QImage::Format_ARGB32_Premultiplied : QImage::Format_RGB32 ) );
 
@@ -85,12 +85,16 @@ static QImage ConvertImage( const wxImage &image )
     unsigned char *alpha = hasAlpha ? image.GetAlpha() : nullptr;
     QRgb colour;
 
+    QImage qtMask;
     QRgb maskedColour;
     if ( hasMask )
     {
         unsigned char r, g, b;
         image.GetOrFindMaskColour( &r, &g, &b );
         maskedColour = qRgb(r, g, b);
+
+        qtMask = QImage(image.GetWidth(), image.GetHeight(), QImage::Format_Mono);
+        qtMask.fill(Qt::color0); // filled with 0s
     }
 
     for (int y = 0; y < image.GetHeight(); ++y)
@@ -104,8 +108,11 @@ static QImage ConvertImage( const wxImage &image )
 
             colour = (a << 24) + (r << 16) + (g << 8) + b;
 
-            if ( qRgb(r, g, b) == maskedColour )
-                colour &= 0x00FFFFFF;
+            if ( !qtMask.isNull() )
+            {
+                if ( qRgb(r, g, b) != maskedColour )
+                    qtMask.setPixel(x, y, Qt::color1); // set to 1
+            }
 
             if (hasAlpha)
             {
@@ -118,6 +125,12 @@ static QImage ConvertImage( const wxImage &image )
             data += 3;
         }
     }
+
+    if ( hasMask )
+    {
+        *mask = new wxMask(new QBitmap{QBitmap::fromImage(qtMask)});
+    }
+
     return qtImage;
 }
 
@@ -139,10 +152,10 @@ class wxBitmapRefData: public wxGDIRefData
             m_mask = nullptr;
         }
 
-        wxBitmapRefData( QPixmap pix )
+        wxBitmapRefData( QPixmap pix, wxMask* mask = nullptr )
             : m_qtPixmap(pix)
         {
-            m_mask = nullptr;
+            m_mask = mask;
         }
 
         virtual ~wxBitmapRefData() { delete m_mask; }
@@ -218,10 +231,12 @@ wxBitmap::wxBitmap(const wxString &filename, wxBitmapType type )
 
 void wxBitmap::InitFromImage(const wxImage& image, int depth, double WXUNUSED(scale) )
 {
-    Qt::ImageConversionFlags flags;
-    if (depth == 1)
-        flags = Qt::MonoOnly;
-    m_refData = new wxBitmapRefData(QPixmap::fromImage(ConvertImage(image), flags));
+    wxMask* mask = nullptr;
+    auto qtImage = depth == 1
+                 ? QBitmap::fromImage(ConvertImage(image))
+                 : QPixmap::fromImage(ConvertImage(image, &mask));
+
+    m_refData = new wxBitmapRefData(qtImage, mask);
 }
 
 wxBitmap::wxBitmap(const wxImage& image, int depth, double scale)
@@ -300,7 +315,15 @@ void wxBitmap::SetMask(wxMask *mask)
 
 wxBitmap wxBitmap::GetSubBitmap(const wxRect& rect) const
 {
-    return wxBitmap(M_PIXDATA.copy(wxQtConvertRect(rect)));
+    wxBitmap bmp = wxBitmap(M_PIXDATA.copy(wxQtConvertRect(rect)));
+
+    if ( M_MASK && M_MASK->GetHandle() )
+    {
+        QBitmap* qtMask = M_MASK->GetHandle();
+        bmp.SetMask(new wxMask(new QBitmap{qtMask->copy(wxQtConvertRect(rect))}));
+    }
+
+    return bmp;
 }
 
 
@@ -494,6 +517,11 @@ wxMask& wxMask::operator=(const wxMask &mask)
     return *this;
 }
 
+wxMask::wxMask(QBitmap* qtBitmap)
+{
+    m_qtBitmap = qtBitmap;
+}
+
 wxMask::wxMask(const wxBitmap& bitmap, const wxColour& colour)
 {
     m_qtBitmap = nullptr;
@@ -530,7 +558,7 @@ bool wxMask::InitFromColour(const wxBitmap& bitmap, const wxColour& colour)
         return false;
 
     delete m_qtBitmap;
-    m_qtBitmap = new QBitmap(bitmap.GetHandle()->createMaskFromColor(colour.GetQColor()));
+    m_qtBitmap = new QBitmap(bitmap.GetHandle()->createMaskFromColor(colour.GetQColor(), Qt::MaskOutColor));
 
     return true;
 }

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -233,7 +233,7 @@ void wxBitmap::InitFromImage(const wxImage& image, int depth, double WXUNUSED(sc
 {
     wxMask* mask = nullptr;
     auto qtImage = depth == 1
-                 ? QBitmap::fromImage(ConvertImage(image))
+                 ? QBitmap::fromImage(ConvertImage(image), Qt::ThresholdDither)
                  : QPixmap::fromImage(ConvertImage(image, &mask));
 
     m_refData = new wxBitmapRefData(qtImage, mask);
@@ -435,7 +435,7 @@ bool wxBitmap::LoadFile(const wxString &name, wxBitmapType type)
     if ( img.load(wxQtConvertString(name), type_name) )
     {
         M_PIXDATA = (img.colorCount() > 0 && img.colorCount() <= 2)
-                  ? QBitmap::fromImage(img)
+                  ? QBitmap::fromImage(img, Qt::ThresholdDither)
                   : QPixmap::fromImage(img);
 
         return true;

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -33,8 +33,11 @@ static wxImage ConvertImage( QImage qtImage )
 
     const int numPixels = qtImage.height() * qtImage.width();
 
-    //Convert to ARGB32 for scanLine
-    qtImage = qtImage.convertToFormat(QImage::Format_ARGB32);
+    // For monochrome bitmaps, we just convert to RGB32 so we don't have to do any
+    // bit twiddling to get at pixels and the same code below should work for any
+    // image format we support.
+    if ( qtImage.depth() == 1 )
+        qtImage = qtImage.convertToFormat(QImage::Format_RGB32);
 
     unsigned char *data = (unsigned char *)malloc(sizeof(char) * 3 * numPixels);
     unsigned char *startData = data;
@@ -76,7 +79,7 @@ static QImage ConvertImage( const wxImage &image )
     const bool hasAlpha = image.HasAlpha();
     const bool hasMask = image.HasMask();
     QImage qtImage( wxQtConvertSize( image.GetSize() ),
-                   ( (hasAlpha || hasMask ) ? QImage::Format_ARGB32 : QImage::Format_RGB32 ) );
+                   ( hasAlpha ? QImage::Format_ARGB32_Premultiplied : QImage::Format_RGB32 ) );
 
     unsigned char *data = image.GetData();
     unsigned char *alpha = hasAlpha ? image.GetAlpha() : nullptr;
@@ -87,25 +90,28 @@ static QImage ConvertImage( const wxImage &image )
     {
         unsigned char r, g, b;
         image.GetOrFindMaskColour( &r, &g, &b );
-        maskedColour = ( r << 16 ) + ( g << 8 ) + b;
+        maskedColour = qRgb(r, g, b);
     }
 
     for (int y = 0; y < image.GetHeight(); ++y)
     {
         for (int x = 0; x < image.GetWidth(); ++x)
         {
+            const unsigned char a = hasAlpha ? alpha[0] : 255;
+            const unsigned char r = data[0];
+            const unsigned char g = data[1];
+            const unsigned char b = data[2];
+
+            colour = (a << 24) + (r << 16) + (g << 8) + b;
+
+            if ( qRgb(r, g, b) == maskedColour )
+                colour &= 0x00FFFFFF;
+
             if (hasAlpha)
             {
-                colour = alpha[0] << 24;
+                colour = qPremultiply(colour);
                 alpha++;
             }
-            else
-                colour = 0;
-
-            colour += (data[0] << 16) + (data[1] << 8) + data[2];
-
-            if ( hasMask && colour != maskedColour )
-                colour += 0xFF000000; // 255 << 24
 
             qtImage.setPixel(x, y, colour);
 

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -702,7 +702,19 @@ void wxQtDCImpl::DoDrawBitmap(const wxBitmap &bmp, wxCoord x, wxCoord y,
     else
     {
             if ( useMask && bmp.GetMask() && bmp.GetMask()->GetHandle() )
-                pix.setMask(*bmp.GetMask()->GetHandle());
+            {
+                // Unfortunately, how Qt applies mask bitmaps is the opposite of how
+                // wx applies them. the mask must therefore be inverted before passing
+                // it to Qt to get the expected result.
+                QBitmap qtMask = *bmp.GetMask()->GetHandle();
+
+                QImage qtImage = qtMask.toImage();
+                qtImage.invertPixels();
+                qtMask = QBitmap::fromImage(qtImage);
+
+                pix.setMask(qtMask);
+            }
+
             m_qtPainter->drawPixmap(x, y, pix);
     }
 }

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -50,10 +50,10 @@
 typedef wxPixelFormat<unsigned char, 32, 2, 1, 0> wxNative32PixelFormat;
 typedef wxPixelData<wxBitmap, wxNative32PixelFormat> wxNative32PixelData;
 #endif // __WXMSW__
-#ifdef __WXOSX__
+#if defined(__WXOSX__) || defined(__WXQT__)
 // 32 bpp xRGB bitmaps are native ones
 typedef wxNativePixelData wxNative32PixelData;
-#endif // __WXOSX__
+#endif // __WXOSX__ || __WXQT__
 
 // ----------------------------------------------------------------------------
 // tests
@@ -83,7 +83,7 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.GetDepth() == 1);
 
     // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) || defined(__WXQT__)
     // draw lines on top and left, but leaving blank top and left lines
     {
         wxMonoPixelData data(mono);
@@ -245,7 +245,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
     {
         // RGBA Bitmap
         wxBitmap bmp(16, 16, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
         {
@@ -253,7 +253,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
             const wxColour clrBg(*wxGREEN);
             const unsigned char alpha = 92;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
             // premultiplied values
             const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
@@ -306,13 +306,13 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
             {
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y), image.GetAlpha(x,y));
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) //|| defined(__WXQT__)
                 // Premultiplied values
                 unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
                 unsigned char b = ((imgc.Blue() * imgc.Alpha()) + 127) / 255;
                 imgc.Set(r, g, b, imgc.Alpha());
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGBA(imgc, bmpc);
             }
             rowStartBmp.OffsetY(dataBmp, 1);
@@ -323,14 +323,14 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
     {
         // RGBA Bitmap
         wxBitmap bmp(16, 16, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
         {
             const wxColour clrFg(*wxCYAN);
             const wxColour clrBg(*wxGREEN);
             const unsigned char alpha = 92;
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
             // premultiplied values
             const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
@@ -412,7 +412,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y), image.GetAlpha(x,y));
                 if ( maskc == *wxWHITE )
                 {
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) //|| defined(__WXQT__)
                     // Premultiplied values
                     unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                     unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
@@ -545,7 +545,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
             {
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour imgc(img.GetRed(x, y), img.GetGreen(x, y), img.GetBlue(x, y), img.GetAlpha(x, y));
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
@@ -596,7 +596,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour maskc(iMask.Red(), iMask.Green(), iMask.Blue());
                 wxColour imgc(img.GetRed(x, y), img.GetGreen(x, y), img.GetBlue(x, y), img.GetAlpha(x, y));
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
@@ -606,7 +606,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
                 CHECK_EQUAL_COLOUR_RGBA(bmpc, imgc);
 
                 wxColour c = maskc == *wxWHITE ? fillCol : maskCol;
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 r = ((c.Red() * imgc.Alpha()) + 127) / 255;
                 g = ((c.Green() * imgc.Alpha()) + 127) / 255;
@@ -810,7 +810,7 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     const wxColour clrBg(*wxGREEN);
     const unsigned char alpha = 92;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // premultiplied values
     const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
@@ -819,7 +819,7 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
 
     // Bitmap to be drawn
     wxBitmap bmp(w, h, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
     {
@@ -873,7 +873,7 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     p1.OffsetX(data24, w / 4); // left side is opaque
     ASSERT_EQUAL_COLOUR_RGB(p1, clrFg);
     p1.OffsetX(data24, w / 2); // right side is with alpha
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // premultiplied values
     ASSERT_EQUAL_RGB(p1, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                          clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
@@ -884,7 +884,7 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
                          (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
 #endif // __WXMSW__ || __WXOSX__
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // Drawing the bitmap on 32 bpp xRGB target
     wxBitmap bmpOut32(w, h, 32);
     REQUIRE_FALSE(bmpOut32.HasAlpha());
@@ -925,7 +925,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
     const wxColour clrBg(*wxGREEN);
     const unsigned char alpha = 92;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
      // premultiplied values
      const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
@@ -934,7 +934,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
 
      // Bitmap with mask to be drawn
      wxBitmap bmp(w, h, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
      bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
      {
@@ -993,7 +993,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         p1.OffsetX(data24, w / 4); // drawn area - left side opaque
         ASSERT_EQUAL_COLOUR_RGB(p1, clrFg);
         p1.OffsetX(data24, w / 2); // drawn area - right side with alpha
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         // premultiplied values
         ASSERT_EQUAL_RGB(p1, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                              clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
@@ -1033,7 +1033,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         p1.OffsetX(data24, w / 4); // left upper side opaque
         ASSERT_EQUAL_COLOUR_RGB(p1, clrFg);
         p1.OffsetX(data24, w / 2); // right upper side with alpha
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         // premultiplied values
         ASSERT_EQUAL_RGB(p1, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                              clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
@@ -1048,7 +1048,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         p1.OffsetX(data24, w / 4); // left lower side - same colour as upper
         ASSERT_EQUAL_COLOUR_RGB(p1, clrFg);
         p1.OffsetX(data24, w / 2); // right lower side - same colour as upper
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
          // premultiplied values
         ASSERT_EQUAL_RGB(p1, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                              clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
@@ -1060,7 +1060,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
 #endif // __WXMSW__ || __WXOSX__
     }
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // Drawing the bitmap on 32 bpp xRGB target using mask
     {
         wxBitmap bmpOut32(w, h, 32);
@@ -1293,7 +1293,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     CHECK(maskClrBottomRight == *wxBLACK);
 
     // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) || defined(__WXQT__)
     bool maskValueTopLeft;
     bool maskValueTopRight;
     bool maskValueBottomLeft;
@@ -1353,7 +1353,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     }
 
     // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) || defined(__WXQT__)
     {
         REQUIRE(subBmpMask.GetDepth() == 1);
         wxMonoPixelData data(subBmpMask);
@@ -1388,7 +1388,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     const wxColour clrLeft(*wxCYAN);
     const unsigned char alpha = 92;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // premultiplied values
     const wxColour clrRight(((clrLeft.Red() * alpha) + 127) / 255, ((clrLeft.Green() * alpha) + 127) / 255, ((clrLeft.Blue() * alpha) + 127) / 255, alpha);
 #else
@@ -1396,7 +1396,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
 #endif // __WXMSW__ || __WXOSX__
 
     wxBitmap bmp(w, h, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
     {
@@ -1495,7 +1495,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     CHECK(maskClrBottomRight == *wxBLACK);
 
     // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) || defined(__WXQT__)
     bool maskValueTopLeft;
     bool maskValueTopRight;
     bool maskValueBottomLeft;
@@ -1555,7 +1555,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     }
 
     // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) || defined(__WXQT__)
     {
         REQUIRE(subBmpMask.GetDepth() == 1);
         wxMonoPixelData data(subBmpMask);

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -82,7 +82,7 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.IsOk());
     REQUIRE(mono.GetDepth() == 1);
 
-    // wxMonoPixelData only exists in wxMSW
+    // wxMonoPixelData only exists in wxMSW and wxQt
 #if defined(__WXMSW__) || defined(__WXQT__)
     // draw lines on top and left, but leaving blank top and left lines
     {
@@ -103,8 +103,8 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     }
     TempFile mono_lines_horse("mono_lines_horse.bmp");
     REQUIRE(mono.SaveFile(mono_lines_horse.GetName(), wxBITMAP_TYPE_BMP));
-#endif      // __WXMSW__
-#endif      // !__WXGTK__
+#endif // __WXMSW__ || __WXQT__
+#endif // !__WXGTK__
 }
 
 TEST_CASE("BitmapTestCase::Mask", "[bitmap][mask]")
@@ -245,7 +245,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
     {
         // RGBA Bitmap
         wxBitmap bmp(16, 16, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
+#if defined(__WXMSW__) || defined(__WXOSX__)
         bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
         {
@@ -258,7 +258,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
             const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
             const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
             wxAlphaPixelData data(bmp);
             REQUIRE(data);
@@ -306,7 +306,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
             {
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y), image.GetAlpha(x,y));
-#if defined(__WXMSW__) || defined(__WXOSX__) //|| defined(__WXQT__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
@@ -323,7 +323,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
     {
         // RGBA Bitmap
         wxBitmap bmp(16, 16, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
+#if defined(__WXMSW__) || defined(__WXOSX__)
         bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
         {
@@ -335,7 +335,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
             const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
             const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
             wxAlphaPixelData data(bmp);
             REQUIRE(data);
@@ -412,13 +412,13 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y), image.GetAlpha(x,y));
                 if ( maskc == *wxWHITE )
                 {
-#if defined(__WXMSW__) || defined(__WXOSX__) //|| defined(__WXQT__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                     // Premultiplied values
                     unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                     unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
                     unsigned char b = ((imgc.Blue() * imgc.Alpha()) + 127) / 255;
                     imgc.Set(r, g, b, imgc.Alpha());
-#endif // __WXMSW__ || __WXOSX
+#endif // __WXMSW__ || __WXOSX || __WXQT__
                     CHECK_EQUAL_COLOUR_RGBA(imgc, bmpc);
                     unmaskedPixelsCount++;
                 }
@@ -551,7 +551,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
                 unsigned char b = ((imgc.Blue() * imgc.Alpha()) + 127) / 255;
                 imgc.Set(r, g, b, imgc.Alpha());
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGBA(bmpc, imgc);
             }
             rowStartBmp.OffsetY(dataBmp, 1);
@@ -602,7 +602,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
                 unsigned char b = ((imgc.Blue() * imgc.Alpha()) + 127) / 255;
                 imgc.Set(r, g, b, imgc.Alpha());
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGBA(bmpc, imgc);
 
                 wxColour c = maskc == *wxWHITE ? fillCol : maskCol;
@@ -612,7 +612,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
                 g = ((c.Green() * imgc.Alpha()) + 127) / 255;
                 b = ((c.Blue() * imgc.Alpha()) + 127) / 255;
                 c.Set(r, g, b);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGB(bmpc, c);
             }
             rowStartBmp.OffsetY(dataBmp, 1);
@@ -815,11 +815,11 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
     const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
     // Bitmap to be drawn
     wxBitmap bmp(w, h, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
+#if defined(__WXMSW__) || defined(__WXOSX__)
     bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
     {
@@ -882,7 +882,7 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     ASSERT_EQUAL_RGB(p1, (clrFg.Red() * alpha + clrBg.Red() * (255 - alpha) + 127) / 255,
                          (clrFg.Green() * alpha + clrBg.Green() * (255 - alpha) + 127) / 255,
                          (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
 #if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // Drawing the bitmap on 32 bpp xRGB target
@@ -910,7 +910,7 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     ASSERT_EQUAL_RGB(p2, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                          clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
                          clrFgAlpha.Blue() + (clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 }
 
 TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]")
@@ -930,11 +930,11 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
      const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
      const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
      // Bitmap with mask to be drawn
      wxBitmap bmp(w, h, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
+#if defined(__WXMSW__) || defined(__WXOSX__)
      bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
      {
@@ -1002,7 +1002,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         ASSERT_EQUAL_RGB(p1, (clrFg.Red() * alpha + clrBg.Red() * (255 - alpha) + 127) / 255,
                              (clrFg.Green() * alpha + clrBg.Green() * (255 - alpha) + 127) / 255,
                              (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
         p1 = rowStart1;
         p1.OffsetY(data24, h / 2);
         p1.OffsetX(data24, w / 4); // masked area - left side
@@ -1042,7 +1042,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         ASSERT_EQUAL_RGB(p1, (clrFg.Red() * alpha + clrBg.Red() * (255 - alpha) + 127) / 255,
                              (clrFg.Green() * alpha + clrBg.Green() * (255 - alpha) + 127) / 255,
                              (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
         p1 = rowStart1;
         p1.OffsetY(data24, h / 2);
         p1.OffsetX(data24, w / 4); // left lower side - same colour as upper
@@ -1057,7 +1057,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         ASSERT_EQUAL_RGB(p1, (clrFg.Red() * alpha + clrBg.Red() * (255 - alpha) + 127) / 255,
                              (clrFg.Green() * alpha + clrBg.Green() * (255 - alpha) + 127) / 255,
                              (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
     }
 
 #if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
@@ -1133,7 +1133,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
                              clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
                              clrFgAlpha.Blue() + (clrBg.Blue() * (255 - alpha) + 127) / 255);
     }
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 }
 
 TEST_CASE("BitmapTestCase::SubBitmapNonAlpha", "[bitmap][subbitmap][nonalpha]")
@@ -1292,7 +1292,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     CHECK(maskClrBottomLeft == *wxBLACK);
     CHECK(maskClrBottomRight == *wxBLACK);
 
-    // wxMonoPixelData only exists in wxMSW
+    // wxMonoPixelData only exists in wxMSW and wxQt
 #if defined(__WXMSW__) || defined(__WXQT__)
     bool maskValueTopLeft;
     bool maskValueTopRight;
@@ -1322,7 +1322,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     CHECK(maskValueTopRight == true);
     CHECK(maskValueBottomLeft == false);
     CHECK(maskValueBottomRight == false);
-#endif      // __WXMSW__
+#endif // __WXMSW__ || __WXQT__
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -1352,7 +1352,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         ASSERT_EQUAL_COLOUR_RGB(p, maskClrBottomRight);
     }
 
-    // wxMonoPixelData only exists in wxMSW
+    // wxMonoPixelData only exists in wxMSW and wxQt
 #if defined(__WXMSW__) || defined(__WXQT__)
     {
         REQUIRE(subBmpMask.GetDepth() == 1);
@@ -1373,7 +1373,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         CHECK(p.Pixel() == maskValueBottomRight);
     }
     REQUIRE(subBmpMask.GetDepth() == 1);
-#endif      // __WXMSW__
+#endif // __WXMSW__ || __WXQT__
 }
 
 TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][withmask]")
@@ -1393,10 +1393,10 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     const wxColour clrRight(((clrLeft.Red() * alpha) + 127) / 255, ((clrLeft.Green() * alpha) + 127) / 255, ((clrLeft.Blue() * alpha) + 127) / 255, alpha);
 #else
     const wxColour clrRight(clrLeft.Red(), clrLeft.Green(), clrLeft.Blue(), alpha);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
     wxBitmap bmp(w, h, 32);
-#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
+#if defined(__WXMSW__) || defined(__WXOSX__)
     bmp.UseAlpha();
 #endif // __WXMSW__ || __WXOSX__
     {
@@ -1494,7 +1494,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     CHECK(maskClrBottomLeft == *wxBLACK);
     CHECK(maskClrBottomRight == *wxBLACK);
 
-    // wxMonoPixelData only exists in wxMSW
+    // wxMonoPixelData only exists in wxMSW and wxQt
 #if defined(__WXMSW__) || defined(__WXQT__)
     bool maskValueTopLeft;
     bool maskValueTopRight;
@@ -1524,7 +1524,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     CHECK(maskValueTopRight == true);
     CHECK(maskValueBottomLeft == false);
     CHECK(maskValueBottomRight == false);
-#endif      // __WXMSW__
+#endif // __WXMSW__ || __WXQT__
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -1554,7 +1554,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         ASSERT_EQUAL_RGB(p, maskClrBottomRight.Red(), maskClrBottomRight.Green(), maskClrBottomRight.Blue());
     }
 
-    // wxMonoPixelData only exists in wxMSW
+    // wxMonoPixelData only exists in wxMSW and wxQt
 #if defined(__WXMSW__) || defined(__WXQT__)
     {
         REQUIRE(subBmpMask.GetDepth() == 1);
@@ -1575,7 +1575,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         CHECK(p.Pixel() == maskValueBottomRight);
     }
     REQUIRE(subBmpMask.GetDepth() == 1);
-#endif      // __WXMSW__
+#endif // __WXMSW__ || __WXQT__
 }
 
 namespace Catch

--- a/tests/graphics/graphbitmap.cpp
+++ b/tests/graphics/graphbitmap.cpp
@@ -26,10 +26,10 @@
 typedef wxPixelFormat<unsigned char, 32, 2, 1, 0> wxNative32PixelFormat;
 typedef wxPixelData<wxBitmap, wxNative32PixelFormat> wxNative32PixelData;
 #endif // __WXMSW__
-#ifdef __WXOSX__
+#if defined(__WXOSX__) || defined(__WXQT__)
 // 32 bpp xRGB bitmaps are native ones
 typedef wxNativePixelData wxNative32PixelData;
-#endif // __WXOSX__
+#endif // __WXOSX__ || __WXQT__
 
 // ----------------------------------------------------------------------------
 // tests
@@ -82,13 +82,13 @@ wxBitmap CreateBitmapRGB(int w, int h, bool withMask)
     return DoCreateBitmapRGB(w, h, 24, withMask);
 }
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
 // 32-bit RGB bitmap
 wxBitmap CreateBitmapXRGB(int w, int h, bool withMask)
 {
     return DoCreateBitmapRGB(w, h, 32, withMask);
 }
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
 wxBitmap CreateBitmapRGBA(int w, int h, bool withMask)
 {
@@ -101,12 +101,12 @@ wxBitmap CreateBitmapRGBA(int w, int h, bool withMask)
         const wxColour clrBg(*wxGREEN);
         const unsigned char alpha = 51;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         // premultiplied values
         const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
         const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
         wxAlphaPixelData data(bmp);
         REQUIRE(data);
@@ -358,7 +358,7 @@ TEST_CASE("GraphicsBitmapTestCase::Create", "[graphbitmap][create]")
 #endif // wxUSE_GRAPHICS_CAIRO
     }
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     SECTION("xRGB bitmap without mask")
     {
         // xRGB bitmap
@@ -467,7 +467,7 @@ TEST_CASE("GraphicsBitmapTestCase::Create", "[graphbitmap][create]")
         }
 #endif // wxUSE_GRAPHICS_CAIRO
     }
-#endif // _WXMSW__ || __WXOSX__
+#endif // _WXMSW__ || __WXOSX__ || __WXQT__
 
     SECTION("RGBA bitmap without mask")
     {
@@ -694,7 +694,7 @@ TEST_CASE("GraphicsBitmapTestCase::SubBitmap", "[graphbitmap][subbitmap][create]
 #endif // wxUSE_GRAPHICS_CAIRO
     }
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     SECTION("xRGB bitmap without mask")
     {
         // xRGB bitmap
@@ -827,7 +827,7 @@ TEST_CASE("GraphicsBitmapTestCase::SubBitmap", "[graphbitmap][subbitmap][create]
         }
 #endif // wxUSE_GRAPHICS_CAIRO
     }
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
     SECTION("RGBA bitmap without mask")
     {


### PR DESCRIPTION
Although the tests are all passing now, testing and reviewing this PR before merging is really appreciated, TIA!

```
> xvfb-run -a -s '-screen 0 1600x1200x24' ./test_gui [bitmap]
Test program for wxWidgets GUI features
build: 3.3.0 (UTF-8,compiler with C++ ABI compatible with gcc 4,STL containers,compatible with 3.2)
compiled using gcc 8.4
running under Linux 4.15.0-213-generic i686 as aliket
Filters: [bitmap]
===============================================================================
All tests passed (4046 assertions in 14 test cases)
```