### PR TITLE
Expand wxDialog::CreateStdDialogButtonSizer docs

### DIFF
--- a/interface/wx/dialog.h
+++ b/interface/wx/dialog.h
@@ -291,6 +291,12 @@ public:
         wxCLOSE, wxHELP, wxNO_DEFAULT.
 
         The sizer lays out the buttons in a manner appropriate to the platform.
+
+        @note Unlike when using wxStdDialogButtonSizer directly, creating the sizer
+              with this method usually results in one of its buttons being default
+              (and having initial focus): @a wxNO_DEFAULT will make the No button
+              the default, otherwise the OK or Yes button will be set as the default
+              when present.
     */
     wxStdDialogButtonSizer* CreateStdDialogButtonSizer(long flags);
 


### PR DESCRIPTION
Add a note explaining that when creating a button sizer with this method, one of the buttons will be usually made the default.

BTW, I wonder whether the notes in other button-sizer-creating `wxDialog` methods such as this
https://github.com/wxWidgets/wxWidgets/blob/dc6a0c069bdde714f22cb0459efd9ad186ce7179/interface/wx/dialog.h#L249-L253
are still relevant.