### PR TITLE
Fix invisible wxStaticLine on macOS >= 13

### DIFF
--- a/src/osx/cocoa/statline.mm
+++ b/src/osx/cocoa/statline.mm
@@ -39,6 +39,7 @@ wxWidgetImplType* wxWidgetImpl::CreateStaticLine( wxWindowMac* wxpeer,
 {
     NSRect r = wxOSXGetFrameForControl( wxpeer, pos , size ) ;
     wxNSBox* v = [[wxNSBox alloc] initWithFrame:r];
+    [v setBoxType:NSBoxSeparator];
     wxWidgetCocoaImpl* c = new wxWidgetCocoaImpl( wxpeer, v );
     return c;
 }


### PR DESCRIPTION
`NSBox` used as a separator must have its type set to `NSBoxSeparator`.

This apparently didn’t matter before in practice, but starting with macOS 13, separators - i.e. narrow NSBoxes - without the type correctly set are invisible.