### PR TITLE
Fix background colour for empty cells in generic wxDataViewCtrl

### DIFF
--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -902,12 +902,13 @@ wxDataViewRendererBase::PrepareForItem(const wxDataViewModel *model,
         }
 
         SetValue(value);
-
-        // Also set up the attributes for this item if it's not empty.
-        wxDataViewItemAttr attr;
-        model->GetAttr(item, column, attr);
-        SetAttr(attr);
     }
+
+    // Also set up the attributes: note that we need to do this even for the
+    // empty cells because background colour is still relevant for them.
+    wxDataViewItemAttr attr;
+    model->GetAttr(item, column, attr);
+    SetAttr(attr);
 
     // Finally determine the enabled/disabled state and apply it, even to the
     // empty cells.

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -2835,7 +2835,6 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
             wxDataViewTreeNode *node = nullptr;
             wxDataViewItem dataitem;
             const int line_height = GetLineHeight(item);
-            bool hasValue = true;
 
             if (!IsVirtualList())
             {
@@ -2847,10 +2846,6 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                 }
 
                 dataitem = node->GetItem();
-
-                if ( !model->HasValue(dataitem, col->GetModelColumn()) )
-                    hasValue = false;
-
             }
             else
             {
@@ -2867,8 +2862,7 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                 state |= wxDATAVIEW_CELL_SELECTED;
 
             cell->SetState(state);
-            if (hasValue)
-                hasValue = cell->PrepareForItem(model, dataitem, col->GetModelColumn());
+            const bool hasValue = cell->PrepareForItem(model, dataitem, col->GetModelColumn());
 
             // draw the background
             if ( !selected )


### PR DESCRIPTION
There were two related problems: first, any attempts to set the background colour for the cells without values were simply ignored because we didn't call wxDataViewModel::GetAttr() at all from PrepareForItem() in this case and, second, PrepareForItem() itself was not called when repainting the control neither, resulting in the existing attribute being reused for the items without values, meaning that they used the last background colour that was set instead of at least not using any background at all.

Fix both of the problems for the generic version. Unfortunately the GTK one still doesn't allow setting the background for the empty cells, but at least when not doing it the code now consistently leaves them without any background.

The following code can be added to MyMusicTreeModel in the dataview sample for testing this:

```cpp
    bool GetAttr( const wxDataViewItem& item, unsigned int col, wxDataViewItemAttr& attr) const override
    {
        if (col != 1)
            return false;

        if (IsContainer(item))
        {
            if (item != m_pop)
                return false;

            attr.SetBackgroundColour(*wxYELLOW);
        }
        else
        {
            attr.SetColour(*wxYELLOW);
            attr.SetBackgroundColour(*wxLIGHT_GREY);
        }

        return true;
    }
```

Closes #23708.

@asmwarrior @jmoraleda Could you please test whether this works for you and, more importantly, if it doesn't break something else?