### PR TITLE
Explain that wxGetSingleChoice()'s size parameters are ignored

### DIFF
--- a/include/wx/generic/choicdgg.h
+++ b/include/wx/generic/choicdgg.h
@@ -20,8 +20,8 @@ class WXDLLIMPEXP_FWD_CORE wxListBoxBase;
 // some (ugly...) constants
 // ----------------------------------------------------------------------------
 
-#define wxCHOICE_HEIGHT 150
-#define wxCHOICE_WIDTH 200
+#define wxCHOICE_HEIGHT 200
+#define wxCHOICE_WIDTH 150
 
 #define wxCHOICEDLG_STYLE \
     (wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxOK | wxCANCEL | wxCENTRE)

--- a/include/wx/generic/choicdgg.h
+++ b/include/wx/generic/choicdgg.h
@@ -20,8 +20,8 @@ class WXDLLIMPEXP_FWD_CORE wxListBoxBase;
 // constants that are no longer used, here for compatibility
 // ----------------------------------------------------------------------------
 
-#define wxCHOICE_HEIGHT 200
-#define wxCHOICE_WIDTH 150
+#define wxCHOICE_HEIGHT 150
+#define wxCHOICE_WIDTH 200
 
 #define wxCHOICEDLG_STYLE \
     (wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxOK | wxCANCEL | wxCENTRE)

--- a/include/wx/generic/choicdgg.h
+++ b/include/wx/generic/choicdgg.h
@@ -17,7 +17,7 @@
 class WXDLLIMPEXP_FWD_CORE wxListBoxBase;
 
 // ----------------------------------------------------------------------------
-// some (ugly...) constants
+// constants that are no longer used, here for compatability
 // ----------------------------------------------------------------------------
 
 #define wxCHOICE_HEIGHT 200

--- a/include/wx/generic/choicdgg.h
+++ b/include/wx/generic/choicdgg.h
@@ -17,7 +17,7 @@
 class WXDLLIMPEXP_FWD_CORE wxListBoxBase;
 
 // ----------------------------------------------------------------------------
-// constants that are no longer used, here for compatability
+// constants that are no longer used, here for compatibility
 // ----------------------------------------------------------------------------
 
 #define wxCHOICE_HEIGHT 200

--- a/interface/wx/choicdlg.h
+++ b/interface/wx/choicdlg.h
@@ -319,7 +319,9 @@ int wxGetSingleChoiceIndex(const wxString& message,
     If @c centre is @true, the message text (which may include new line
     characters) is centred; if @false, the message is left-justified.
 
-    Note that the @c width and @c height parameters are ignored for these functions.
+    Note that the @c width and @c height parameters are ignored.
+    To change the dialog's size, create a @c wxSingleChoiceDialog object instead
+    of calling @c wxGetSingleChoice() and change its size before presenting it.
 
     @header{wx/choicdlg.h}
 

--- a/interface/wx/choicdlg.h
+++ b/interface/wx/choicdlg.h
@@ -6,16 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////
 
 /**
-    Default width of the choice dialog.
-*/
-#define wxCHOICE_WIDTH 150
-
-/**
-    Default height of the choice dialog.
-*/
-#define wxCHOICE_HEIGHT 200
-
-/**
     Default style of the choice dialog.
 */
 #define wxCHOICEDLG_STYLE (wxDEFAULT_DIALOG_STYLE | wxOK | wxCANCEL | wxCENTRE | wxRESIZE_BORDER)
@@ -328,6 +318,8 @@ int wxGetSingleChoiceIndex(const wxString& message,
 
     If @c centre is @true, the message text (which may include new line
     characters) is centred; if @false, the message is left-justified.
+
+    Note that the @c width and @c height parameters are ignored for these functions.
 
     @header{wx/choicdlg.h}
 


### PR DESCRIPTION
Also, remove `wxCHOICE*` constants from the help that are not used for anything.
Finally, explain that you can resize a `wxSingleChoiceDialog` object instead if you need to change the dialog's size.