### PR TITLE
Fix wxComboCtrl popup behaviour under some Wayland compositors

### DIFF
--- a/src/gtk/popupwin.cpp
+++ b/src/gtk/popupwin.cpp
@@ -106,8 +106,12 @@ bool wxPopupWindow::Create( wxWindow *parent, int style )
     g_object_ref( m_widget );
 
     gtk_widget_set_name( m_widget, "wxPopupWindow" );
-    // wxPopupWindow is used for different windows as well
-    // gtk_window_set_type_hint( GTK_WINDOW(m_widget), GDK_WINDOW_TYPE_HINT_COMBO );
+
+    // While wxPopupWindow is used for different windows as well, we don't
+    // really know how is it going to be used but we do know that without the
+    // hint at all, it doesn't work correctly, at least under Wayland, where
+    // GTK only maps COMBO and {DROPDOWN,POPUP}_MENU to popups, so do set it.
+    gtk_window_set_type_hint( GTK_WINDOW(m_widget), GDK_WINDOW_TYPE_HINT_COMBO );
 
     // Popup windows can be created without parent, so handle this correctly.
     if (parent)


### PR DESCRIPTION
We need to set the window type hint to COMBO in order to use a popup window for it under Wayland and while not doing it seems to still work with GNOME/mutter, it is required with the other compositors such as KDE Plasma or Sway and doesn't seem to do any harm under GNOME, so do it always and hope that it doesn't result in any problems with not combobox-like popups.

This basically undoes 62d934aab8 (Don't set HINT_COMBO as wxPopupWindow is used for different windows as well, 2008-10-07).

Closes #23908.