### PR TITLE
Fix `wxBusyInfo` layout under GTK

### DIFF
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3542,7 +3542,11 @@ void MyFrame::ShowRichBusyInfo(wxCommandEvent& WXUNUSED(event))
                 .Transparency(4*wxALPHA_OPAQUE/5)
         );
 
-    wxSleep(5);
+    for ( int i = 0; i < 20; i++ )
+    {
+        wxTheApp->Yield();
+        wxMilliSleep(250);
+    }
 }
 
 #endif // wxUSE_BUSYINFO

--- a/src/generic/busyinfo.cpp
+++ b/src/generic/busyinfo.cpp
@@ -59,6 +59,21 @@ void wxBusyInfo::Init(const wxBusyInfoFlags& flags)
                                                   wxDefaultSize,
                                                   wxALIGN_CENTRE);
         title->SetFont(title->GetFont().Scaled(2));
+
+#ifdef __WXGTK__
+        // This bad hack is needed to fix layout under GTK: the font sent above
+        // is not taken into account for the size calculation until the window
+        // is shown but we need the correct size when computing the best size
+        // below, as otherwise we would make the entire frame too small and
+        // when the correct size is used for the actual layout later, the title
+        // control would take too much space pushing the text below it outside
+        // of the window bounds.
+        //
+        // So preemptively make it about as big as it's going to be to prevent
+        // this from happening.
+        title->SetMinSize(2*title->GetBestSize());
+#endif // __WXGTK__
+
 #if wxUSE_MARKUP
         title->SetLabelMarkup(flags.m_title);
 #else


### PR DESCRIPTION
This is horrible but fixes a user-visible (user-invisible?) problem, so still worth it.