### PR TITLE
Provide MinGW-specific instructions for building applications

### DIFF
--- a/docs/doxygen/overviews/install.md
+++ b/docs/doxygen/overviews/install.md
@@ -187,7 +187,17 @@ e.g. if you use `AC_CONFIG_MACRO_DIRS([m4])`).
 
 For applications using Microsoft Visual Studio IDE, simply add the provided
 `wxwidgets.props` property sheet file to your project as explained in the
-[instructions](@ref msw_build_apps) and build the project as usual.
+[instructions](@ref msw_build_apps_msvc) and build the project as usual.
+
+
+### MSW, with MinGW
+
+If you use MinGW in any Unix-like environment (Cygwin, MSYS2 etc), please
+follow the instructions for Unix systems.
+
+Otherwise, i.e. when building using `mingw32-make` or using `g++` directly from
+the command line, please follow [these instructions](@ref msw_build_apps_other)
+and provide the list of required compiler and build options manually.
 
 
 ### Mac, with Xcode
@@ -233,4 +243,4 @@ If you use another IDE, under Unix you should run `wx-config --cxxflags` and
 `wx-config --libs` commands separately and copy-and-paste their output to the
 "Additional preprocessor options" and "Additional linker options" fields in
 your IDE, respectively. Under MSW systems you need to configure the IDE using
-the instructions in the [manual setup](@ref msw_build_apps) section.
+the instructions in the [manual setup](@ref msw_build_apps_other) section.

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -470,11 +470,11 @@ need to:
 
 * Add the list of libraries to link with to the linker input. The exact list
   depends on which libraries you use and whether you built wxWidgets in
-  monolithic or default multlib mode and basically should include all the
-  relevant libraries from the directory above, e.g. `wxmsw31ud_core.lib
-  wxbase31ud.lib wxtiffd.lib wxjpegd.lib wxpngd.lib wxzlibd.lib wxregexud.lib
-  wxexpatd.lib` for a debug build of an application using the core library only
-  (all wxWidgets applications use the base library).
+  monolithic or default multi-lib mode and basically should include all the
+  relevant libraries from the directory above, e.g. `wxmsw34ud_core.lib
+  wxbase34ud.lib wxtiffd.lib wxjpegd.lib wxpngd.lib wxzlibd.lib wxregexud.lib
+  wxexpatd.lib` for a debug build of an application using the core library of
+  wxWidgets 3.4 only (all wxWidgets applications use the base library).
 
 
 For example, to compile your program with gcc using debug wxWidgets DLLs

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -455,18 +455,22 @@ Here is what you need to do:
   - compiler
   - resource compiler
   include paths.
-* If using MSVC, prepend `$WXWIN\include\msvc` to the include paths too.
-  Otherwise, append `<wx-lib-dir>\mswu[d]` to the include paths, where "d" should
+* Append `<wx-lib-dir>\mswu[d]` to the include paths, where "d" should
   be used for debug builds only.
+  When using MSVC, there is a simpler alternative which allows to use the
+  same compiler options for debug and release builds: just prepend
+  `$WXWIN\include\msvc` to the include paths **instead** of the paths above.
 * Define the following symbols for the preprocessor:
   - `__WXMSW__` to ensure you use the correct wxWidgets port.
   - `NDEBUG` if you want to build in release mode, i.e. disable asserts.
   - `WXUSINGDLL` if you are using DLL build of wxWidgets.
 * Add `<wx-lib-dir>` directory described above to the libraries path.
 
-When using MSVC, the libraries are linked automatically using "#pragma
-comment(lib)" feature of this compiler. With all the other compilers you also
-need to:
+When using MSVC, using `include\msvc` in the compiler include path has another
+advantage: the header found in this directory ensures that all the required
+libraries are linked automatically using `#pragma comment(lib)` feature of this
+compiler. With the other compilers, or if you don't use `include\msvc` with
+MSVC, you also need to:
 
 * Add the list of libraries to link with to the linker input. The exact list
   depends on which libraries you use and whether you built wxWidgets in

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -414,6 +414,12 @@ The full list of the build settings follows:
 Building Applications Using wxWidgets  {#msw_build_apps}
 =====================================
 
+Note: If you want to use CMake for building your project, please see
+@ref overview_cmake.
+
+Using Microsoft Visual C++ IDE         {#msw_build_apps_msvc}
+------------------------------
+
 If you use MSVS for building your project, simply add
 `wxwidgets.props` property sheet to (all) your project(s) using wxWidgets
 by using "View|Property Manager" menu item to open the property manager
@@ -425,10 +431,8 @@ If you've created a new empty project (i.e. chose "Empty Project" in the
 you need to change "Linker|System|SubSystem" in the project properties to
 "Windows", from the default "Console". You don't need to do anything else.
 
-If you want to use CMake for building your project, please see
-@ref overview_cmake.
-
-Otherwise follow the instructions below for "manual" setup of your project.
+Using Other Compilers or Command Line  {#msw_build_apps_other}
+-------------------------------------
 
 We suppose that wxWidgets sources are under the directory `$WXWIN` (notice that
 different tool chains refer to environment variables such as WXWIN in
@@ -436,13 +440,14 @@ different ways, e.g. MSVC users should use `$``(WXWIN)` instead of just
 `$WXWIN`). And we will use `<wx-lib-dir>` as a shortcut for the subdirectory of
 `$WXWIN\lib` which is composed from several parts separated by underscore:
 first, a compiler-specific prefix (e.g. "vc" for MSVC, "gcc" for g++ or the
-value of `COMPILER_PREFIX` if you set it explicitly), then optional "x64" if
-building in 64 bits and finally either "lib" or "dll" depending on whether
-static or dynamic wx libraries are being used.
+value of `COMPILER_PREFIX` if you set it explicitly), then "x64" if building in
+64 bits using MSVC (but not any other compilers) and finally either "lib" or
+"dll" depending on whether static or dynamic wx libraries are being used.
 
 For example, WXWIN could be "c:\wxWidgets\3.4.5" and `<wx-lib-dir>` could be
 `c:\wxWidgets\3.4.5\lib\vc_x64_lib` for 64-bit static libraries built with
-MSVC.
+MSVC but for shared libraries built with gcc it would be
+`c:\wxWidgets\3.4.5\lib\gcc_dll` instead.
 
 Here is what you need to do:
 
@@ -471,6 +476,18 @@ need to:
   wxexpatd.lib` for a debug build of an application using the core library only
   (all wxWidgets applications use the base library).
 
+
+For example, to compile your program with gcc using debug wxWidgets DLLs
+you would need to use the following options for the compiler (and `windres`
+resource compiler):
+
+    -I$WXWIN/include -I$WXWIN/lib/gcc_dll/mswud -D__WXMSW__ -DWXUSINGDLL
+
+and
+
+    -L$WXWIN/lib/gcc_dll
+
+for the linker.
 
 Finally, please notice that the makefiles and project files provided with
 wxWidgets samples show which flags should be used when building applications


### PR DESCRIPTION
We had instructions for building wxWidgets with MinGW but not for building the applications using wxWidgets, so add them too now in the hope that it will be helpful to people who struggle to find the options to use for building -- or at the very least to the people who have to answer the questions about this, as they could now just point to these instructions.

---

This is not much and more improvements would be definitely welcome, but better than nothing. Or at least I hope so: please let me know if I wrote anything wrong, as I didn't really test this.