### PR TITLE
Fixing MSW Dark Mode crash with empty wxListCtrl

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3408,7 +3408,7 @@ void wxListCtrl::OnPaint(wxPaintEvent& event)
     const long top = GetTopItem();
     const long bottom = wxMin(top + countPerPage, itemCount - 1);
 
-    if ( needToErase )
+    if ( needToErase && itemCount )
     {
         wxRect lastRect;
         GetItemRect(bottom, lastRect);


### PR DESCRIPTION
Thanks very much for all the recent work on MSW Dark Mode.

I'm seeing an empty wxListCtrl will crash when Dark Mode is enabled on MSW due to a recent-ish change: 9710592cc4c35f60d52257e8d159e1b2448a268c

If `itemCount` is 0, the local `bottom` index becomes -1, which leads to an assert failing downstream. This small fix should prevent that. I've tried to create a minimal repro which can be pasted over the top of the _minimal_ sample:

```
#include <wx/wx.h>
#include <wx/listctrl.h>
#include <wx/msw/app.h>

class MyFrame : public wxFrame {
  public:
    MyFrame()
        : wxFrame( nullptr, wxID_ANY, "Dark Mode wxListCtrl Crash", wxDefaultPosition, wxSize(800, 600) )
    {
        wxPanel* panel = new wxPanel( this, wxID_ANY );
        mListCtrl = new wxListCtrl( panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT );
    }

    wxListCtrl*     mListCtrl;
};

class MyApp : public wxApp
{
  public:
    virtual bool OnInit()
    {
        wxApp::MSWEnableDarkMode();

        MyFrame* frame = new MyFrame();
        frame->Show(true);
        return true;
    }
};

wxIMPLEMENT_APP(MyApp);
```