### PR TITLE
Don't slow the entire program down to a crawl if a `wxGLCanvasEGL` is entirely hidden

### DIFF
--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -705,6 +705,8 @@ bool wxGLCanvasEGL::SwapBuffers()
 #ifdef GDK_WINDOWING_X11
     if (wxGTKImpl::IsX11(window))
     {
+        // TODO: We need to check if it's really shown on screen, i.e. if it's
+        // not completely occluded even if it hadn't been explicitly hidden.
         if ( !IsShownOnScreen() )
         {
             // Trying to draw on a hidden window is useless and can actually be
@@ -713,6 +715,12 @@ bool wxGLCanvasEGL::SwapBuffers()
             wxLogTrace(TRACE_EGL, "Window %p is hidden, not drawing", this);
             return false;
         }
+
+        // As long as the TODO comment above is not resolved, we must disable
+        // blocking in eglSwapBuffers(), as it would make all the other, not
+        // occluded, application windows impossible to use. This is clearly not
+        // ideal, but better than making the application unusable.
+        eglSwapInterval(m_display, 0);
     }
 #endif // GDK_WINDOWING_X11
 #ifdef GDK_WINDOWING_WAYLAND

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -434,7 +434,7 @@ static void wl_frame_callback_handler(void* data,
                                       struct wl_callback *,
                                       uint32_t)
 {
-    wxLogTrace(TRACE_EGL, "In frame callback handler");
+    wxLogTrace(TRACE_EGL, "In frame callback handler for window %p", data);
 
     wxGLCanvasEGL *glc = static_cast<wxGLCanvasEGL *>(data);
     glc->m_readyToDraw = true;
@@ -710,7 +710,7 @@ bool wxGLCanvasEGL::SwapBuffers()
             // Trying to draw on a hidden window is useless and can actually be
             // harmful if the compositor blocks in eglSwapBuffers() in this
             // case, so avoid it.
-            wxLogTrace(TRACE_EGL, "Not drawing hidden window");
+            wxLogTrace(TRACE_EGL, "Window %p is hidden, not drawing", this);
             return false;
         }
     }
@@ -723,7 +723,7 @@ bool wxGLCanvasEGL::SwapBuffers()
         // worst if we're called before the window is realized.
         if ( !m_readyToDraw )
         {
-            wxLogTrace(TRACE_EGL, "Not ready to draw yet");
+            wxLogTrace(TRACE_EGL, "Window %p is not not ready to draw yet", this);
             return false;
         }
 
@@ -736,7 +736,7 @@ bool wxGLCanvasEGL::SwapBuffers()
     }
 #endif // GDK_WINDOWING_WAYLAND
 
-    wxLogTrace(TRACE_EGL, "Swapping buffers");
+    wxLogTrace(TRACE_EGL, "Swapping buffers for window %p", this);
 
     return eglSwapBuffers(m_display, m_surface);
 }


### PR DESCRIPTION
- Show the window in wxGLCanvasEGL tracing messages
- Disable blocking in eglSwapBuffers() when using X11 too
