### PR TITLE
Return true from AddCatalog() if message ID matches language

### DIFF
--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1346,9 +1346,27 @@ bool wxTranslations::AddCatalog(const wxString& domain,
         return true;
 
     const wxString msgIdLang = wxUILocale::GetLanguageCanonicalName(msgIdLanguage);
-    const wxString domain_lang = GetBestTranslation(domain, msgIdLang);
 
-    if ( msgIdLang == domain_lang )
+    // Check if the original strings can be used directly.
+    bool canUseUntranslared = false;
+    if ( m_lang.empty() )
+    {
+        // If we are using the default language, check if the message ID
+        // language is acceptable for this system.
+        const wxString domain_lang = GetBestTranslation(domain, msgIdLang);
+
+        if ( msgIdLang == domain_lang )
+            canUseUntranslared = true;
+    }
+    else // But if we have a fixed language, we should just check it instead.
+    {
+        // Consider message IDs for another region using the same language
+        // acceptable.
+        if ( msgIdLang.BeforeFirst('_') == m_lang.BeforeFirst('_') )
+            canUseUntranslared = true;
+    }
+
+    if ( canUseUntranslared )
     {
         wxLogTrace(TRACE_I18N,
                     wxS("not using translations for domain '%s' with msgid language '%s'"),

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -239,7 +239,7 @@ void IntlTestCase::IsAvailable()
     CPPUNIT_ASSERT_EQUAL( origLocale, setlocale(LC_ALL, nullptr) );
 }
 
-TEST_CASE("wxTranslations::Available", "[translations]")
+TEST_CASE("wxTranslations::AddCatalog", "[translations]")
 {
     // We currently have translations for French and Japanese in this test
     // directory, check that loading those succeeds but loading others doesn't.
@@ -269,6 +269,21 @@ TEST_CASE("wxTranslations::Available", "[translations]")
     {
         trans.SetLanguage(wxLANGUAGE_ITALIAN);
         CHECK_FALSE( trans.AddAvailableCatalog(domain) );
+    }
+
+    // And loading catalog using the same language as message IDs should
+    // "succeed" too, even if there is no such file, as in this case the
+    // message IDs themselves can be used directly.
+    SECTION("Untranslated")
+    {
+        trans.SetLanguage(wxLANGUAGE_GERMAN);
+        CHECK( trans.AddCatalog(domain, wxLANGUAGE_GERMAN) );
+
+        // Using a different region should still work.
+        CHECK( trans.AddCatalog(domain, wxLANGUAGE_GERMAN_SWISS) );
+
+        // But using a completely different language should not.
+        CHECK_FALSE( trans.AddCatalog(domain, wxLANGUAGE_DUTCH) );
     }
 }
 


### PR DESCRIPTION
When the original messages language matches the language of the locale being used, these strings can be used directly and so AddCatalog() should still return true for them but it didn't do it any more after the changes of 94b1a17aeb (Add AddAvailableCatalog() and use it in AddStdCatalog(), 2023-09-30).

See #18227.

Closes #24019.