### PR TITLE
Fix logging bug in the event sample

### DIFF
--- a/samples/event/gestures.cpp
+++ b/samples/event/gestures.cpp
@@ -23,7 +23,7 @@ MyGestureFrame::MyGestureFrame()
     SetSizeHints(wxMin(800,dsplySz.GetWidth()), wxMin(600,dsplySz.GetHeight()));
 
     // Log to the text control
-    delete wxLog::SetActiveTarget(new wxLogTextCtrl(m_logText));
+    m_logOld = wxLog::SetActiveTarget(new wxLogTextCtrl(m_logText));
 
     // Bind all gestures to the same event handler, which must run before
     // the other handlers, to clear the log window
@@ -64,6 +64,7 @@ MyGesturePanel::MyGesturePanel(MyGestureFrame *parent)
 
 void MyGestureFrame::OnQuit(wxCloseEvent& WXUNUSED(event))
 {
+    delete wxLog::SetActiveTarget(m_logOld);
     Destroy();
 }
 

--- a/samples/event/gestures.h
+++ b/samples/event/gestures.h
@@ -12,6 +12,7 @@ public:
     void OnQuit(wxCloseEvent& event);
 
 private:
+    wxLog *m_logOld;
     wxTextCtrl *m_logText;
 };
 


### PR DESCRIPTION
The gestures frame created its own log target and deleted the previous one but did not restore it when being closed.

This left the current log target invalid which led to a crash when calling any wxLog*() function after gestures frame was closed.

Fix this by restoring the previous log target when gestures frame is closed.

Closes #23767.

Should be backported to 3.2.