### PR TITLE
Ensure that the currently shown wxSimplebook page has focus

### DIFF
--- a/include/wx/simplebook.h
+++ b/include/wx/simplebook.h
@@ -195,9 +195,17 @@ protected:
     virtual void DoShowPage(wxWindow* page, bool show) override
     {
         if ( show )
+        {
             page->ShowWithEffect(m_showEffect, m_showTimeout);
+
+            // Unlike simple Show(), ShowWithEffect() doesn't necessarily give
+            // focus to the window, but we do expect the new page to have focus.
+            page->SetFocus();
+        }
         else
+        {
             page->HideWithEffect(m_hideEffect, m_hideTimeout);
+        }
     }
 
 private:


### PR DESCRIPTION
When calling wxSimplebook::ChangeSelection(), the focus remained on the
previous, now hidden, page, unless it was explicitly set to one of the
controls on the new page.

This was completely unexpected as it could result in the user
(inadvertently) changing the values of the already "accepted" controls
on the last page, so don't let this happen and always set the focus to
the new page explicitly, even if this hasn't been done by
ShowWithEffect() which doesn't do it at least under wxMSW.
