### PR TITLE
Clean up Wayland resources on `wxGLCanvas` destructor

### DIFF
--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -619,6 +619,7 @@ wxGLCanvasEGL::~wxGLCanvasEGL()
     if ( m_surface )
         eglDestroySurface(m_display, m_surface);
 #ifdef GDK_WINDOWING_WAYLAND
+    DestroyWaylandSubsurface();
     g_clear_pointer(&m_wlEGLWindow, wl_egl_window_destroy);
     g_clear_pointer(&m_wlSurface, wl_surface_destroy);
 #endif


### PR DESCRIPTION
If the wxGLCanvas is destroyed immediately (without hiding it first), the GTKs widget's `unmap` signal which usually destroys the Wayland resources is not emitted. Thus, we need to ensure they are destroyed on the destructor instead.

This fixes an use-after-free issue, sometimes causing a crash, because one of the leaked resources is the canvas's Wayland frame callback.

Fixes #24013