### PR TITLE
Fixes for suppressing bogus GTK diagnostics

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -93,7 +93,7 @@ jobs:
             git fetch --depth=1 origin master
             if git diff origin/master \
                ':**.h' ':**.cpp' \
-               | grep -E '^\+.*(wxOVERRIDE|wxNOEXCEPT|[^"_@A-Za-z0-9]NULL[^"_A-Za-z0-9])'; then
+               | grep -E '^\+.*(wxOVERRIDE|wxNOEXCEPT|[^"_@A-Za-z0-9]NULL([- ,;()+*/%&=!?]|$))'; then
               echo "::error ::Please use C++11 equivalents of the deprecated macros in the new code."
               exit 1
             fi

--- a/docs/doxygen/overviews/envvars.h
+++ b/docs/doxygen/overviews/envvars.h
@@ -45,6 +45,12 @@ wxWidgets programs.
          This can be helpful when running older programs recompiled with
          wxWidgets 3.1 or later, as these asserts are mostly harmless and can
          be safely ignored if the code works as expected.}
+@itemdef{WXSUPPRESS_GTK_DIAGNOSTICS,
+         If set to a non-zero value, wxApp::GTKSuppressDiagnostics() is called
+         on program startup using the numeric value of this variable or the
+         default value if it's not a number, so that e.g. setting it to "yes"
+         suppresses all GTK diagnostics while setting it to 16 only suppresses
+         GTK warning messages.}
 */
 
 @see wxSystemOptions

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1042,6 +1042,11 @@ public:
         This function can be called to suppress GTK diagnostic messages that
         are output on the standard error stream by default.
 
+        If @c WXSUPPRESS_GTK_DIAGNOSTICS environment variable is set to a
+        non-zero value, wxWidgets automatically calls this function on program
+        startup with the value of this variable as @a flags if it's a number or
+        with the default flags value otherwise.
+
         The default value of the argument disables all messages, but you
         can pass in a mask flag to specifically disable only particular
         categories of messages.

--- a/samples/preferences/preferences.cpp
+++ b/samples/preferences/preferences.cpp
@@ -282,6 +282,13 @@ bool MyApp::OnInit()
     if ( !wxApp::OnInit() )
         return false;
 
+#ifdef __WXGTK__
+    // Many version of wxGTK generate spurious diagnostic messages when
+    // destroying wxNotebook (or removing pages from it), allow wxWidgets to
+    // suppress them.
+    GTKAllowDiagnosticsControl();
+#endif // __WXGTK__
+
     // This will be used in the title of the preferences dialog under some
     // platforms, don't leave it as default "Preferences" because this would
     // result in rather strange "Preferences Preferences" title.

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -273,6 +273,9 @@ LogFilterByMessage::~LogFilterByMessage()
 /* static */
 void wxApp::GTKSuppressDiagnostics(int flags)
 {
+    // Allow Install() to actually do something.
+    GTKAllowDiagnosticsControl();
+
     static wxGTKImpl::LogFilterByLevel s_logFilter;
     s_logFilter.SetLevelToIgnore(flags);
     s_logFilter.Install();

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -392,6 +392,19 @@ bool wxApp::OnInitGui()
     }
 #endif
 
+    // Suppress GTK diagnostics if requested: this is convenient if the program
+    // doesn't use GTKAllowDiagnosticsControl() itself.
+    wxString suppress;
+    if ( wxGetEnv("WXSUPPRESS_GTK_DIAGNOSTICS", &suppress) )
+    {
+        long flags;
+        if ( !suppress.ToLong(&flags) )
+            flags = -1; // Suppress everything by default.
+
+        if ( flags != 0 )
+            GTKSuppressDiagnostics(flags);
+    }
+
     return true;
 }
 

--- a/src/gtk/notebook.cpp
+++ b/src/gtk/notebook.cpp
@@ -431,7 +431,7 @@ wxNotebookPage *wxNotebook::DoRemovePage( size_t page )
     // Suppress bogus assertion failures happening deep inside ATK (used by
     // GTK) that can't be avoided in any other way, see #22176.
     wxGTKImpl::LogFilterByMessage filterLog(
-        "gtk_notebook_get_tab_label: assertion 'list != nullptr' failed"
+        "gtk_notebook_get_tab_label: assertion 'list != NULL' failed"
     );
 
     // we don't need to unparent the client->m_widget; GTK+ will do


### PR DESCRIPTION
This got completely broken for 2 different reasons in master, fix this now.

The first commit here also needs to be backported to 3.2.