### PR TITLE
Fix CHOICE constant values that were reversed

### DIFF
--- a/include/wx/generic/choicdgg.h
+++ b/include/wx/generic/choicdgg.h
@@ -20,8 +20,8 @@ class WXDLLIMPEXP_FWD_CORE wxListBoxBase;
 // some (ugly...) constants
 // ----------------------------------------------------------------------------
 
-#define wxCHOICE_HEIGHT 150
-#define wxCHOICE_WIDTH 200
+#define wxCHOICE_HEIGHT 200
+#define wxCHOICE_WIDTH 150
 
 #define wxCHOICEDLG_STYLE \
     (wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxOK | wxCANCEL | wxCENTRE)


### PR DESCRIPTION
These constants are backwards from how they are documented in the help. I believe the ones in the help are correct, so use that.

It doesn't appear that these constants are actually applied to anything though, so this is mostly a consistency fix.