### PR TITLE
Remove wxNODISCARD from wxBasicString::Get() declaration

### DIFF
--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -104,7 +104,7 @@ public:
 
     // retrieve a copy of our string - caller must SysFreeString() it later!
     wxDEPRECATED_MSG("use Copy() instead")
-    wxNODISCARD BSTR Get() const { return Copy(); }
+    BSTR Get() const { return Copy(); }
 private:
     // actual string
     BSTR m_bstrBuf;


### PR DESCRIPTION
Using both wxDEPRECATED_MSG and wxNODISCARD for some reason breaks compilation with clang (when using C++17 or newer standard).

Since wxBasicString::Get() is deprecated, one warning should be enough so just remove wxNODISCARD from the method declaration.

Closes #23952.