### PR TITLE
Fix `wxGLCanvasEGL::IsShownOnScreen()` under Wayland

### DIFF
--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -750,9 +750,11 @@ bool wxGLCanvasEGL::IsShownOnScreen() const
             return GetXWindow() && wxGLCanvasBase::IsShownOnScreen();
         case wxDisplayWayland:
             return m_readyToDraw && wxGLCanvasBase::IsShownOnScreen();
-        default:
-            return false;
+        case wxDisplayNone:
+            break;
     }
+
+    return false;
 }
 
 #endif // wxUSE_GLCANVAS && wxUSE_GLCANVAS_EGL

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -577,17 +577,13 @@ void wxGLCanvasEGL::CreateWaylandSubsurface()
     m_wlSubsurface = wl_subcompositor_get_subsurface(m_wlSubcompositor,
                                                      m_wlSurface,
                                                      surface);
+    wxCHECK_RET( m_wlSubsurface, "Unable to get EGL subsurface" );
+
     wl_subsurface_set_desync(m_wlSubsurface);
     wxEGLUpdatePosition(this);
     m_wlFrameCallbackHandler = wl_surface_frame(surface);
     wl_callback_add_listener(m_wlFrameCallbackHandler,
                              &wl_frame_listener, this);
-
-    if ( m_surface == EGL_NO_SURFACE )
-    {
-        wxFAIL_MSG("Unable to create EGL surface");
-        return;
-    }
 #endif
 }
 

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -745,7 +745,7 @@ bool wxGLCanvasEGL::IsShownOnScreen() const
         case wxDisplayX11:
             return GetXWindow() && wxGLCanvasBase::IsShownOnScreen();
         case wxDisplayWayland:
-            return m_readyToDraw && wxGLCanvasBase::IsShownOnScreen();
+            return m_wlSubsurface && wxGLCanvasBase::IsShownOnScreen();
         case wxDisplayNone:
             break;
     }


### PR DESCRIPTION
This should fix #23899.

@joanbm I'd be grateful for your review, as I've changed a check added by your recent commit which seemed misplaced to me, but I don't understand this (sub)surface stuff well enough to be really sure. TIA!