### PR TITLE
Don´t search for wxstd MO files w/ version number, just look for wxstd.mo

### DIFF
--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1312,13 +1312,6 @@ wxArrayString wxTranslations::GetAvailableTranslations(const wxString& domain) c
 
 bool wxTranslations::AddStdCatalog()
 {
-    // Try loading the message catalog for this version first, but fall back to
-    // the name without the version if it's not found, as message catalogs
-    // typically won't have the version in their names under non-Unix platforms
-    // (i.e. where they're not installed by our own "make install").
-    if ( AddCatalog("wxstd-" wxSTRINGIZE(wxMAJOR_VERSION) "." wxSTRINGIZE(wxMINOR_VERSION)) )
-        return true;
-
     if ( AddCatalog(wxS("wxstd")) )
         return true;
 


### PR DESCRIPTION
Searching for a translated "wxstd-3.3.mo" file is supposed to fallback to searching for a translated "wxstd.mo" file if it can't find it. However, it does not work that way because English is the default `wxLanguage` argument that `AddStdCatalog()` passes to `AddCatalog()`. What happens then is that `AddCatalog()` can't find a translated "wxstd-3.3.mo" file and falls back to English and returns true. Then `AddStdCatalog()` accepts that true response and never attempts to call `AddCatalog()` again with just "wxstd". Hence, my "fix" is to simply look for a translated "wxstd.mo" and not try to look for a file with the version number in it.

I've tested this on Spanish Windows and unless I'm misunderstanding something, it seems like the fallback branch to look for "wxstd.mo" would never get ran--it will always fall back to English and give up if wxstd-3.3.mo isn't found.