### PR TITLE
Fix crash when dragging in `wxAuiNotebook`

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -239,10 +239,15 @@ protected:
     wxPoint m_clickPt = wxDefaultPosition;
     wxWindow* m_clickTab = nullptr;
     bool m_isDragging = false;
+
     wxAuiTabContainerButton* m_hoverButton = nullptr;
     wxAuiTabContainerButton* m_pressedButton = nullptr;
 
     void SetHoverTab(wxWindow* wnd);
+
+private:
+    // Reset dragging-related fields above to their initial values.
+    void DoEndDragging();
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxAuiTabCtrl);

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -236,11 +236,11 @@ protected:
 
 protected:
 
-    wxPoint m_clickPt;
-    wxWindow* m_clickTab;
-    bool m_isDragging;
-    wxAuiTabContainerButton* m_hoverButton;
-    wxAuiTabContainerButton* m_pressedButton;
+    wxPoint m_clickPt = wxDefaultPosition;
+    wxWindow* m_clickTab = nullptr;
+    bool m_isDragging = false;
+    wxAuiTabContainerButton* m_hoverButton = nullptr;
+    wxAuiTabContainerButton* m_pressedButton = nullptr;
 
     void SetHoverTab(wxWindow* wnd);
 

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2607,6 +2607,8 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
         if (dest_tabs->TabHitTest(pt.x, pt.y, &dest_location_tab))
         {
             int src_idx = evt.GetSelection();
+            wxCHECK_RET( src_idx != -1, "Invalid source tab?" );
+
             int dest_idx = dest_tabs->GetIdxFromWindow(dest_location_tab);
 
             // prevent jumpy drag

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1013,10 +1013,6 @@ wxAuiTabCtrl::wxAuiTabCtrl(wxWindow* parent,
                            long style) : wxControl(parent, id, pos, size, style)
 {
     SetName(wxT("wxAuiTabCtrl"));
-    m_clickPt = wxDefaultPosition;
-    m_isDragging = false;
-    m_hoverButton = nullptr;
-    m_pressedButton = nullptr;
 }
 
 wxAuiTabCtrl::~wxAuiTabCtrl()

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1019,6 +1019,13 @@ wxAuiTabCtrl::~wxAuiTabCtrl()
 {
 }
 
+void wxAuiTabCtrl::DoEndDragging()
+{
+    m_clickPt = wxDefaultPosition;
+    m_isDragging = false;
+    m_clickTab = nullptr;
+}
+
 void wxAuiTabCtrl::OnPaint(wxPaintEvent&)
 {
     wxPaintDC dc(this);
@@ -1053,9 +1060,9 @@ void wxAuiTabCtrl::OnSize(wxSizeEvent& evt)
 void wxAuiTabCtrl::OnLeftDown(wxMouseEvent& evt)
 {
     CaptureMouse();
-    m_clickPt = wxDefaultPosition;
-    m_isDragging = false;
-    m_clickTab = nullptr;
+
+    // Reset any previous values first.
+    DoEndDragging();
     m_pressedButton = nullptr;
 
 
@@ -1095,11 +1102,12 @@ void wxAuiTabCtrl::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event))
 {
     if (m_isDragging)
     {
-        m_clickPt = wxDefaultPosition;
-        m_isDragging = false;
+        const auto clickTab = m_clickTab;
+
+        DoEndDragging();
 
         wxAuiNotebookEvent evt(wxEVT_AUINOTEBOOK_CANCEL_DRAG, m_windowId);
-        evt.SetSelection(GetIdxFromWindow(m_clickTab));
+        evt.SetSelection(GetIdxFromWindow(clickTab));
         evt.SetOldSelection(evt.GetSelection());
         evt.SetEventObject(this);
         GetEventHandler()->ProcessEvent(evt);
@@ -1113,11 +1121,12 @@ void wxAuiTabCtrl::OnLeftUp(wxMouseEvent& evt)
 
     if (m_isDragging)
     {
-        m_clickPt = wxDefaultPosition;
-        m_isDragging = false;
+        const auto clickTab = m_clickTab;
+
+        DoEndDragging();
 
         wxAuiNotebookEvent e(wxEVT_AUINOTEBOOK_END_DRAG, m_windowId);
-        e.SetSelection(GetIdxFromWindow(m_clickTab));
+        e.SetSelection(GetIdxFromWindow(clickTab));
         e.SetOldSelection(e.GetSelection());
         e.SetEventObject(this);
         GetEventHandler()->ProcessEvent(e);
@@ -1154,9 +1163,7 @@ void wxAuiTabCtrl::OnLeftUp(wxMouseEvent& evt)
         m_pressedButton = nullptr;
     }
 
-    m_clickPt = wxDefaultPosition;
-    m_isDragging = false;
-    m_clickTab = nullptr;
+    DoEndDragging();
 }
 
 void wxAuiTabCtrl::OnMiddleUp(wxMouseEvent& evt)

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1099,6 +1099,7 @@ void wxAuiTabCtrl::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event))
 {
     if (m_isDragging)
     {
+        m_clickPt = wxDefaultPosition;
         m_isDragging = false;
 
         wxAuiNotebookEvent evt(wxEVT_AUINOTEBOOK_CANCEL_DRAG, m_windowId);
@@ -1116,6 +1117,7 @@ void wxAuiTabCtrl::OnLeftUp(wxMouseEvent& evt)
 
     if (m_isDragging)
     {
+        m_clickPt = wxDefaultPosition;
         m_isDragging = false;
 
         wxAuiNotebookEvent e(wxEVT_AUINOTEBOOK_END_DRAG, m_windowId);


### PR DESCRIPTION
The import commit (which needs to be backported to 3.2) here is the first one, the next ones are just refactorings trying to make the re-occurrence of such bugs less likely.