### PR TITLE
Fix using wxStaticBoxSizer in samples

### DIFF
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -2421,16 +2421,17 @@ public:
 #endif
         wxSizer * const sizerTop = new wxBoxSizer(wxVERTICAL);
 
-        wxSizer* sizerText = new wxStaticBoxSizer(wxVERTICAL, this, "Notification Texts");
+        wxStaticBoxSizer* sizerText = new wxStaticBoxSizer(wxVERTICAL, this, "Notification Texts");
+        wxStaticBox* const sizerTextBox = sizerText->GetStaticBox();
 
-        sizerText->Add(new wxStaticText(this, wxID_ANY, "&Title:"),
+        sizerText->Add(new wxStaticText(sizerTextBox, wxID_ANY, "&Title:"),
             wxSizerFlags());
-        m_textTitle = new wxTextCtrl(this, wxID_ANY, "Notification Title");
+        m_textTitle = new wxTextCtrl(sizerTextBox, wxID_ANY, "Notification Title");
         sizerText->Add(m_textTitle, wxSizerFlags().Expand());
 
-        sizerText->Add(new wxStaticText(this, wxID_ANY, "&Message:"),
+        sizerText->Add(new wxStaticText(sizerTextBox, wxID_ANY, "&Message:"),
             wxSizerFlags());
-        m_textMessage = new wxTextCtrl(this, wxID_ANY, "A message within the notification",
+        m_textMessage = new wxTextCtrl(sizerTextBox, wxID_ANY, "A message within the notification",
             wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE);
         m_textMessage->SetMinSize(wxSize(300, -1));
         sizerText->Add(m_textMessage, wxSizerFlags().Expand());
@@ -2468,13 +2469,14 @@ public:
         m_showTimeout->SetSelection(0);
         sizerTop->Add(m_showTimeout, wxSizerFlags().Expand().Border());
 
-        wxSizer* sizerActions = new wxStaticBoxSizer(wxVERTICAL, this, "Additional Actions");
+        wxStaticBoxSizer* sizerActions = new wxStaticBoxSizer(wxVERTICAL, this, "Additional Actions");
+        wxStaticBox* const sizerActionsBox = sizerActions->GetStaticBox();
 
-        m_actionList = new wxListBox(this, wxID_ANY);
+        m_actionList = new wxListBox(sizerActionsBox, wxID_ANY);
         sizerActions->Add(m_actionList, wxSizerFlags().Expand());
 
         wxSizer* sizerActionMod = new wxBoxSizer(wxHORIZONTAL);
-        sizerActionMod->Add(new wxStaticText(this, wxID_ANY, "ID:"), wxSizerFlags().Center());
+        sizerActionMod->Add(new wxStaticText(sizerActionsBox, wxID_ANY, "ID:"), wxSizerFlags().Center());
         const wxString actionIds[] =
         {
             "wxID_DELETE",
@@ -2482,19 +2484,19 @@ public:
             "wxID_OK",
             "wxID_CANCEL"
         };
-        m_actionChoice = new wxChoice(this, wxID_ANY,
+        m_actionChoice = new wxChoice(sizerActionsBox, wxID_ANY,
             wxDefaultPosition, wxDefaultSize,
             WXSIZEOF(actionIds), actionIds
             );
         m_actionChoice->SetSelection(0);
         sizerActionMod->Add(m_actionChoice);
-        sizerActionMod->Add(new wxStaticText(this, wxID_ANY, "Custom label:"), wxSizerFlags().Center());
-        m_actionCaption = new wxTextCtrl(this, wxID_ANY);
+        sizerActionMod->Add(new wxStaticText(sizerActionsBox, wxID_ANY, "Custom label:"), wxSizerFlags().Center());
+        m_actionCaption = new wxTextCtrl(sizerActionsBox, wxID_ANY);
         sizerActionMod->Add(m_actionCaption);
-        wxButton* actionAddBtn = new wxButton(this, wxID_ADD);
+        wxButton* actionAddBtn = new wxButton(sizerActionsBox, wxID_ADD);
         actionAddBtn->Bind(wxEVT_BUTTON, &TestNotificationMessageWindow::OnActionAddClicked, this);
         sizerActionMod->Add(actionAddBtn);
-        wxButton* actionRemoveBtn = new wxButton(this, wxID_REMOVE);
+        wxButton* actionRemoveBtn = new wxButton(sizerActionsBox, wxID_REMOVE);
         actionRemoveBtn->Bind(wxEVT_BUTTON, &TestNotificationMessageWindow::OnActionRemoveClicked, this);
         sizerActionMod->Add(actionRemoveBtn);
 
@@ -2502,26 +2504,27 @@ public:
 
         sizerTop->Add(sizerActions, wxSizerFlags().Expand().Border());
 
-        wxSizer* sizerSettings = new wxStaticBoxSizer(wxVERTICAL, this, "Notification Settings");
+        wxStaticBoxSizer* sizerSettings = new wxStaticBoxSizer(wxVERTICAL, this, "Notification Settings");
+        wxStaticBox* const sizerSettingsBox = sizerSettings->GetStaticBox();
 
 #ifdef wxHAS_NATIVE_NOTIFICATION_MESSAGE
-        m_useGeneric = new wxCheckBox(this, wxID_ANY, "Use &generic notifications");
+        m_useGeneric = new wxCheckBox(sizerSettingsBox, wxID_ANY, "Use &generic notifications");
         sizerSettings->Add(m_useGeneric);
 #endif
 
-        m_delayShow = new wxCheckBox(this, wxID_ANY, "&Delay show");
+        m_delayShow = new wxCheckBox(sizerSettingsBox, wxID_ANY, "&Delay show");
 #if defined(__WXOSX__)
         m_delayShow->SetValue(true);
 #endif
         sizerSettings->Add(m_delayShow);
 
-        m_handleEvents = new wxCheckBox(this, wxID_ANY, "&Handle events");
+        m_handleEvents = new wxCheckBox(sizerSettingsBox, wxID_ANY, "&Handle events");
         m_handleEvents->SetValue(true);
         sizerSettings->Add(m_handleEvents);
 
 #if defined(__WXMSW__) && wxUSE_TASKBARICON
         m_taskbarIcon = nullptr;
-        m_useTaskbar = new wxCheckBox(this, wxID_ANY, "Use persistent &taskbar icon");
+        m_useTaskbar = new wxCheckBox(sizerSettingsBox, wxID_ANY, "Use persistent &taskbar icon");
         m_useTaskbar->SetValue(false);
         sizerSettings->Add(m_useTaskbar);
 #endif
@@ -3797,18 +3800,20 @@ StdButtonSizerDialog::StdButtonSizerDialog(wxWindow *parent)
     m_chkboxAffirmativeButton = new wxCheckBox(this, wxID_ANY, "Enable Affirmative Button");
 
     wxStaticBoxSizer *const sizer1 = new wxStaticBoxSizer(wxVERTICAL, this, "Affirmative Button");
+    wxStaticBox* const sizer1Box = sizer1->GetStaticBox();
 
-    m_radiobtnOk = new wxRadioButton(this, wxID_ANY, "Ok", wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
-    m_radiobtnYes = new wxRadioButton(this, wxID_ANY, "Yes");
+    m_radiobtnOk = new wxRadioButton(sizer1Box, wxID_ANY, "Ok", wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+    m_radiobtnYes = new wxRadioButton(sizer1Box, wxID_ANY, "Yes");
 
     wxBoxSizer *const sizerInside2 = new wxBoxSizer(wxVERTICAL);
 
     m_chkboxDismissButton = new wxCheckBox(this, wxID_ANY, "Enable Dismiss Button");
 
     wxStaticBoxSizer *const sizer2 = new wxStaticBoxSizer(wxVERTICAL, this, "Dismiss Button");
+    wxStaticBox* const sizer2Box = sizer2->GetStaticBox();
 
-    m_radiobtnCancel = new wxRadioButton(this, wxID_ANY, "Cancel", wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
-    m_radiobtnClose = new wxRadioButton(this, wxID_ANY, "Close");
+    m_radiobtnCancel = new wxRadioButton(sizer2Box, wxID_ANY, "Cancel", wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+    m_radiobtnClose = new wxRadioButton(sizer2Box, wxID_ANY, "Close");
 
     wxBoxSizer *const sizer3 = new wxBoxSizer(wxHORIZONTAL);
 
@@ -3824,7 +3829,7 @@ StdButtonSizerDialog::StdButtonSizerDialog(wxWindow *parent)
     sizer->Add(sizerInside1, 0, 0, 0);
     sizerInside1->Add(m_chkboxAffirmativeButton, 0, wxALL, 5);
     sizerInside1->Add(sizer1, 0, wxALL, 5);
-    sizerInside1->SetItemMinSize(sizer1, sizer1->GetStaticBox()->GetBestSize());    // to prevent wrapping of static box label
+    sizerInside1->SetItemMinSize(sizer1, sizer1Box->GetBestSize());    // to prevent wrapping of static box label
 
     sizer2->Add(m_radiobtnCancel, 0, wxALL, 5);
     sizer2->Add(m_radiobtnClose, 0, wxALL, 5);
@@ -3832,7 +3837,7 @@ StdButtonSizerDialog::StdButtonSizerDialog(wxWindow *parent)
     sizer->Add(sizerInside2, 0, 0, 0);
     sizerInside2->Add(m_chkboxDismissButton, 0, wxALL, 5);
     sizerInside2->Add(sizer2, 0, wxALL, 5);
-    sizerInside2->SetItemMinSize(sizer2, sizer2->GetStaticBox()->GetBestSize());    // to prevent wrapping of static box label
+    sizerInside2->SetItemMinSize(sizer2, sizer2Box->GetBestSize());    // to prevent wrapping of static box label
 
     sizerTop->Add(sizer, 0, wxALL, 5);
 
@@ -4081,17 +4086,17 @@ wxPanel* SettingsDialog::CreateAestheticSettingsPage(wxWindow* parent)
     wxArrayString backgroundStyleChoices;
     backgroundStyleChoices.Add("Colour");
     backgroundStyleChoices.Add("Image");
-    wxStaticBox* staticBox3 = new wxStaticBox(panel, wxID_ANY, "Background style:");
 
-    wxBoxSizer* styleSizer = new wxStaticBoxSizer( staticBox3, wxVERTICAL );
+    wxStaticBoxSizer* styleSizer = new wxStaticBoxSizer(wxVERTICAL, panel, "Background style:");
+    wxStaticBox* const styleSizerBox = styleSizer->GetStaticBox();
     item0->Add(styleSizer, 0, wxGROW|wxALL, 5);
 
     wxBoxSizer* itemSizer2 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxChoice* choice2 = new wxChoice(panel, ID_BACKGROUND_STYLE, wxDefaultPosition, wxDefaultSize, backgroundStyleChoices);
+    wxChoice* choice2 = new wxChoice(styleSizerBox, ID_BACKGROUND_STYLE, wxDefaultPosition, wxDefaultSize, backgroundStyleChoices);
     choice2->SetValidator(wxGenericValidator(&m_settingsData.m_bgStyle));
 
-    itemSizer2->Add(new wxStaticText(panel, wxID_ANY, "&Window:"), 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+    itemSizer2->Add(new wxStaticText(styleSizerBox, wxID_ANY, "&Window:"), 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
     itemSizer2->Add(5, 5, 1, wxALL, 0);
     itemSizer2->Add(choice2, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
 
@@ -4100,10 +4105,9 @@ wxPanel* SettingsDialog::CreateAestheticSettingsPage(wxWindow* parent)
 #if wxUSE_SPINCTRL
     //// FONT SIZE SELECTION
 
-    wxStaticBox* staticBox1 = new wxStaticBox(panel, wxID_ANY, "Tile font size:");
-    wxBoxSizer* itemSizer5 = new wxStaticBoxSizer( staticBox1, wxHORIZONTAL );
+    wxStaticBoxSizer* itemSizer5 = new wxStaticBoxSizer(wxHORIZONTAL, panel, "Tile font size:");
 
-    wxSpinCtrl* spinCtrl = new wxSpinCtrl(panel, ID_FONT_SIZE, wxEmptyString);
+    wxSpinCtrl* spinCtrl = new wxSpinCtrl(itemSizer5->GetStaticBox(), ID_FONT_SIZE, wxEmptyString);
     spinCtrl->SetValidator(wxGenericValidator(&m_settingsData.m_titleFontSize));
     itemSizer5->Add(spinCtrl, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 
@@ -4152,20 +4156,22 @@ bool TestMessageBoxDialog::Create()
     wxSizer * const sizerTop = new wxBoxSizer(wxVERTICAL);
 
     // this sizer allows to configure the messages shown in the message box
-    wxSizer * const
+    wxStaticBoxSizer * const
         sizerMsgs = new wxStaticBoxSizer(wxVERTICAL, this, "&Messages");
-    sizerMsgs->Add(new wxStaticText(this, wxID_ANY, "&Title:"));
-    m_textTitle = new wxTextCtrl(this, wxID_ANY, "Test Message Box");
+    wxStaticBox* const sizerMsgsBox = sizerMsgs->GetStaticBox();
+
+    sizerMsgs->Add(new wxStaticText(sizerMsgsBox, wxID_ANY, "&Title:"));
+    m_textTitle = new wxTextCtrl(sizerMsgsBox, wxID_ANY, "Test Message Box");
     sizerMsgs->Add(m_textTitle, wxSizerFlags().Expand().Border(wxBOTTOM));
 
-    sizerMsgs->Add(new wxStaticText(this, wxID_ANY, "&Main message:"));
-    m_textMsg = new wxTextCtrl(this, wxID_ANY, "Hello from a box!",
+    sizerMsgs->Add(new wxStaticText(sizerMsgsBox, wxID_ANY, "&Main message:"));
+    m_textMsg = new wxTextCtrl(sizerMsgsBox, wxID_ANY, "Hello from a box!",
                                wxDefaultPosition, wxDefaultSize,
                                wxTE_MULTILINE);
     sizerMsgs->Add(m_textMsg, wxSizerFlags(1).Expand().Border(wxBOTTOM));
 
-    sizerMsgs->Add(new wxStaticText(this, wxID_ANY, "&Extended message:"));
-    m_textExtMsg = new wxTextCtrl(this, wxID_ANY, "",
+    sizerMsgs->Add(new wxStaticText(sizerMsgsBox, wxID_ANY, "&Extended message:"));
+    m_textExtMsg = new wxTextCtrl(sizerMsgsBox, wxID_ANY, "",
                                   wxDefaultPosition, wxDefaultSize,
                                   wxTE_MULTILINE);
     sizerMsgs->Add(m_textExtMsg, wxSizerFlags().Expand());
@@ -4176,29 +4182,30 @@ bool TestMessageBoxDialog::Create()
     AddAdditionalTextOptions(sizerTop);
 
     // this one is for configuring the buttons
-    wxSizer * const
-    sizerBtnsBox = new wxStaticBoxSizer(wxVERTICAL, this, "&Buttons");
+    wxStaticBoxSizer * const
+    sizerBtns = new wxStaticBoxSizer(wxVERTICAL, this, "&Buttons");
+    wxStaticBox* const sizerBtnsBox = sizerBtns->GetStaticBox();
 
-    wxFlexGridSizer * const sizerBtns = new wxFlexGridSizer(2, 5, 5);
-    sizerBtns->AddGrowableCol(1);
+    wxFlexGridSizer * const sizerBtnDetails = new wxFlexGridSizer(2, 5, 5);
+    sizerBtnDetails->AddGrowableCol(1);
 
-    sizerBtns->Add(new wxStaticText(this, wxID_ANY, "Button(s)"));
-    sizerBtns->Add(new wxStaticText(this, wxID_ANY, "Custom label"));
+    sizerBtnDetails->Add(new wxStaticText(sizerBtnsBox, wxID_ANY, "Button(s)"));
+    sizerBtnDetails->Add(new wxStaticText(sizerBtnsBox, wxID_ANY, "Custom label"));
 
     for ( int n = 0; n < Btn_Max; n++ )
     {
-        m_buttons[n] = new wxCheckBox(this, wxID_ANY, ms_btnInfo[n].name);
-        sizerBtns->Add(m_buttons[n], wxSizerFlags().Centre().Left());
+        m_buttons[n] = new wxCheckBox(sizerBtnsBox, wxID_ANY, ms_btnInfo[n].name);
+        sizerBtnDetails->Add(m_buttons[n], wxSizerFlags().Centre().Left());
 
-        m_labels[n] = new wxTextCtrl(this, wxID_ANY);
-        sizerBtns->Add(m_labels[n], wxSizerFlags().Expand());
+        m_labels[n] = new wxTextCtrl(sizerBtnsBox, wxID_ANY);
+        sizerBtnDetails->Add(m_labels[n], wxSizerFlags().Expand());
 
         m_labels[n]->Bind(wxEVT_UPDATE_UI,
                           &TestMessageBoxDialog::OnUpdateLabelUI, this);
     }
 
-    sizerBtnsBox->Add(sizerBtns, wxSizerFlags().Expand());
-    sizerTop->Add(sizerBtnsBox, wxSizerFlags().Expand().Border());
+    sizerBtns->Add(sizerBtnDetails, wxSizerFlags().Expand());
+    sizerTop->Add(sizerBtns, wxSizerFlags().Expand().Border());
 
 
     // icon choice
@@ -4225,15 +4232,16 @@ bool TestMessageBoxDialog::Create()
 
 
     // miscellaneous other stuff
-    wxSizer * const
+    wxStaticBoxSizer * const
         sizerFlags = new wxStaticBoxSizer(wxHORIZONTAL, this, "&Other flags");
+    wxStaticBox* const sizerFlagsBox = sizerFlags->GetStaticBox();
 
-    m_chkNoDefault = new wxCheckBox(this, wxID_ANY, "Make \"No\" &default");
+    m_chkNoDefault = new wxCheckBox(sizerFlagsBox, wxID_ANY, "Make \"No\" &default");
     m_chkNoDefault->Bind(wxEVT_UPDATE_UI,
                          &TestMessageBoxDialog::OnUpdateNoDefaultUI, this);
     sizerFlags->Add(m_chkNoDefault, wxSizerFlags().Border());
 
-    m_chkCentre = new wxCheckBox(this, wxID_ANY, "Centre on &parent");
+    m_chkCentre = new wxCheckBox(sizerFlagsBox, wxID_ANY, "Centre on &parent");
     sizerFlags->Add(m_chkCentre, wxSizerFlags().Border());
 
     // add any additional flag from subclasses
@@ -4438,29 +4446,30 @@ TestRichMessageDialog::TestRichMessageDialog(wxWindow *parent)
 
 void TestRichMessageDialog::AddAdditionalTextOptions(wxSizer *sizer)
 {
-    wxSizer * const sizerMsgs = new wxStaticBoxSizer(wxVERTICAL, this,
+    wxStaticBoxSizer * const sizerMsgs = new wxStaticBoxSizer(wxVERTICAL, this,
                                                      "&Additional Elements");
+    wxStaticBox* const sizerMsgsBox = sizerMsgs->GetStaticBox();
 
     // add an option to show a check box.
     wxSizer * const sizerCheckBox = new wxBoxSizer(wxHORIZONTAL);
-    sizerCheckBox->Add(new wxStaticText(this, wxID_ANY, "&Check box:"),
+    sizerCheckBox->Add(new wxStaticText(sizerMsgsBox, wxID_ANY, "&Check box:"),
                        wxSizerFlags().Centre().Border(wxRIGHT));
-    m_textCheckBox = new wxTextCtrl(this, wxID_ANY);
+    m_textCheckBox = new wxTextCtrl(sizerMsgsBox, wxID_ANY);
     sizerCheckBox->Add(m_textCheckBox, wxSizerFlags(1).Centre());
     sizerMsgs->Add(sizerCheckBox, wxSizerFlags().Expand().Border(wxBOTTOM));
 
     // add option to show a detailed text.
-    sizerMsgs->Add(new wxStaticText(this, wxID_ANY, "&Detailed message:"));
-    m_textDetailed = new wxTextCtrl(this, wxID_ANY, "",
+    sizerMsgs->Add(new wxStaticText(sizerMsgsBox, wxID_ANY, "&Detailed message:"));
+    m_textDetailed = new wxTextCtrl(sizerMsgsBox, wxID_ANY, "",
                                     wxDefaultPosition, wxDefaultSize,
                                     wxTE_MULTILINE);
     sizerMsgs->Add(m_textDetailed, wxSizerFlags().Expand());
 
     // add option to show footer text
     wxSizer * const sizerFooter = new wxBoxSizer(wxHORIZONTAL);
-    sizerFooter->Add(new wxStaticText(this, wxID_ANY, "&Footer Text:"),
+    sizerFooter->Add(new wxStaticText(sizerMsgsBox, wxID_ANY, "&Footer Text:"),
         wxSizerFlags().Centre().Border(wxRIGHT));
-    m_textFooter = new wxTextCtrl(this, wxID_ANY);
+    m_textFooter = new wxTextCtrl(sizerMsgsBox, wxID_ANY);
     sizerFooter->Add(m_textFooter, wxSizerFlags(1).Centre());
 
     // add option to select footer icon
@@ -4473,9 +4482,9 @@ void TestRichMessageDialog::AddAdditionalTextOptions(wxSizer *sizer)
         "Auth needed"
     };
 
-    sizerFooter->Add(new wxStaticText(this, wxID_ANY, "Icon:"),
+    sizerFooter->Add(new wxStaticText(sizerMsgsBox, wxID_ANY, "Icon:"),
         wxSizerFlags().Centre().Border(wxLEFT));
-    m_iconsFooter = new wxChoice(this, wxID_ANY,
+    m_iconsFooter = new wxChoice(sizerMsgsBox, wxID_ANY,
         wxDefaultPosition, wxDefaultSize,
         WXSIZEOF(icons), icons);
     // Make the None the default:
@@ -4487,12 +4496,12 @@ void TestRichMessageDialog::AddAdditionalTextOptions(wxSizer *sizer)
     sizer->Add(sizerMsgs, wxSizerFlags().Expand().Border());
 }
 
-void TestRichMessageDialog::AddAdditionalFlags(wxSizer *sizer)
+void TestRichMessageDialog::AddAdditionalFlags(wxStaticBoxSizer *sizer)
 {
     // add checkbox to set the initial state for the checkbox shown
     // in the dialog.
     m_initialValueCheckBox =
-        new wxCheckBox(this, wxID_ANY, "Checkbox initially checked");
+        new wxCheckBox(sizer->GetStaticBox(), wxID_ANY, "Checkbox initially checked");
     sizer->Add(m_initialValueCheckBox, wxSizerFlags().Border());
 }
 

--- a/samples/dialogs/dialogs.h
+++ b/samples/dialogs/dialogs.h
@@ -201,7 +201,7 @@ protected:
     void PrepareMessageDialog(wxMessageDialogBase &dlg);
 
     virtual void AddAdditionalTextOptions(wxSizer *WXUNUSED(sizer)) { }
-    virtual void AddAdditionalFlags(wxSizer *WXUNUSED(sizer)) { }
+    virtual void AddAdditionalFlags(wxStaticBoxSizer *WXUNUSED(sizer)) { }
 
     void ShowResult(int res);
 
@@ -268,7 +268,7 @@ public:
 protected:
     // overrides method in base class
     virtual void AddAdditionalTextOptions(wxSizer *sizer) override;
-    virtual void AddAdditionalFlags(wxSizer *sizer) override;
+    virtual void AddAdditionalFlags(wxStaticBoxSizer *sizer) override;
 
     void OnApply(wxCommandEvent& event);
 

--- a/samples/widgets/activityindicator.cpp
+++ b/samples/widgets/activityindicator.cpp
@@ -26,6 +26,7 @@
 #ifndef WX_PRECOMP
     #include "wx/button.h"
     #include "wx/sizer.h"
+    #include "wx/statbox.h"
     #include "wx/stattext.h"
 #endif
 
@@ -80,7 +81,7 @@ protected:
 
     // the indicator itself and the sizer it is in
     wxActivityIndicator *m_indicator;
-    wxSizer *m_sizerIndicator;
+    wxStaticBoxSizer *m_sizerIndicator;
 
 private:
     wxDECLARE_EVENT_TABLE();
@@ -110,15 +111,16 @@ IMPLEMENT_WIDGETS_PAGE(ActivityIndicatorWidgetsPage,
 
 void ActivityIndicatorWidgetsPage::CreateContent()
 {
-    wxSizer* const sizerOper = new wxStaticBoxSizer(wxVERTICAL, this,
+    wxStaticBoxSizer* const sizerOper = new wxStaticBoxSizer(wxVERTICAL, this,
                                                     "&Operations");
+    wxStaticBox* const sizerOperBox = sizerOper->GetStaticBox();
 
-    sizerOper->Add(new wxButton(this, ActivityIndicator_Start, "&Start"),
+    sizerOper->Add(new wxButton(sizerOperBox, ActivityIndicator_Start, "&Start"),
                    wxSizerFlags().Expand().Border());
-    sizerOper->Add(new wxButton(this, ActivityIndicator_Stop, "&Stop"),
+    sizerOper->Add(new wxButton(sizerOperBox, ActivityIndicator_Stop, "&Stop"),
                    wxSizerFlags().Expand().Border());
 
-    sizerOper->Add(new wxStaticText(this, ActivityIndicator_IsRunning,
+    sizerOper->Add(new wxStaticText(sizerOperBox, ActivityIndicator_IsRunning,
                                     "Indicator is initializing..."),
                    wxSizerFlags().Expand().Border());
 
@@ -139,7 +141,7 @@ void ActivityIndicatorWidgetsPage::RecreateWidget()
 {
     m_sizerIndicator->Clear(true /* delete windows */);
 
-    m_indicator = new wxActivityIndicator(this, wxID_ANY,
+    m_indicator = new wxActivityIndicator(m_sizerIndicator->GetStaticBox(), wxID_ANY,
                                           wxDefaultPosition, wxDefaultSize,
                                           GetAttrs().m_defaultFlags);
 

--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -155,7 +155,8 @@ protected:
 
     wxSizer *CreateSizerWithSmallTextAndLabel(const wxString& label,
                                               wxWindowID id,
-                                              wxTextCtrl **ppText);
+                                              wxTextCtrl **ppText,
+                                              wxWindow* parent = nullptr);
 
 #if wxUSE_IMAGE
     void RescaleImage(wxImage& image, int w, int h);
@@ -266,11 +267,12 @@ BitmapComboBoxWidgetsPage::BitmapComboBoxWidgetsPage(WidgetsBookCtrl *book,
 // create a sizer containing a label and a small text ctrl
 wxSizer *BitmapComboBoxWidgetsPage::CreateSizerWithSmallTextAndLabel(const wxString& label,
                                                                     wxWindowID id,
-                                                                    wxTextCtrl **ppText)
+                                                                    wxTextCtrl **ppText,
+                                                                    wxWindow* parent)
 {
-    wxControl* control = new wxStaticText(this, wxID_ANY, label);
+    wxControl* control = new wxStaticText(parent ? parent : this, wxID_ANY, label);
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    wxTextCtrl *text = new wxTextCtrl(this, id, wxEmptyString,
+    wxTextCtrl *text = new wxTextCtrl(parent ? parent : this, id, wxEmptyString,
         wxDefaultPosition, wxSize(50,wxDefaultCoord), wxTE_PROCESS_ENTER);
 
     sizerRow->Add(control, 0, wxRIGHT | wxALIGN_CENTRE_VERTICAL, 5);
@@ -296,8 +298,9 @@ void BitmapComboBoxWidgetsPage::CreateContent()
 
     wxSizer *sizerLeft = new wxBoxSizer(wxVERTICAL);
 
-    // left pane - style box
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
+    // left pane - style
+    wxStaticBoxSizer *sizerStyle = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerStyleBox = sizerStyle->GetStaticBox();
 
 
     // should be in sync with ComboKind_XXX values
@@ -313,69 +316,66 @@ void BitmapComboBoxWidgetsPage::CreateContent()
                                  WXSIZEOF(kinds), kinds,
                                  1, wxRA_SPECIFY_COLS);
 
-    wxSizer *sizerStyle = new wxStaticBoxSizer(box, wxVERTICAL);
+    m_chkSort = CreateCheckBoxAndAddToSizer(sizerStyle, "&Sort items", wxID_ANY, sizerStyleBox);
+    m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerStyle, "Process &Enter",wxID_ANY, sizerStyleBox);
+    m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerStyle, "&Read only", wxID_ANY, sizerStyleBox);
 
-    m_chkSort = CreateCheckBoxAndAddToSizer(sizerStyle, "&Sort items");
-    m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerStyle, "Process &Enter");
-    m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerStyle, "&Read only");
-
-    wxButton *btn = new wxButton(this, BitmapComboBoxPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerStyleBox, BitmapComboBoxPage_Reset, "&Reset");
     sizerStyle->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 3);
 
     sizerLeft->Add(sizerStyle, wxSizerFlags().Expand());
     sizerLeft->Add(m_radioKind, 0, wxGROW | wxALL, 5);
 
-    // left pane - other options box
-    box = new wxStaticBox(this, wxID_ANY, "Demo options");
-
-    wxSizer *sizerOptions = new wxStaticBoxSizer(box, wxVERTICAL);
+    // left pane - other options
+    wxStaticBoxSizer *sizerOptions = new wxStaticBoxSizer(wxVERTICAL, this, "Demo options");
 
     sizerRow = CreateSizerWithSmallTextAndLabel("Control &height:",
                                                 BitmapComboBoxPage_ChangeHeight,
-                                                &m_textChangeHeight);
+                                                &m_textChangeHeight,
+                                                sizerOptions->GetStaticBox());
     m_textChangeHeight->SetSize(20, wxDefaultCoord);
     sizerOptions->Add(sizerRow, 0, wxALL | wxFIXED_MINSIZE /*| wxGROW*/, 5);
 
     sizerLeft->Add( sizerOptions, wxSizerFlags().Expand().Border(wxTOP, 2));
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY,
-        "&Change wxBitmapComboBox contents");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change wxBitmapComboBox contents");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
-    btn = new wxButton(this, BitmapComboBoxPage_ContainerTests, "Run &tests");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_ContainerTests, "Run &tests");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
 #if wxUSE_IMAGE
-    btn = new wxButton(this, BitmapComboBoxPage_AddWidgetIcons, "Add &widget icons");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_AddWidgetIcons, "Add &widget icons");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, BitmapComboBoxPage_LoadFromFile, "Insert image from &file");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_LoadFromFile, "Insert image from &file");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, BitmapComboBoxPage_SetFromFile, "&Set image from file");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_SetFromFile, "&Set image from file");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 #endif
 
-    btn = new wxButton(this, BitmapComboBoxPage_AddSeveralWithImages, "A&ppend a few strings with images");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_AddSeveralWithImages, "A&ppend a few strings with images");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, BitmapComboBoxPage_AddSeveral, "Append a &few strings");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_AddSeveral, "Append a &few strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, BitmapComboBoxPage_AddMany, "Append &many strings");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_AddMany, "Append &many strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(BitmapComboBoxPage_Delete,
                                             "&Delete this item",
                                             BitmapComboBoxPage_DeleteText,
-                                            &m_textDelete);
+                                            &m_textDelete,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, BitmapComboBoxPage_DeleteSel, "Delete &selection");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_DeleteSel, "Delete &selection");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, BitmapComboBoxPage_Clear, "&Clear");
+    btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_Clear, "&Clear");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
 #if wxUSE_IMAGE

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -249,41 +249,42 @@ void ButtonWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
-
-    m_chkBitmapOnly = CreateCheckBoxAndAddToSizer(sizerLeft, "&Bitmap only");
-    m_chkTextAndBitmap = CreateCheckBoxAndAddToSizer(sizerLeft, "Text &and bitmap");
-    m_chkFit = CreateCheckBoxAndAddToSizer(sizerLeft, "&Fit exactly");
-    m_chkAuthNeeded = CreateCheckBoxAndAddToSizer(sizerLeft, "Require a&uth");
+    m_chkBitmapOnly = CreateCheckBoxAndAddToSizer(sizerLeft, "&Bitmap only", wxID_ANY, sizerLeftBox);
+    m_chkTextAndBitmap = CreateCheckBoxAndAddToSizer(sizerLeft, "Text &and bitmap", wxID_ANY, sizerLeftBox);
+    m_chkFit = CreateCheckBoxAndAddToSizer(sizerLeft, "&Fit exactly", wxID_ANY, sizerLeftBox);
+    m_chkAuthNeeded = CreateCheckBoxAndAddToSizer(sizerLeft, "Require a&uth", wxID_ANY, sizerLeftBox);
 #if wxUSE_COMMANDLINKBUTTON
-    m_chkCommandLink = CreateCheckBoxAndAddToSizer(sizerLeft, "Use command &link button");
+    m_chkCommandLink = CreateCheckBoxAndAddToSizer(sizerLeft, "Use command &link button", wxID_ANY, sizerLeftBox);
 #endif
 #if wxUSE_MARKUP
-    m_chkUseMarkup = CreateCheckBoxAndAddToSizer(sizerLeft, "Interpret &markup");
+    m_chkUseMarkup = CreateCheckBoxAndAddToSizer(sizerLeft, "Interpret &markup", wxID_ANY, sizerLeftBox);
 #endif // wxUSE_MARKUP
-    m_chkDefault = CreateCheckBoxAndAddToSizer(sizerLeft, "&Default");
+    m_chkDefault = CreateCheckBoxAndAddToSizer(sizerLeft, "&Default", wxID_ANY, sizerLeftBox);
 
     m_chkUseBitmapClass = CreateCheckBoxAndAddToSizer(sizerLeft,
-        "Use wxBitmapButton");
+        "Use wxBitmapButton", wxID_ANY, sizerLeftBox);
     m_chkUseBitmapClass->SetValue(true);
 
-    m_chkDisable = CreateCheckBoxAndAddToSizer(sizerLeft, "Disable");
+    m_chkDisable = CreateCheckBoxAndAddToSizer(sizerLeft, "Disable", wxID_ANY, sizerLeftBox);
 
     sizerLeft->AddSpacer(5);
 
-    wxSizer *sizerUseLabels =
-        new wxStaticBoxSizer(wxVERTICAL, this,
+    wxStaticBoxSizer *sizerUseLabels =
+        new wxStaticBoxSizer(wxVERTICAL, sizerLeftBox,
                 "&Use the following bitmaps in addition to the normal one?");
+    wxStaticBox* const sizerUseLabelsBox = sizerUseLabels->GetStaticBox();
+
     m_chkUsePressed = CreateCheckBoxAndAddToSizer(sizerUseLabels,
-        "&Pressed (small help icon)");
+        "&Pressed (small help icon)", wxID_ANY, sizerUseLabelsBox);
     m_chkUseFocused = CreateCheckBoxAndAddToSizer(sizerUseLabels,
-        "&Focused (small error icon)");
+        "&Focused (small error icon)", wxID_ANY, sizerUseLabelsBox);
     m_chkUseCurrent = CreateCheckBoxAndAddToSizer(sizerUseLabels,
-        "&Current (small warning icon)");
+        "&Current (small warning icon)", wxID_ANY, sizerUseLabelsBox);
     m_chkUseDisabled = CreateCheckBoxAndAddToSizer(sizerUseLabels,
-        "&Disabled (broken image icon)");
+        "&Disabled (broken image icon)", wxID_ANY, sizerUseLabelsBox);
     sizerLeft->Add(sizerUseLabels, wxSizerFlags().Expand().Border());
 
     sizerLeft->AddSpacer(10);
@@ -292,26 +293,28 @@ void ButtonWidgetsPage::CreateContent()
     {
         "left", "right", "top", "bottom",
     };
-    m_radioImagePos = new wxRadioBox(this, wxID_ANY, "Image &position",
+    m_radioImagePos = new wxRadioBox(sizerLeftBox, wxID_ANY, "Image &position",
                                      wxDefaultPosition, wxDefaultSize,
                                      WXSIZEOF(dirs), dirs);
     sizerLeft->Add(m_radioImagePos, wxSizerFlags().Expand().Border());
 
+    wxStaticBoxSizer* sizerImageMargins = new wxStaticBoxSizer(wxVERTICAL, sizerLeftBox, "Image margins");
+    wxStaticBox* const sizerImageMarginsBox = sizerImageMargins->GetStaticBox();
     wxSizer* sizerImageMarginsRow = CreateSizerWithTextAndButton(ButtonPage_ChangeImageMargins,
-                                           "Horizontal and vertical", wxID_ANY, &m_textImageMarginH);
+                                           "Horizontal and vertical", wxID_ANY, &m_textImageMarginH,
+                                            sizerImageMarginsBox);
     wxIntegerValidator<int> validatorMargH;
     validatorMargH.SetRange(0, 100);
     m_textImageMarginH->SetValidator(validatorMargH);
 
     wxIntegerValidator<int> validatorMargV;
     validatorMargV.SetRange(0, 100);
-    m_textImageMarginV = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, validatorMargV);
+    m_textImageMarginV = new wxTextCtrl(sizerImageMarginsBox, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, validatorMargV);
     sizerImageMarginsRow->Add(m_textImageMarginV, wxSizerFlags(1).CentreVertical().Border(wxLEFT));
 
     m_textImageMarginH->SetValue(wxString::Format("%d", m_imageMarginH));
     m_textImageMarginV->SetValue(wxString::Format("%d", m_imageMarginV));
 
-    wxSizer* sizerImageMargins = new wxStaticBoxSizer(wxVERTICAL, this, "Image margins");
     sizerImageMargins->Add(sizerImageMarginsRow, wxSizerFlags().Border().Centre());
     sizerLeft->Add(sizerImageMargins, wxSizerFlags().Expand().Border());
 
@@ -332,10 +335,10 @@ void ButtonWidgetsPage::CreateContent()
         "bottom",
     };
 
-    m_radioHAlign = new wxRadioBox(this, wxID_ANY, "&Horz alignment",
+    m_radioHAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Horz alignment",
                                    wxDefaultPosition, wxDefaultSize,
                                    WXSIZEOF(halign), halign);
-    m_radioVAlign = new wxRadioBox(this, wxID_ANY, "&Vert alignment",
+    m_radioVAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Vert alignment",
                                    wxDefaultPosition, wxDefaultSize,
                                    WXSIZEOF(valign), valign);
 
@@ -344,17 +347,18 @@ void ButtonWidgetsPage::CreateContent()
 
     sizerLeft->AddSpacer(5);
 
-    wxButton *btn = new wxButton(this, ButtonPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, ButtonPage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder(wxALL));
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY, "&Operations");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Operations");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxSizer *sizerRow = CreateSizerWithTextAndButton(ButtonPage_ChangeLabel,
                                                      "Change label",
                                                      wxID_ANY,
-                                                     &m_textLabel);
+                                                     &m_textLabel,
+                                                     sizerMiddleBox);
     m_textLabel->SetValue("&Press me!");
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
@@ -362,7 +366,8 @@ void ButtonWidgetsPage::CreateContent()
     m_sizerNote = CreateSizerWithTextAndButton(ButtonPage_ChangeNote,
                                                "Change note",
                                                wxID_ANY,
-                                               &m_textNote);
+                                               &m_textNote,
+                                               sizerMiddleBox);
     m_textNote->SetValue("Writes down button clicks in the log.");
 
     sizerMiddle->Add(m_sizerNote, wxSizerFlags().Expand().Border());

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -165,15 +165,15 @@ void CheckBoxWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
-
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     m_chkRight = CreateCheckBoxAndAddToSizer
                  (
                     sizerLeft,
                     "&Right aligned",
-                    CheckboxPage_ChkRight
+                    CheckboxPage_ChkRight,
+                    sizerLeftBox
                  );
 
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
@@ -185,28 +185,29 @@ void CheckBoxWidgetsPage::CreateContent()
         "&user-settable 3rd state",
     };
 
-    m_radioKind = new wxRadioBox(this, wxID_ANY, "&Kind",
+    m_radioKind = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Kind",
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(kinds), kinds,
                                  1);
     sizerLeft->Add(m_radioKind, 0, wxGROW | wxALL, 5);
-    wxButton *btn = new wxButton(this, CheckboxPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, CheckboxPage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY, "&Operations");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Operations");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     sizerMiddle->Add(CreateSizerWithTextAndButton(CheckboxPage_ChangeLabel,
                                                      "Change label",
                                                      wxID_ANY,
-                                                     &m_textLabel),
+                                                     &m_textLabel,
+                                                     sizerMiddleBox),
                      0, wxALL | wxGROW, 5);
-    sizerMiddle->Add(new wxButton(this, CheckboxPage_Check, "&Check it"),
+    sizerMiddle->Add(new wxButton(sizerMiddleBox, CheckboxPage_Check, "&Check it"),
                      0, wxALL | wxGROW, 5);
-    sizerMiddle->Add(new wxButton(this, CheckboxPage_Uncheck, "&Uncheck it"),
+    sizerMiddle->Add(new wxButton(sizerMiddleBox, CheckboxPage_Uncheck, "&Uncheck it"),
                      0, wxALL | wxGROW, 5);
-    sizerMiddle->Add(new wxButton(this, CheckboxPage_PartCheck,
+    sizerMiddle->Add(new wxButton(sizerMiddleBox, CheckboxPage_PartCheck,
                                   "Put in &3rd state"),
                      0, wxALL | wxGROW, 5);
 

--- a/samples/widgets/choice.cpp
+++ b/samples/widgets/choice.cpp
@@ -203,54 +203,52 @@ void ChoiceWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY,
-        "&Set choice parameters");
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set choice parameters");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
-    m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeft, "&Sort items");
+    m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeft, "&Sort items", wxID_ANY, sizerLeftBox);
 
-    wxButton *btn = new wxButton(this, ChoicePage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, ChoicePage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY,
-        "&Change choice contents");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change choice contents");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    btn = new wxButton(this, ChoicePage_Add, "&Add this string");
-    m_textAdd = new wxTextCtrl(this, ChoicePage_AddText, "test item 0");
+    btn = new wxButton(sizerMiddleBox, ChoicePage_Add, "&Add this string");
+    m_textAdd = new wxTextCtrl(sizerMiddleBox, ChoicePage_AddText, "test item 0");
     sizerRow->Add(btn, 0, wxRIGHT, 5);
     sizerRow->Add(m_textAdd, 1, wxLEFT, 5);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ChoicePage_AddSeveral, "&Insert a few strings");
+    btn = new wxButton(sizerMiddleBox, ChoicePage_AddSeveral, "&Insert a few strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ChoicePage_AddMany, "Add &many strings");
+    btn = new wxButton(sizerMiddleBox, ChoicePage_AddMany, "Add &many strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    btn = new wxButton(this, ChoicePage_Change, "C&hange current");
-    m_textChange = new wxTextCtrl(this, ChoicePage_ChangeText, wxEmptyString);
+    btn = new wxButton(sizerMiddleBox, ChoicePage_Change, "C&hange current");
+    m_textChange = new wxTextCtrl(sizerMiddleBox, ChoicePage_ChangeText, wxEmptyString);
     sizerRow->Add(btn, 0, wxRIGHT, 5);
     sizerRow->Add(m_textChange, 1, wxLEFT, 5);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    btn = new wxButton(this, ChoicePage_Delete, "&Delete this item");
-    m_textDelete = new wxTextCtrl(this, ChoicePage_DeleteText, wxEmptyString);
+    btn = new wxButton(sizerMiddleBox, ChoicePage_Delete, "&Delete this item");
+    m_textDelete = new wxTextCtrl(sizerMiddleBox, ChoicePage_DeleteText, wxEmptyString);
     sizerRow->Add(btn, 0, wxRIGHT, 5);
     sizerRow->Add(m_textDelete, 1, wxLEFT, 5);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ChoicePage_DeleteSel, "Delete &selection");
+    btn = new wxButton(sizerMiddleBox, ChoicePage_DeleteSel, "Delete &selection");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ChoicePage_Clear, "&Clear");
+    btn = new wxButton(sizerMiddleBox, ChoicePage_Clear, "&Clear");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ChoicePage_ContainerTests, "Run &tests");
+    btn = new wxButton(sizerMiddleBox, ChoicePage_ContainerTests, "Run &tests");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     // right pane

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -27,6 +27,7 @@
     #include "wx/app.h"
     #include "wx/log.h"
     #include "wx/radiobox.h"
+    #include "wx/statbox.h"
 #endif
 
 #include "wx/artprov.h"
@@ -141,11 +142,13 @@ void ColourPickerWidgetsPage::CreateContent()
     // left pane
     wxSizer *boxleft = new wxBoxSizer(wxVERTICAL);
 
-    wxStaticBoxSizer *clrbox = new wxStaticBoxSizer(wxVERTICAL, this, "&ColourPicker style");
-    m_chkColourTextCtrl = CreateCheckBoxAndAddToSizer(clrbox, "With textctrl");
-    m_chkColourShowLabel = CreateCheckBoxAndAddToSizer(clrbox, "With label");
-    m_chkColourShowAlpha = CreateCheckBoxAndAddToSizer(clrbox, "With opacity");
-    boxleft->Add(clrbox, 0, wxALL|wxGROW, 5);
+    wxStaticBoxSizer *styleSizer = new wxStaticBoxSizer(wxVERTICAL, this, "&ColourPicker style");
+    wxStaticBox* const styleSizerBox = styleSizer->GetStaticBox();
+
+    m_chkColourTextCtrl = CreateCheckBoxAndAddToSizer(styleSizer, "With textctrl", wxID_ANY, styleSizerBox);
+    m_chkColourShowLabel = CreateCheckBoxAndAddToSizer(styleSizer, "With label", wxID_ANY, styleSizerBox);
+    m_chkColourShowAlpha = CreateCheckBoxAndAddToSizer(styleSizer, "With opacity", wxID_ANY, styleSizerBox);
+    boxleft->Add(styleSizer, 0, wxALL|wxGROW, 5);
 
     boxleft->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
                  0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -268,28 +268,31 @@ void ComboboxWidgetsPage::CreateContent()
         "drop down",
     };
 
-    m_radioKind = new wxRadioBox(this, wxID_ANY, "Combobox &kind:",
+    wxStaticBoxSizer *sizerLeftTop = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftTopBox = sizerLeftTop->GetStaticBox();
+
+    m_radioKind = new wxRadioBox(sizerLeftTopBox, wxID_ANY, "Combobox &kind:",
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(kinds), kinds,
                                  1, wxRA_SPECIFY_COLS);
 
-    wxSizer *sizerLeftTop = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
-
-    m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeftTop, "&Sort items");
-    m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerLeftTop, "&Read only");
-    m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerLeftTop, "Process &Enter");
+    m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeftTop, "&Sort items", wxID_ANY, sizerLeftTopBox);
+    m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerLeftTop, "&Read only", wxID_ANY, sizerLeftTopBox);
+    m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerLeftTop, "Process &Enter", wxID_ANY, sizerLeftTopBox);
 
     sizerLeftTop->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
     sizerLeftTop->Add(m_radioKind, 0, wxGROW | wxALL, 5);
 
-    wxButton *btn = new wxButton(this, ComboPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftTopBox, ComboPage_Reset, "&Reset");
     sizerLeftTop->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // lower left pane
-    wxSizer *sizerLeftBottom = new wxStaticBoxSizer(wxVERTICAL, this, "&Popup");
-    sizerLeftBottom->Add(new wxButton(this, ComboPage_Popup, "&Show"),
+    wxStaticBoxSizer *sizerLeftBottom = new wxStaticBoxSizer(wxVERTICAL, this, "&Popup");
+    wxStaticBox* const sizerLeftBottomBox = sizerLeftBottom->GetStaticBox();
+
+    sizerLeftBottom->Add(new wxButton(sizerLeftBottomBox, ComboPage_Popup, "&Show"),
                          wxSizerFlags().Border().Centre());
-    sizerLeftBottom->Add(new wxButton(this, ComboPage_Dismiss, "&Hide"),
+    sizerLeftBottom->Add(new wxButton(sizerLeftBottomBox, ComboPage_Dismiss, "&Hide"),
                          wxSizerFlags().Border().Centre());
 
 
@@ -299,23 +302,24 @@ void ComboboxWidgetsPage::CreateContent()
     sizerLeft->Add(sizerLeftBottom, wxSizerFlags().Expand());
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY,
-        "&Change combobox contents");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change combobox contents");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxSizer *sizerRow;
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_SetCurrent,
                                             "Current &selection",
                                             ComboPage_CurText,
-                                            &m_textCur);
+                                            &m_textCur,
+                                            sizerMiddleBox);
 
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     wxTextCtrl *text;
     sizerRow = CreateSizerWithTextAndLabel("Insertion Point",
                                            ComboPage_InsertionPointText,
-                                           &text);
+                                           &text,
+                                           sizerMiddleBox);
     text->SetEditable(false);
 
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
@@ -323,52 +327,58 @@ void ComboboxWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(ComboPage_Insert,
                                             "&Insert this string",
                                             ComboPage_InsertText,
-                                            &m_textInsert);
+                                            &m_textInsert,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_Add,
                                             "&Add this string",
                                             ComboPage_AddText,
-                                            &m_textAdd);
+                                            &m_textAdd,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_SetFirst,
                                             "Change &1st string",
                                             ComboPage_SetFirstText,
-                                            &m_textSetFirst);
+                                            &m_textSetFirst,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ComboPage_AddSeveral, "&Append a few strings");
+    btn = new wxButton(sizerMiddleBox, ComboPage_AddSeveral, "&Append a few strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ComboPage_AddMany, "Append &many strings");
+    btn = new wxButton(sizerMiddleBox, ComboPage_AddMany, "Append &many strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_Change,
                                             "C&hange current",
                                             ComboPage_ChangeText,
-                                            &m_textChange);
+                                            &m_textChange,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_Delete,
                                             "&Delete this item",
                                             ComboPage_DeleteText,
-                                            &m_textDelete);
+                                            &m_textDelete,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ComboPage_DeleteSel, "Delete &selection");
+    btn = new wxButton(sizerMiddleBox, ComboPage_DeleteSel, "Delete &selection");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ComboPage_Clear, "&Clear");
+    btn = new wxButton(sizerMiddleBox, ComboPage_Clear, "&Clear");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(ComboPage_SetValue,
                                             "SetValue",
                                             ComboPage_SetValueText,
-                                            &m_textSetValue);
+                                            &m_textSetValue,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ComboPage_ContainerTests, "Run &tests");
+    btn = new wxButton(sizerMiddleBox, ComboPage_ContainerTests, "Run &tests");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
 

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -159,9 +159,11 @@ void DatePickerWidgetsPage::CreateContent()
                                  1, wxRA_SPECIFY_COLS);
     sizerLeft->Add(m_radioKind, wxSizerFlags().Expand().Border());
 
-    wxSizer* const sizerStyle = new wxStaticBoxSizer(wxVERTICAL, this, "&Style");
-    m_chkStyleCentury = CreateCheckBoxAndAddToSizer(sizerStyle, "Show &century");
-    m_chkStyleAllowNone = CreateCheckBoxAndAddToSizer(sizerStyle, "Allow &no value");
+    wxStaticBoxSizer* const sizerStyle = new wxStaticBoxSizer(wxVERTICAL, this, "&Style");
+    wxStaticBox* const sizerStyleBox = sizerStyle->GetStaticBox();
+
+    m_chkStyleCentury = CreateCheckBoxAndAddToSizer(sizerStyle, "Show &century", wxID_ANY, sizerStyleBox);
+    m_chkStyleAllowNone = CreateCheckBoxAndAddToSizer(sizerStyle, "Allow &no value", wxID_ANY, sizerStyleBox);
 
     sizerLeft->Add(sizerStyle, wxSizerFlags().Expand().Border());
 

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -177,32 +177,34 @@ void DirCtrlWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "Dir control details");
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "Dir control details");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
-
-    sizerLeft->Add( CreateSizerWithTextAndButton( DirCtrlPage_SetPath , "Set &path", wxID_ANY, &m_path ),
+    sizerLeft->Add( CreateSizerWithTextAndButton( DirCtrlPage_SetPath , "Set &path", wxID_ANY, &m_path, sizerLeftBox),
                     0, wxALL | wxALIGN_RIGHT , 5 );
 
-    wxSizer *sizerUseFlags =
-        new wxStaticBoxSizer(wxVERTICAL, this, "&Flags");
-    m_chkDirOnly = CreateCheckBoxAndAddToSizer(sizerUseFlags, "wxDIRCTRL_DIR_ONLY");
-    m_chk3D      = CreateCheckBoxAndAddToSizer(sizerUseFlags, "wxDIRCTRL_3D_INTERNAL");
-    m_chkFirst   = CreateCheckBoxAndAddToSizer(sizerUseFlags, "wxDIRCTRL_SELECT_FIRST");
-    m_chkFilters = CreateCheckBoxAndAddToSizer(sizerUseFlags, "wxDIRCTRL_SHOW_FILTERS");
-    m_chkLabels  = CreateCheckBoxAndAddToSizer(sizerUseFlags, "wxDIRCTRL_EDIT_LABELS");
-    m_chkMulti   = CreateCheckBoxAndAddToSizer(sizerUseFlags, "wxDIRCTRL_MULTIPLE");
-    sizerLeft->Add(sizerUseFlags, wxSizerFlags().Expand().Border());
+    wxStaticBoxSizer *sizerFlags = new wxStaticBoxSizer(wxVERTICAL, sizerLeftBox, "&Flags");
+    wxStaticBox* const sizerFlagsBox = sizerFlags->GetStaticBox();
 
-    wxSizer *sizerFilters =
-        new wxStaticBoxSizer(wxVERTICAL, this, "&Filters");
+    m_chkDirOnly = CreateCheckBoxAndAddToSizer(sizerFlags, "wxDIRCTRL_DIR_ONLY", wxID_ANY, sizerFlagsBox);
+    m_chk3D      = CreateCheckBoxAndAddToSizer(sizerFlags, "wxDIRCTRL_3D_INTERNAL", wxID_ANY, sizerFlagsBox);
+    m_chkFirst   = CreateCheckBoxAndAddToSizer(sizerFlags, "wxDIRCTRL_SELECT_FIRST", wxID_ANY, sizerFlagsBox);
+    m_chkFilters = CreateCheckBoxAndAddToSizer(sizerFlags, "wxDIRCTRL_SHOW_FILTERS", wxID_ANY, sizerFlagsBox);
+    m_chkLabels  = CreateCheckBoxAndAddToSizer(sizerFlags, "wxDIRCTRL_EDIT_LABELS", wxID_ANY, sizerFlagsBox);
+    m_chkMulti   = CreateCheckBoxAndAddToSizer(sizerFlags, "wxDIRCTRL_MULTIPLE", wxID_ANY, sizerFlagsBox);
+    sizerLeft->Add(sizerFlags, wxSizerFlags().Expand().Border());
+
+    wxStaticBoxSizer *sizerFilters = new wxStaticBoxSizer(wxVERTICAL, sizerLeftBox, "&Filters");
+    wxStaticBox* const sizerFiltersBox = sizerFilters->GetStaticBox();
+
     m_fltr[0] = CreateCheckBoxAndAddToSizer(sizerFilters, wxString::Format("all files (%s)|%s",
-                            wxFileSelectorDefaultWildcardStr, wxFileSelectorDefaultWildcardStr));
-    m_fltr[1] = CreateCheckBoxAndAddToSizer(sizerFilters, "C++ files (*.cpp; *.h)|*.cpp;*.h");
-    m_fltr[2] = CreateCheckBoxAndAddToSizer(sizerFilters, "PNG images (*.png)|*.png");
+                            wxFileSelectorDefaultWildcardStr, wxFileSelectorDefaultWildcardStr),
+                            wxID_ANY, sizerFiltersBox);
+    m_fltr[1] = CreateCheckBoxAndAddToSizer(sizerFilters, "C++ files (*.cpp; *.h)|*.cpp;*.h", wxID_ANY, sizerFiltersBox);
+    m_fltr[2] = CreateCheckBoxAndAddToSizer(sizerFilters, "PNG images (*.png)|*.png", wxID_ANY, sizerFiltersBox);
     sizerLeft->Add(sizerFilters, wxSizerFlags().Expand().Border());
 
-    wxButton *btn = new wxButton(this, DirCtrlPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerFiltersBox, DirCtrlPage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // keep consistency between enum and labels of radiobox

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -27,6 +27,7 @@
     #include "wx/app.h"
     #include "wx/log.h"
     #include "wx/radiobox.h"
+    #include "wx/statbox.h"
     #include "wx/textctrl.h"
 #endif
 
@@ -142,16 +143,18 @@ DirPickerWidgetsPage::DirPickerWidgetsPage(WidgetsBookCtrl *book,
 void DirPickerWidgetsPage::CreateContent()
 {
     // left pane
-    wxSizer *boxleft = new wxBoxSizer(wxVERTICAL);
+    wxSizer *sizerLeft = new wxBoxSizer(wxVERTICAL);
 
-    wxStaticBoxSizer *dirbox = new wxStaticBoxSizer(wxVERTICAL, this, "&DirPicker style");
-    m_chkDirTextCtrl = CreateCheckBoxAndAddToSizer(dirbox, "With textctrl");
-    m_chkDirMustExist = CreateCheckBoxAndAddToSizer(dirbox, "Dir must exist");
-    m_chkDirChangeDir = CreateCheckBoxAndAddToSizer(dirbox, "Change working dir");
-    m_chkSmall = CreateCheckBoxAndAddToSizer(dirbox, "&Small version");
-    boxleft->Add(dirbox, 0, wxALL|wxGROW, 5);
+    wxStaticBoxSizer *sizerStyle = new wxStaticBoxSizer(wxVERTICAL, this, "&DirPicker style");
+    wxStaticBox* const sizerStyleBox = sizerStyle->GetStaticBox();
 
-    boxleft->Add(CreateSizerWithTextAndButton
+    m_chkDirTextCtrl = CreateCheckBoxAndAddToSizer(sizerStyle, "With textctrl", wxID_ANY, sizerStyleBox);
+    m_chkDirMustExist = CreateCheckBoxAndAddToSizer(sizerStyle, "Dir must exist", wxID_ANY, sizerStyleBox);
+    m_chkDirChangeDir = CreateCheckBoxAndAddToSizer(sizerStyle, "Change working dir", wxID_ANY, sizerStyleBox);
+    m_chkSmall = CreateCheckBoxAndAddToSizer(sizerStyle, "&Small version", wxID_ANY, sizerStyleBox);
+    sizerLeft->Add(sizerStyle, 0, wxALL|wxGROW, 5);
+
+    sizerLeft->Add(CreateSizerWithTextAndButton
                  (
                     PickerPage_SetDir,
                     "&Initial directory",
@@ -159,9 +162,9 @@ void DirPickerWidgetsPage::CreateContent()
                     &m_textInitialDir
                  ), wxSizerFlags().Expand().Border());
 
-    boxleft->AddSpacer(10);
+    sizerLeft->AddSpacer(10);
 
-    boxleft->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
+    sizerLeft->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
                  0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     Reset();    // set checkboxes state
@@ -178,7 +181,7 @@ void DirPickerWidgetsPage::CreateContent()
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);
-    sz->Add(boxleft, 0, wxGROW|wxALL, 5);
+    sz->Add(sizerLeft, 0, wxGROW|wxALL, 5);
     sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
 
     SetSizer(sz);

--- a/samples/widgets/editlbox.cpp
+++ b/samples/widgets/editlbox.cpp
@@ -130,16 +130,15 @@ void EditableListboxWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY,
-                                       "&Set listbox parameters");
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set listbox parameters");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
-    m_chkAllowNew = CreateCheckBoxAndAddToSizer(sizerLeft, "Allow new items");
-    m_chkAllowEdit = CreateCheckBoxAndAddToSizer(sizerLeft, "Allow editing items");
-    m_chkAllowDelete = CreateCheckBoxAndAddToSizer(sizerLeft, "Allow deleting items");
-    m_chkAllowNoReorder = CreateCheckBoxAndAddToSizer(sizerLeft, "Block user reordering");
+    m_chkAllowNew = CreateCheckBoxAndAddToSizer(sizerLeft, "Allow new items", wxID_ANY, sizerLeftBox);
+    m_chkAllowEdit = CreateCheckBoxAndAddToSizer(sizerLeft, "Allow editing items", wxID_ANY, sizerLeftBox);
+    m_chkAllowDelete = CreateCheckBoxAndAddToSizer(sizerLeft, "Allow deleting items", wxID_ANY, sizerLeftBox);
+    m_chkAllowNoReorder = CreateCheckBoxAndAddToSizer(sizerLeft, "Block user reordering", wxID_ANY, sizerLeftBox);
 
-    wxButton *btn = new wxButton(this, EditableListboxPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, EditableListboxPage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // right pane

--- a/samples/widgets/filectrl.cpp
+++ b/samples/widgets/filectrl.cpp
@@ -173,19 +173,20 @@ void FileCtrlWidgetsPage::CreateContent()
     sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetFilename , "Set &filename", wxID_ANY, &m_filename ),
                     0, wxALL | wxEXPAND , 5 );
 
-    wxSizer *sizerUseFlags =
-        new wxStaticBoxSizer( wxVERTICAL, this, "&Flags");
+    wxStaticBoxSizer *sizerFlags = new wxStaticBoxSizer( wxVERTICAL, this, "&Flags");
+    wxStaticBox* const sizerFlagsBox = sizerFlags->GetStaticBox();
 
-    m_chkMultiple   = CreateCheckBoxAndAddToSizer( sizerUseFlags, "wxFC_MULTIPLE");
-    m_chkNoShowHidden   = CreateCheckBoxAndAddToSizer( sizerUseFlags, "wxFC_NOSHOWHIDDEN");
-    sizerLeft->Add( sizerUseFlags, wxSizerFlags().Expand().Border() );
+    m_chkMultiple   = CreateCheckBoxAndAddToSizer( sizerFlags, "wxFC_MULTIPLE", wxID_ANY, sizerFlagsBox );
+    m_chkNoShowHidden   = CreateCheckBoxAndAddToSizer( sizerFlags, "wxFC_NOSHOWHIDDEN", wxID_ANY, sizerFlagsBox );
+    sizerLeft->Add( sizerFlags, wxSizerFlags().Expand().Border() );
 
-    wxSizer *sizerFilters =
-        new wxStaticBoxSizer( wxVERTICAL, this, "&Filters");
+    wxStaticBoxSizer *sizerFilters = new wxStaticBoxSizer( wxVERTICAL, this, "&Filters");
+    wxStaticBox* const sizerFiltersBox = sizerFilters->GetStaticBox();
+
     m_fltr[0] = CreateCheckBoxAndAddToSizer( sizerFilters, wxString::Format("all files (%s)|%s",
-                wxFileSelectorDefaultWildcardStr, wxFileSelectorDefaultWildcardStr ) );
-    m_fltr[1] = CreateCheckBoxAndAddToSizer( sizerFilters, "C++ files (*.cpp; *.h)|*.cpp;*.h" );
-    m_fltr[2] = CreateCheckBoxAndAddToSizer( sizerFilters, "PNG images (*.png)|*.png");
+                wxFileSelectorDefaultWildcardStr, wxFileSelectorDefaultWildcardStr ), wxID_ANY, sizerFiltersBox );
+    m_fltr[1] = CreateCheckBoxAndAddToSizer( sizerFilters, "C++ files (*.cpp; *.h)|*.cpp;*.h", wxID_ANY, sizerFiltersBox );
+    m_fltr[2] = CreateCheckBoxAndAddToSizer( sizerFilters, "PNG images (*.png)|*.png", wxID_ANY, sizerFiltersBox );
     sizerLeft->Add( sizerFilters, wxSizerFlags().Expand().Border() );
 
     wxButton *btn = new wxButton( this, FileCtrlPage_Reset, "&Reset" );

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -27,6 +27,7 @@
     #include "wx/app.h"
     #include "wx/log.h"
     #include "wx/radiobox.h"
+    #include "wx/statbox.h"
     #include "wx/textctrl.h"
 #endif
 
@@ -159,24 +160,26 @@ FilePickerWidgetsPage::FilePickerWidgetsPage(WidgetsBookCtrl *book,
 void FilePickerWidgetsPage::CreateContent()
 {
     // left pane
-    wxSizer *boxleft = new wxBoxSizer(wxVERTICAL);
+    wxSizer *leftSizer = new wxBoxSizer(wxVERTICAL);
 
     static const wxString mode[] = { "open", "save" };
     m_radioFilePickerMode = new wxRadioBox(this, wxID_ANY, "wxFilePicker mode",
                                            wxDefaultPosition, wxDefaultSize,
                                            WXSIZEOF(mode), mode);
-    boxleft->Add(m_radioFilePickerMode, 0, wxALL|wxGROW, 5);
+    leftSizer->Add(m_radioFilePickerMode, 0, wxALL|wxGROW, 5);
 
-    wxStaticBoxSizer *filebox = new wxStaticBoxSizer(wxVERTICAL, this, "&FilePicker style");
-    m_chkFileTextCtrl = CreateCheckBoxAndAddToSizer(filebox, "With textctrl");
-    m_chkFileOverwritePrompt = CreateCheckBoxAndAddToSizer(filebox, "Overwrite prompt");
-    m_chkFileMustExist = CreateCheckBoxAndAddToSizer(filebox, "File must exist");
-    m_chkFileChangeDir = CreateCheckBoxAndAddToSizer(filebox, "Change working dir");
-    m_chkSmall = CreateCheckBoxAndAddToSizer(filebox, "&Small version");
+    wxStaticBoxSizer *styleSizer = new wxStaticBoxSizer(wxVERTICAL, this, "&FilePicker style");
+    wxStaticBox* const styleSizerBox = styleSizer->GetStaticBox();
 
-    boxleft->Add(filebox, 0, wxALL|wxGROW, 5);
+    m_chkFileTextCtrl = CreateCheckBoxAndAddToSizer(styleSizer, "With textctrl", wxID_ANY, styleSizerBox);
+    m_chkFileOverwritePrompt = CreateCheckBoxAndAddToSizer(styleSizer, "Overwrite prompt", wxID_ANY, styleSizerBox);
+    m_chkFileMustExist = CreateCheckBoxAndAddToSizer(styleSizer, "File must exist", wxID_ANY, styleSizerBox);
+    m_chkFileChangeDir = CreateCheckBoxAndAddToSizer(styleSizer, "Change working dir", wxID_ANY, styleSizerBox);
+    m_chkSmall = CreateCheckBoxAndAddToSizer(styleSizer, "&Small version", wxID_ANY, styleSizerBox);
 
-    boxleft->Add(CreateSizerWithTextAndButton
+    leftSizer->Add(styleSizer, 0, wxALL|wxGROW, 5);
+
+    leftSizer->Add(CreateSizerWithTextAndButton
                  (
                     PickerPage_SetDir,
                     "&Initial directory",
@@ -184,9 +187,9 @@ void FilePickerWidgetsPage::CreateContent()
                     &m_textInitialDir
                  ), wxSizerFlags().Expand().Border());
 
-    boxleft->AddSpacer(10);
+    leftSizer->AddSpacer(10);
 
-    boxleft->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
+    leftSizer->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
                  0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     Reset();    // set checkboxes state
@@ -207,7 +210,7 @@ void FilePickerWidgetsPage::CreateContent()
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);
-    sz->Add(boxleft, 0, wxGROW|wxALL, 5);
+    sz->Add(leftSizer, 0, wxGROW|wxALL, 5);
     sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
 
     SetSizer(sz);

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -27,6 +27,7 @@
     #include "wx/app.h"
     #include "wx/log.h"
     #include "wx/radiobox.h"
+    #include "wx/statbox.h"
 #endif
 
 #include "wx/artprov.h"
@@ -134,15 +135,16 @@ FontPickerWidgetsPage::FontPickerWidgetsPage(WidgetsBookCtrl *book,
 void FontPickerWidgetsPage::CreateContent()
 {
     // left pane
-    wxSizer *boxleft = new wxBoxSizer(wxVERTICAL);
+    wxSizer *leftSizer = new wxBoxSizer(wxVERTICAL);
+    wxStaticBoxSizer *styleSizer = new wxStaticBoxSizer(wxVERTICAL, this, "&FontPicker style");
+    wxStaticBox* const styleSizerBox = styleSizer->GetStaticBox();
 
-    wxStaticBoxSizer *fontbox = new wxStaticBoxSizer(wxVERTICAL, this, "&FontPicker style");
-    m_chkFontTextCtrl = CreateCheckBoxAndAddToSizer(fontbox, "With textctrl");
-    m_chkFontDescAsLabel = CreateCheckBoxAndAddToSizer(fontbox, "Font desc as btn label");
-    m_chkFontUseFontForLabel = CreateCheckBoxAndAddToSizer(fontbox, "Use font for label");
-    boxleft->Add(fontbox, 0, wxALL|wxGROW, 5);
+    m_chkFontTextCtrl = CreateCheckBoxAndAddToSizer(styleSizer, "With textctrl", wxID_ANY, styleSizerBox);
+    m_chkFontDescAsLabel = CreateCheckBoxAndAddToSizer(styleSizer, "Font desc as btn label", wxID_ANY, styleSizerBox);
+    m_chkFontUseFontForLabel = CreateCheckBoxAndAddToSizer(styleSizer, "Use font for label", wxID_ANY, styleSizerBox);
+    leftSizer->Add(styleSizer, 0, wxALL|wxGROW, 5);
 
-    boxleft->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
+    leftSizer->Add(new wxButton(this, PickerPage_Reset, "&Reset"),
                  0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     Reset();    // set checkboxes state
@@ -159,7 +161,7 @@ void FontPickerWidgetsPage::CreateContent()
 
     // global pane
     wxSizer *sz = new wxBoxSizer(wxHORIZONTAL);
-    sz->Add(boxleft, 0, wxGROW|wxALL, 5);
+    sz->Add(leftSizer, 0, wxGROW|wxALL, 5);
     sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
 
     SetSizer(sz);

--- a/samples/widgets/gauge.cpp
+++ b/samples/widgets/gauge.cpp
@@ -196,27 +196,27 @@ void GaugeWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
-
-    m_chkVert = CreateCheckBoxAndAddToSizer(sizerLeft, "&Vertical");
-    m_chkSmooth = CreateCheckBoxAndAddToSizer(sizerLeft, "&Smooth");
-    m_chkProgress = CreateCheckBoxAndAddToSizer(sizerLeft, "&Progress");
+    m_chkVert = CreateCheckBoxAndAddToSizer(sizerLeft, "&Vertical", wxID_ANY, sizerLeftBox);
+    m_chkSmooth = CreateCheckBoxAndAddToSizer(sizerLeft, "&Smooth", wxID_ANY, sizerLeftBox);
+    m_chkProgress = CreateCheckBoxAndAddToSizer(sizerLeft, "&Progress", wxID_ANY, sizerLeftBox);
 
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
 
-    wxButton *btn = new wxButton(this, GaugePage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, GaugePage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY, "&Change gauge value");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change gauge value");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxTextCtrl *text;
     wxSizer *sizerRow = CreateSizerWithTextAndLabel("Current value",
                                                     GaugePage_CurValueText,
-                                                    &text);
+                                                    &text,
+                                                    sizerMiddleBox);
     text->SetEditable(false);
 
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
@@ -224,24 +224,26 @@ void GaugeWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(GaugePage_SetValue,
                                             "Set &value",
                                             GaugePage_ValueText,
-                                            &m_textValue);
+                                            &m_textValue,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(GaugePage_SetRange,
                                             "Set &range",
                                             GaugePage_RangeText,
-                                            &m_textRange);
+                                            &m_textRange,
+                                            sizerMiddleBox);
     m_textRange->SetValue( wxString::Format("%lu", m_range) );
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, GaugePage_Progress, "Simulate &progress");
+    btn = new wxButton(sizerMiddleBox, GaugePage_Progress, "Simulate &progress");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, GaugePage_IndeterminateProgress,
+    btn = new wxButton(sizerMiddleBox, GaugePage_IndeterminateProgress,
                        "Simulate &indeterminate job");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, GaugePage_Clear, "&Clear");
+    btn = new wxButton(sizerMiddleBox, GaugePage_Clear, "&Clear");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     // right pane

--- a/samples/widgets/headerctrl.cpp
+++ b/samples/widgets/headerctrl.cpp
@@ -85,7 +85,7 @@ protected:
 
     // the control itself and the sizer it is in
     wxHeaderCtrlSimple *m_header;
-    wxSizer *m_sizerHeader;
+    wxStaticBoxSizer *m_sizerHeader;
     // the check boxes for header styles
     wxCheckBox *m_chkAllowReorder;
     wxCheckBox *m_chkAllowHide;
@@ -129,27 +129,31 @@ void HeaderCtrlWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // header style
-    wxSizer *sizerHeader = new wxStaticBoxSizer(wxVERTICAL, this, "&Header style");
-    m_chkAllowReorder = CreateCheckBoxAndAddToSizer(sizerHeader, "Allow &reorder");
-    m_chkAllowHide = CreateCheckBoxAndAddToSizer(sizerHeader, "Alow &hide");
-    m_chkBitmapOnRight = CreateCheckBoxAndAddToSizer(sizerHeader, "&Bitmap on right");
+    wxStaticBoxSizer *styleSizer = new wxStaticBoxSizer(wxVERTICAL, this, "&Header style");
+    wxStaticBox* const styleSizerBox = styleSizer->GetStaticBox();
+
+    m_chkAllowReorder = CreateCheckBoxAndAddToSizer(styleSizer, "Allow &reorder", wxID_ANY, styleSizerBox);
+    m_chkAllowHide = CreateCheckBoxAndAddToSizer(styleSizer, "Alow &hide", wxID_ANY, styleSizerBox);
+    m_chkBitmapOnRight = CreateCheckBoxAndAddToSizer(styleSizer, "&Bitmap on right", wxID_ANY, styleSizerBox);
     ResetHeaderStyle();
 
-    sizerHeader->AddStretchSpacer();
-    wxButton* btnReset = new wxButton(this, wxID_ANY, "&Reset");
-    sizerHeader->Add(btnReset, wxSizerFlags().CenterHorizontal().Border());
-    sizerTop->Add(sizerHeader, wxSizerFlags().Expand());
+    styleSizer->AddStretchSpacer();
+    wxButton* btnReset = new wxButton(styleSizerBox, wxID_ANY, "&Reset");
+    styleSizer->Add(btnReset, wxSizerFlags().CenterHorizontal().Border());
+    sizerTop->Add(styleSizer, wxSizerFlags().Expand());
 
     // column flags
     for ( int i = 0; i < (int)WXSIZEOF(m_colSettings); i++ )
     {
-        wxSizer* sizerCol = new wxStaticBoxSizer(wxVERTICAL, this, wxString::Format("Column %i style", i+1));
-        m_colSettings[i].chkAllowResize = CreateCheckBoxAndAddToSizer(sizerCol, "Allow resize");
-        m_colSettings[i].chkAllowReorder = CreateCheckBoxAndAddToSizer(sizerCol, "Allow reorder");
-        m_colSettings[i].chkAllowSort = CreateCheckBoxAndAddToSizer(sizerCol, "Allow sort");
-        m_colSettings[i].chkAllowHide = CreateCheckBoxAndAddToSizer(sizerCol, "Hidden");
-        m_colSettings[i].chkWithBitmap = CreateCheckBoxAndAddToSizer(sizerCol, "With bitmap");
-        m_colSettings[i].rbAlignments = new wxRadioBox(this, wxID_ANY, "Alignment",
+        wxStaticBoxSizer* sizerCol = new wxStaticBoxSizer(wxVERTICAL, this, wxString::Format("Column %i style", i+1));
+        wxStaticBox* const sizerColBox = sizerCol->GetStaticBox();
+
+        m_colSettings[i].chkAllowResize = CreateCheckBoxAndAddToSizer(sizerCol, "Allow resize", wxID_ANY, sizerColBox);
+        m_colSettings[i].chkAllowReorder = CreateCheckBoxAndAddToSizer(sizerCol, "Allow reorder", wxID_ANY, sizerColBox);
+        m_colSettings[i].chkAllowSort = CreateCheckBoxAndAddToSizer(sizerCol, "Allow sort", wxID_ANY, sizerColBox);
+        m_colSettings[i].chkAllowHide = CreateCheckBoxAndAddToSizer(sizerCol, "Hidden", wxID_ANY, sizerColBox);
+        m_colSettings[i].chkWithBitmap = CreateCheckBoxAndAddToSizer(sizerCol, "With bitmap", wxID_ANY, sizerColBox);
+        m_colSettings[i].rbAlignments = new wxRadioBox(sizerColBox, wxID_ANY, "Alignment",
                wxDefaultPosition, wxDefaultSize, WXSIZEOF(gs_colAlignments), gs_colAlignments,
                2, wxRA_SPECIFY_COLS);
         sizerCol->Add(m_colSettings[i].rbAlignments, wxSizerFlags().Expand().Border());
@@ -192,7 +196,7 @@ void HeaderCtrlWidgetsPage::RecreateWidget()
 
     long flags = GetAttrs().m_defaultFlags | GetHeaderStyleFlags();
 
-    m_header = new wxHeaderCtrlSimple(this, wxID_ANY,
+    m_header = new wxHeaderCtrlSimple(m_sizerHeader->GetStaticBox(), wxID_ANY,
                                       wxDefaultPosition, wxDefaultSize,
                                       flags);
 

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -154,14 +154,13 @@ void HyperlinkWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "Hyperlink details");
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "Hyperlink details");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
-
-    sizerLeft->Add( CreateSizerWithTextAndButton( HyperlinkPage_SetLabel , "Set &Label", wxID_ANY, &m_label ),
+    sizerLeft->Add( CreateSizerWithTextAndButton( HyperlinkPage_SetLabel , "Set &Label", wxID_ANY, &m_label, sizerLeftBox ),
                     0, wxALL | wxALIGN_RIGHT , 5 );
 
-    sizerLeft->Add( CreateSizerWithTextAndButton( HyperlinkPage_SetURL , "Set &URL", wxID_ANY, &m_url ),
+    sizerLeft->Add( CreateSizerWithTextAndButton( HyperlinkPage_SetURL , "Set &URL", wxID_ANY, &m_url, sizerLeftBox ),
                     0, wxALL | wxALIGN_RIGHT , 5 );
 
     static const wxString alignments[] =
@@ -173,14 +172,14 @@ void HyperlinkWidgetsPage::CreateContent()
     wxCOMPILE_TIME_ASSERT( WXSIZEOF(alignments) == Align_Max,
                            AlignMismatch );
 
-    m_radioAlignMode = new wxRadioBox(this, wxID_ANY, "alignment",
+    m_radioAlignMode = new wxRadioBox(sizerLeftBox, wxID_ANY, "alignment",
                                       wxDefaultPosition, wxDefaultSize,
                                       WXSIZEOF(alignments), alignments);
     m_radioAlignMode->SetSelection(1);  // start with "centre" selected since
                                         // wxHL_DEFAULT_STYLE contains wxHL_ALIGN_CENTRE
     sizerLeft->Add(m_radioAlignMode, 0, wxALL|wxGROW, 5);
 
-    m_checkGeneric = new wxCheckBox(this, wxID_ANY, "Use generic version",
+    m_checkGeneric = new wxCheckBox(sizerLeftBox, wxID_ANY, "Use generic version",
                                     wxDefaultPosition, wxDefaultSize);
     sizerLeft->Add(m_checkGeneric, 0, wxALL|wxGROW, 5);
 

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -274,9 +274,23 @@ void ListboxWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY,
-        "&Set listbox parameters");
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set listbox parameters");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
+
+    m_chkVScroll = CreateCheckBoxAndAddToSizer
+                   (
+                    sizerLeft,
+                    "Always show &vertical scrollbar",
+                    wxID_ANY, sizerLeftBox
+                   );
+    m_chkHScroll = CreateCheckBoxAndAddToSizer
+                   (
+                    sizerLeft,
+                    "Show &horizontal scrollbar",
+                    wxID_ANY, sizerLeftBox
+                   );
+    m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeft, "&Sort items", wxID_ANY, sizerLeftBox);
+    m_chkOwnerDraw = CreateCheckBoxAndAddToSizer(sizerLeft, "&Owner drawn", wxID_ANY, sizerLeftBox);
 
     static const wxString modes[] =
     {
@@ -285,7 +299,7 @@ void ListboxWidgetsPage::CreateContent()
         "multiple",
     };
 
-    m_radioSelMode = new wxRadioBox(this, wxID_ANY, "Selection &mode:",
+    m_radioSelMode = new wxRadioBox(sizerLeftBox, wxID_ANY, "Selection &mode:",
                                     wxDefaultPosition, wxDefaultSize,
                                     WXSIZEOF(modes), modes,
                                     1, wxRA_SPECIFY_COLS);
@@ -300,23 +314,10 @@ void ListboxWidgetsPage::CreateContent()
       , "rearrange list"
 #endif // wxUSE_REARRANGECTRL
     };
-    m_radioListType = new wxRadioBox(this, wxID_ANY, "&List type:",
+    m_radioListType = new wxRadioBox(sizerLeftBox, wxID_ANY, "&List type:",
                                     wxDefaultPosition, wxDefaultSize,
                                     WXSIZEOF(listTypes), listTypes,
                                     1, wxRA_SPECIFY_COLS);
-
-    m_chkVScroll = CreateCheckBoxAndAddToSizer
-                   (
-                    sizerLeft,
-                    "Always show &vertical scrollbar"
-                   );
-    m_chkHScroll = CreateCheckBoxAndAddToSizer
-                   (
-                    sizerLeft,
-                    "Show &horizontal scrollbar"
-                   );
-    m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeft, "&Sort items");
-    m_chkOwnerDraw = CreateCheckBoxAndAddToSizer(sizerLeft, "&Owner drawn");
 
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
     sizerLeft->Add(m_radioSelMode, 0, wxGROW | wxALL, 5);
@@ -324,67 +325,66 @@ void ListboxWidgetsPage::CreateContent()
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
     sizerLeft->Add(m_radioListType, 0, wxGROW | wxALL, 5);
 
-    wxButton *btn = new wxButton(this, ListboxPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, ListboxPage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY,
-        "&Change listbox contents");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change listbox contents");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    btn = new wxButton(this, ListboxPage_Add, "&Add this string");
-    m_textAdd = new wxTextCtrl(this, ListboxPage_AddText, "test item \t0");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_Add, "&Add this string");
+    m_textAdd = new wxTextCtrl(sizerMiddleBox, ListboxPage_AddText, "test item \t0");
     sizerRow->Add(btn, 0, wxRIGHT, 5);
     sizerRow->Add(m_textAdd, 1, wxLEFT, 5);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_AddSeveral, "&Insert a few strings");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_AddSeveral, "&Insert a few strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_AddMany, "Add &many strings");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_AddMany, "Add &many strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    btn = new wxButton(this, ListboxPage_Change, "C&hange current");
-    m_textChange = new wxTextCtrl(this, ListboxPage_ChangeText, wxEmptyString);
+    btn = new wxButton(sizerMiddleBox, ListboxPage_Change, "C&hange current");
+    m_textChange = new wxTextCtrl(sizerMiddleBox, ListboxPage_ChangeText, wxEmptyString);
     sizerRow->Add(btn, 0, wxRIGHT, 5);
     sizerRow->Add(m_textChange, 1, wxLEFT, 5);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    btn = new wxButton(this, ListboxPage_EnsureVisible, "Make item &visible");
-    m_textEnsureVisible = new wxTextCtrl(this, ListboxPage_EnsureVisibleText, wxEmptyString);
+    btn = new wxButton(sizerMiddleBox, ListboxPage_EnsureVisible, "Make item &visible");
+    m_textEnsureVisible = new wxTextCtrl(sizerMiddleBox, ListboxPage_EnsureVisibleText, wxEmptyString);
     sizerRow->Add(btn, 0, wxRIGHT, 5);
     sizerRow->Add(m_textEnsureVisible, 1, wxLEFT, 5);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    btn = new wxButton(this, ListboxPage_Delete, "&Delete this item");
-    m_textDelete = new wxTextCtrl(this, ListboxPage_DeleteText, wxEmptyString);
+    btn = new wxButton(sizerMiddleBox, ListboxPage_Delete, "&Delete this item");
+    m_textDelete = new wxTextCtrl(sizerMiddleBox, ListboxPage_DeleteText, wxEmptyString);
     sizerRow->Add(btn, 0, wxRIGHT, 5);
     sizerRow->Add(m_textDelete, 1, wxLEFT, 5);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_DeleteSel, "Delete &selection");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_DeleteSel, "Delete &selection");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_Clear, "&Clear");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_Clear, "&Clear");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_MoveUp, "Move item &up");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_MoveUp, "Move item &up");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_MoveDown, "Move item &down");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_MoveDown, "Move item &down");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_GetTopItem, "Get top item");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_GetTopItem, "Get top item");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_GetCountPerPage, "Get count per page");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_GetCountPerPage, "Get count per page");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ListboxPage_ContainerTests, "Run &tests");
+    btn = new wxButton(sizerMiddleBox, ListboxPage_ContainerTests, "Run &tests");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     // right pane

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -199,7 +199,8 @@ void BookWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     // must be in sync with Orient enum
     wxArrayString orientations;
@@ -211,59 +212,62 @@ void BookWidgetsPage::CreateContent()
     wxASSERT_MSG( orientations.GetCount() == Orient_Max,
                   "forgot to update something" );
 
-    m_chkImages = new wxCheckBox(this, wxID_ANY, "Show &images");
-    m_radioOrient = new wxRadioBox(this, wxID_ANY, "&Tab orientation",
+    m_chkImages = new wxCheckBox(sizerLeftBox, wxID_ANY, "Show &images");
+    m_radioOrient = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Tab orientation",
                                    wxDefaultPosition, wxDefaultSize,
                                    orientations, 1, wxRA_SPECIFY_COLS);
-
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
 
     sizerLeft->Add(m_chkImages, 0, wxALL, 5);
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
     sizerLeft->Add(m_radioOrient, 0, wxALL, 5);
 
-    wxButton *btn = new wxButton(this, BookPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, BookPage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY, "&Contents");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Contents");
+    wxStaticBox* const sizerMidleBox = sizerMiddle->GetStaticBox();
 
     wxTextCtrl *text;
     wxSizer *sizerRow = CreateSizerWithTextAndLabel("Number of pages: ",
                                                     BookPage_NumPagesText,
-                                                    &text);
+                                                    &text,
+                                                    sizerMidleBox);
     text->SetEditable(false);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndLabel("Current selection: ",
                                            BookPage_CurSelectText,
-                                           &text);
+                                           &text,
+                                           sizerMidleBox);
     text->SetEditable(false);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(BookPage_SelectPage,
                                             "&Select page",
                                             BookPage_SelectText,
-                                            &m_textSelect);
+                                            &m_textSelect,
+                                            sizerMidleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, BookPage_AddPage, "&Add page");
+    btn = new wxButton(sizerMidleBox, BookPage_AddPage, "&Add page");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(BookPage_InsertPage,
                                             "&Insert page at",
                                             BookPage_InsertText,
-                                            &m_textInsert);
+                                            &m_textInsert,
+                                            sizerMidleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(BookPage_RemovePage,
                                             "&Remove page",
                                             BookPage_RemoveText,
-                                            &m_textRemove);
+                                            &m_textRemove,
+                                            sizerMidleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, BookPage_DeleteAll, "&Delete All");
+    btn = new wxButton(sizerMidleBox, BookPage_DeleteAll, "&Delete All");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     // right pane

--- a/samples/widgets/odcombobox.cpp
+++ b/samples/widgets/odcombobox.cpp
@@ -329,90 +329,93 @@ void ODComboboxWidgetsPage::CreateContent()
     wxSizer *sizerLeft = new wxBoxSizer(wxVERTICAL);
 
     // left pane - style box
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
+    wxStaticBoxSizer *sizerStyle = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerStyleBox = sizerStyle->GetStaticBox();
 
-    wxSizer *sizerStyle = new wxStaticBoxSizer(box, wxVERTICAL);
-
-    m_chkSort = CreateCheckBoxAndAddToSizer(sizerStyle, "&Sort items");
-    m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerStyle, "&Read only");
-    m_chkDclickcycles = CreateCheckBoxAndAddToSizer(sizerStyle, "&Double-click Cycles");
+    m_chkSort = CreateCheckBoxAndAddToSizer(sizerStyle, "&Sort items", wxID_ANY, sizerStyleBox);
+    m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerStyle, "&Read only", wxID_ANY, sizerStyleBox);
+    m_chkDclickcycles = CreateCheckBoxAndAddToSizer(sizerStyle, "&Double-click Cycles", wxID_ANY, sizerStyleBox);
 
     sizerStyle->AddSpacer(4);
 
-    m_chkBitmapbutton = CreateCheckBoxAndAddToSizer(sizerStyle, "&Bitmap button");
-    m_chkStdbutton = CreateCheckBoxAndAddToSizer(sizerStyle, "B&lank button background");
+    m_chkBitmapbutton = CreateCheckBoxAndAddToSizer(sizerStyle, "&Bitmap button", wxID_ANY, sizerStyleBox);
+    m_chkStdbutton = CreateCheckBoxAndAddToSizer(sizerStyle, "B&lank button background", wxID_ANY, sizerStyleBox);
 
-    wxButton *btn = new wxButton(this, ODComboPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerStyleBox, ODComboPage_Reset, "&Reset");
     sizerStyle->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 3);
 
     sizerLeft->Add(sizerStyle, wxSizerFlags().Expand());
 
     // left pane - popup adjustment box
-    box = new wxStaticBox(this, wxID_ANY, "Adjust &popup");
-
-    wxSizer *sizerPopupPos = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerPopupPos = new wxStaticBoxSizer(wxVERTICAL, this, "Adjust &popup");
+    wxStaticBox* const sizerPopupPosBox = sizerPopupPos->GetStaticBox();
 
     sizerRow = CreateSizerWithTextAndLabel("Min. Width:",
                                            ODComboPage_PopupMinWidth,
-                                           &m_textPopupMinWidth);
+                                           &m_textPopupMinWidth,
+                                           sizerPopupPosBox);
     m_textPopupMinWidth->SetValue("-1");
     sizerPopupPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndLabel("Max. Height:",
                                            ODComboPage_PopupHeight,
-                                           &m_textPopupHeight);
+                                           &m_textPopupHeight,
+                                           sizerPopupPosBox);
     m_textPopupHeight->SetValue("-1");
     sizerPopupPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    m_chkAlignpopupright = CreateCheckBoxAndAddToSizer(sizerPopupPos, "Align Right");
+    m_chkAlignpopupright = CreateCheckBoxAndAddToSizer(sizerPopupPos, "Align Right", wxID_ANY, sizerPopupPosBox);
 
     sizerLeft->Add(sizerPopupPos, wxSizerFlags().Expand().Border(wxTOP, 2));
 
     // left pane - button adjustment box
-    box = new wxStaticBox(this, wxID_ANY, "Adjust &button");
-
-    wxSizer *sizerButtonPos = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerButtonPos = new wxStaticBoxSizer(wxVERTICAL, this, "Adjust &button");
+    wxStaticBox* const sizerButtonPosBox = sizerButtonPos->GetStaticBox();
 
     sizerRow = CreateSizerWithTextAndLabel("Width:",
                                            ODComboPage_ButtonWidth,
-                                           &m_textButtonWidth);
+                                           &m_textButtonWidth,
+                                           sizerButtonPosBox);
     m_textButtonWidth->SetValue("-1");
     sizerButtonPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndLabel("VSpacing:",
                                            ODComboPage_ButtonSpacing,
-                                           &m_textButtonSpacing);
+                                           &m_textButtonSpacing,
+                                           sizerButtonPosBox);
     m_textButtonSpacing->SetValue("0");
     sizerButtonPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndLabel("Height:",
                                            ODComboPage_ButtonHeight,
-                                           &m_textButtonHeight);
+                                           &m_textButtonHeight,
+                                           sizerButtonPosBox);
     m_textButtonHeight->SetValue("-1");
     sizerButtonPos->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    m_chkAlignbutleft = CreateCheckBoxAndAddToSizer(sizerButtonPos, "Align Left");
+    m_chkAlignbutleft = CreateCheckBoxAndAddToSizer(sizerButtonPos, "Align Left", wxID_ANY, sizerButtonPosBox);
 
     sizerLeft->Add(sizerButtonPos, wxSizerFlags().Expand().Border(wxTOP, 2));
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY,
-        "&Change combobox contents");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change combobox contents");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
-    btn = new wxButton(this, ODComboPage_ContainerTests, "Run &tests");
+    btn = new wxButton(sizerMiddleBox, ODComboPage_ContainerTests, "Run &tests");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndLabel("Current selection",
                                            ODComboPage_CurText,
-                                           &text);
+                                           &text,
+                                           sizerMiddleBox);
     text->SetEditable(false);
 
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndLabel("Insertion Point",
                                            ODComboPage_InsertionPointText,
-                                           &text);
+                                           &text,
+                                           sizerMiddleBox);
     text->SetEditable(false);
 
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
@@ -420,37 +423,41 @@ void ODComboboxWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(ODComboPage_Insert,
                                             "&Insert this string",
                                             ODComboPage_InsertText,
-                                            &m_textInsert);
+                                            &m_textInsert,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(ODComboPage_Add,
                                             "&Add this string",
                                             ODComboPage_AddText,
-                                            &m_textAdd);
+                                            &m_textAdd,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ODComboPage_AddSeveral, "&Append a few strings");
+    btn = new wxButton(sizerMiddleBox, ODComboPage_AddSeveral, "&Append a few strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ODComboPage_AddMany, "Append &many strings");
+    btn = new wxButton(sizerMiddleBox, ODComboPage_AddMany, "Append &many strings");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(ODComboPage_Change,
                                             "C&hange current",
                                             ODComboPage_ChangeText,
-                                            &m_textChange);
+                                            &m_textChange,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(ODComboPage_Delete,
                                             "&Delete this item",
                                             ODComboPage_DeleteText,
-                                            &m_textDelete);
+                                            &m_textDelete,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ODComboPage_DeleteSel, "Delete &selection");
+    btn = new wxButton(sizerMiddleBox, ODComboPage_DeleteSel, "Delete &selection");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
-    btn = new wxButton(this, ODComboPage_Clear, "&Clear");
+    btn = new wxButton(sizerMiddleBox, ODComboPage_Clear, "&Clear");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
 
     // right pane

--- a/samples/widgets/radiobox.cpp
+++ b/samples/widgets/radiobox.cpp
@@ -195,69 +195,78 @@ void RadioWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
-
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerleftBox = sizerLeft->GetStaticBox();
 
     m_chkSpecifyRows = CreateCheckBoxAndAddToSizer
                        (
                         sizerLeft,
-                        "Major specifies &rows count"
+                        "Major specifies &rows count",
+                        wxID_ANY,
+                        sizerleftBox
                        );
 
     wxSizer *sizerRow;
     sizerRow = CreateSizerWithTextAndLabel("&Major dimension:",
                                            wxID_ANY,
-                                           &m_textMajorDim);
+                                           &m_textMajorDim,
+                                           sizerleftBox);
     sizerLeft->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndLabel("&Number of buttons:",
                                            wxID_ANY,
-                                           &m_textNumBtns);
+                                           &m_textNumBtns,
+                                           sizerleftBox);
     sizerLeft->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     wxButton *btn;
-    btn = new wxButton(this, RadioPage_Update, "&Update");
+    btn = new wxButton(sizerleftBox, RadioPage_Update, "&Update");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().Border());
 
     sizerLeft->AddSpacer(5);
 
-    btn = new wxButton(this, RadioPage_Reset, "&Reset");
+    btn = new wxButton(sizerleftBox, RadioPage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().Border(wxALL, 15));
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY, "&Change parameters");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change parameters");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     sizerRow = CreateSizerWithTextAndLabel("Current selection:",
                                            wxID_ANY,
-                                           &m_textCurSel);
+                                           &m_textCurSel,
+                                           sizerMiddleBox);
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(RadioPage_Selection,
                                             "&Change selection:",
-                                           wxID_ANY,
-                                           &m_textSel);
+                                             wxID_ANY,
+                                             &m_textSel,
+                                             sizerMiddleBox);
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(RadioPage_Label,
                                             "&Label for box:",
                                             wxID_ANY,
-                                            &m_textLabel);
+                                            &m_textLabel,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(RadioPage_LabelBtn,
                                             "&Label for buttons:",
                                             wxID_ANY,
-                                            &m_textLabelBtns);
+                                            &m_textLabelBtns,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     m_chkEnableItem = CreateCheckBoxAndAddToSizer(sizerMiddle,
                                                   "Disable &2nd item",
-                                                  RadioPage_EnableItem);
+                                                  RadioPage_EnableItem,
+                                                  sizerMiddleBox);
     m_chkShowItem = CreateCheckBoxAndAddToSizer(sizerMiddle,
                                                 "Hide 2nd &item",
-                                                RadioPage_ShowItem);
+                                                RadioPage_ShowItem,
+                                                sizerMiddleBox);
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxHORIZONTAL);

--- a/samples/widgets/searchctrl.cpp
+++ b/samples/widgets/searchctrl.cpp
@@ -149,22 +149,21 @@ void SearchCtrlWidgetsPage::CreateContent()
     CreateControl();
 
 
-    wxSizer* box = new wxStaticBoxSizer(
-        new wxStaticBox(this, -1, "Options"),
-        wxVERTICAL);
+    wxStaticBoxSizer* sizerOptions = new wxStaticBoxSizer(wxVERTICAL, this, "Options");
+    wxStaticBox* const sizerOptionsBox = sizerOptions->GetStaticBox();
 
-    m_searchBtnCheck = new wxCheckBox(this, ID_SEARCH_CB, "Search button");
-    m_cancelBtnCheck = new wxCheckBox(this, ID_CANCEL_CB, "Cancel button");
-    m_menuBtnCheck   = new wxCheckBox(this, ID_MENU_CB,   "Search menu");
+    m_searchBtnCheck = new wxCheckBox(sizerOptionsBox, ID_SEARCH_CB, "Search button");
+    m_cancelBtnCheck = new wxCheckBox(sizerOptionsBox, ID_CANCEL_CB, "Cancel button");
+    m_menuBtnCheck   = new wxCheckBox(sizerOptionsBox, ID_MENU_CB,   "Search menu");
 
     m_searchBtnCheck->SetValue(true);
 
-    box->Add(m_searchBtnCheck, wxSizerFlags().Border());
-    box->Add(m_cancelBtnCheck, wxSizerFlags().Border());
-    box->Add(m_menuBtnCheck,   wxSizerFlags().Border());
+    sizerOptions->Add(m_searchBtnCheck, wxSizerFlags().Border());
+    sizerOptions->Add(m_cancelBtnCheck, wxSizerFlags().Border());
+    sizerOptions->Add(m_menuBtnCheck,   wxSizerFlags().Border());
 
     wxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
-    sizer->Add(box, wxSizerFlags().Expand().TripleBorder());
+    sizer->Add(sizerOptions, wxSizerFlags().Expand().TripleBorder());
     sizer->Add(m_srchCtrl, wxSizerFlags().Centre().TripleBorder());
 
     SetSizer(sizer);

--- a/samples/widgets/slider.cpp
+++ b/samples/widgets/slider.cpp
@@ -278,13 +278,13 @@ void SliderWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
-    m_chkInverse = CreateCheckBoxAndAddToSizer(sizerLeft, "&Inverse");
-    m_chkTicks = CreateCheckBoxAndAddToSizer(sizerLeft, "Show &ticks");
-    m_chkMinMaxLabels = CreateCheckBoxAndAddToSizer(sizerLeft, "Show min/max &labels");
-    m_chkValueLabel = CreateCheckBoxAndAddToSizer(sizerLeft, "Show &value label");
+    m_chkInverse = CreateCheckBoxAndAddToSizer(sizerLeft, "&Inverse", wxID_ANY, sizerLeftBox);
+    m_chkTicks = CreateCheckBoxAndAddToSizer(sizerLeft, "Show &ticks", wxID_ANY, sizerLeftBox);
+    m_chkMinMaxLabels = CreateCheckBoxAndAddToSizer(sizerLeft, "Show min/max &labels", wxID_ANY, sizerLeftBox);
+    m_chkValueLabel = CreateCheckBoxAndAddToSizer(sizerLeft, "Show &value label", wxID_ANY, sizerLeftBox);
     static const wxString sides[] =
     {
         "default",
@@ -293,15 +293,15 @@ void SliderWidgetsPage::CreateContent()
         "left",
         "right",
     };
-    m_radioSides = new wxRadioBox(this, SliderPage_RadioSides, "&Label position",
+    m_radioSides = new wxRadioBox(sizerLeftBox, SliderPage_RadioSides, "&Label position",
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(sides), sides,
                                  1, wxRA_SPECIFY_COLS);
     sizerLeft->Add(m_radioSides, wxSizerFlags().Expand().Border());
     m_chkBothSides = CreateCheckBoxAndAddToSizer
-                     (sizerLeft, "&Both sides", SliderPage_BothSides);
+                     (sizerLeft, "&Both sides", SliderPage_BothSides, sizerLeftBox);
     m_chkSelectRange = CreateCheckBoxAndAddToSizer
-                     (sizerLeft, "&Selection range", SliderPage_SelectRange);
+                     (sizerLeft, "&Selection range", SliderPage_SelectRange, sizerLeftBox);
 #if wxUSE_TOOLTIPS
     m_chkBothSides->SetToolTip("\"Both sides\" is only supported \nin Universal");
     m_chkSelectRange->SetToolTip("\"Select range\" is only supported \nin wxMSW");
@@ -309,17 +309,18 @@ void SliderWidgetsPage::CreateContent()
 
     sizerLeft->AddSpacer(5);
 
-    wxButton *btn = new wxButton(this, SliderPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, SliderPage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().Border(wxALL, 15));
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY, "&Change slider value");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change slider value");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxTextCtrl *text;
     wxSizer *sizerRow = CreateSizerWithTextAndLabel("Current value",
                                                     SliderPage_CurValueText,
-                                                    &text);
+                                                    &text,
+                                                    sizerMiddleBox);
     text->SetEditable(false);
 
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
@@ -327,15 +328,17 @@ void SliderWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(SliderPage_SetValue,
                                             "Set &value",
                                             SliderPage_ValueText,
-                                            &m_textValue);
+                                            &m_textValue,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(SliderPage_SetMinAndMax,
                                             "&Min and max",
                                             SliderPage_MinText,
-                                            &m_textMin);
+                                            &m_textMin,
+                                            sizerMiddleBox);
 
-    m_textMax = new wxTextCtrl(this, SliderPage_MaxText, wxEmptyString);
+    m_textMax = new wxTextCtrl(sizerMiddleBox, SliderPage_MaxText, wxEmptyString);
     sizerRow->Add(m_textMax, wxSizerFlags(1).CentreVertical().Border(wxLEFT));
 
     m_textMin->SetValue( wxString::Format("%d", m_min) );
@@ -346,9 +349,10 @@ void SliderWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(SliderPage_SetRange,
                                             "&Selection",
                                             SliderPage_RangeMinText,
-                                            &m_textRangeMin);
+                                            &m_textRangeMin,
+                                            sizerMiddleBox);
 
-    m_textRangeMax = new wxTextCtrl(this, SliderPage_RangeMaxText, wxEmptyString);
+    m_textRangeMax = new wxTextCtrl(sizerMiddleBox, SliderPage_RangeMaxText, wxEmptyString);
     sizerRow->Add(m_textRangeMax, wxSizerFlags(1).CentreVertical().Border(wxLEFT));
 
     m_textRangeMin->SetValue( wxString::Format("%d", m_rangeMin) );
@@ -359,21 +363,24 @@ void SliderWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(SliderPage_SetLineSize,
                                             "Li&ne size",
                                             SliderPage_LineSizeText,
-                                            &m_textLineSize);
+                                            &m_textLineSize,
+                                            sizerMiddleBox);
 
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(SliderPage_SetPageSize,
                                             "P&age size",
                                             SliderPage_PageSizeText,
-                                            &m_textPageSize);
+                                            &m_textPageSize,
+                                            sizerMiddleBox);
 
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 
     sizerRow = CreateSizerWithTextAndButton(SliderPage_SetTickFreq,
                                             "Tick &frequency",
                                             SliderPage_TickFreqText,
-                                            &m_textTickFreq);
+                                            &m_textTickFreq,
+                                            sizerMiddleBox);
 
     m_textTickFreq->SetValue("10");
 
@@ -382,7 +389,8 @@ void SliderWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(SliderPage_SetThumbLen,
                                             "Thumb &length",
                                             SliderPage_ThumbLenText,
-                                            &m_textThumbLen);
+                                            &m_textThumbLen,
+                                            sizerMiddleBox);
 
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());
 

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -251,14 +251,15 @@ void SpinBtnWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set style");
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
-    m_chkVert = CreateCheckBoxAndAddToSizer(sizerLeft, "&Vertical");
-    m_chkArrowKeys = CreateCheckBoxAndAddToSizer(sizerLeft, "&Arrow Keys");
-    m_chkWrap = CreateCheckBoxAndAddToSizer(sizerLeft, "&Wrap");
+    m_chkVert = CreateCheckBoxAndAddToSizer(sizerLeft, "&Vertical", wxID_ANY, sizerLeftBox);
+    m_chkArrowKeys = CreateCheckBoxAndAddToSizer(sizerLeft, "&Arrow Keys", wxID_ANY, sizerLeftBox);
+    m_chkWrap = CreateCheckBoxAndAddToSizer(sizerLeft, "&Wrap", wxID_ANY, sizerLeftBox);
     m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerLeft,
-                                                    "Process &Enter");
+                                                    "Process &Enter",
+                                                     wxID_ANY, sizerLeftBox);
 
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
 
@@ -269,7 +270,7 @@ void SpinBtnWidgetsPage::CreateContent()
         "right",
     };
 
-    m_radioAlign = new wxRadioBox(this, wxID_ANY, "&Text alignment",
+    m_radioAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Text alignment",
                                    wxDefaultPosition, wxDefaultSize,
                                    WXSIZEOF(halign), halign, 1);
 
@@ -277,19 +278,18 @@ void SpinBtnWidgetsPage::CreateContent()
 
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
 
-    wxButton *btn = new wxButton(this, SpinBtnPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, SpinBtnPage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY,
-        "&Change spinbtn value");
-
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change spinbtn value");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxTextCtrl *text;
     wxSizer *sizerRow = CreateSizerWithTextAndLabel("Current value",
                                                     SpinBtnPage_CurValueText,
-                                                    &text);
+                                                    &text,
+                                                    sizerMiddleBox);
     text->SetEditable(false);
 
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
@@ -297,15 +297,17 @@ void SpinBtnWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(SpinBtnPage_SetValue,
                                             "Set &value",
                                             SpinBtnPage_ValueText,
-                                            &m_textValue);
+                                            &m_textValue,
+                                            sizerMiddleBox);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton(SpinBtnPage_SetMinAndMax,
                                             "&Min and max",
                                             SpinBtnPage_MinText,
-                                            &m_textMin);
+                                            &m_textMin,
+                                            sizerMiddleBox);
 
-    m_textMax = new wxTextCtrl(this, SpinBtnPage_MaxText, wxEmptyString);
+    m_textMax = new wxTextCtrl(sizerMiddleBox, SpinBtnPage_MaxText, wxEmptyString);
     sizerRow->Add(m_textMax, 1, wxLEFT | wxALIGN_CENTRE_VERTICAL, 5);
 
     m_textMin->SetValue( wxString::Format("%d", m_min) );
@@ -316,14 +318,16 @@ void SpinBtnWidgetsPage::CreateContent()
     sizerRow = CreateSizerWithTextAndButton(SpinBtnPage_SetBase,
                                             "Set &base",
                                             SpinBtnPage_BaseText,
-                                            &m_textBase);
+                                            &m_textBase,
+                                            sizerMiddleBox);
     m_textBase->SetValue("10");
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
 
     sizerRow = CreateSizerWithTextAndButton( SpinBtnPage_SetIncrement,
                                              "Set Increment",
                                              SpinBtnPage_SetIncrementText,
-                                             &m_textIncrement );
+                                             &m_textIncrement,
+                                             sizerMiddleBox);
     m_textIncrement->SetValue( "1" );
     sizerMiddle->Add( sizerRow, 0, wxALL | wxGROW, 5 );
 

--- a/samples/widgets/statbmp.cpp
+++ b/samples/widgets/statbmp.cpp
@@ -78,7 +78,7 @@ void StatBmpWidgetsPage::CreateContent()
 {
 
     static const wxString choices[] = { "native", "generic" };
-    m_radio = new wxRadioBox(this, wxID_ANY, "implementation",
+    m_radio = new wxRadioBox(this, wxID_ANY, "Implementation",
                              wxDefaultPosition, wxDefaultSize,
                              WXSIZEOF(choices), choices);
     static const wxString scaleChoices[] = { "None", "Fill", "Aspect Fit", "Aspect Fill" };
@@ -150,13 +150,13 @@ void StatBmpWidgetsPage::RecreateWidget()
 
     if (m_radio->GetSelection() == 0)
     {
-        m_statbmp = new wxStaticBitmap(this, wxID_ANY, bmp,
+        m_statbmp = new wxStaticBitmap(m_sbsizer->GetStaticBox(), wxID_ANY, bmp,
                                        wxDefaultPosition, wxDefaultSize,
                                        style);
     }
     else
     {
-        m_statbmp = new wxGenericStaticBitmap(this, wxID_ANY, bmp,
+        m_statbmp = new wxGenericStaticBitmap(m_sbsizer->GetStaticBox(), wxID_ANY, bmp,
                                               wxDefaultPosition, wxDefaultSize,
                                               style);
     }

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -223,21 +223,23 @@ void StaticWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     m_chkGeneric = CreateCheckBoxAndAddToSizer(sizerLeft,
-                                               "&Generic wxStaticText");
+                                               "&Generic wxStaticText",
+                                               wxID_ANY,  sizerLeftBox);
     m_chkGeneric->Bind(wxEVT_CHECKBOX, &StaticWidgetsPage::OnRecreate, this);
 
 #ifdef wxHAS_WINDOW_LABEL_IN_STATIC_BOX
-    m_chkBoxWithCheck = CreateCheckBoxAndAddToSizer(sizerLeft, "Checkable &box");
+    m_chkBoxWithCheck = CreateCheckBoxAndAddToSizer(sizerLeft, "Checkable &box", wxID_ANY, sizerLeftBox);
     m_chkBoxWithCheck->Bind(wxEVT_CHECKBOX, &StaticWidgetsPage::OnRecreate, this);
 #endif // wxHAS_WINDOW_LABEL_IN_STATIC_BOX
 
-    m_chkVert = CreateCheckBoxAndAddToSizer(sizerLeft, "&Vertical line");
+    m_chkVert = CreateCheckBoxAndAddToSizer(sizerLeft, "&Vertical line", wxID_ANY, sizerLeftBox);
     m_chkVert->Bind(wxEVT_CHECKBOX, &StaticWidgetsPage::OnRecreate, this);
 
-    m_chkAutoResize = CreateCheckBoxAndAddToSizer(sizerLeft, "&Fit to text");
+    m_chkAutoResize = CreateCheckBoxAndAddToSizer(sizerLeft, "&Fit to text", wxID_ANY, sizerLeftBox);
     m_chkAutoResize->Bind(wxEVT_CHECKBOX, &StaticWidgetsPage::OnRecreate, this);
 
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
@@ -256,12 +258,12 @@ void StaticWidgetsPage::CreateContent()
         "bottom",
     };
 
-    m_radioHAlign = new wxRadioBox(this, wxID_ANY, "&Horz alignment",
+    m_radioHAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Horz alignment",
                                    wxDefaultPosition, wxDefaultSize,
                                    WXSIZEOF(halign), halign, 3);
     m_radioHAlign->Bind(wxEVT_RADIOBOX, &StaticWidgetsPage::OnRecreate, this);
 
-    m_radioVAlign = new wxRadioBox(this, wxID_ANY, "&Vert alignment",
+    m_radioVAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Vert alignment",
                                    wxDefaultPosition, wxDefaultSize,
                                    WXSIZEOF(valign), valign, 3);
     m_radioVAlign->SetToolTip("Relevant for Generic wxStaticText only");
@@ -273,7 +275,7 @@ void StaticWidgetsPage::CreateContent()
 
     sizerLeft->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
 
-    m_chkEllipsize = CreateCheckBoxAndAddToSizer(sizerLeft, "&Ellipsize");
+    m_chkEllipsize = CreateCheckBoxAndAddToSizer(sizerLeft, "&Ellipsize", wxID_ANY, sizerLeftBox);
     m_chkEllipsize->Bind(wxEVT_CHECKBOX,
                          &StaticWidgetsPage::OnCheckEllipsize, this);
 
@@ -284,7 +286,7 @@ void StaticWidgetsPage::CreateContent()
         "&end",
     };
 
-    m_radioEllipsize = new wxRadioBox(this, wxID_ANY, "&Ellipsize mode",
+    m_radioEllipsize = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Ellipsize mode",
                                       wxDefaultPosition, wxDefaultSize,
                                       WXSIZEOF(ellipsizeMode), ellipsizeMode,
                                       3);
@@ -292,40 +294,41 @@ void StaticWidgetsPage::CreateContent()
 
     sizerLeft->Add(m_radioEllipsize, 0, wxGROW | wxALL, 5);
 
-    wxButton *b0 = new wxButton(this, wxID_ANY, "&Reset");
+    wxButton *b0 = new wxButton(sizerLeftBox, wxID_ANY, "&Reset");
     b0->Bind(wxEVT_BUTTON, &StaticWidgetsPage::OnButtonReset, this);
     sizerLeft->Add(b0, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // middle pane
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this,
-                                                "&Change labels");
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change labels");
+    wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
-    m_textBox = new wxTextCtrl(this, wxID_ANY, wxEmptyString);
-    wxButton *b1 = new wxButton(this, wxID_ANY, "Change &box label");
+    m_textBox = new wxTextCtrl(sizerMiddleBox, wxID_ANY, wxEmptyString);
+    wxButton *b1 = new wxButton(sizerMiddleBox, wxID_ANY, "Change &box label");
     b1->Bind(wxEVT_BUTTON, &StaticWidgetsPage::OnButtonBoxText, this);
     sizerMiddle->Add(m_textBox, 0, wxEXPAND|wxALL, 5);
     sizerMiddle->Add(b1, 0, wxLEFT|wxBOTTOM, 5);
 
-    m_textLabel = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
+    m_textLabel = new wxTextCtrl(sizerMiddleBox, wxID_ANY, wxEmptyString,
                                  wxDefaultPosition, wxDefaultSize,
                                  wxTE_MULTILINE|wxHSCROLL);
-    wxButton *b2 = new wxButton(this, wxID_ANY, "Change &text label");
+    wxButton *b2 = new wxButton(sizerMiddleBox, wxID_ANY, "Change &text label");
     b2->Bind(wxEVT_BUTTON, &StaticWidgetsPage::OnButtonLabelText, this);
     sizerMiddle->Add(m_textLabel, 0, wxEXPAND|wxALL, 5);
     sizerMiddle->Add(b2, 0, wxLEFT|wxBOTTOM, 5);
 
 #if wxUSE_MARKUP
-    m_textLabelWithMarkup = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
+    m_textLabelWithMarkup = new wxTextCtrl(sizerMiddleBox, wxID_ANY, wxEmptyString,
                                            wxDefaultPosition, wxDefaultSize,
                                            wxTE_MULTILINE|wxHSCROLL);
 
-    wxButton *b3 = new wxButton(this, wxID_ANY, "Change decorated text label");
+    wxButton *b3 = new wxButton(sizerMiddleBox, wxID_ANY, "Change decorated text label");
     b3->Bind(wxEVT_BUTTON, &StaticWidgetsPage::OnButtonLabelWithMarkupText, this);
     sizerMiddle->Add(m_textLabelWithMarkup, 0, wxEXPAND|wxALL, 5);
     sizerMiddle->Add(b3, 0, wxLEFT|wxBOTTOM, 5);
 
     m_chkGreen = CreateCheckBoxAndAddToSizer(sizerMiddle,
-                                             "Decorated label on g&reen");
+                                             "Decorated label on g&reen",
+                                             wxID_ANY, sizerMiddleBox);
     m_chkGreen->Bind(wxEVT_CHECKBOX, &StaticWidgetsPage::OnRecreate, this);
 #endif // wxUSE_MARKUP
 

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -158,13 +158,14 @@ public:
 
 protected:
     // create an info text contorl
-    wxTextCtrl *CreateInfoText();
+    wxTextCtrl *CreateInfoText(wxWindow* parent);
 
     // create a horz sizer holding a static text and this text control
     wxSizer *CreateTextWithLabelSizer(const wxString& label,
                                       wxTextCtrl *text,
                                       const wxString& label2 = wxEmptyString,
-                                      wxTextCtrl *text2 = nullptr);
+                                      wxTextCtrl *text2 = nullptr,
+                                      wxWindow* statBoxParent = nullptr);
 
     // event handlers
     void OnButtonReset(wxCommandEvent& event);
@@ -234,7 +235,7 @@ protected:
 
     // the textctrl itself and the sizer it is in
     wxTextCtrl *m_text;
-    wxSizer *m_sizerText;
+    wxStaticBoxSizer *m_sizerText;
 
     // the information text zones
     wxTextCtrl *m_textPosCur,
@@ -416,35 +417,35 @@ void TextWidgetsPage::CreateContent()
         "multi line",
     };
 
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "&Set textctrl parameters");
-    m_radioTextLines = new wxRadioBox(this, wxID_ANY, "&Number of lines:",
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set textctrl parameters");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
+
+    m_radioTextLines = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Number of lines:",
                                       wxDefaultPosition, wxDefaultSize,
                                       WXSIZEOF(modes), modes,
                                       1, wxRA_SPECIFY_COLS);
-
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
 
     sizerLeft->Add(m_radioTextLines, 0, wxGROW | wxALL, 5);
     sizerLeft->AddSpacer(5);
 
     m_chkPassword = CreateCheckBoxAndAddToSizer(
-                        sizerLeft, "&Password control", TextPage_Password
+                        sizerLeft, "&Password control", TextPage_Password, sizerLeftBox
                     );
     m_chkReadonly = CreateCheckBoxAndAddToSizer(
-                        sizerLeft, "&Read-only mode"
+                        sizerLeft, "&Read-only mode", wxID_ANY, sizerLeftBox
                     );
     m_chkProcessEnter = CreateCheckBoxAndAddToSizer(
-                        sizerLeft, "Process &Enter"
+                        sizerLeft, "Process &Enter", wxID_ANY, sizerLeftBox
                     );
     m_chkProcessTab = CreateCheckBoxAndAddToSizer(
-                        sizerLeft, "Process &Tab"
+                        sizerLeft, "Process &Tab", wxID_ANY, sizerLeftBox
                     );
     m_chkFilename = CreateCheckBoxAndAddToSizer(
-                        sizerLeft, "&Filename control"
+                        sizerLeft, "&Filename control", wxID_ANY, sizerLeftBox
                     );
     m_chkNoVertScrollbar = CreateCheckBoxAndAddToSizer(
                         sizerLeft, "No &vertical scrollbar",
-                        TextPage_NoVertScrollbar
+                        TextPage_NoVertScrollbar, sizerLeftBox
                     );
     m_chkFilename->Disable(); // not implemented yet
     sizerLeft->AddSpacer(5);
@@ -457,7 +458,7 @@ void TextWidgetsPage::CreateContent()
         "best wrap",
     };
 
-    m_radioWrap = new wxRadioBox(this, TextPage_WrapLines, "&Wrap style:",
+    m_radioWrap = new wxRadioBox(sizerLeftBox, TextPage_WrapLines, "&Wrap style:",
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(wrap), wrap,
                                  1, wxRA_SPECIFY_COLS);
@@ -470,7 +471,7 @@ void TextWidgetsPage::CreateContent()
         "right",
     };
 
-    m_radioAlign = new wxRadioBox(this, wxID_ANY, "&Text alignment",
+    m_radioAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Text alignment",
                                     wxDefaultPosition, wxDefaultSize,
                                     WXSIZEOF(halign), halign, 1);
     sizerLeft->Add(m_radioAlign, 0, wxGROW | wxALL, 5);
@@ -483,7 +484,7 @@ void TextWidgetsPage::CreateContent()
         "rich edit 2.0",
     };
 
-    m_radioKind = new wxRadioBox(this, wxID_ANY, "Control &kind",
+    m_radioKind = new wxRadioBox(sizerLeftBox, wxID_ANY, "Control &kind",
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(kinds), kinds,
                                  1, wxRA_SPECIFY_COLS);
@@ -492,62 +493,62 @@ void TextWidgetsPage::CreateContent()
     sizerLeft->Add(m_radioKind, 0, wxGROW | wxALL, 5);
 #endif // __WXMSW__
 
-    wxButton *btn = new wxButton(this, TextPage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, TextPage_Reset, "&Reset");
     sizerLeft->Add(2, 2, 0, wxGROW | wxALL, 1); // spacer
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY, "&Change contents:");
-    wxSizer *sizerMiddleUp = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddleUp = new wxStaticBoxSizer(wxVERTICAL, this, "&Change contents:");
+    wxStaticBox* const sizerMiddleUpBox = sizerMiddleUp->GetStaticBox();
 
-    btn = new wxButton(this, TextPage_Set, "&Set text value");
+    btn = new wxButton(sizerMiddleUpBox, TextPage_Set, "&Set text value");
     sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
 
-    btn = new wxButton(this, TextPage_Add, "&Append text");
+    btn = new wxButton(sizerMiddleUpBox, TextPage_Add, "&Append text");
     sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
 
-    btn = new wxButton(this, TextPage_Insert, "&Insert text");
+    btn = new wxButton(sizerMiddleUpBox, TextPage_Insert, "&Insert text");
     sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
 
-    btn = new wxButton(this, TextPage_Load, "&Load file");
+    btn = new wxButton(sizerMiddleUpBox, TextPage_Load, "&Load file");
     sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
 
-    btn = new wxButton(this, TextPage_Clear, "&Clear");
+    btn = new wxButton(sizerMiddleUpBox, TextPage_Clear, "&Clear");
     sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
 
-    btn = new wxButton(this, TextPage_StreamRedirector, "St&ream redirection");
+    btn = new wxButton(sizerMiddleUpBox, TextPage_StreamRedirector, "St&ream redirection");
     sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
 
-    wxStaticBox *box4 = new wxStaticBox(this, wxID_ANY, "&Info:");
-    wxSizer *sizerMiddleDown = new wxStaticBoxSizer(box4, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddleDown = new wxStaticBoxSizer(wxVERTICAL, this, "&Info:");
+    wxStaticBox* const sizerMiddleDownBox = sizerMiddleDown->GetStaticBox();
 
-    m_textPosCur = CreateInfoText();
-    m_textRowCur = CreateInfoText();
-    m_textColCur = CreateInfoText();
+    m_textPosCur = CreateInfoText(sizerMiddleDownBox);
+    m_textRowCur = CreateInfoText(sizerMiddleDownBox);
+    m_textColCur = CreateInfoText(sizerMiddleDownBox);
 
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
     sizerRow->Add(CreateTextWithLabelSizer
                   (
                     "Current pos:",
-                    m_textPosCur
+                    m_textPosCur, "", nullptr, sizerMiddleDownBox
                   ),
                   0, wxRIGHT, 5);
     sizerRow->Add(CreateTextWithLabelSizer
                   (
                     "Col:",
-                    m_textColCur
+                    m_textColCur, "", nullptr, sizerMiddleDownBox
                   ),
                   0, wxLEFT | wxRIGHT, 5);
     sizerRow->Add(CreateTextWithLabelSizer
                   (
                     "Row:",
-                    m_textRowCur
+                    m_textRowCur, "", nullptr, sizerMiddleDownBox
                   ),
                   0, wxLEFT, 5);
     sizerMiddleDown->Add(sizerRow, 0, wxALL, 5);
 
-    m_textLineLast = CreateInfoText();
-    m_textPosLast = CreateInfoText();
+    m_textLineLast = CreateInfoText(sizerMiddleDownBox);
+    m_textPosLast = CreateInfoText(sizerMiddleDownBox);
     sizerMiddleDown->Add
                      (
                         CreateTextWithLabelSizer
@@ -555,13 +556,14 @@ void TextWidgetsPage::CreateContent()
                           "Number of lines:",
                           m_textLineLast,
                           "Last position:",
-                          m_textPosLast
+                          m_textPosLast,
+                          sizerMiddleDownBox
                         ),
                         0, wxALL, 5
                      );
 
-    m_textSelFrom = CreateInfoText();
-    m_textSelTo = CreateInfoText();
+    m_textSelFrom = CreateInfoText(sizerMiddleDownBox);
+    m_textSelTo = CreateInfoText(sizerMiddleDownBox);
     sizerMiddleDown->Add
                      (
                         CreateTextWithLabelSizer
@@ -569,12 +571,13 @@ void TextWidgetsPage::CreateContent()
                           "Selection: from",
                           m_textSelFrom,
                           "to",
-                          m_textSelTo
+                          m_textSelTo,
+                          sizerMiddleDownBox
                         ),
                         0, wxALL, 5
                      );
 
-    m_textRange = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
+    m_textRange = new wxTextCtrl(sizerMiddleDownBox, wxID_ANY, wxEmptyString,
                                  wxDefaultPosition, wxDefaultSize,
                                  wxTE_READONLY);
     sizerMiddleDown->Add
@@ -582,7 +585,8 @@ void TextWidgetsPage::CreateContent()
                         CreateTextWithLabelSizer
                         (
                           "Range 10..20:",
-                          m_textRange
+                          m_textRange,
+                          "", nullptr, sizerMiddleDownBox
                         ),
                         0, wxALL, 5
                      );
@@ -591,7 +595,7 @@ void TextWidgetsPage::CreateContent()
                      (
                           new wxStaticText
                           (
-                            this,
+                            sizerMiddleDownBox,
                             wxID_ANY,
                             "Alt-click in the text to see HitTest() result"
                           ),
@@ -603,8 +607,7 @@ void TextWidgetsPage::CreateContent()
     sizerMiddle->Add(sizerMiddleDown, 1, wxGROW | wxTOP, 5);
 
     // right pane
-    wxStaticBox *box3 = new wxStaticBox(this, wxID_ANY, "&Text:");
-    m_sizerText = new wxStaticBoxSizer(box3, wxHORIZONTAL);
+    m_sizerText = new wxStaticBoxSizer(wxHORIZONTAL, this, "&Text:");
     Reset();
     CreateText();
     m_sizerText->SetMinSize(150, 0);
@@ -622,7 +625,7 @@ void TextWidgetsPage::CreateContent()
 // creation helpers
 // ----------------------------------------------------------------------------
 
-wxTextCtrl *TextWidgetsPage::CreateInfoText()
+wxTextCtrl *TextWidgetsPage::CreateInfoText(wxWindow* parent)
 {
     static int s_maxWidth = 0;
     if ( !s_maxWidth )
@@ -631,7 +634,7 @@ wxTextCtrl *TextWidgetsPage::CreateInfoText()
         GetTextExtent("9999999", &s_maxWidth, nullptr);
     }
 
-    wxTextCtrl *text = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
+    wxTextCtrl *text = new wxTextCtrl(parent, wxID_ANY, wxEmptyString,
                                       wxDefaultPosition,
                                       wxSize(s_maxWidth, wxDefaultCoord),
                                       wxTE_READONLY);
@@ -641,15 +644,16 @@ wxTextCtrl *TextWidgetsPage::CreateInfoText()
 wxSizer *TextWidgetsPage::CreateTextWithLabelSizer(const wxString& label,
                                                  wxTextCtrl *text,
                                                  const wxString& label2,
-                                                 wxTextCtrl *text2)
+                                                 wxTextCtrl *text2,
+                                                 wxWindow* statBoxParent)
 {
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    sizerRow->Add(new wxStaticText(this, wxID_ANY, label), 0,
+    sizerRow->Add(new wxStaticText(statBoxParent ? statBoxParent : this, wxID_ANY, label), 0,
                   wxALIGN_CENTRE_VERTICAL | wxRIGHT, 5);
     sizerRow->Add(text, 0, wxALIGN_CENTRE_VERTICAL);
     if ( text2 )
     {
-        sizerRow->Add(new wxStaticText(this, wxID_ANY, label2), 0,
+        sizerRow->Add(new wxStaticText(statBoxParent ? statBoxParent : this, wxID_ANY, label2), 0,
                       wxALIGN_CENTRE_VERTICAL | wxLEFT | wxRIGHT, 5);
         sizerRow->Add(text2, 0, wxALIGN_CENTRE_VERTICAL);
     }
@@ -781,7 +785,7 @@ void TextWidgetsPage::CreateText()
         valueOld = "Hello, Universe!";
     }
 
-    m_text = new WidgetsTextCtrl(this, TextPage_Textctrl, valueOld, flags);
+    m_text = new WidgetsTextCtrl(m_sizerText->GetStaticBox(), TextPage_Textctrl, valueOld, flags);
 
 #if 0
     if ( m_chkFilename->GetValue() )

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -220,41 +220,42 @@ void ToggleWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBox *box = new wxStaticBox(this, wxID_ANY, "Styles");
-
-    wxSizer *sizerLeft = new wxStaticBoxSizer(box, wxVERTICAL);
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "Styles");
+    wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
 #ifdef wxHAS_BITMAPTOGGLEBUTTON
-    m_chkBitmapOnly = CreateCheckBoxAndAddToSizer(sizerLeft, "&Bitmap only");
-    m_chkTextAndBitmap = CreateCheckBoxAndAddToSizer(sizerLeft, "Text &and bitmap");
+    m_chkBitmapOnly = CreateCheckBoxAndAddToSizer(sizerLeft, "&Bitmap only", wxID_ANY, sizerLeftBox);
+    m_chkTextAndBitmap = CreateCheckBoxAndAddToSizer(sizerLeft, "Text &and bitmap", wxID_ANY, sizerLeftBox);
 #endif // wxHAS_BITMAPTOGGLEBUTTON
 
 #if wxUSE_MARKUP
-    m_chkUseMarkup = CreateCheckBoxAndAddToSizer(sizerLeft, "Interpret &markup");
+    m_chkUseMarkup = CreateCheckBoxAndAddToSizer(sizerLeft, "Interpret &markup", wxID_ANY, sizerLeftBox);
 #endif // wxUSE_MARKUP
 
-    m_chkFit = CreateCheckBoxAndAddToSizer(sizerLeft, "&Fit exactly");
-    m_chkDisable = CreateCheckBoxAndAddToSizer(sizerLeft, "Disable");
+    m_chkFit = CreateCheckBoxAndAddToSizer(sizerLeft, "&Fit exactly", wxID_ANY, sizerLeftBox);
+    m_chkDisable = CreateCheckBoxAndAddToSizer(sizerLeft, "Disable", wxID_ANY, sizerLeftBox);
 
 #ifdef wxHAS_BITMAPTOGGLEBUTTON
     m_chkUseBitmapClass = CreateCheckBoxAndAddToSizer(sizerLeft,
-        "Use wxBitmapToggleButton");
+        "Use wxBitmapToggleButton", wxID_ANY, sizerLeftBox);
     m_chkUseBitmapClass->SetValue(true);
 
 
     sizerLeft->AddSpacer(5);
 
-    wxSizer *sizerUseLabels =
-        new wxStaticBoxSizer(wxVERTICAL, this,
+    wxStaticBoxSizer *sizerUseLabels =
+        new wxStaticBoxSizer(wxVERTICAL, sizerLeftBox,
                 "&Use the following bitmaps in addition to the normal one?");
+    wxStaticBox* const sizerUseLabelsBox = sizerUseLabels->GetStaticBox();
+
     m_chkUsePressed = CreateCheckBoxAndAddToSizer(sizerUseLabels,
-        "&Pressed (small help icon)");
+        "&Pressed (small help icon)", wxID_ANY, sizerUseLabelsBox);
     m_chkUseFocused = CreateCheckBoxAndAddToSizer(sizerUseLabels,
-        "&Focused (small error icon)");
+        "&Focused (small error icon)", wxID_ANY, sizerUseLabelsBox);
     m_chkUseCurrent = CreateCheckBoxAndAddToSizer(sizerUseLabels,
-        "&Current (small warning icon)");
+        "&Current (small warning icon)", wxID_ANY, sizerUseLabelsBox);
     m_chkUseDisabled = CreateCheckBoxAndAddToSizer(sizerUseLabels,
-        "&Disabled (broken image icon)");
+        "&Disabled (broken image icon)", wxID_ANY, sizerUseLabelsBox);
     sizerLeft->Add(sizerUseLabels, wxSizerFlags().Expand().Border());
 
     sizerLeft->AddSpacer(10);
@@ -263,7 +264,7 @@ void ToggleWidgetsPage::CreateContent()
     {
         "left", "right", "top", "bottom",
     };
-    m_radioImagePos = new wxRadioBox(this, wxID_ANY, "Image &position",
+    m_radioImagePos = new wxRadioBox(sizerLeftBox, wxID_ANY, "Image &position",
                                      wxDefaultPosition, wxDefaultSize,
                                      WXSIZEOF(dirs), dirs);
     sizerLeft->Add(m_radioImagePos, wxSizerFlags().Expand().Border());
@@ -284,10 +285,10 @@ void ToggleWidgetsPage::CreateContent()
         "bottom",
     };
 
-    m_radioHAlign = new wxRadioBox(this, wxID_ANY, "&Horz alignment",
+    m_radioHAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Horz alignment",
                                    wxDefaultPosition, wxDefaultSize,
                                    WXSIZEOF(halign), halign);
-    m_radioVAlign = new wxRadioBox(this, wxID_ANY, "&Vert alignment",
+    m_radioVAlign = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Vert alignment",
                                    wxDefaultPosition, wxDefaultSize,
                                    WXSIZEOF(valign), valign);
 
@@ -297,17 +298,17 @@ void ToggleWidgetsPage::CreateContent()
 
     sizerLeft->AddSpacer(5);
 
-    wxButton *btn = new wxButton(this, TogglePage_Reset, "&Reset");
+    wxButton *btn = new wxButton(sizerLeftBox, TogglePage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().Border(wxALL, 15));
 
     // middle pane
-    wxStaticBox *box2 = new wxStaticBox(this, wxID_ANY, "&Operations");
-    wxSizer *sizerMiddle = new wxStaticBoxSizer(box2, wxVERTICAL);
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Operations");
 
     wxSizer *sizerRow = CreateSizerWithTextAndButton(TogglePage_ChangeLabel,
                                                      "Change label",
                                                      wxID_ANY,
-                                                     &m_textLabel);
+                                                     &m_textLabel,
+                                                     sizerMiddle->GetStaticBox());
     m_textLabel->SetValue("&Toggle me!");
 
     sizerMiddle->Add(sizerRow, wxSizerFlags().Expand().Border());

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -514,11 +514,11 @@ WidgetsFrame::WidgetsFrame(const wxString& title)
 
     // the lower one only has the log listbox and a button to clear it
 #if USE_LOG
-    wxSizer *sizerDown = new wxStaticBoxSizer(
+    wxStaticBoxSizer *sizerDown = new wxStaticBoxSizer(
         new wxStaticBox( m_panel, wxID_ANY, "&Log window" ),
         wxVERTICAL);
 
-    m_lboxLog = new wxListBox(m_panel, wxID_ANY);
+    m_lboxLog = new wxListBox(sizerDown->GetStaticBox(), wxID_ANY);
     sizerDown->Add(m_lboxLog, wxSizerFlags(1).Expand().Border());
     sizerDown->SetMinSize(100, 150);
 #else
@@ -1391,7 +1391,7 @@ wxSizer *WidgetsPage::CreateSizerWithText(wxControl *control,
                                           wxTextCtrl **ppText)
 {
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
-    wxTextCtrl *text = new wxTextCtrl(this, id, wxEmptyString,
+    wxTextCtrl *text = new wxTextCtrl(control->GetParent(), id, wxEmptyString,
         wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
 
     sizerRow->Add(control, wxSizerFlags(0).Border(wxRIGHT).CentreVertical());
@@ -1406,9 +1406,10 @@ wxSizer *WidgetsPage::CreateSizerWithText(wxControl *control,
 // create a sizer containing a label and a text ctrl
 wxSizer *WidgetsPage::CreateSizerWithTextAndLabel(const wxString& label,
                                                   wxWindowID id,
-                                                  wxTextCtrl **ppText)
+                                                  wxTextCtrl **ppText,
+                                                  wxWindow* statBoxParent)
 {
-    return CreateSizerWithText(new wxStaticText(this, wxID_ANY, label),
+    return CreateSizerWithText(new wxStaticText(statBoxParent ? statBoxParent: this, wxID_ANY, label),
         id, ppText);
 }
 
@@ -1416,16 +1417,18 @@ wxSizer *WidgetsPage::CreateSizerWithTextAndLabel(const wxString& label,
 wxSizer *WidgetsPage::CreateSizerWithTextAndButton(wxWindowID idBtn,
                                                    const wxString& label,
                                                    wxWindowID id,
-                                                   wxTextCtrl **ppText)
+                                                   wxTextCtrl **ppText,
+                                                   wxWindow* statBoxParent)
 {
-    return CreateSizerWithText(new wxButton(this, idBtn, label), id, ppText);
+    return CreateSizerWithText(new wxButton(statBoxParent ? statBoxParent: this, idBtn, label), id, ppText);
 }
 
 wxCheckBox *WidgetsPage::CreateCheckBoxAndAddToSizer(wxSizer *sizer,
                                                      const wxString& label,
-                                                     wxWindowID id)
+                                                     wxWindowID id,
+                                                     wxWindow* statBoxParent)
 {
-    wxCheckBox *checkbox = new wxCheckBox(this, id, label);
+    wxCheckBox *checkbox = new wxCheckBox(statBoxParent ? statBoxParent: this, id, label);
     sizer->Add(checkbox, wxSizerFlags().HorzBorder());
     sizer->AddSpacer(2);
 

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -172,18 +172,21 @@ protected:
     // create a sizer containing a label and a text ctrl
     wxSizer *CreateSizerWithTextAndLabel(const wxString& label,
                                          wxWindowID id = wxID_ANY,
-                                         wxTextCtrl **ppText = nullptr);
+                                         wxTextCtrl **ppText = nullptr,
+                                         wxWindow* statBoxParent = nullptr);
 
     // create a sizer containing a button and a text ctrl
     wxSizer *CreateSizerWithTextAndButton(wxWindowID idBtn,
                                           const wxString& labelBtn,
                                           wxWindowID id = wxID_ANY,
-                                          wxTextCtrl **ppText = nullptr);
+                                          wxTextCtrl **ppText = nullptr,
+                                          wxWindow* statBoxParent = nullptr);
 
     // create a checkbox and add it to the sizer
     wxCheckBox *CreateCheckBoxAndAddToSizer(wxSizer *sizer,
                                             const wxString& label,
-                                            wxWindowID id = wxID_ANY);
+                                            wxWindowID id = wxID_ANY,
+                                            wxWindow* statBoxParent = nullptr);
 
 public:
     // the head of the linked list containinginfo about all pages


### PR DESCRIPTION
If a control is contained in a wxStaticBoxSizer or its child sizer, wxStaticBoxSizer::GetStaticBox() should be used as the control's parent.

However, widgets and dialogs samples did not do that, which resulted in flooding the message log in widgets sample with warnings about this; in dialogs sample the warnings were shown in the debug output.

Fix this by always using the static box as the control's parent when the control is contained (directly or indirectly) in a wxStaticBoxSizer.

The warnings are not there in 3.2 branch, but if backporting this should comprise of just replacing `nullptr` with `NULL`, perhaps it could be backported, to promote to correct usage of `wxStaticBoxSizer`.