### PR TITLE
Fix page origin in wxGTK when printing in landscape mode

### DIFF
--- a/src/gtk/print.cpp
+++ b/src/gtk/print.cpp
@@ -702,6 +702,11 @@ int wxGtkPrintDialog::ShowModal()
     gtk_print_operation_set_default_page_setup (printOp, pgSetup);
     g_object_unref(pgSetup);
 
+    // By default the origin of the Cairo context is in the upper left
+    // corner of the printable area, but wx convention is to have it in
+    // the upper left corner of the paper, so change this.
+    gtk_print_operation_set_use_full_page(printOp, TRUE);
+
     // Show the dialog if needed.
     GError* gError = nullptr;
     GtkPrintOperationResult response = gtk_print_operation_run
@@ -2197,15 +2202,6 @@ void wxGtkPrinterDCImpl::StartPage()
     // to not affect _gtk_print_context_rotate_according_to_orientation() which
     // is used in GTK+ itself and wouldn't work correctly if we applied these
     // transformations before it is called.
-
-    // By default the origin of the Cairo context is in the upper left
-    // corner of the printable area. We need to translate it so that it
-    // is in the upper left corner of the paper (without margins)
-    GtkPageSetup *setup = gtk_print_context_get_page_setup( m_gpc );
-    gdouble ml, mt;
-    ml = gtk_page_setup_get_left_margin (setup, GTK_UNIT_POINTS);
-    mt = gtk_page_setup_get_top_margin (setup, GTK_UNIT_POINTS);
-    cairo_translate(m_cairo, -ml, -mt);
 
 #if wxCAIRO_SCALE
     cairo_scale( m_cairo, 72.0 / (double)m_resolution, 72.0 / (double)m_resolution );


### PR DESCRIPTION
Using the "left" and "top" margin doesn't work in this case and we would
actually need to use "bottom" and "left" ones to offset the origin
correctly in landscape orientation (and something else for the reverse
landscape, and reverse portrait one, too), but there actually seems to
be a simpler way to put the origin where we want it without translating
it explicitly: we can just tell GTK that we want to use the full page,
rather than just the printable area, by setting "use-full-page" property
to true, so simply do this instead.

Co-authored-by: Alex Shvartzkop <dudesuchamazing@gmail.com>

Closes #23860.
