### PR TITLE
Improve consistency of checkboxes in wxListCtrl

### DIFF
--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -282,7 +282,8 @@ public:
                            const wxRect& rect,
                            const wxRect& rectHL,
                            bool highlighted,
-                           bool current );
+                           bool current,
+                           bool checked );
 
 private:
     // set the line to contain num items (only can be > 1 in report mode)

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1386,6 +1386,8 @@ public:
 
         Always returns false if checkboxes support hadn't been enabled.
 
+        For a control with @c wxLC_VIRTUAL style, this uses OnGetItemIsChecked().
+
         @param item Item (zero-based) index.
 
         @since 3.1.0
@@ -1397,6 +1399,10 @@ public:
 
         This method only works if checkboxes support had been successfully
         enabled using EnableCheckBoxes().
+
+        For a control with @c wxLC_VIRTUAL style, this will only generate the
+        @c EVT_LIST_ITEM_CHECKED and @c EVT_LIST_ITEM_UNCHECKED events. See
+        OnGetItemIsChecked() for information on how to update the checkbox state.
 
         @param item Item (zero-based) index.
         @param check If @true, check the item, otherwise uncheck.

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1276,7 +1276,8 @@ void MyListCtrl::OnChecked(wxListEvent& event)
 
     if ( IsVirtual() )
     {
-        CheckItem(event.GetIndex(), true);
+        m_checked.SelectItem(event.GetIndex(), true);
+        RefreshItem(event.GetIndex());
     }
 
     event.Skip();
@@ -1288,7 +1289,8 @@ void MyListCtrl::OnUnChecked(wxListEvent& event)
 
     if ( IsVirtual() )
     {
-        CheckItem(event.GetIndex(), false);
+        m_checked.SelectItem(event.GetIndex(), false);
+        RefreshItem(event.GetIndex());
     }
 
     event.Skip();
@@ -1513,34 +1515,9 @@ wxString MyListCtrl::OnGetItemText(long item, long column) const
     }
 }
 
-void MyListCtrl::CheckItem(long item, bool check)
-{
-    if ( IsVirtual() )
-    {
-        m_checked.SelectItem(item, check);
-        RefreshItem(item);
-    }
-    else
-    {
-        wxListCtrl::CheckItem(item, check);
-    }
-}
-
-bool MyListCtrl::IsItemChecked(long item) const
-{
-    if ( IsVirtual() )
-    {
-        return m_checked.IsSelected(item);
-    }
-    else
-    {
-        return wxListCtrl::IsItemChecked(item);
-    }
-}
-
 bool MyListCtrl::OnGetItemIsChecked(long item) const
 {
-    return IsItemChecked(item);
+    return m_checked.IsSelected(item);
 }
 
 int MyListCtrl::OnGetItemColumnImage(long item, long column) const

--- a/samples/listctrl/listtest.h
+++ b/samples/listctrl/listtest.h
@@ -74,9 +74,6 @@ public:
 
     void OnRightClick(wxMouseEvent& event);
 
-    virtual void CheckItem(long item, bool check) override;
-    virtual bool IsItemChecked(long item) const override;
-
 private:
     void ShowContextMenu(const wxPoint& pos, long item);
     void SetColumnImage(int col, int image);

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -737,7 +737,8 @@ void wxListLineData::DrawInReportMode( wxDC *dc,
                                        const wxRect& rect,
                                        const wxRect& rectHL,
                                        bool highlighted,
-                                       bool current )
+                                       bool current,
+                                       bool checked )
 {
     // TODO: later we should support setting different attributes for
     //       different columns - to do it, just add "col" argument to
@@ -758,7 +759,7 @@ void wxListLineData::DrawInReportMode( wxDC *dc,
         rr.x += MARGIN_AROUND_CHECKBOX;
 
         int flags = 0;
-        if (m_checked)
+        if (checked)
             flags |= wxCONTROL_CHECKED;
         wxRendererNative::Get().DrawCheckBox(m_owner, *dc, rr, flags);
 
@@ -2095,7 +2096,8 @@ void wxListMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                                              rectLine,
                                              GetLineHighlightRect(line),
                                              IsHighlighted(line),
-                                             line == m_current );
+                                             line == m_current,
+                                             IsItemChecked(line) );
         }
 
         if ( HasFlag(wxLC_HRULES) )
@@ -3904,10 +3906,13 @@ bool wxListMainWindow::EnableCheckBoxes(bool enable)
 
 void wxListMainWindow::CheckItem(long item, bool state)
 {
-    wxListLineData *line = GetLine((size_t)item);
-    line->Check(state);
+    if ( !IsVirtual() )
+    {
+        wxListLineData* line = GetLine((size_t)item);
+        line->Check(state);
 
-    RefreshLine(item);
+        RefreshLine(item);
+    }
 
     SendNotify(item, state ? wxEVT_LIST_ITEM_CHECKED
         : wxEVT_LIST_ITEM_UNCHECKED);
@@ -3915,8 +3920,16 @@ void wxListMainWindow::CheckItem(long item, bool state)
 
 bool wxListMainWindow::IsItemChecked(long item) const
 {
-    wxListLineData *line = GetLine((size_t)item);
-    return line->IsChecked();
+    if ( !IsVirtual() )
+    {
+        wxListLineData* line = GetLine((size_t)item);
+        return line->IsChecked();
+    }
+    else
+    {
+        wxGenericListCtrl* listctrl = GetListCtrl();
+        return listctrl->OnGetItemIsChecked(item);
+    }
 }
 
 bool wxListMainWindow::IsInsideCheckBox(long item, int x, int y)

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -3906,6 +3906,8 @@ bool wxListMainWindow::EnableCheckBoxes(bool enable)
 
 void wxListMainWindow::CheckItem(long item, bool state)
 {
+    wxCHECK_RET( HasCheckBoxes(), "checkboxes are disabled" );
+
     if ( !IsVirtual() )
     {
         wxListLineData* line = GetLine((size_t)item);
@@ -3920,6 +3922,9 @@ void wxListMainWindow::CheckItem(long item, bool state)
 
 bool wxListMainWindow::IsItemChecked(long item) const
 {
+    if ( !HasCheckBoxes() )
+        return false;
+
     if ( !IsVirtual() )
     {
         wxListLineData* line = GetLine((size_t)item);

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1511,7 +1511,10 @@ void wxListCtrl::CheckItem(long item, bool state)
 
 bool wxListCtrl::IsItemChecked(long item) const
 {
-    return ListView_GetCheckState(GetHwnd(), (UINT)item) != 0;
+    if ( IsVirtual() )
+        return OnGetItemIsChecked(item);
+    else
+        return ListView_GetCheckState(GetHwnd(), (UINT)item) != 0;
 }
 
 void wxListCtrl::ShowSortIndicator(int idx, bool ascending)

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1494,7 +1494,19 @@ bool wxListCtrl::EnableCheckBoxes(bool enable)
 
 void wxListCtrl::CheckItem(long item, bool state)
 {
-    ListView_SetCheckState(GetHwnd(), (UINT)item, (BOOL)state);
+    if ( IsVirtual() )
+    {
+        // ListView_SetCheckState does nothing for a virtual control, so generate
+        // the event that would normally be generated in the LVN_ITEMCHANGED callback.
+        wxListEvent le(state ? wxEVT_LIST_ITEM_CHECKED : wxEVT_LIST_ITEM_UNCHECKED, GetId());
+        le.SetEventObject(this);
+        le.m_itemIndex = item;
+        GetEventHandler()->ProcessEvent(le);
+    }
+    else
+    {
+        ListView_SetCheckState(GetHwnd(), (UINT)item, (BOOL)state);
+    }
 }
 
 bool wxListCtrl::IsItemChecked(long item) const

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1494,6 +1494,8 @@ bool wxListCtrl::EnableCheckBoxes(bool enable)
 
 void wxListCtrl::CheckItem(long item, bool state)
 {
+    wxCHECK_RET( HasCheckBoxes(), "checkboxes are disabled" );
+
     if ( IsVirtual() )
     {
         // ListView_SetCheckState does nothing for a virtual control, so generate
@@ -1511,6 +1513,9 @@ void wxListCtrl::CheckItem(long item, bool state)
 
 bool wxListCtrl::IsItemChecked(long item) const
 {
+    if ( !HasCheckBoxes() )
+        return false;
+
     if ( IsVirtual() )
         return OnGetItemIsChecked(item);
     else

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -257,6 +257,11 @@ bool wxListCtrl::Create(wxWindow *parent,
     if ( !MSWCreateControl(WC_LISTVIEW, wxEmptyString, pos, size) )
         return false;
 
+    // LISTVIEW generates and endless stream of LVN_ODCACHEHINT event for a
+    // virtual wxListCtrl, so disable WS_EX_COMPOSITED.
+    if ( IsVirtual() )
+        MSWDisableComposited();
+
     const wxVisualAttributes& defAttrs = GetDefaultAttributes();
 
     if ( wxMSWDarkMode::IsActive() )


### PR DESCRIPTION
Improve consistency of checkboxes in `wxListCtrl` between virtual and report mode, and between the generic and MSW implementation, see #23869.

Also disable `WS_EX_COMPOSITED` for virtual `wxListCtrl` because it generates an endless stream of cache events, see #23878.