### PR TITLE
Fix a crash in wxAUI

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -488,6 +488,8 @@ void wxWindowQt::SetFocus()
 
 void wxWindowQt::QtSetMinSize(const wxSize& minSize)
 {
+    if ( !GetHandle() ) return;
+
     if ( minSize.x >= 0 )
         GetHandle()->setMinimumWidth(minSize.x);
 
@@ -497,6 +499,8 @@ void wxWindowQt::QtSetMinSize(const wxSize& minSize)
 
 void wxWindowQt::QtSetMaxSize(const wxSize& maxSize)
 {
+    if ( !GetHandle() ) return;
+
     if ( maxSize.x >= 0 )
         GetHandle()->setMaximumWidth(maxSize.x);
 


### PR DESCRIPTION
`wxAUI` has a special window "`wxTabFrame`" for which `GetHandle()` returns `nullptr`. This is a problem because this commit 3c68696 (Make wxTopLevelWindow::SetSizeHints() work in wxQt) doesn't account for the rare situation in which a `wxWindow` is actually created without the underlying handle, resulting in a crash when we try to call `Set{Min,Max}Size()` for this type of windows.