### PR TITLE
Implement wxSearchCtrl::GetEditHWND() correctly in wxMSW

### DIFF
--- a/include/wx/generic/srchctlg.h
+++ b/include/wx/generic/srchctlg.h
@@ -175,6 +175,12 @@ protected:
 private:
     friend class wxSearchButton;
 
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+    // Implement wxMSW-specific pure virtual function by forwarding it to the
+    // real text entry.
+    virtual WXHWND GetEditHWND() const override;
+#endif
+
     // Implement pure virtual function inherited from wxCompositeWindow.
     virtual wxWindowList GetCompositeWindowParts() const override;
 

--- a/include/wx/srchctrl.h
+++ b/include/wx/srchctrl.h
@@ -27,12 +27,6 @@
         : public wxCompositeWindow< wxNavigationEnabled<wxControl> >,
           public wxTextEntry
     {
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
-    private:
-        // implement this to return the HWND of the EDIT control
-        // can return nullptr here as this TextEntry is just a proxy
-        virtual WXHWND GetEditHWND() const override  { wxFAIL_MSG("unreachable"); return nullptr; }
-#endif
     };
 #elif defined(__WXMAC__)
     // search control was introduced in Mac OS X 10.3 Panther

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -530,6 +530,13 @@ void wxSearchCtrl::LayoutControls()
     }
 }
 
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+WXHWND wxSearchCtrl::GetEditHWND() const
+{
+    return m_text->GetHWND();
+}
+#endif // wxMSW
+
 wxWindowList wxSearchCtrl::GetCompositeWindowParts() const
 {
     wxWindowList parts;


### PR DESCRIPTION
Since the changes of 4d76a87015 (Make wxSearchCtrl inherit from wxTextEntry in all ports, 2023-07-09, see #23697) GetEditHWND() returned null for wxSearchCtrl which was considered to be correct because all wxTextEntry functions were supposed to be forwarded to wxSearchTextCtrl anyhow.

This wasn't really correct, however, as GetEditHWND() was also called from SetHint(), resulting in an assert failure and falling back on generic hint implementation which, while mostly working, suffers from some problems that the native implementation doesn't have.

So make this function return the actual HWND used by the associated text entry to fix this and allow SetHint() to work as before and also forestall any problems due to not having the right HWND in the future.

Closes #23975.