### PR TITLE
Fixes for showing popup menus under Wayland

### DIFF
--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -3245,6 +3245,9 @@ public:
         The position where the menu will appear can be specified either as a
         wxPoint @a pos or by two integers (@a x and @a y).
 
+        @note The position is ignored when using wxGTK with Wayland because
+              Wayland doesn't provide support for positioning the menu.
+
         Note that this function switches focus to this window before showing
         the menu.
 

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6064,6 +6064,19 @@ bool wxWindowGTK::DoPopupMenu( wxMenu *menu, int x, int y )
     wxPopupMenuPositionCallbackData data;
     gpointer userdata;
     GtkMenuPositionFunc posfunc;
+
+#ifdef GDK_WINDOWING_WAYLAND
+    wxArrayGdkWindows windows;
+    if ( wxGTKImpl::IsWayland(GTKGetWindow(windows)) )
+    {
+        // We can't position the menu at the requested position when using
+        // Wayland and trying to do it results in the menu not being shown at
+        // all somehow, so don't even try.
+        x =
+        y = -1;
+    }
+#endif // Wayland
+
     if ( x == -1 && y == -1 )
     {
         // use GTK's default positioning algorithm


### PR DESCRIPTION
This fixes #23892 and also the problem with not showing the menu at all when using fixed coordinates, which I can 100% reliably reproduce myself here even though it wasn't reported there somehow.

The diff I used for testing all the various cases:
```diff
diff --git a/samples/minimal/minimal.cpp b/samples/minimal/minimal.cpp
index 5f32257c6b..ae78749cc5 100644
--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -175,6 +175,31 @@ MyFrame::MyFrame(const wxString& title)
     CreateStatusBar(2);
     SetStatusText("Welcome to wxWidgets!");
 #endif // wxUSE_STATUSBAR
+
+    auto const popupMenu = [this](wxPoint pt = wxDefaultPosition) {
+        wxMenu menu;
+        menu.Append(wxID_ABOUT, "About me");
+        menu.AppendSeparator();
+        menu.Append(wxID_EXIT, "Bye");
+        wxPrintf("Showing popup menu at (%d, %d)\n", pt.x, pt.y);
+        PopupMenu(&menu, pt);
+    };
+
+    Bind(wxEVT_LEFT_UP, [=](wxMouseEvent& e) {
+        if ( e.ControlDown() )
+            popupMenu();
+        else
+            CallAfter([=]() { popupMenu(); });
+    });
+
+    Bind(wxEVT_RIGHT_UP, [=](wxMouseEvent& e) {
+        wxPoint pt(200, 200);
+
+        if ( e.ControlDown() )
+            popupMenu(pt);
+        else
+            CallAfter([=]() { popupMenu(pt); });
+    });
 }
 
 
```