### PR TITLE
Include standard library memory header file

### DIFF
--- a/src/common/fs_arc.cpp
+++ b/src/common/fs_arc.cpp
@@ -8,6 +8,8 @@
 
 #include "wx/wxprec.h"
 
+#include <memory>
+
 #if wxUSE_FS_ARCHIVE
 
 #include "wx/fs_arc.h"

--- a/src/common/rendcmn.cpp
+++ b/src/common/rendcmn.cpp
@@ -17,6 +17,7 @@
 
 #include "wx/wxprec.h"
 
+#include <memory>
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"


### PR DESCRIPTION
If setup.h uses `#defines wxUSE_INTL 0` then compilation fails in fs_arc.cpp and rendcmn.cpp because they both use `std::unique_ptr` but the required header file `memory` is no longer included. Both files include `wx/intl.h` which in turn includes `wx/translation.h` which only includes `memory` if `wxUSE_INTL` is defined.

This PR fixes the problem by including `memory` in the two files.
