### PR TITLE
Fix `AddStdCatalog()` under MSW and add functions without msg ID fallback

### DIFF
--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -151,16 +151,24 @@ public:
     // get languages available for this app
     wxArrayString GetAvailableTranslations(const wxString& domain) const;
 
-    // find best translation language for given domain
+    // find best available translation language for given domain
+    wxString GetBestAvailableTranslation(const wxString& domain);
+
     wxString GetBestTranslation(const wxString& domain, wxLanguage msgIdLanguage);
     wxString GetBestTranslation(const wxString& domain,
                                 const wxString& msgIdLanguage = wxASCII_STR("en"));
+
+    // add catalog for the given domain returning true if it could be found by
+    // wxTranslationsLoader
+    bool AddAvailableCatalog(const wxString& domain);
 
     // add standard wxWidgets catalog ("wxstd")
     bool AddStdCatalog();
 
     // add catalog with given domain name and language, looking it up via
-    // wxTranslationsLoader
+    // wxTranslationsLoader -- unlike AddAvailableCatalog(), this function also
+    // returns true if this catalog is not needed at all because msgIdLanguage
+    // is an acceptable language to use directly
     bool AddCatalog(const wxString& domain,
                     wxLanguage msgIdLanguage = wxLANGUAGE_ENGLISH_US);
 
@@ -186,7 +194,7 @@ public:
 
 private:
     // perform loading of the catalog via m_loader
-    bool LoadCatalog(const wxString& domain, const wxString& lang, const wxString& msgIdLang);
+    bool LoadCatalog(const wxString& domain, const wxString& lang);
 
     // find catalog by name in a linked list, return nullptr if !found
     wxMsgCatalog *FindCatalog(const wxString& domain) const;

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -390,7 +390,10 @@ public:
     bool AddCatalog(const wxString& domain, wxLanguage msgIdLanguage);
 
     /**
-        Calls wxTranslations::AddCatalog(const wxString&, wxLanguage, const wxString&).
+        Calls wxTranslations::AddCatalog(const wxString&, const wxString&).
+
+        This overload shouldn't be used any longer as @a msgIdCharset is
+        just ignored.
     */
     bool AddCatalog(const wxString& domain, wxLanguage msgIdLanguage,
                     const wxString& msgIdCharset);

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -180,34 +180,6 @@ public:
                     wxLanguage msgIdLanguage = wxLANGUAGE_ENGLISH_US);
 
     /**
-        Same as AddCatalog(const wxString&, wxLanguage), but takes two
-        additional arguments, @a msgIdLanguage and @a msgIdCharset.
-
-        This overload is only available in non-Unicode build.
-
-        @param domain
-            The catalog domain to add.
-
-        @param msgIdLanguage
-            Specifies the language of "msgid" strings in source code
-            (i.e. arguments to GetString(), wxGetTranslation() and the _() macro).
-            It is used if AddCatalog() cannot find any catalog for current language:
-            if the language is same as source code language, then strings from source
-            code are used instead.
-
-        @param msgIdCharset
-            Lets you specify the charset used for msgids in sources
-            in case they use 8-bit characters (e.g. German or French strings).
-
-        @return
-            @true if catalog was successfully loaded, @false otherwise (which might
-            mean that the catalog is not found or that it isn't in the correct format).
-     */
-    bool AddCatalog(const wxString& domain,
-                    wxLanguage msgIdLanguage,
-                    const wxString& msgIdCharset);
-
-    /**
         Check if the given catalog is loaded, and returns @true if it is.
 
         According to GNU gettext tradition, each catalog normally corresponds to

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -90,6 +90,18 @@ public:
     wxArrayString GetAvailableTranslations(const wxString& domain) const;
 
     /**
+        Returns the best available translation for the required language.
+
+        For wxLANGUAGE_DEFAULT, this function returns the available translation
+        best matching one of wxUILocale::GetPreferredUILanguages(). Otherwise
+        it simply returns the language set with SetLanguage() if it's available
+        or empty string otherwise.
+
+        @since 3.3.0
+     */
+    wxString GetBestAvailableTranslation(const wxString& domain);
+
+    /**
         Returns the best UI language for the @a domain.
 
         The language is determined from the preferred UI language or languages
@@ -97,6 +109,13 @@ public:
         correspond to the default @em locale as obtained from
         wxLocale::GetSystemLanguage() as operating systems have separate
         language and regional (i.e. locale) settings.
+
+        Please note that that this function may return the language
+        corresponding to @a msgIdLanguage if this language is considered to be
+        acceptable, i.e. is part of wxUILocale::GetPreferredUILanguages(),
+        indicating that it is fine not to use translations at all on this
+        system. If this is undesirable, GetBestAvailableTranslation() should be
+        used which doesn't consider the messages ID language as being available.
 
         @param domain
             The catalog domain to look for.
@@ -124,20 +143,37 @@ public:
 
         @return @true if a suitable catalog was found, @false otherwise
 
-        @see AddCatalog()
+        @see AddAvailableCatalog()
      */
     bool AddStdCatalog();
 
     /**
         Add a catalog for use with the current locale.
 
-        By default, it is searched for in standard places (see
+        By default, the catalog is searched for in standard places (see
         wxFileTranslationsLoader), but you may also prepend additional
         directories to the search path with
         wxFileTranslationsLoader::AddCatalogLookupPathPrefix().
 
         All loaded catalogs will be used for message lookup by GetString() for
         the current locale.
+
+        @return
+            @true if catalog was successfully loaded, @false otherwise, usually
+            because it wasn't found
+
+        @since 3.3.0
+     */
+    bool AddAvailableCatalog(const wxString& domain);
+
+    /**
+        Add a catalog for use with the current locale or fall back to the
+        original messages language.
+
+        This function behaves like AddAvailableCatalog() but also checks if the
+        strings used in the program, written in @a msgIdLanguage, can be used
+        without any translations on the current system and also returns @true
+        in this case, unlike AddAvailableCatalog().
 
         By default, i.e. if @a msgIdLanguage is not given, @c msgid strings are assumed
         to be in English and written only using 7-bit ASCII characters.
@@ -155,8 +191,10 @@ public:
             code are used instead.
 
         @return
-            @true if catalog was successfully loaded, @false otherwise (which might
-            mean that the catalog is not found or that it isn't in the correct format).
+            @true if catalog was successfully loaded or loading it is
+            unnecessary because the original messages can be used directly,
+            @false otherwise (which might mean that the catalog is not found or
+            that it isn't in the correct format).
      */
     bool AddCatalog(const wxString& domain,
                     wxLanguage msgIdLanguage = wxLANGUAGE_ENGLISH_US);
@@ -167,7 +205,7 @@ public:
         According to GNU gettext tradition, each catalog normally corresponds to
         'domain' which is more or less the application name.
 
-        @see AddCatalog()
+        @see AddAvailableCatalog()
      */
     bool IsLoaded(const wxString& domain) const;
 
@@ -302,7 +340,7 @@ public:
         (in this order).
 
         This only applies to subsequent invocations of
-        wxTranslations::AddCatalog().
+        wxTranslations::AddAvailableCatalog().
     */
     static void AddCatalogLookupPathPrefix(const wxString& prefix);
 };
@@ -312,8 +350,7 @@ public:
     resources.
 
     If you wish to store translation MO files in resources, you have to
-    enable this loader before calling wxTranslations::AddCatalog() or
-    wxLocale::AddCatalog():
+    enable this loader before calling wxTranslations::AddAvailableCatalog():
 
     @code
     wxTranslations::Get()->SetLoader(new wxResourceTranslationsLoader);

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -113,25 +113,7 @@ public:
     wxString GetBestTranslation(const wxString& domain, wxLanguage msgIdLanguage);
 
     /**
-        Returns the best UI language for the @a domain.
-
-        The language is determined from the preferred UI language or languages
-        list the user configured in the OS. Notice that this may or may not
-        correspond to the default @em locale as obtained from
-        wxLocale::GetSystemLanguage() as operating systems have separate
-        language and regional (i.e. locale) settings.
-
-        @param domain
-            The catalog domain to look for.
-
-        @param msgIdLanguage
-            Specifies the language of "msgid" strings in source code
-            (i.e. arguments to GetString(), wxGetTranslation() and the _() macro).
-
-        @return Language code if a suitable match was found, empty string
-                otherwise.
-
-        @since 2.9.5
+        @overload
      */
     wxString GetBestTranslation(const wxString& domain,
                                 const wxString& msgIdLanguage = "en");

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -797,16 +797,11 @@ bool wxLocale::AddCatalog(const wxString& domain, wxLanguage msgIdLanguage)
     return t->AddCatalog(domain, msgIdLanguage);
 }
 
-// add a catalog to our linked list
-bool wxLocale::AddCatalog(const wxString& szDomain,
+bool wxLocale::AddCatalog(const wxString& domain,
                         wxLanguage      msgIdLanguage,
-                        const wxString& msgIdCharset)
+                        const wxString& WXUNUSED(msgIdCharset))
 {
-    wxTranslations *t = wxTranslations::Get();
-    if ( !t )
-        return false;
-    wxUnusedVar(msgIdCharset);
-    return t->AddCatalog(szDomain, msgIdLanguage);
+    return AddCatalog(domain, msgIdLanguage);
 }
 
 bool wxLocale::IsLoaded(const wxString& domain) const

--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1316,7 +1316,7 @@ bool wxTranslations::AddStdCatalog()
     // the name without the version if it's not found, as message catalogs
     // typically won't have the version in their names under non-Unix platforms
     // (i.e. where they're not installed by our own "make install").
-    if ( AddCatalog("wxstd-" wxSTRINGIZE(wxMAJOR_VERSION) "." wxSTRINGIZE(wxMINOR_VERSION)) )
+    if ( AddAvailableCatalog("wxstd-" wxSTRINGIZE(wxMAJOR_VERSION) "." wxSTRINGIZE(wxMINOR_VERSION)) )
         return true;
 
     if ( AddCatalog(wxS("wxstd")) )
@@ -1325,12 +1325,9 @@ bool wxTranslations::AddStdCatalog()
     return false;
 }
 
-bool wxTranslations::AddCatalog(const wxString& domain,
-                                wxLanguage msgIdLanguage)
+bool wxTranslations::AddAvailableCatalog(const wxString& domain)
 {
-    const wxString msgIdLang = wxUILocale::GetLanguageCanonicalName(msgIdLanguage);
-    const wxString domain_lang = GetBestTranslation(domain, msgIdLang);
-
+    const wxString domain_lang = GetBestAvailableTranslation(domain);
     if ( domain_lang.empty() )
     {
         wxLogTrace(TRACE_I18N,
@@ -1339,15 +1336,31 @@ bool wxTranslations::AddCatalog(const wxString& domain,
         return false;
     }
 
-    wxLogTrace(TRACE_I18N,
-                wxS("adding '%s' translation for domain '%s' (msgid language '%s')"),
-                domain_lang, domain, msgIdLang);
+    return LoadCatalog(domain, domain_lang);
+}
 
-    return LoadCatalog(domain, domain_lang, msgIdLang);
+bool wxTranslations::AddCatalog(const wxString& domain,
+                                wxLanguage msgIdLanguage)
+{
+    if ( AddAvailableCatalog(domain) )
+        return true;
+
+    const wxString msgIdLang = wxUILocale::GetLanguageCanonicalName(msgIdLanguage);
+    const wxString domain_lang = GetBestTranslation(domain, msgIdLang);
+
+    if ( msgIdLang == domain_lang )
+    {
+        wxLogTrace(TRACE_I18N,
+                    wxS("not using translations for domain '%s' with msgid language '%s'"),
+                    domain, msgIdLang);
+        return true;
+    }
+
+    return false;
 }
 
 
-bool wxTranslations::LoadCatalog(const wxString& domain, const wxString& lang, const wxString& msgIdLang)
+bool wxTranslations::LoadCatalog(const wxString& domain, const wxString& lang)
 {
     wxCHECK_MSG( m_loader, false, "loader can't be null" );
 
@@ -1382,15 +1395,6 @@ bool wxTranslations::LoadCatalog(const wxString& domain, const wxString& lang, c
         wxString baselang = lang.BeforeFirst('_');
         if ( lang != baselang )
             cat = m_loader->LoadCatalog(domain, baselang);
-    }
-
-    if ( !cat )
-    {
-        // It is OK to not load catalog if the msgid language and m_language match,
-        // in which case we can directly display the texts embedded in program's
-        // source code:
-        if ( msgIdLang == lang )
-            return true;
     }
 
     if ( cat )
@@ -1430,14 +1434,56 @@ wxString wxTranslations::GetBestTranslation(const wxString& domain,
 wxString wxTranslations::GetBestTranslation(const wxString& domain,
                                             const wxString& msgIdLanguage)
 {
-    // explicitly set language should always be respected
-    if ( !m_lang.empty() )
-        return m_lang;
+    wxString lang = GetBestAvailableTranslation(domain);
+    if ( lang.empty() )
+    {
+        wxArrayString available;
+        available.push_back(msgIdLanguage);
+        available.push_back(msgIdLanguage.BeforeFirst('_'));
+        lang = GetPreferredUILanguage(available);
+        if ( lang.empty() )
+        {
+            wxLogTrace(TRACE_I18N,
+                       "no available language for domain '%s'", domain);
+        }
+        else
+        {
+            wxLogTrace(TRACE_I18N,
+                       "using message ID language '%s' for domain '%s'", lang);
+        }
+    }
 
-    wxArrayString available(GetAvailableTranslations(domain));
-    // it's OK to have duplicates, so just add msgid language
-    available.push_back(msgIdLanguage);
-    available.push_back(msgIdLanguage.BeforeFirst('_'));
+    return lang;
+}
+
+wxString wxTranslations::GetBestAvailableTranslation(const wxString& domain)
+{
+    const wxArrayString available(GetAvailableTranslations(domain));
+    if ( !m_lang.empty() )
+    {
+        wxLogTrace(TRACE_I18N,
+                   "searching for best translation to %s for domain '%s'",
+                   m_lang, domain);
+
+        wxString lang;
+        if ( available.Index(m_lang) != wxNOT_FOUND )
+        {
+            lang = m_lang;
+        }
+        else
+        {
+            const wxString baselang = m_lang.BeforeFirst('_');
+            if ( baselang != m_lang && available.Index(baselang) != wxNOT_FOUND )
+                lang = baselang;
+        }
+
+        if ( lang.empty() )
+            wxLogTrace(TRACE_I18N, " => no available translations found");
+        else
+            wxLogTrace(TRACE_I18N, " => found '%s'", lang);
+
+        return lang;
+    }
 
     wxLogTrace(TRACE_I18N, "choosing best language for domain '%s'", domain);
     LogTraceArray(" - available translations", available);

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -239,6 +239,39 @@ void IntlTestCase::IsAvailable()
     CPPUNIT_ASSERT_EQUAL( origLocale, setlocale(LC_ALL, nullptr) );
 }
 
+TEST_CASE("wxTranslations::Available", "[translations]")
+{
+    // We currently have translations for French and Japanese in this test
+    // directory, check that loading those succeeds but loading others doesn't.
+    wxFileTranslationsLoader::AddCatalogLookupPathPrefix("./intl");
+
+    const wxString domain("internat");
+
+    wxTranslations trans;
+
+    SECTION("All")
+    {
+        auto available = trans.GetAvailableTranslations(domain);
+        REQUIRE( available.size() == 2 );
+
+        available.Sort();
+        CHECK( available[0] == "fr" );
+        CHECK( available[1] == "ja" );
+    }
+
+    SECTION("French")
+    {
+        trans.SetLanguage(wxLANGUAGE_FRENCH);
+        CHECK( trans.AddAvailableCatalog(domain) );
+    }
+
+    SECTION("Italian")
+    {
+        trans.SetLanguage(wxLANGUAGE_ITALIAN);
+        CHECK_FALSE( trans.AddAvailableCatalog(domain) );
+    }
+}
+
 TEST_CASE("wxLocale::Default", "[locale]")
 {
     const int langDef = wxUILocale::GetSystemLanguage();


### PR DESCRIPTION
This replaces #23886 and somewhat addresses #18227: it doesn't change `AddCatalog()` but adds a new function which behaves as described there.

@vslavik Your review would be highly appreciated because I'm really not sure if I'm doing the right thing here, but, as I explained in #18227, I don't see any other reasonable solution. TIA!