### PR TITLE
Make wxMSW date/time picker controls locale aware

### DIFF
--- a/include/wx/msw/datetimectrl.h
+++ b/include/wx/msw/datetimectrl.h
@@ -51,6 +51,7 @@ protected:
 #if wxUSE_INTL
     // Override to return the date/time format used by this control.
     virtual wxLocaleInfo MSWGetFormat() const = 0;
+    void MSWSetTimeFormat(wxLocaleInfo index);
 #endif // wxUSE_INTL
 
     // Override to indicate whether we can have no date at all.

--- a/include/wx/msw/private/uilocale.h
+++ b/include/wx/msw/private/uilocale.h
@@ -21,4 +21,6 @@
 
 WXDLLIMPEXP_BASE wxString wxTranslateFromUnicodeFormat(const wxString& fmt);
 
+WXDLLIMPEXP_BASE wxString wxGetMSWDateTimeFormat(wxLocaleInfo index);
+
 #endif // _WX_MSW_PRIVATE_UILOCALE_H_

--- a/include/wx/msw/timectrl.h
+++ b/include/wx/msw/timectrl.h
@@ -10,6 +10,9 @@
 #ifndef _WX_MSW_TIMECTRL_H_
 #define _WX_MSW_TIMECTRL_H_
 
+#include "wx/uilocale.h"
+#include "wx/msw/private/uilocale.h"
+
 // ----------------------------------------------------------------------------
 // wxTimePickerCtrl
 // ----------------------------------------------------------------------------
@@ -41,9 +44,16 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxTimePickerCtrlNameStr)
     {
-        return MSWCreateDateTimePicker(parent, id, dt,
-                                       pos, size, style,
-                                       validator, name);
+        bool ok = MSWCreateDateTimePicker(parent, id, dt,
+                                          pos, size, style,
+                                          validator, name);
+#if wxUSE_INTL
+        if (ok)
+        {
+            MSWSetTimeFormat(wxLOCALE_TIME_FMT);
+        }
+#endif
+        return ok;
     }
 
     // Override MSW-specific functions used during control creation.

--- a/src/msw/datectrl.cpp
+++ b/src/msw/datectrl.cpp
@@ -33,6 +33,8 @@
 
 #include "wx/datectrl.h"
 #include "wx/dateevt.h"
+#include "wx/uilocale.h"
+#include "wx/msw/private/uilocale.h"
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxDatePickerCtrl, wxControl);
 
@@ -58,9 +60,16 @@ wxDatePickerCtrl::Create(wxWindow *parent,
     if ( !(style & wxDP_DROPDOWN) )
         style |= wxDP_SPIN;
 
-    return MSWCreateDateTimePicker(parent, id, dt,
-                                   pos, size, style,
-                                   validator, name);
+    bool ok = MSWCreateDateTimePicker(parent, id, dt,
+                                      pos, size, style,
+                                      validator, name);
+#if wxUSE_INTL
+    if (ok)
+    {
+        MSWSetTimeFormat(wxLOCALE_SHORT_DATE_FMT);
+    }
+#endif
+    return ok;
 }
 
 WXDWORD wxDatePickerCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const

--- a/src/msw/datetimectrl.cpp
+++ b/src/msw/datetimectrl.cpp
@@ -32,6 +32,7 @@
 #endif // WX_PRECOMP
 
 #include "wx/msw/private/datecontrols.h"
+#include "wx/msw/private/uilocale.h"
 
 // apparently some versions of mingw define these macros erroneously
 #ifndef DateTime_GetSystemtime
@@ -120,6 +121,16 @@ wxDateTimePickerCtrl::MSWCreateDateTimePicker(wxWindow *parent,
     }
 
     return true;
+}
+
+void wxDateTimePickerCtrl::MSWSetTimeFormat(wxLocaleInfo index)
+{
+    wxString formatStr = wxGetMSWDateTimeFormat(index);
+    if (!formatStr.empty())
+    {
+        const TCHAR* format = formatStr.t_str();
+        DateTime_SetFormat(GetHwnd(), format);
+    }
 }
 
 void wxDateTimePickerCtrl::SetValue(const wxDateTime& dt)

--- a/src/msw/uilocale.cpp
+++ b/src/msw/uilocale.cpp
@@ -109,6 +109,27 @@ LCTYPE wxGetLCTYPEFormatFromLocalInfo(wxLocaleInfo index)
     return 0;
 }
 
+WXDLLIMPEXP_BASE wxString wxGetMSWDateTimeFormat(wxLocaleInfo index)
+{
+    wxString format;
+    wxString localeName = wxUILocale::GetCurrent().GetName();
+    const wchar_t* name = localeName.wc_str();
+    LCTYPE lctype = wxGetLCTYPEFormatFromLocalInfo(index);
+    if (lctype != 0)
+    {
+        wchar_t buf[256];
+        if (::GetLocaleInfoEx(name, lctype, buf, WXSIZEOF(buf)))
+        {
+            format = buf;
+        }
+        else
+        {
+            wxLogLastError(wxT("GetLocaleInfoEx"));
+        }
+    }
+    return format;
+}
+
 // ----------------------------------------------------------------------------
 // wxLocaleIdent::GetName() implementation for MSW
 // ----------------------------------------------------------------------------

--- a/src/msw/uilocale.cpp
+++ b/src/msw/uilocale.cpp
@@ -113,6 +113,11 @@ WXDLLIMPEXP_BASE wxString wxGetMSWDateTimeFormat(wxLocaleInfo index)
 {
     wxString format;
     wxString localeName = wxUILocale::GetCurrent().GetName();
+    if (localeName.IsSameAs("C"))
+    {
+        localeName = "en-US";
+    }
+
     const wchar_t* name = localeName.wc_str();
     LCTYPE lctype = wxGetLCTYPEFormatFromLocalInfo(index);
     if (lctype != 0)


### PR DESCRIPTION
- Add helper function to retrieve native format specs from wxUILocale
- Add function declaration of the helper function in msw/private/uilocale.h
- Adjust code for date/time picker to set native format specification