### PR TITLE
Use premultiplied ARGB32 format for wxBitmap under wxQt

### DIFF
--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -23,8 +23,10 @@ public:
     wxBitmap(int width, int height, const wxDC& dc);
     wxBitmap(const char* const* bits);
     wxBitmap(const wxString &filename, wxBitmapType type = wxBITMAP_TYPE_XPM);
+#if wxUSE_IMAGE
     wxBitmap(const wxImage& image, int depth = wxBITMAP_SCREEN_DEPTH, double scale = 1.0);
     wxBitmap(const wxImage& image, const wxDC& dc);
+#endif // wxUSE_IMAGE
 
     // Convert from wxIcon / wxCursor
     wxBitmap(const wxIcon& icon) { CopyFromIcon(icon); }
@@ -82,7 +84,9 @@ protected:
     virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const override;
 
 private:
+#if wxUSE_IMAGE
     void InitFromImage(const wxImage& image, int depth, double WXUNUSED(scale));
+#endif
 
     wxDECLARE_DYNAMIC_CLASS(wxBitmap);
 };

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -109,7 +109,7 @@ public:
     virtual ~wxMask();
 
     // Construct a mask from QBitmap, takes ownership.
-    wxMask(QBitmap* qtBitmap);
+    explicit wxMask(QBitmap* qtBitmap);
 
     wxBitmap GetBitmap() const;
 

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -72,6 +72,9 @@ public:
     // disappear in the future
     bool HasAlpha() const override;
 
+    // Blend mask with alpha channel and remove the mask
+    void QtBlendMaskWithAlpha();
+
     QPixmap *GetHandle() const;
 
 protected:

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -105,6 +105,9 @@ public:
     wxMask(const wxBitmap& bitmap);
     virtual ~wxMask();
 
+    // Construct a mask from QBitmap, takes ownership.
+    wxMask(QBitmap* qtBitmap);
+
     wxBitmap GetBitmap() const;
 
     // Implementation

--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -191,6 +191,24 @@ typedef wxPixelFormat<unsigned char, 24, 0, 1, 2> wxImagePixelFormat;
     typedef wxPixelFormat<unsigned char, 24, 0, 1, 2> wxNativePixelFormat;
 
     #define wxPIXEL_FORMAT_ALPHA 3
+
+    template<>
+    struct wxPixelFormat<void, 1, -1, -1, -1, -1, bool>
+    {
+        // the type which may hold the entire pixel value
+        typedef bool PixelType;
+
+        // size of one pixel in bits
+        static const int BitsPerPixel = 1;
+
+        // size of one pixel in ChannelType units (usually bytes)
+        static const int SizePixel = 1;
+
+        // true if we have an alpha channel (together with the other channels, this
+        // doesn't cover the case of wxImage which stores alpha separately)
+        enum { HasAlpha = false };
+    };
+    typedef wxPixelFormat<void, 1, -1, -1, -1, -1, bool> wxMonoPixelFormat;
 #endif
 
 // the (most common) native format for bitmaps with alpha channel
@@ -695,7 +713,7 @@ struct wxPixelDataOut<wxBitmap>
     };
 };
 
-    #if defined(__WXMSW__)
+    #if defined(__WXMSW__) || defined(__WXQT__)
         template <>
         struct wxPixelDataOut<wxBitmap>::wxPixelDataIn<wxMonoPixelFormat> : public wxPixelDataBase
         {
@@ -943,7 +961,7 @@ typedef wxPixelData<wxImage> wxImagePixelData;
 typedef wxPixelData<wxBitmap, wxNativePixelFormat> wxNativePixelData;
 typedef wxPixelData<wxBitmap, wxAlphaPixelFormat> wxAlphaPixelData;
 
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) || defined(__WXQT__)
 typedef wxPixelData<wxBitmap, wxMonoPixelFormat> wxMonoPixelData;
 #endif
 

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -1608,21 +1608,6 @@ wxCairoBitmapData::wxCairoBitmapData( wxGraphicsRenderer* renderer, cairo_surfac
     m_buffer = nullptr;
 }
 
-namespace
-{
-#ifdef wxHAS_RAW_BITMAP
-// Return true if the pixel is masked under this platform
-inline bool IsMasked(wxNativePixelData::Iterator& p)
-{
-#ifndef __WXQT__
-    return p.Red()+p.Green()+p.Blue() == 0;
-#else
-    return p.Red()+p.Green()+p.Blue() != 0;
-#endif
-}
-#endif
-}
-
 wxCairoBitmapData::wxCairoBitmapData( wxGraphicsRenderer* renderer, const wxBitmap& bmp )
     : wxGraphicsBitmapData(renderer)
 {
@@ -1750,7 +1735,7 @@ wxCairoBitmapData::wxCairoBitmapData( wxGraphicsRenderer* renderer, const wxBitm
             wxUint32* const rowStartDst = data;
             for (int x=0; x < pixData.GetWidth(); x++)
             {
-                if ( IsMasked(p) )
+                if (p.Red()+p.Green()+p.Blue() == 0)
                     *data = 0;
 
                 ++data;

--- a/src/generic/imaglist.cpp
+++ b/src/generic/imaglist.cpp
@@ -106,6 +106,10 @@ wxBitmap wxGenericImageList::GetImageListBitmap(const wxBitmap& bitmap) const
 #endif // wxUSE_IMAGE
     }
 
+#ifdef __WXQT__
+    bmpResized.QtBlendMaskWithAlpha();
+#endif
+
     return bmpResized;
 }
 

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -696,7 +696,9 @@ bool wxMask::InitFromMonoBitmap(const wxBitmap& bitmap)
 
 wxBitmap wxMask::GetBitmap() const
 {
-    return wxBitmap(*m_qtBitmap);
+    QImage qtImage = m_qtBitmap->toImage();
+    qtImage.invertPixels();
+    return wxBitmap(QBitmap::fromImage(qtImage));
 }
 
 QBitmap *wxMask::GetHandle() const

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -220,8 +220,7 @@ wxBitmap::wxBitmap(int width, int height, const wxDC& dc)
 // Create a wxBitmap from xpm data
 wxBitmap::wxBitmap(const char* const* bits)
 {
-    m_refData = new wxBitmapRefData();
-    M_PIXDATA = QPixmap( bits );
+    m_refData = new wxBitmapRefData(QPixmap( bits ));
 }
 
 wxBitmap::wxBitmap(const wxString &filename, wxBitmapType type )

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -29,9 +29,9 @@
 
 static wxImage ConvertImage( QImage qtImage )
 {
-    bool hasAlpha = qtImage.hasAlphaChannel();
+    const bool hasAlpha = qtImage.hasAlphaChannel();
 
-    int numPixels = qtImage.height() * qtImage.width();
+    const int numPixels = qtImage.height() * qtImage.width();
 
     // Convert monochrome bitmaps to RGB32 so we don't have to do any
     // bit twiddling to get at pixels, and the same code below should
@@ -48,11 +48,11 @@ static wxImage ConvertImage( QImage qtImage )
 
     unsigned char *startAlpha = alpha;
 
-    for (int y = 0; y < qtImage.height(); y++)
+    for (int y = 0; y < qtImage.height(); ++y)
     {
         QRgb *line = (QRgb*)qtImage.scanLine(y);
 
-        for (int x = 0; x < qtImage.width(); x++)
+        for (int x = 0; x < qtImage.width(); ++x)
         {
             QRgb colour = line[x];
 
@@ -70,16 +70,14 @@ static wxImage ConvertImage( QImage qtImage )
             data += 3;
         }
     }
-    if (hasAlpha)
-        return wxImage(wxQtConvertSize(qtImage.size()), startData, startAlpha);
-    else
-        return wxImage(wxQtConvertSize(qtImage.size()), startData);
+
+    return wxImage(wxQtConvertSize(qtImage.size()), startData, startAlpha);
 }
 
 static QImage ConvertImage( const wxImage &image, wxMask** mask = nullptr  )
 {
-    bool hasAlpha = image.HasAlpha();
-    bool hasMask = image.HasMask() && mask;
+    const bool hasAlpha = image.HasAlpha();
+    const bool hasMask = image.HasMask() && mask;
     QImage qtImage( wxQtConvertSize( image.GetSize() ),
                    ( hasAlpha ? QImage::Format_ARGB32_Premultiplied : QImage::Format_RGB32 ) );
 
@@ -99,9 +97,9 @@ static QImage ConvertImage( const wxImage &image, wxMask** mask = nullptr  )
         qtMask.fill(Qt::color0); // filled with 0s
     }
 
-    for (int y = 0; y < image.GetHeight(); y++)
+    for (int y = 0; y < image.GetHeight(); ++y)
     {
-        for (int x = 0; x < image.GetWidth(); x++)
+        for (int x = 0; x < image.GetWidth(); ++x)
         {
             const unsigned char a = hasAlpha ? alpha[0] : 255;
             const unsigned char r = data[0];

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -618,6 +618,20 @@ bool wxBitmap::HasAlpha() const
     return M_PIXDATA.hasAlphaChannel();
 }
 
+void wxBitmap::QtBlendMaskWithAlpha()
+{
+    // For performance reasons, permanently merge the mask with pixmap's
+    // alpha channel, if it has any. Notice that the bitmap can still be
+    // converted to wxImage, but without mask information.
+
+    if ( IsOk() && HasAlpha() && M_MASK && M_MASK->GetHandle() )
+    {
+        AllocExclusive();
+        M_PIXDATA.setMask(*M_MASK->GetHandle());
+        wxDELETE(M_MASK);
+    }
+}
+
 //-----------------------------------------------------------------------------
 // wxMask
 //-----------------------------------------------------------------------------

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -275,16 +275,22 @@ bool wxBitmap::Create(int width, int height, const wxDC& WXUNUSED(dc))
 
 int wxBitmap::GetHeight() const
 {
+    wxCHECK_MSG( IsOk(), -1, "invalid bitmap" );
+
     return M_PIXDATA.height();
 }
 
 int wxBitmap::GetWidth() const
 {
+    wxCHECK_MSG( IsOk(), -1, "invalid bitmap" );
+
     return M_PIXDATA.width();
 }
 
 int wxBitmap::GetDepth() const
 {
+    wxCHECK_MSG( IsOk(), -1, "invalid bitmap" );
+
     return M_PIXDATA.depth();
 }
 

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -383,25 +383,21 @@ wxBitmap wxBitmap::GetSubBitmap(const wxRect& rect) const
     return bmp;
 }
 
-
-bool wxBitmap::SaveFile(const wxString &name, wxBitmapType type,
-              const wxPalette *WXUNUSED(palette) ) const
+namespace
 {
-    wxCHECK_MSG( IsOk(), false, "invalid bitmap" );
-
-    //Try to save using Qt
-    const char* type_name = nullptr;
+inline const char* wxQtConvertBitmapType(wxBitmapType type)
+{
     switch (type)
     {
-        case wxBITMAP_TYPE_BMP:  type_name = "bmp";  break;
-        case wxBITMAP_TYPE_ICO:  type_name = "ico";  break;
-        case wxBITMAP_TYPE_JPEG: type_name = "jpeg"; break;
-        case wxBITMAP_TYPE_PNG:  type_name = "png";  break;
-        case wxBITMAP_TYPE_GIF:  type_name = "gif";  break;
-        case wxBITMAP_TYPE_CUR:  type_name = "cur";  break;
-        case wxBITMAP_TYPE_TIFF: type_name = "tif";  break;
-        case wxBITMAP_TYPE_XBM:  type_name = "xbm";  break;
-        case wxBITMAP_TYPE_PCX:  type_name = "pcx";  break;
+        case wxBITMAP_TYPE_BMP:  return "bmp";
+        case wxBITMAP_TYPE_ICO:  return "ico";
+        case wxBITMAP_TYPE_JPEG: return "jpeg";
+        case wxBITMAP_TYPE_PNG:  return "png";
+        case wxBITMAP_TYPE_GIF:  return "gif";
+        case wxBITMAP_TYPE_CUR:  return "cur";
+        case wxBITMAP_TYPE_TIFF: return "tif";
+        case wxBITMAP_TYPE_XBM:  return "xbm";
+        case wxBITMAP_TYPE_PCX:  return "pcx";
         case wxBITMAP_TYPE_BMP_RESOURCE:
         case wxBITMAP_TYPE_ICO_RESOURCE:
         case wxBITMAP_TYPE_CUR_RESOURCE:
@@ -427,10 +423,19 @@ bool wxBitmap::SaveFile(const wxString &name, wxBitmapType type,
         case wxBITMAP_TYPE_MAX:
         case wxBITMAP_TYPE_ANY:
         default:
-            break;
+            return nullptr;
     }
+}
+} // anonymous namespace
 
-    if ( M_PIXDATA.save(wxQtConvertString(name), type_name) )
+bool wxBitmap::SaveFile(const wxString &name, wxBitmapType type,
+              const wxPalette *WXUNUSED(palette) ) const
+{
+    wxCHECK_MSG( IsOk(), false, "invalid bitmap" );
+
+    //Try to save using Qt
+
+    if ( M_PIXDATA.save(wxQtConvertString(name), wxQtConvertBitmapType(type)) )
     {
         return true;
     }
@@ -448,48 +453,8 @@ bool wxBitmap::LoadFile(const wxString &name, wxBitmapType type)
     //Try to load using Qt
     AllocExclusive();
 
-    const char* type_name = nullptr;
-    switch (type)
-    {
-        case wxBITMAP_TYPE_BMP:  type_name = "bmp";  break;
-        case wxBITMAP_TYPE_ICO:  type_name = "ico";  break;
-        case wxBITMAP_TYPE_JPEG: type_name = "jpeg"; break;
-        case wxBITMAP_TYPE_PNG:  type_name = "png";  break;
-        case wxBITMAP_TYPE_GIF:  type_name = "gif";  break;
-        case wxBITMAP_TYPE_CUR:  type_name = "cur";  break;
-        case wxBITMAP_TYPE_TIFF: type_name = "tif";  break;
-        case wxBITMAP_TYPE_XBM:  type_name = "xbm";  break;
-        case wxBITMAP_TYPE_PCX:  type_name = "pcx";  break;
-        case wxBITMAP_TYPE_BMP_RESOURCE:
-        case wxBITMAP_TYPE_ICO_RESOURCE:
-        case wxBITMAP_TYPE_CUR_RESOURCE:
-        case wxBITMAP_TYPE_XBM_DATA:
-        case wxBITMAP_TYPE_XPM:
-        case wxBITMAP_TYPE_XPM_DATA:
-        case wxBITMAP_TYPE_TIFF_RESOURCE:
-        case wxBITMAP_TYPE_GIF_RESOURCE:
-        case wxBITMAP_TYPE_PNG_RESOURCE:
-        case wxBITMAP_TYPE_JPEG_RESOURCE:
-        case wxBITMAP_TYPE_PNM:
-        case wxBITMAP_TYPE_PNM_RESOURCE:
-        case wxBITMAP_TYPE_PCX_RESOURCE:
-        case wxBITMAP_TYPE_PICT:
-        case wxBITMAP_TYPE_PICT_RESOURCE:
-        case wxBITMAP_TYPE_ICON:
-        case wxBITMAP_TYPE_ICON_RESOURCE:
-        case wxBITMAP_TYPE_ANI:
-        case wxBITMAP_TYPE_IFF:
-        case wxBITMAP_TYPE_TGA:
-        case wxBITMAP_TYPE_MACCURSOR:
-        case wxBITMAP_TYPE_MACCURSOR_RESOURCE:
-        case wxBITMAP_TYPE_MAX:
-        case wxBITMAP_TYPE_ANY:
-        default:
-            break;
-    }
-
     QImage img;
-    if ( img.load(wxQtConvertString(name), type_name) )
+    if ( img.load(wxQtConvertString(name), wxQtConvertBitmapType(type)) )
     {
         M_PIXDATA = (img.colorCount() > 0 && img.colorCount() <= 2)
                   ? QBitmap::fromImage(img, Qt::ThresholdDither)

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -233,7 +233,7 @@ void wxBitmap::InitFromImage(const wxImage& image, int depth, double WXUNUSED(sc
 {
     wxMask* mask = nullptr;
     auto qtImage = depth == 1
-                 ? QBitmap::fromImage(ConvertImage(image))
+                 ? QBitmap::fromImage(ConvertImage(image), Qt::ThresholdDither)
                  : QPixmap::fromImage(ConvertImage(image, &mask));
 
     m_refData = new wxBitmapRefData(qtImage, mask);
@@ -435,7 +435,7 @@ bool wxBitmap::LoadFile(const wxString &name, wxBitmapType type)
     if ( img.load(wxQtConvertString(name), type_name) )
     {
         M_PIXDATA = (img.colorCount() > 0 && img.colorCount() <= 2)
-                  ? QBitmap::fromImage(img)
+                  ? QBitmap::fromImage(img, Qt::ThresholdDither)
                   : QPixmap::fromImage(img);
 
         return true;

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -26,7 +26,7 @@
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/utils.h"
 
-
+#if wxUSE_IMAGE
 static wxImage ConvertImage( QImage qtImage )
 {
     const bool hasAlpha = qtImage.hasAlphaChannel();
@@ -133,6 +133,7 @@ static QImage ConvertImage( const wxImage &image, wxMask** mask = nullptr  )
 
     return qtImage;
 }
+#endif // wxUSE_IMAGE
 
 //-----------------------------------------------------------------------------
 // wxBitmapRefData
@@ -228,6 +229,7 @@ wxBitmap::wxBitmap(const wxString &filename, wxBitmapType type )
     LoadFile(filename, type);
 }
 
+#if wxUSE_IMAGE
 void wxBitmap::InitFromImage(const wxImage& image, int depth, double WXUNUSED(scale) )
 {
     wxMask* mask = nullptr;
@@ -247,6 +249,7 @@ wxBitmap::wxBitmap(const wxImage& image, const wxDC& dc)
 {
     InitFromImage(image, -1, dc.GetContentScaleFactor());
 }
+#endif // wxUSE_IMAGE
 
 wxBitmap::wxBitmap(const wxCursor& cursor)
 {

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -50,10 +50,22 @@
 typedef wxPixelFormat<unsigned char, 32, 2, 1, 0> wxNative32PixelFormat;
 typedef wxPixelData<wxBitmap, wxNative32PixelFormat> wxNative32PixelData;
 #endif // __WXMSW__
-#ifdef __WXOSX__
+#if defined(__WXOSX__) || defined(__WXQT__)
 // 32 bpp xRGB bitmaps are native ones
 typedef wxNativePixelData wxNative32PixelData;
-#endif // __WXOSX__
+#endif // __WXOSX__ || __WXQT__
+
+// masked/unmasked colours are revered in wxQt:
+
+#ifndef __WXQT__
+#define wxMASK_COLOUR_OPAQUE        wxWHITE
+#define wxMASK_COLOUR_TRANSPARENT   wxBLACK
+#else // __WXQT__
+#define wxMASK_COLOUR_OPAQUE        wxBLACK
+#define wxMASK_COLOUR_TRANSPARENT   wxWHITE
+#endif // !__WXQT__
+
+static const wxColour wxMASK_COLOUR = *wxMASK_COLOUR_OPAQUE;
 
 // ----------------------------------------------------------------------------
 // tests
@@ -82,8 +94,8 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.IsOk());
     REQUIRE(mono.GetDepth() == 1);
 
-    // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+    // wxMonoPixelData only exists in wxMSW and wxQt
+#if defined(__WXMSW__) || defined(__WXQT__)
     // draw lines on top and left, but leaving blank top and left lines
     {
         wxMonoPixelData data(mono);
@@ -103,8 +115,8 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     }
     TempFile mono_lines_horse("mono_lines_horse.bmp");
     REQUIRE(mono.SaveFile(mono_lines_horse.GetName(), wxBITMAP_TYPE_BMP));
-#endif      // __WXMSW__
-#endif      // !__WXGTK__
+#endif // __WXMSW__ || __WXQT__
+#endif // !__WXGTK__
 }
 
 TEST_CASE("BitmapTestCase::Mask", "[bitmap][mask]")
@@ -225,7 +237,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue());
                 wxColour maskc(iMask.Red(), iMask.Green(), iMask.Blue());
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y));
-                if ( maskc == *wxWHITE )
+                if ( maskc == wxMASK_COLOUR )
                 {
                     CHECK_EQUAL_COLOUR_RGB(imgc, bmpc);
                     unmaskedPixelsCount++;
@@ -253,12 +265,12 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
             const wxColour clrBg(*wxGREEN);
             const unsigned char alpha = 92;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
             // premultiplied values
             const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
             const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
             wxAlphaPixelData data(bmp);
             REQUIRE(data);
@@ -306,13 +318,13 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
             {
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y), image.GetAlpha(x,y));
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
                 unsigned char b = ((imgc.Blue() * imgc.Alpha()) + 127) / 255;
                 imgc.Set(r, g, b, imgc.Alpha());
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGBA(imgc, bmpc);
             }
             rowStartBmp.OffsetY(dataBmp, 1);
@@ -330,12 +342,12 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
             const wxColour clrFg(*wxCYAN);
             const wxColour clrBg(*wxGREEN);
             const unsigned char alpha = 92;
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
             // premultiplied values
             const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
             const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
             wxAlphaPixelData data(bmp);
             REQUIRE(data);
@@ -410,15 +422,15 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour maskc(iMask.Red(), iMask.Green(), iMask.Blue());
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y), image.GetAlpha(x,y));
-                if ( maskc == *wxWHITE )
+                if ( maskc == wxMASK_COLOUR )
                 {
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                     // Premultiplied values
                     unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                     unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
                     unsigned char b = ((imgc.Blue() * imgc.Alpha()) + 127) / 255;
                     imgc.Set(r, g, b, imgc.Alpha());
-#endif // __WXMSW__ || __WXOSX
+#endif // __WXMSW__ || __WXOSX || __WXQT__
                     CHECK_EQUAL_COLOUR_RGBA(imgc, bmpc);
                     unmaskedPixelsCount++;
                 }
@@ -506,7 +518,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
                 wxColour maskc(iMask.Red(), iMask.Green(), iMask.Blue());
                 wxColour imgc(img.GetRed(x, y), img.GetGreen(x, y), img.GetBlue(x, y));
                 CHECK_EQUAL_COLOUR_RGB(bmpc, imgc);
-                wxColour c = maskc == *wxWHITE ? fillCol : maskCol;
+                wxColour c = maskc == wxMASK_COLOUR ? fillCol : maskCol;
                 CHECK_EQUAL_COLOUR_RGB(bmpc, c);
             }
             rowStartBmp.OffsetY(dataBmp, 1);
@@ -545,13 +557,13 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
             {
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour imgc(img.GetRed(x, y), img.GetGreen(x, y), img.GetBlue(x, y), img.GetAlpha(x, y));
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
                 unsigned char b = ((imgc.Blue() * imgc.Alpha()) + 127) / 255;
                 imgc.Set(r, g, b, imgc.Alpha());
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGBA(bmpc, imgc);
             }
             rowStartBmp.OffsetY(dataBmp, 1);
@@ -596,23 +608,23 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour maskc(iMask.Red(), iMask.Green(), iMask.Blue());
                 wxColour imgc(img.GetRed(x, y), img.GetGreen(x, y), img.GetBlue(x, y), img.GetAlpha(x, y));
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 unsigned char r = ((imgc.Red() * imgc.Alpha()) + 127) / 255;
                 unsigned char g = ((imgc.Green() * imgc.Alpha()) + 127) / 255;
                 unsigned char b = ((imgc.Blue() * imgc.Alpha()) + 127) / 255;
                 imgc.Set(r, g, b, imgc.Alpha());
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGBA(bmpc, imgc);
 
-                wxColour c = maskc == *wxWHITE ? fillCol : maskCol;
-#if defined(__WXMSW__) || defined(__WXOSX__)
+                wxColour c = maskc == wxMASK_COLOUR ? fillCol : maskCol;
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 r = ((c.Red() * imgc.Alpha()) + 127) / 255;
                 g = ((c.Green() * imgc.Alpha()) + 127) / 255;
                 b = ((c.Blue() * imgc.Alpha()) + 127) / 255;
                 c.Set(r, g, b);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGB(bmpc, c);
             }
             rowStartBmp.OffsetY(dataBmp, 1);
@@ -810,12 +822,12 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     const wxColour clrBg(*wxGREEN);
     const unsigned char alpha = 92;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // premultiplied values
     const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
     const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
     // Bitmap to be drawn
     wxBitmap bmp(w, h, 32);
@@ -873,7 +885,7 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     p1.OffsetX(data24, w / 4); // left side is opaque
     ASSERT_EQUAL_COLOUR_RGB(p1, clrFg);
     p1.OffsetX(data24, w / 2); // right side is with alpha
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // premultiplied values
     ASSERT_EQUAL_RGB(p1, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                          clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
@@ -882,9 +894,9 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     ASSERT_EQUAL_RGB(p1, (clrFg.Red() * alpha + clrBg.Red() * (255 - alpha) + 127) / 255,
                          (clrFg.Green() * alpha + clrBg.Green() * (255 - alpha) + 127) / 255,
                          (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // Drawing the bitmap on 32 bpp xRGB target
     wxBitmap bmpOut32(w, h, 32);
     REQUIRE_FALSE(bmpOut32.HasAlpha());
@@ -910,7 +922,7 @@ TEST_CASE("BitmapTestCase::DrawAlpha", "[bitmap][draw][alpha]")
     ASSERT_EQUAL_RGB(p2, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                          clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
                          clrFgAlpha.Blue() + (clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 }
 
 TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]")
@@ -925,12 +937,12 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
     const wxColour clrBg(*wxGREEN);
     const unsigned char alpha = 92;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
      // premultiplied values
      const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
      const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
      // Bitmap with mask to be drawn
      wxBitmap bmp(w, h, 32);
@@ -993,7 +1005,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         p1.OffsetX(data24, w / 4); // drawn area - left side opaque
         ASSERT_EQUAL_COLOUR_RGB(p1, clrFg);
         p1.OffsetX(data24, w / 2); // drawn area - right side with alpha
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         // premultiplied values
         ASSERT_EQUAL_RGB(p1, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                              clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
@@ -1002,7 +1014,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         ASSERT_EQUAL_RGB(p1, (clrFg.Red() * alpha + clrBg.Red() * (255 - alpha) + 127) / 255,
                              (clrFg.Green() * alpha + clrBg.Green() * (255 - alpha) + 127) / 255,
                              (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
         p1 = rowStart1;
         p1.OffsetY(data24, h / 2);
         p1.OffsetX(data24, w / 4); // masked area - left side
@@ -1033,7 +1045,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         p1.OffsetX(data24, w / 4); // left upper side opaque
         ASSERT_EQUAL_COLOUR_RGB(p1, clrFg);
         p1.OffsetX(data24, w / 2); // right upper side with alpha
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         // premultiplied values
         ASSERT_EQUAL_RGB(p1, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                              clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
@@ -1042,13 +1054,13 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         ASSERT_EQUAL_RGB(p1, (clrFg.Red() * alpha + clrBg.Red() * (255 - alpha) + 127) / 255,
                              (clrFg.Green() * alpha + clrBg.Green() * (255 - alpha) + 127) / 255,
                              (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
         p1 = rowStart1;
         p1.OffsetY(data24, h / 2);
         p1.OffsetX(data24, w / 4); // left lower side - same colour as upper
         ASSERT_EQUAL_COLOUR_RGB(p1, clrFg);
         p1.OffsetX(data24, w / 2); // right lower side - same colour as upper
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
          // premultiplied values
         ASSERT_EQUAL_RGB(p1, clrFgAlpha.Red() + (clrBg.Red() * (255 - alpha) + 127) / 255,
                              clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
@@ -1057,10 +1069,10 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
         ASSERT_EQUAL_RGB(p1, (clrFg.Red() * alpha + clrBg.Red() * (255 - alpha) + 127) / 255,
                              (clrFg.Green() * alpha + clrBg.Green() * (255 - alpha) + 127) / 255,
                              (clrFg.Blue() * alpha + clrBg.Blue() * (255 - alpha) + 127) / 255);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
     }
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // Drawing the bitmap on 32 bpp xRGB target using mask
     {
         wxBitmap bmpOut32(w, h, 32);
@@ -1133,7 +1145,7 @@ TEST_CASE("BitmapTestCase::DrawAlphaWithMask", "[bitmap][draw][alpha][withmask]"
                              clrFgAlpha.Green() + (clrBg.Green() * (255 - alpha) + 127) / 255,
                              clrFgAlpha.Blue() + (clrBg.Blue() * (255 - alpha) + 127) / 255);
     }
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 }
 
 TEST_CASE("BitmapTestCase::SubBitmapNonAlpha", "[bitmap][subbitmap][nonalpha]")
@@ -1287,13 +1299,13 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         p.OffsetX(data, w / 2); // bottom-right point
         maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
     }
-    CHECK(maskClrTopLeft == *wxWHITE);
-    CHECK(maskClrTopRight == *wxWHITE);
-    CHECK(maskClrBottomLeft == *wxBLACK);
-    CHECK(maskClrBottomRight == *wxBLACK);
+    CHECK(maskClrTopLeft == *wxMASK_COLOUR_OPAQUE);
+    CHECK(maskClrTopRight == *wxMASK_COLOUR_OPAQUE);
+    CHECK(maskClrBottomLeft == *wxMASK_COLOUR_TRANSPARENT);
+    CHECK(maskClrBottomRight == *wxMASK_COLOUR_TRANSPARENT);
 
-    // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+    // wxMonoPixelData only exists in wxMSW and wxQt
+#if defined(__WXMSW__) || defined(__WXQT__)
     bool maskValueTopLeft;
     bool maskValueTopRight;
     bool maskValueBottomLeft;
@@ -1322,7 +1334,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     CHECK(maskValueTopRight == true);
     CHECK(maskValueBottomLeft == false);
     CHECK(maskValueBottomRight == false);
-#endif      // __WXMSW__
+#endif // __WXMSW__ || __WXQT__
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -1352,8 +1364,8 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         ASSERT_EQUAL_COLOUR_RGB(p, maskClrBottomRight);
     }
 
-    // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+    // wxMonoPixelData only exists in wxMSW and wxQt
+#if defined(__WXMSW__) || defined(__WXQT__)
     {
         REQUIRE(subBmpMask.GetDepth() == 1);
         wxMonoPixelData data(subBmpMask);
@@ -1373,7 +1385,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         CHECK(p.Pixel() == maskValueBottomRight);
     }
     REQUIRE(subBmpMask.GetDepth() == 1);
-#endif      // __WXMSW__
+#endif // __WXMSW__ || __WXQT__
 }
 
 TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][withmask]")
@@ -1388,12 +1400,12 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     const wxColour clrLeft(*wxCYAN);
     const unsigned char alpha = 92;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     // premultiplied values
     const wxColour clrRight(((clrLeft.Red() * alpha) + 127) / 255, ((clrLeft.Green() * alpha) + 127) / 255, ((clrLeft.Blue() * alpha) + 127) / 255, alpha);
 #else
     const wxColour clrRight(clrLeft.Red(), clrLeft.Green(), clrLeft.Blue(), alpha);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
     wxBitmap bmp(w, h, 32);
 #if defined(__WXMSW__) || defined(__WXOSX__)
@@ -1489,13 +1501,13 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         p.OffsetX(data, w / 2); // bottom-right point
         maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
     }
-    CHECK(maskClrTopLeft == *wxWHITE);
-    CHECK(maskClrTopRight == *wxWHITE);
-    CHECK(maskClrBottomLeft == *wxBLACK);
-    CHECK(maskClrBottomRight == *wxBLACK);
+    CHECK(maskClrTopLeft == *wxMASK_COLOUR_OPAQUE);
+    CHECK(maskClrTopRight == *wxMASK_COLOUR_OPAQUE);
+    CHECK(maskClrBottomLeft == *wxMASK_COLOUR_TRANSPARENT);
+    CHECK(maskClrBottomRight == *wxMASK_COLOUR_TRANSPARENT);
 
-    // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+    // wxMonoPixelData only exists in wxMSW and wxQt
+#if defined(__WXMSW__) || defined(__WXQT__)
     bool maskValueTopLeft;
     bool maskValueTopRight;
     bool maskValueBottomLeft;
@@ -1524,7 +1536,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     CHECK(maskValueTopRight == true);
     CHECK(maskValueBottomLeft == false);
     CHECK(maskValueBottomRight == false);
-#endif      // __WXMSW__
+#endif // __WXMSW__ || __WXQT__
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -1554,8 +1566,8 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         ASSERT_EQUAL_RGB(p, maskClrBottomRight.Red(), maskClrBottomRight.Green(), maskClrBottomRight.Blue());
     }
 
-    // wxMonoPixelData only exists in wxMSW
-#if defined(__WXMSW__)
+    // wxMonoPixelData only exists in wxMSW and wxQt
+#if defined(__WXMSW__) || defined(__WXQT__)
     {
         REQUIRE(subBmpMask.GetDepth() == 1);
         wxMonoPixelData data(subBmpMask);
@@ -1575,7 +1587,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         CHECK(p.Pixel() == maskValueBottomRight);
     }
     REQUIRE(subBmpMask.GetDepth() == 1);
-#endif      // __WXMSW__
+#endif // __WXMSW__ || __WXQT__
 }
 
 namespace Catch

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -55,18 +55,6 @@ typedef wxPixelData<wxBitmap, wxNative32PixelFormat> wxNative32PixelData;
 typedef wxNativePixelData wxNative32PixelData;
 #endif // __WXOSX__ || __WXQT__
 
-// masked/unmasked colours are revered in wxQt:
-
-#ifndef __WXQT__
-#define wxMASK_COLOUR_OPAQUE        wxWHITE
-#define wxMASK_COLOUR_TRANSPARENT   wxBLACK
-#else // __WXQT__
-#define wxMASK_COLOUR_OPAQUE        wxBLACK
-#define wxMASK_COLOUR_TRANSPARENT   wxWHITE
-#endif // !__WXQT__
-
-static const wxColour wxMASK_COLOUR = *wxMASK_COLOUR_OPAQUE;
-
 // ----------------------------------------------------------------------------
 // tests
 // ----------------------------------------------------------------------------
@@ -237,7 +225,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue());
                 wxColour maskc(iMask.Red(), iMask.Green(), iMask.Blue());
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y));
-                if ( maskc == wxMASK_COLOUR )
+                if ( maskc == *wxWHITE )
                 {
                     CHECK_EQUAL_COLOUR_RGB(imgc, bmpc);
                     unmaskedPixelsCount++;
@@ -422,7 +410,7 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
                 wxColour bmpc(iBmp.Red(), iBmp.Green(), iBmp.Blue(), iBmp.Alpha());
                 wxColour maskc(iMask.Red(), iMask.Green(), iMask.Blue());
                 wxColour imgc(image.GetRed(x, y), image.GetGreen(x, y), image.GetBlue(x, y), image.GetAlpha(x,y));
-                if ( maskc == wxMASK_COLOUR )
+                if ( maskc == *wxWHITE )
                 {
 #if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                     // Premultiplied values
@@ -518,7 +506,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
                 wxColour maskc(iMask.Red(), iMask.Green(), iMask.Blue());
                 wxColour imgc(img.GetRed(x, y), img.GetGreen(x, y), img.GetBlue(x, y));
                 CHECK_EQUAL_COLOUR_RGB(bmpc, imgc);
-                wxColour c = maskc == wxMASK_COLOUR ? fillCol : maskCol;
+                wxColour c = maskc == *wxWHITE ? fillCol : maskCol;
                 CHECK_EQUAL_COLOUR_RGB(bmpc, c);
             }
             rowStartBmp.OffsetY(dataBmp, 1);
@@ -617,7 +605,7 @@ TEST_CASE("BitmapTestCase::FromImage", "[bitmap][image][convertfrom]")
 #endif // __WXMSW__ || __WXOSX__ || __WXQT__
                 CHECK_EQUAL_COLOUR_RGBA(bmpc, imgc);
 
-                wxColour c = maskc == wxMASK_COLOUR ? fillCol : maskCol;
+                wxColour c = maskc == *wxWHITE ? fillCol : maskCol;
 #if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
                 // Premultiplied values
                 r = ((c.Red() * imgc.Alpha()) + 127) / 255;
@@ -1299,10 +1287,10 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         p.OffsetX(data, w / 2); // bottom-right point
         maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
     }
-    CHECK(maskClrTopLeft == *wxMASK_COLOUR_OPAQUE);
-    CHECK(maskClrTopRight == *wxMASK_COLOUR_OPAQUE);
-    CHECK(maskClrBottomLeft == *wxMASK_COLOUR_TRANSPARENT);
-    CHECK(maskClrBottomRight == *wxMASK_COLOUR_TRANSPARENT);
+    CHECK(maskClrTopLeft == *wxWHITE);
+    CHECK(maskClrTopRight == *wxWHITE);
+    CHECK(maskClrBottomLeft == *wxBLACK);
+    CHECK(maskClrBottomRight == *wxBLACK);
 
     // wxMonoPixelData only exists in wxMSW and wxQt
 #if defined(__WXMSW__) || defined(__WXQT__)
@@ -1501,10 +1489,10 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         p.OffsetX(data, w / 2); // bottom-right point
         maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
     }
-    CHECK(maskClrTopLeft == *wxMASK_COLOUR_OPAQUE);
-    CHECK(maskClrTopRight == *wxMASK_COLOUR_OPAQUE);
-    CHECK(maskClrBottomLeft == *wxMASK_COLOUR_TRANSPARENT);
-    CHECK(maskClrBottomRight == *wxMASK_COLOUR_TRANSPARENT);
+    CHECK(maskClrTopLeft == *wxWHITE);
+    CHECK(maskClrTopRight == *wxWHITE);
+    CHECK(maskClrBottomLeft == *wxBLACK);
+    CHECK(maskClrBottomRight == *wxBLACK);
 
     // wxMonoPixelData only exists in wxMSW and wxQt
 #if defined(__WXMSW__) || defined(__WXQT__)

--- a/tests/graphics/graphbitmap.cpp
+++ b/tests/graphics/graphbitmap.cpp
@@ -26,10 +26,10 @@
 typedef wxPixelFormat<unsigned char, 32, 2, 1, 0> wxNative32PixelFormat;
 typedef wxPixelData<wxBitmap, wxNative32PixelFormat> wxNative32PixelData;
 #endif // __WXMSW__
-#ifdef __WXOSX__
+#if defined(__WXOSX__) || defined(__WXQT__)
 // 32 bpp xRGB bitmaps are native ones
 typedef wxNativePixelData wxNative32PixelData;
-#endif // __WXOSX__
+#endif // __WXOSX__ || __WXQT__
 
 // ----------------------------------------------------------------------------
 // tests
@@ -82,13 +82,13 @@ wxBitmap CreateBitmapRGB(int w, int h, bool withMask)
     return DoCreateBitmapRGB(w, h, 24, withMask);
 }
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
 // 32-bit RGB bitmap
 wxBitmap CreateBitmapXRGB(int w, int h, bool withMask)
 {
     return DoCreateBitmapRGB(w, h, 32, withMask);
 }
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
 wxBitmap CreateBitmapRGBA(int w, int h, bool withMask)
 {
@@ -101,12 +101,12 @@ wxBitmap CreateBitmapRGBA(int w, int h, bool withMask)
         const wxColour clrBg(*wxGREEN);
         const unsigned char alpha = 51;
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
         // premultiplied values
         const wxColour clrFgAlpha(((clrFg.Red() * alpha) + 127) / 255, ((clrFg.Green() * alpha) + 127) / 255, ((clrFg.Blue() * alpha) + 127) / 255);
 #else
         const wxColour clrFgAlpha(clrFg);
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
         wxAlphaPixelData data(bmp);
         REQUIRE(data);
@@ -358,7 +358,7 @@ TEST_CASE("GraphicsBitmapTestCase::Create", "[graphbitmap][create]")
 #endif // wxUSE_GRAPHICS_CAIRO
     }
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     SECTION("xRGB bitmap without mask")
     {
         // xRGB bitmap
@@ -467,7 +467,7 @@ TEST_CASE("GraphicsBitmapTestCase::Create", "[graphbitmap][create]")
         }
 #endif // wxUSE_GRAPHICS_CAIRO
     }
-#endif // _WXMSW__ || __WXOSX__
+#endif // _WXMSW__ || __WXOSX__ || __WXQT__
 
     SECTION("RGBA bitmap without mask")
     {
@@ -694,7 +694,7 @@ TEST_CASE("GraphicsBitmapTestCase::SubBitmap", "[graphbitmap][subbitmap][create]
 #endif // wxUSE_GRAPHICS_CAIRO
     }
 
-#if defined(__WXMSW__) || defined(__WXOSX__)
+#if defined(__WXMSW__) || defined(__WXOSX__) || defined(__WXQT__)
     SECTION("xRGB bitmap without mask")
     {
         // xRGB bitmap
@@ -827,7 +827,7 @@ TEST_CASE("GraphicsBitmapTestCase::SubBitmap", "[graphbitmap][subbitmap][create]
         }
 #endif // wxUSE_GRAPHICS_CAIRO
     }
-#endif // __WXMSW__ || __WXOSX__
+#endif // __WXMSW__ || __WXOSX__ || __WXQT__
 
     SECTION("RGBA bitmap without mask")
     {


### PR DESCRIPTION
[bitmap] & [graphbitmap] tests pass successfully with these changes. also the image and drawing samples work as expected.