### PR TITLE
Override Set{Min,Max}Size and DoSetSizeHints() to pass size informati…

### DIFF
--- a/include/wx/qt/toplevel.h
+++ b/include/wx/qt/toplevel.h
@@ -45,6 +45,13 @@ public:
     // Styles
     virtual void SetWindowStyleFlag( long style ) override;
     virtual long GetWindowStyleFlag() const override;
+
+protected:
+    void QtSetSizeIncrement(int width, int height);
+
+    virtual void DoSetSizeHints( int minW, int minH,
+                                 int maxW, int maxH,
+                                 int incW, int incH) override;
 };
 
 #endif // _WX_QT_TOPLEVEL_H_

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -136,6 +136,10 @@ public:
     virtual bool SetBackgroundColour(const wxColour& colour) override;
     virtual bool SetForegroundColour(const wxColour& colour) override;
 
+    // Min/max sizes
+    virtual void SetMinSize(const wxSize& minSize) override;
+    virtual void SetMaxSize(const wxSize& maxSize) override;
+
     QWidget *GetHandle() const override;
 
 #if wxUSE_DRAG_AND_DROP
@@ -224,6 +228,11 @@ protected:
     // overridden in wxFrame to use its central widget rather than the frame
     // itself.
     virtual QWidget* QtGetParentWidget() const { return GetHandle(); }
+
+    // Set{Min,Max}Size() and DoSetSizeHints() overrides call these functions
+    // to transfer min/max size informations to Qt.
+    void QtSetMinSize(const wxSize& minSize);
+    void QtSetMaxSize(const wxSize& maxSize);
 
     QWidget *m_qtWindow;
 

--- a/src/qt/toplevel.cpp
+++ b/src/qt/toplevel.cpp
@@ -245,3 +245,22 @@ long wxTopLevelWindowQt::GetWindowStyleFlag() const
 
     return winStyle;
 }
+
+void wxTopLevelWindowQt::QtSetSizeIncrement(int width, int height)
+{
+    const int w = wxMax(0, width);
+    const int h = wxMax(0, height);
+
+    GetHandle()->setSizeIncrement(w, h);
+}
+
+void wxTopLevelWindowQt::DoSetSizeHints( int minW, int minH,
+                                         int maxW, int maxH,
+                                         int incW, int incH)
+{
+    QtSetMinSize(wxSize(minW, minH));
+    QtSetMaxSize(wxSize(maxW, maxH));
+    QtSetSizeIncrement(incW, incH);
+
+    wxTopLevelWindowBase::DoSetSizeHints(minW, minH, maxW, maxH, incW, incH);
+}

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -486,6 +486,36 @@ void wxWindowQt::SetFocus()
     GetHandle()->setFocus();
 }
 
+void wxWindowQt::QtSetMinSize(const wxSize& minSize)
+{
+    if ( minSize.x >= 0 )
+        GetHandle()->setMinimumWidth(minSize.x);
+
+    if ( minSize.y >= 0 )
+        GetHandle()->setMinimumHeight(minSize.y);
+}
+
+void wxWindowQt::QtSetMaxSize(const wxSize& maxSize)
+{
+    if ( maxSize.x >= 0 )
+        GetHandle()->setMaximumWidth(maxSize.x);
+
+    if ( maxSize.y >= 0 )
+        GetHandle()->setMaximumHeight(maxSize.y);
+}
+
+void wxWindowQt::SetMinSize(const wxSize& minSize)
+{
+    QtSetMinSize(minSize);
+    wxWindowBase::SetMinSize(minSize);
+}
+
+void wxWindowQt::SetMaxSize(const wxSize& maxSize)
+{
+    QtSetMaxSize(maxSize);
+    wxWindowBase::SetMaxSize(maxSize);
+}
+
 /* static */ void wxWindowQt::QtReparent( QWidget *child, QWidget *parent )
 {
     // Backup the attributes which will be changed during the reparenting:


### PR DESCRIPTION
…on to Qt

Setting min/max widget size at the wxWidgets level is not enough to take effect unless the information is also set at the Qt level.