### PR TITLE
Fix using *.* in wxDir under MSW

### DIFF
--- a/src/msw/dir.cpp
+++ b/src/msw/dir.cpp
@@ -28,6 +28,11 @@
 #include "wx/dir.h"
 
 #include "wx/msw/private.h"
+#include <shlwapi.h>
+
+#ifdef __VISUALC__
+    #pragma comment(lib, "shlwapi")
+#endif
 
 // ----------------------------------------------------------------------------
 // define the types and functions used for file searching
@@ -71,23 +76,7 @@ CheckFoundMatch(const FIND_STRUCT* finddata, const wxString& filter)
     if ( filter.empty() )
         return true;
 
-    // Otherwise do check the match validity. Notice that we must do it
-    // case-insensitively because the case of the file names is not supposed to
-    // matter under Windows.
-    wxString fn(finddata.cFileName);
-
-    // However if the filter contains only special characters (which is a
-    // common case), we can skip the case conversion.
-    if ( filter.find_first_not_of(wxS("*?.")) == wxString::npos )
-    {
-        // And maybe even skip the check entirely if we have a filter that we
-        // know matches everything. This is more than just an optimization, as
-        // "*.*" it wouldn't match the files without extension according to
-        // wxString::Matches(), but it should.
-        return filter == wxS("*.*") || filter == wxS("*") || fn.Matches(filter);
-    }
-
-    return fn.MakeUpper().Matches(filter.Upper());
+    return ::PathMatchSpecEx(finddata->cFileName, filter, PMSF_NORMAL) == S_OK;
 }
 
 inline bool

--- a/src/msw/dir.cpp
+++ b/src/msw/dir.cpp
@@ -27,9 +27,7 @@
 
 #include "wx/dir.h"
 
-#ifdef __WINDOWS__
-    #include "wx/msw/private.h"
-#endif
+#include "wx/msw/private.h"
 
 // ----------------------------------------------------------------------------
 // define the types and functions used for file searching

--- a/src/msw/dir.cpp
+++ b/src/msw/dir.cpp
@@ -86,7 +86,13 @@ CheckFoundMatch(const FIND_STRUCT* finddata, const wxString& filter)
     // However if the filter contains only special characters (which is a
     // common case), we can skip the case conversion.
     if ( filter.find_first_not_of(wxS("*?.")) == wxString::npos )
-        return fn.Matches(filter);
+    {
+        // And maybe even skip the check entirely if we have a filter that we
+        // know matches everything. This is more than just an optimization, as
+        // "*.*" it wouldn't match the files without extension according to
+        // wxString::Matches(), but it should.
+        return filter == wxS("*.*") || filter == wxS("*") || fn.Matches(filter);
+    }
 
     return fn.MakeUpper().Matches(filter.Upper());
 }

--- a/src/msw/dir.cpp
+++ b/src/msw/dir.cpp
@@ -76,7 +76,7 @@ CheckFoundMatch(const FIND_STRUCT* finddata, const wxString& filter)
     if ( filter.empty() )
         return true;
 
-    return ::PathMatchSpecEx(finddata->cFileName, filter, PMSF_NORMAL) == S_OK;
+    return ::PathMatchSpec(finddata->cFileName, filter) == TRUE;
 }
 
 inline bool

--- a/tests/file/dir.cpp
+++ b/tests/file/dir.cpp
@@ -167,7 +167,7 @@ TEST_CASE_METHOD(DirTestCase, "Dir::Traverse", "[dir]")
     }
     else if (wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "d" + WILDCARD_ALL) == 4)
     {
-        WARN("PathMatchSpecEx() seems to work under Wine now");
+        WARN("PathMatchSpec() seems to work under Wine now");
     }
 
     // enum all files according to the filter
@@ -287,14 +287,14 @@ TEST_CASE("Dir::Match", "[.]")
 
     // Show the results of matching the pattern using various functions.
     wxPrintf("%-15s %20s %20s %20s\n",
-             "File", "wxString::Matches", "wxMatchWild", "PathMatchSpecEx");
+             "File", "wxString::Matches", "wxMatchWild", "PathMatchSpec");
     for ( const auto& fn : filenames )
     {
         wxPrintf("%-15s %20d %20d %20d\n",
                  fn,
                  fn.Matches(filter),
                  wxMatchWild(filter, fn),
-                 PathMatchSpecEx(fn.wc_str(), filter.wc_str(), PMSF_NORMAL) == S_OK);
+                 PathMatchSpec(fn.wc_str(), filter.wc_str()) == TRUE);
     }
 }
 

--- a/tests/file/dir.cpp
+++ b/tests/file/dir.cpp
@@ -20,6 +20,16 @@
 #define DIRTEST_FOLDER      wxString("dirTest_folder")
 #define SEP                 wxFileName::GetPathSeparator()
 
+// We can't use wxFileSelectorDefaultWildcardStr from wxCore here, so define
+// our own.
+const char WILDCARD_ALL[] =
+#if defined(__WXMSW__)
+"*.*"
+#else // Unix/Mac
+"*"
+#endif
+;
+
 // ----------------------------------------------------------------------------
 // test fixture
 // ----------------------------------------------------------------------------
@@ -144,6 +154,9 @@ TEST_CASE_METHOD(DirTestCase, "Dir::Traverse", "[dir]")
     // enum all files
     wxArrayString files;
     CHECK( wxDir::GetAllFiles(DIRTEST_FOLDER, &files) == 4 );
+
+    // enum all files using an explicit wildcard
+    CHECK(wxDir::GetAllFiles(DIRTEST_FOLDER, &files, WILDCARD_ALL) == 4);
 
     // enum all files according to the filter
     CHECK( wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "*.foo") == 1 );

--- a/tests/file/dir.cpp
+++ b/tests/file/dir.cpp
@@ -22,7 +22,7 @@
 
 // We can't use wxFileSelectorDefaultWildcardStr from wxCore here, so define
 // our own.
-const char WILDCARD_ALL[] =
+const wxString WILDCARD_ALL =
 #if defined(__WXMSW__)
 "*.*"
 #else // Unix/Mac
@@ -157,6 +157,9 @@ TEST_CASE_METHOD(DirTestCase, "Dir::Traverse", "[dir]")
 
     // enum all files using an explicit wildcard
     CHECK(wxDir::GetAllFiles(DIRTEST_FOLDER, &files, WILDCARD_ALL) == 4);
+
+    // enum all files using an explicit wildcard different from WILDCARD_ALL
+    CHECK(wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "d" + WILDCARD_ALL) == 4);
 
     // enum all files according to the filter
     CHECK( wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "*.foo") == 1 );

--- a/tests/file/dir.cpp
+++ b/tests/file/dir.cpp
@@ -159,7 +159,16 @@ TEST_CASE_METHOD(DirTestCase, "Dir::Traverse", "[dir]")
     CHECK(wxDir::GetAllFiles(DIRTEST_FOLDER, &files, WILDCARD_ALL) == 4);
 
     // enum all files using an explicit wildcard different from WILDCARD_ALL
-    CHECK(wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "d" + WILDCARD_ALL) == 4);
+    //
+    // broken under Wine, see https://bugs.winehq.org/show_bug.cgi?id=55677
+    if ( !wxIsRunningUnderWine() )
+    {
+        CHECK(wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "d" + WILDCARD_ALL) == 4);
+    }
+    else if (wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "d" + WILDCARD_ALL) == 4)
+    {
+        WARN("PathMatchSpecEx() seems to work under Wine now");
+    }
 
     // enum all files according to the filter
     CHECK( wxDir::GetAllFiles(DIRTEST_FOLDER, &files, "*.foo") == 1 );

--- a/tests/file/dir.cpp
+++ b/tests/file/dir.cpp
@@ -257,3 +257,45 @@ TEST_CASE_METHOD(DirTestCase, "Dir::GetName", "[dir]")
     CHECK( d.GetNameWithSep() == "/" );
 #endif
 }
+
+// Disabled by default test allowing to check the result of matching against
+// the given filter.
+#ifdef __WXMSW__
+
+#include "wx/msw/wrapwin.h"
+#include <shlwapi.h>
+#ifdef __VISUALC__
+    #pragma comment(lib, "shlwapi")
+#endif
+
+#include "wx/crt.h"
+#include "wx/filefn.h"
+
+TEST_CASE("Dir::Match", "[.]")
+{
+    wxString filter;
+    REQUIRE( wxGetEnv("WX_TEST_DIR_FILTER", &filter) );
+
+    static const wxString filenames[] =
+    {
+        "foo",
+        "foo.bar",
+        "foo.bar.baz",
+        ".hidden",
+        ".hidden.ext",
+    };
+
+    // Show the results of matching the pattern using various functions.
+    wxPrintf("%-15s %20s %20s %20s\n",
+             "File", "wxString::Matches", "wxMatchWild", "PathMatchSpecEx");
+    for ( const auto& fn : filenames )
+    {
+        wxPrintf("%-15s %20d %20d %20d\n",
+                 fn,
+                 fn.Matches(filter),
+                 wxMatchWild(filter, fn),
+                 PathMatchSpecEx(fn.wc_str(), filter.wc_str(), PMSF_NORMAL) == S_OK);
+    }
+}
+
+#endif // __WXMSW__


### PR DESCRIPTION
Using "*.*" as a wildcard is supposed to match everything under MSW, but
ever since the changes of 4daceaacbd (Check that files returned from
wxDir::FindXXX() match the filter., 2013-04-08, see #3432) it only
matched the files with extension because we double-checked the match
returned by the native MSW function (which does handle "*.*" correctly)
using our own wxString::Matches() which doesn't handle it specially.

Fix this by skipping the call to Matches() when "*.*" is used: we know
that this wildcard matches everything, so rechecking the match would be
useless at best, even if it were not actively harmful. And also skip
this call for "*" because calling Matches("*") always succeeds anyhow.

This also fixes the same bug in wxFind{First,Next}File() and any other
code using them such as wx{File,Dir}Ctrl.

Closes #23905.
