### PR TITLE
Make using EGL under Wayland from outside wxEVT_PAINT work again

### DIFF
--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -799,6 +799,12 @@ bool wxGLCanvasEGL::SwapBuffers()
         if ( !m_readyToDraw )
         {
             wxLogTrace(TRACE_EGL, "Window %p is not not ready to draw yet", this);
+
+            // When the application draws the window from a timer or idle event
+            // handler, we need to ensure that it's going to be called again if
+            // we didn't do anything this time, so request another repaint.
+            Refresh();
+
             return false;
         }
 


### PR DESCRIPTION
Since the changes of 194a7be33f (Improve wxGLCanvasEGL refresh logic
under Wayland, 2023-05-17, see #23554) drawing on wxGLCanvas from
wxEVT_IDLE handler without refreshing the window first didn't work any
longer because the "ready to draw" flag was always false in this case.

To make this work again, refresh the window ourselves to ensure that it
does get redrawn. This is less efficient than drawing on it from
wxEVT_PAINT because all the code executed by the application prior to
calling SwapBuffers() is just wasted, but better than not updating the
window at all.

The recommended way of doing things remains, just as it always was, to
draw from wxEVT_PAINT and call Refresh() in the application code when
the window needs to be updated.

Closes #23996.
