### PR TITLE
Minor fix to the recently added wxBitmap::QtBlendMaskWithAlpha()

### DIFF
--- a/src/generic/imaglist.cpp
+++ b/src/generic/imaglist.cpp
@@ -107,6 +107,13 @@ wxBitmap wxGenericImageList::GetImageListBitmap(const wxBitmap& bitmap) const
     }
 
 #ifdef __WXQT__
+    // In wxQt the returned bitmap is used with native list/tree controls which require
+    // the bitmap to already have its mask applied to it, as it's used directly by Qt
+    // and not via our wxDC::DrawBitmap() which would apply the mask itself, so we must
+    // take it into account here -- the only alternative would be for the controls to do
+    // it themselves, but then this would happen every time the bitmap is drawn, which
+    // would be less efficient than doing it just once here.
+
     bmpResized.QtBlendMaskWithAlpha();
 #endif
 

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -597,7 +597,7 @@ void wxBitmap::QtBlendMaskWithAlpha()
     // alpha channel, if it has any. Notice that the bitmap can still be
     // converted to wxImage, but without mask information.
 
-    if ( IsOk() && HasAlpha() && M_MASK && M_MASK->GetHandle() )
+    if ( IsOk() && M_MASK && M_MASK->GetHandle() )
     {
         AllocExclusive();
         M_PIXDATA.setMask(*M_MASK->GetHandle());


### PR DESCRIPTION
Testing for the alpha channel support was a mistake because it is completely common to initially have a bitmap without an alpha channel ( in which case HasAlpha() returns false ) and Qt correctly converts it to an appropriate format when the mask is set.

Should be part of 1e43b37 (Added QtBlendMaskWithAlpha() to wxBitmap under wxQt)

@vadz Sorry for pushing untested code because adding `HasAlpha()` was a last minute change that I thought was a trivial change, but it's not.