### PR TITLE
Fix wxContextMenuEvent event propagation under wxQt

### DIFF
--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -149,10 +149,20 @@ protected:
         if ( !this->GetHandler() )
             return;
 
-        if ( !this->GetHandler()->QtHandleContextMenuEvent(this, event) )
-            Widget::contextMenuEvent(event);
-        else
-            event->accept();
+        this->GetHandler()->QtHandleContextMenuEvent(this, event);
+
+        // Notice that we are simply accepting the event and deliberately not
+        // calling Widget::contextMenuEvent(event); here because the context menu
+        // is supposed to be shown from a wxEVT_CONTEXT_MENU handler and not from
+        // QWidget::contextMenuEvent() overrides (and we are already in one of
+        // these overrides to perform QContextMenuEvent --> wxContextMenuEvent
+        // translation).
+        // More importantly, the default implementation of contextMenuEvent() simply
+        // ignores the context event, which means that the event will be propagated
+        // to the parent widget again which is undesirable here because the event may
+        // have already been propagated at the wxWidgets level.
+
+        event->accept();
     }
 
     //wxDropFilesEvent


### PR DESCRIPTION
Also fixes this test case:
https://github.com/wxWidgets/wxWidgets/blob/7fbe3698c5e3eb89693e8a4e9f54e7f89d69ec87/tests/events/propagation.cpp#L655-L697