### PR TITLE
Fix wxWindow::SetClientSize() under wxQt

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1098,6 +1098,12 @@ void wxWindowQt::DoSetClientSize(int width, int height)
     geometry.setWidth( width );
     geometry.setHeight( height );
     qtWidget->setGeometry( geometry );
+
+    if ( qtWidget != GetHandle() )
+    {
+        // Resize the window to be as small as the client size but no smaller
+        wxQtSetClientSize(GetHandle(), width, height);
+    }
 }
 
 void wxWindowQt::DoMoveWindow(int x, int y, int width, int height)

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1008,6 +1008,23 @@ void wxWindowQt::DoGetPosition(int *x, int *y) const
     *y = qtWidget->y();
 }
 
+namespace
+{
+inline void wxQtSetClientSize(QWidget* qtWidget, int width, int height)
+{
+    // There doesn't seem to be any way to change Qt frame size directly, so
+    // change the widget size, but take into account the extra margins
+    // corresponding to the frame decorations.
+    const QSize frameSize = qtWidget->frameSize();
+    const QSize innerSize = qtWidget->geometry().size();
+    const QSize frameSizeDiff = frameSize - innerSize;
+
+    const int clientWidth = std::max(width - frameSizeDiff.width(), 0);
+    const int clientHeight = std::max(height - frameSizeDiff.height(), 0);
+
+    qtWidget->resize(clientWidth, clientHeight);
+}
+}
 
 void wxWindowQt::DoGetSize(int *width, int *height) const
 {
@@ -1089,17 +1106,7 @@ void wxWindowQt::DoMoveWindow(int x, int y, int width, int height)
 
     qtWidget->move( x, y );
 
-    // There doesn't seem to be any way to change Qt frame size directly, so
-    // change the widget size, but take into account the extra margins
-    // corresponding to the frame decorations.
-    const QSize frameSize = qtWidget->frameSize();
-    const QSize innerSize = qtWidget->geometry().size();
-    const QSize frameSizeDiff = frameSize - innerSize;
-
-    const int clientWidth = std::max(width - frameSizeDiff.width(), 0);
-    const int clientHeight = std::max(height - frameSizeDiff.height(), 0);
-
-    qtWidget->resize(clientWidth, clientHeight);
+    wxQtSetClientSize(qtWidget, width, height);
 }
 
 #if wxUSE_TOOLTIPS


### PR DESCRIPTION
AFAICS, this does not introduce any regression. Moreover, this solves the problem mentioned [here](https://github.com/wxWidgets/wxWidgets/pull/23904#discussion_r1338711704) because the popup always has a size of (0, 0)