### PR TITLE
Don't find hidden items when using incremental tree search

### DIFF
--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -369,6 +369,13 @@ private:
     // operation.
     void ResetFindState();
 
+    // Find the next item, either looking inside the collapsed items or not.
+    enum
+    {
+        Next_Any     = 0,
+        Next_Visible = 1
+    };
+    wxTreeItemId DoGetNext(const wxTreeItemId& item, int flags = 0) const;
 
     // True if we're using custom colours/font, respectively, or false if we're
     // using the default colours and should update them whenever system colours

--- a/interface/wx/timer.h
+++ b/interface/wx/timer.h
@@ -126,8 +126,8 @@ public:
 
         To make your code more readable you may also use the following symbolic constants:
         - wxTIMER_CONTINUOUS: Start a normal, continuously running, timer
-        - wxTIMER_ONE_SHOT: Start a one shot timer
-        Alternatively, use StartOnce().
+        - wxTIMER_ONE_SHOT: Start a one shot timer. Alternatively, and
+        preferably, call StartOnce() instead of this function.
 
         If the timer was already running, it will be stopped by this method before
         restarting it.

--- a/samples/stc/stctest.cpp
+++ b/samples/stc/stctest.cpp
@@ -668,7 +668,7 @@ AppAbout::AppAbout (wxWindow *parent,
     m_timer = nullptr;
     if (milliseconds > 0) {
         m_timer = new wxTimer (this, myID_ABOUTTIMER);
-        m_timer->Start (milliseconds, wxTIMER_ONE_SHOT);
+        m_timer->StartOnce(milliseconds);
     }
 
     // Get version of Scintilla

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -3168,7 +3168,7 @@ void wxListMainWindow::OnChar( wxKeyEvent &event )
 
                 // Notice that we should start the timer even if we didn't find
                 // anything to make sure we reset the search state later.
-                m_findTimer->Start(wxListFindTimer::DELAY, wxTIMER_ONE_SHOT);
+                m_findTimer->StartOnce(wxListFindTimer::DELAY);
 
                 // restart timer even when there's no match so bell get's reset
                 if ( item != (size_t)-1 )

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -2420,7 +2420,7 @@ void wxListMainWindow::OnRenameCancelled(size_t itemEdit)
 void wxListMainWindow::OnFindTimer()
 {
     m_findPrefix.clear();
-    if ( m_findBell )
+    if ( m_findBell == -1 )
         m_findBell = 1;
 }
 
@@ -3182,7 +3182,7 @@ void wxListMainWindow::OnChar( wxKeyEvent &event )
 
                     // Reset the bell flag if it had been temporarily disabled
                     // before.
-                    if ( m_findBell )
+                    if ( m_findBell == -1 )
                         m_findBell = 1;
                 }
                 else // No such item

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -1594,7 +1594,7 @@ void wxGenericTreeCtrl::ResetTextControl()
 void wxGenericTreeCtrl::ResetFindState()
 {
     m_findPrefix.clear();
-    if ( m_findBell )
+    if ( m_findBell == -1 )
         m_findBell = 1;
 }
 
@@ -3397,7 +3397,7 @@ void wxGenericTreeCtrl::OnChar( wxKeyEvent &event )
 
                     // Reset the bell flag if it had been temporarily disabled
                     // before.
-                    if ( m_findBell )
+                    if ( m_findBell == -1 )
                         m_findBell = 1;
                 }
                 else // No such item

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -3389,7 +3389,7 @@ void wxGenericTreeCtrl::OnChar( wxKeyEvent &event )
 
                 // Notice that we should start the timer even if we didn't find
                 // anything to make sure we reset the search state later.
-                m_findTimer->Start(wxTreeFindTimer::DELAY, wxTIMER_ONE_SHOT);
+                m_findTimer->StartOnce(wxTreeFindTimer::DELAY);
 
                 if ( id.IsOk() )
                 {

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -1492,28 +1492,35 @@ wxTreeItemId wxGenericTreeCtrl::GetPrevSibling(const wxTreeItemId& item) const
 // Only for internal use right now, but should probably be public
 wxTreeItemId wxGenericTreeCtrl::GetNext(const wxTreeItemId& item) const
 {
+    return DoGetNext(item, Next_Any);
+}
+
+wxTreeItemId
+wxGenericTreeCtrl::DoGetNext(const wxTreeItemId& item, int flags) const
+{
     wxCHECK_MSG( item.IsOk(), wxTreeItemId(), wxT("invalid tree item") );
 
     wxGenericTreeItem *i = (wxGenericTreeItem*) item.m_pItem;
 
     // First see if there are any children.
-    wxArrayGenericTreeItems& children = i->GetChildren();
-    if (children.GetCount() > 0)
+    if ( !(flags & Next_Visible) || i->IsExpanded() )
     {
-         return children.Item(0);
+        wxArrayGenericTreeItems& children = i->GetChildren();
+        if (children.GetCount() > 0)
+        {
+             return children.Item(0);
+        }
     }
-    else
-    {
-         // Try a sibling of this or ancestor instead
-         wxTreeItemId p = item;
-         wxTreeItemId toFind;
-         do
-         {
-              toFind = GetNextSibling(p);
-              p = GetItemParent(p);
-         } while (p.IsOk() && !toFind.IsOk());
-         return toFind;
-    }
+
+     // Try a sibling of this or ancestor instead
+     wxTreeItemId p = item;
+     wxTreeItemId toFind;
+     do
+     {
+          toFind = GetNextSibling(p);
+          p = GetItemParent(p);
+     } while (p.IsOk() && !toFind.IsOk());
+     return toFind;
 }
 
 wxTreeItemId wxGenericTreeCtrl::GetFirstVisibleItem() const
@@ -1537,16 +1544,7 @@ wxTreeItemId wxGenericTreeCtrl::GetNextVisible(const wxTreeItemId& item) const
     wxCHECK_MSG( item.IsOk(), wxTreeItemId(), wxT("invalid tree item") );
     wxASSERT_MSG( IsVisible(item), wxT("this item itself should be visible") );
 
-    wxTreeItemId id = item;
-    if (id.IsOk())
-    {
-        while (id = GetNext(id), id.IsOk())
-        {
-            if (IsVisible(id))
-                return id;
-        }
-    }
-    return wxTreeItemId();
+    return DoGetNext(item, Next_Visible);
 }
 
 wxTreeItemId wxGenericTreeCtrl::GetPrevVisible(const wxTreeItemId& item) const

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -1612,13 +1612,13 @@ wxTreeItemId wxGenericTreeCtrl::FindItem(const wxTreeItemId& idParent,
     wxTreeItemId itemid = idParent;
     if ( prefix.length() == 1 )
     {
-        itemid = GetNext(itemid);
+        itemid = DoGetNext(itemid, Next_Visible);
     }
 
     // look for the item starting with the given prefix after it
     while ( itemid.IsOk() && !GetItemText(itemid).Lower().StartsWith(prefix) )
     {
-        itemid = GetNext(itemid);
+        itemid = DoGetNext(itemid, Next_Visible);
     }
 
     // if we haven't found anything...
@@ -1629,14 +1629,14 @@ wxTreeItemId wxGenericTreeCtrl::FindItem(const wxTreeItemId& idParent,
         if ( HasFlag(wxTR_HIDE_ROOT) )
         {
             // can't select virtual root
-            itemid = GetNext(itemid);
+            itemid = DoGetNext(itemid, Next_Visible);
         }
 
         // and try all the items (stop when we get to the one we started from)
         while ( itemid.IsOk() && itemid != idParent &&
                     !GetItemText(itemid).Lower().StartsWith(prefix) )
         {
-            itemid = GetNext(itemid);
+            itemid = DoGetNext(itemid, Next_Visible);
         }
         // If we haven't found the item but wrapped back to the one we started
         // from, id.IsOk() must be false


### PR DESCRIPTION
Only the last commit here is important, the rest is just some minor cleanup.

I don't know if anybody has any objections to this, i.e. likes the current behaviour, but personally it drives me crazy because, as a user, I definitely want to go to the visible item when typing a first couple of the letters in its name and not some item 4 levels deep in the collapsed part of the tree.