### PR TITLE
Improve item sorting in generic wxFileCtrl and wxDirCtrl

### DIFF
--- a/src/generic/dirctrlg.cpp
+++ b/src/generic/dirctrlg.cpp
@@ -234,13 +234,6 @@ bool wxIsDriveAvailable(const wxString& dirName)
 
 #if wxUSE_DIRDLG
 
-// Function which is called by quick sort. We want to override the default wxArrayString behaviour,
-// and sort regardless of case.
-static int wxCMPFUNC_CONV wxDirCtrlStringCompareFunction(const wxString& strFirst, const wxString& strSecond)
-{
-    return strFirst.CmpNoCase(strSecond);
-}
-
 //-----------------------------------------------------------------------------
 // wxDirItemData
 //-----------------------------------------------------------------------------
@@ -713,7 +706,7 @@ void wxGenericDirCtrl::PopulateNode(wxTreeItemId parentId)
             while (d.GetNext(&eachFilename));
         }
     }
-    dirs.Sort(wxDirCtrlStringCompareFunction);
+    dirs.Sort(wxCmpNatural);
 
     // Now do the filenames -- but only if we're allowed to
     if (!HasFlag(wxDIRCTRL_DIR_ONLY))
@@ -744,7 +737,7 @@ void wxGenericDirCtrl::PopulateNode(wxTreeItemId parentId)
                 }
             }
         }
-        filenames.Sort(wxDirCtrlStringCompareFunction);
+        filenames.Sort(wxCmpNatural);
     }
 
     // Now we really know whether we have any children so tell the tree control

--- a/src/generic/filectrlg.cpp
+++ b/src/generic/filectrlg.cpp
@@ -60,7 +60,7 @@ int wxCALLBACK wxFileDataNameCompare( wxIntPtr data1, wxIntPtr data2, wxIntPtr s
      if (fd2->IsDir() && !fd1->IsDir())
          return sortOrder;
 
-     return sortOrder*wxStrcmp( fd1->GetFileName(), fd2->GetFileName() );
+     return sortOrder*wxCmpNatural( fd1->GetFileName(), fd2->GetFileName() );
 }
 
 static
@@ -104,7 +104,7 @@ int wxCALLBACK wxFileDataTypeCompare(wxIntPtr data1, wxIntPtr data2, wxIntPtr so
      if (fd2->IsLink() && !fd1->IsLink())
          return sortOrder;
 
-     return sortOrder*wxStrcmp( fd1->GetFileType(), fd2->GetFileType() );
+     return sortOrder*wxStricmp( fd1->GetFileType(), fd2->GetFileType() );
 }
 
 static


### PR DESCRIPTION
When users browse for files or folders on a modern system, they expect to see them sorted in the natural order.
However, to sort its items (files and folders) `wxFileCtrl` used simple string compare and `wxDirCtrl` case-insensitive string compare.

For example, this is how an example folder looks in File Explorer:
![sort-explorer](https://github.com/wxWidgets/wxWidgets/assets/12495521/2a7a0f14-bd7a-47c5-b92b-913305d8e5de)
but this is how it looks in `wxFileCtrl` and `wxDirCtrl`, where one can see the unexpected order, e.g., `Z` before `a` (for `čáp` may be only for Czech and Slovaks):
![sort-filectrl](https://github.com/wxWidgets/wxWidgets/assets/12495521/513a98af-6cd9-41a5-a478-8e1cf863f931) ![sort-dirctrl](https://github.com/wxWidgets/wxWidgets/assets/12495521/7c4ae61a-b8ed-42ec-b7d3-eefd8558cedb)

Therefore, I think it is better to use `wxCmpNatural()` for file and folder names and `wxStricmp()` for file extensions.