### PR TITLE
Fix wxTLW::SetSizeHints() implementation under wxQt

### DIFF
--- a/src/qt/toplevel.cpp
+++ b/src/qt/toplevel.cpp
@@ -248,16 +248,25 @@ long wxTopLevelWindowQt::GetWindowStyleFlag() const
 
 void wxTopLevelWindowQt::DoSetSizeHints( int minW, int minH,
                                          int maxW, int maxH,
-                                         int incW, int incH)
+                                         int incW, int incH )
 {
-    GetHandle()->setMinimumWidth(wxMax(0, minW));
-    GetHandle()->setMinimumHeight(wxMax(0, minH));
+    // The value -1 is special which means no constraints will be used.
+    // In other words, use the Qt defaults if -1 was specified.
 
-    GetHandle()->setMaximumWidth(wxMax(0, maxW));
-    GetHandle()->setMaximumHeight(wxMax(0, maxH));
+    if ( maxW == wxDefaultCoord )
+        maxW = QWIDGETSIZE_MAX;
+    if ( maxH == wxDefaultCoord )
+        maxH = QWIDGETSIZE_MAX;
 
-    GetHandle()->setSizeIncrement(wxMax(0, incW),
-                                  wxMax(0, incH));
+    minW = wxMax(0, minW);
+    minH = wxMax(0, minH);
+
+    incW = wxMax(0, incW);
+    incH = wxMax(0, incH);
+
+    GetHandle()->setMinimumSize(minW, minH);
+    GetHandle()->setMaximumSize(maxW, maxH);
+    GetHandle()->setSizeIncrement(incW, incH);
 
     wxTopLevelWindowBase::DoSetSizeHints(minW, minH, maxW, maxH, incW, incH);
 }


### PR DESCRIPTION
As documented, the value -1 is special which means no constraints will be used. But, passing -1 as `maxsize` end up with Qt making the window **non-resizable** at all (because `maxsize` will be the same as `minsize`).

In other words, we should use the Qt defaults if -1 was specified.