### PR TITLE
Fix missing richtext docs

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -5132,6 +5132,19 @@ void wxQueueEvent(wxEvtHandler* dest, wxEvent *event);
 
 #if wxUSE_GUI
 
+/**
+    Find a window with the focus, that is also a descendant of the given window.
+    This is used to determine the window to initially send commands to.
+
+    @header{wx/event.h}
+
+    @param ancestor
+        The ancestor window for the focused window to find.
+    @return
+        The window found or NULL.
+*/
+wxWindow* wxFindFocusDescendant(wxWindow* ancestor);
+
 wxEventType wxEVT_BUTTON;
 wxEventType wxEVT_CHECKBOX;
 wxEventType wxEVT_CHOICE;

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -5132,19 +5132,6 @@ void wxQueueEvent(wxEvtHandler* dest, wxEvent *event);
 
 #if wxUSE_GUI
 
-/**
-    Find a window with the focus, that is also a descendant of the given window.
-    This is used to determine the window to initially send commands to.
-
-    @header{wx/event.h}
-
-    @param ancestor
-        The ancestor window for the focused window to find.
-    @return
-        The window found or NULL.
-*/
-wxWindow* wxFindFocusDescendant(wxWindow* ancestor);
-
 wxEventType wxEVT_BUTTON;
 wxEventType wxEVT_CHECKBOX;
 wxEventType wxEVT_CHOICE;

--- a/interface/wx/richtext/richtextformatdlg.h
+++ b/interface/wx/richtext/richtextformatdlg.h
@@ -164,6 +164,11 @@ public:
                             int flags = wxRICHTEXT_SETSTYLE_WITH_UNDO|wxRICHTEXT_SETSTYLE_OPTIMIZE);
 
     /**
+        Apply attributes to the object being edited, if any.
+    */
+    virtual bool ApplyStyle(wxRichTextCtrl* ctrl, int flags = wxRICHTEXT_SETSTYLE_WITH_UNDO);
+
+    /**
         Creation: see wxRichTextFormattingDialog() "the constructor" for
         details about the parameters.
     */
@@ -239,6 +244,17 @@ public:
         Currently the only option is Option_AllowPixelFontSize.
     */
     int GetOptions() const { return m_options; }
+
+    /**
+        If editing the attributes for a particular object, such as an image,
+        set the object so the code can initialize attributes such as size correctly.
+    */
+    void SetObject(wxRichTextObject* obj) { m_object = obj; }
+
+    /**
+        Returns the object of which the attributes are to edited (if any).
+     */
+    wxRichTextObject* GetObject() const;
 
     /**
         Returns @true if the given option is present.

--- a/interface/wx/richtext/richtextstyles.h
+++ b/interface/wx/richtext/richtextstyles.h
@@ -557,6 +557,11 @@ public:
         form is for convenient setting of the most commonly-used attributes.
     */
     void SetLevelAttributes(int level, const wxRichTextAttr& attr);
+
+    /**
+        Convenience function for setting the major attributes for a list level specification.
+     */
+    void SetAttributes(int i, int leftIndent, int leftSubIndent, int bulletStyle, const wxString& bulletSymbol = wxEmptyString);
 };
 
 
@@ -582,9 +587,19 @@ public:
     wxRichTextStyleSheet();
 
     /**
+        Copy constructor.
+     */
+    wxRichTextStyleSheet(const wxRichTextStyleSheet& sheet);
+
+    /**
         Destructor.
     */
     virtual ~wxRichTextStyleSheet();
+
+    /*
+        Copies given style sheet.
+     */
+    void Copy(const wxRichTextStyleSheet& sheet);
 
     /**
         Adds a definition to the character style list.


### PR DESCRIPTION
Adds a number of API docs for methods (directly or indirectly) used in the implementation of the RichText sample.
