### PR TITLE
Fix inserting new items into wxListBox under wxQt

### DIFF
--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -315,7 +315,7 @@ int wxListBox::DoInsertItems(const wxArrayStringsAdapter & items,
 
 int wxListBox::DoInsertOneItem(const wxString& text, unsigned int pos)
 {
-    QListWidgetItem* item = new QListWidgetItem();
+    QListWidgetItem* item = new wxQtListWidgetItem();
     item->setText(wxQtConvertString( text ));
     if ( m_hasCheckBoxes )
     {

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -323,7 +323,7 @@ int wxListBox::DoInsertOneItem(const wxString& text, unsigned int pos)
         item->setCheckState(Qt::Unchecked);
     }
     m_qtListWidget->insertItem(pos, item);
-    return pos;
+    return IsSorted() ? m_qtListWidget->row(item) : pos;
 }
 
 void wxListBox::DoSetItemClientData(unsigned int n, void *clientData)


### PR DESCRIPTION
Use the right type when inserting new items into the list box. This ensures that the `wxEVT_CHECKLISTBOX` event is emitted for these new items. And in fact, it should be part of this commit 16da1a1 when `wxQtListWidgetItem` was introduced.