### PR TITLE
Fix return type of wxBitmap::UseAlpha() under wxMSW

### DIFF
--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -177,7 +177,7 @@ public:
     void SetMask(wxMask *mask);
 
     bool HasAlpha() const;
-    void UseAlpha(bool use = true);
+    bool UseAlpha(bool use = true);
     void ResetAlpha() { UseAlpha(false); }
 
     // old synonyms for CreateWithDIPSize() and GetLogicalXXX() functions

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -1222,16 +1222,13 @@ wxDC *wxBitmap::GetSelectedInto() const
 #endif
 }
 
-void wxBitmap::UseAlpha(bool use)
+bool wxBitmap::UseAlpha(bool use)
 {
-    if ( GetBitmapData() )
-    {
-        // Only 32bpp bitmaps can contain alpha channel.
-        if ( use && GetBitmapData()->m_depth < 32 )
-            use = false;
+    if ( !GetBitmapData() || (use && GetBitmapData()->m_depth < 32) )
+        return false;
 
-        GetBitmapData()->m_hasAlpha = use;
-    }
+    GetBitmapData()->m_hasAlpha = use;
+    return true;
 }
 
 bool wxBitmap::HasAlpha() const


### PR DESCRIPTION
The method should return bool but was returning void.

Closes #23903.