### PR TITLE
Fix recent wxGTK regression when using wide string entry point

### DIFF
--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -21,8 +21,13 @@ struct WXDLLIMPEXP_BASE wxInitData
     // Get the single global object.
     static wxInitData& Get();
 
-    // Initialize from ANSI command line arguments.
+    // Initialize from ANSI command line arguments: argv contents should be
+    // static, i.e. remain valid until the end of the program.
     void Initialize(int argc, char** argv);
+
+    // Initialize from wide command line arguments: here we currently make a
+    // copy of the arguments internally, so they don't need to be static.
+    void InitializeFromWide(int argc, wchar_t** argv);
 
     // This function is used instead of the dtor because the global object can
     // be initialized multiple times.
@@ -47,9 +52,10 @@ struct WXDLLIMPEXP_BASE wxInitData
     wchar_t** argvMSW = nullptr;
 #else // !__WINDOWS__
     // Under other platforms we typically need the original, non-Unicode
-    // command line version, so we keep it too. Unlike argv that we allocate,
-    // this pointer doesn't need to be freed.
+    // command line version, so we keep it too. This pointer may or not need to
+    // be freed, as indicated by ownsArgvA flag.
     char** argvA = nullptr;
+    bool ownsArgvA = false;
 #endif // __WINDOWS__
 
     wxDECLARE_NO_COPY_CLASS(wxInitData);

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -205,6 +205,35 @@ void wxInitData::MSWInitialize()
 
 #endif // __WINDOWS__
 
+void wxInitData::InitializeFromWide(int argcIn, wchar_t** argvIn)
+{
+    // For simplicity, make a copy of the arguments, even though we could avoid
+    // it -- but this would complicate the cleanup.
+    argc = argcIn;
+    argv = new wchar_t*[argc + 1];
+    argv[argc] = nullptr;
+
+#ifdef __WINDOWS__
+    // Not used in this case and shouldn't be passed to LocalFree().
+    argvMSW = nullptr;
+#else // !__WINDOWS__
+    // We need to convert from wide arguments back to the narrow ones.
+    argvA = new char*[argc + 1];
+    argvA[argc] = nullptr;
+
+    ownsArgvA = true;
+#endif // __WINDOWS__/!__WINDOWS__
+
+    for ( int i = 0; i < argc; i++ )
+    {
+        argv[i] = wxCRT_StrdupW(argvIn[i]);
+
+#ifndef __WINDOWS__
+        argvA[i] = wxStrdup(wxConvUTF8.cWC2MB(argv[i]));
+#endif // !__WINDOWS__
+    }
+}
+
 void wxInitData::Free()
 {
 #ifdef __WINDOWS__
@@ -224,6 +253,18 @@ void wxInitData::Free()
         {
             free(argv[i]);
         }
+
+#ifndef __WINDOWS__
+        if ( ownsArgvA )
+        {
+            for ( int i = 0; i < argc; i++ )
+            {
+                free(argvA[i]);
+            }
+
+            wxDELETEA(argvA);
+        }
+#endif // !__WINDOWS__
 
         wxDELETEA(argv);
         argc = 0;
@@ -292,6 +333,15 @@ bool wxEntryStart(int& argc, wxChar **argv)
 {
     // do minimal, always necessary, initialization
     // --------------------------------------------
+
+    // typically the command line arguments would be already initialized before
+    // we're called, e.g. both the entry point taking (narrow) char argv and
+    // the MSW one, using the entire (wide) string command line do it, but if
+    // this function is called directly from the application initialization
+    // code this wouldn't be the case, and we need to handle this too
+    auto& initData = wxInitData::Get();
+    if ( !initData.argc )
+        initData.InitializeFromWide(argc, argv);
 
     // initialize wxRTTI
     if ( !DoCommonPreInit() )


### PR DESCRIPTION
The changes of 5f17915e63 (Store original command line options passed to
main(), 2023-09-02) didn't account for the possibility of the
application using an entry point such as wxEntry(), wxEntryStart() or
wxInitialize() with wide character argv under Unix -- where this is
typically not the case but still possible and if any of the wide string
overloads of these functions were called, wxInitData::arg[cv] remained
uninitialized resulting in a crash in gtk_init_check() later.

Fix this by ensuring we do initialize them in this case too and also
reconstruct the original narrow string argvA from wide string arguments
in this case, which is a bit wasteful but unavoidable if we're not
provided access to the original main() arguments.
