### PR TITLE
Try to make bug report instructions even more clear

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,29 +11,49 @@ assignees: ''
 IMPORTANT NOTE
 --------------
 
-Please note that this entry field uses [Markdown][1], which means that you
-need to escape any code snippets pasted here using fenced code blocks,
-i.e. by putting ``` before and after it. Also escape, using
-backslash, i.e. `\<` any angle brackets to prevent them from being
-interpreted as HTML tags.
+Please note that this entry field uses Markdown, see
 
-Use the Preview tab to review your issue before submitting it to verify that
-your formatting is correct.
+https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
 
-[1]: https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
+if you're unfamiliar with it, and make sure to use the "Preview" tab just above
+to review your issue before submitting it to verify that your formatting is
+correct.
 
----
+In particular, please use code blocks, i.e. put ``` on a separate line before
+and after any block of code or long text (such as compiler or make output).
 
-Describe the bug:
+Also make sure to escape, using backslash, i.e. `\<`, any angle brackets
+to prevent them from being interpreted as HTML tags.
+
+Finally, feel free to remove the explanatory comments, including this one,
+after reading (and hopefully following) them.
+
+-->
+
+### Description
+<!--
+Please use the following sections in your report:
+
+#### Bug description:
+
 A clear and concise description of what the bug is.
 
-Expected vs observed behaviour:
+#### Expected vs observed behaviour:
+
 Please describe what you expected to happen and what actually happens. Make
 sure to explain what exactly is the problem, just attaching a screenshot is
 not always sufficient. When in doubt, please provide more details rather
 than too few.
 
-Patch or snippet allowing to reproduce the problem:
+#### Stack trace:
+
+If relevant, i.e. if the problem is a crash or an assert failure, please run
+the program under debugger and copy and paste here (as text, not as an image:
+you can use Ctrl+C in MSVS "Stack" window) the stack shown when you break into
+the debugger once the problem happens.
+
+#### Patch or snippet allowing to reproduce the problem:
+
 Please attach the smallest possible patch allowing to reproduce the problem
 in a sample. If there is absolutely no appropriate sample, please attach a
 minimal self-contained example in a single file.
@@ -41,7 +61,8 @@ minimal self-contained example in a single file.
 Skip this step if the problem can be reproduced in one of the samples
 without any changes.
 
-To Reproduce:
+#### To Reproduce:
+
 Steps to reproduce the behaviour, please make them as detailed as possible.
 For example:
 
@@ -51,17 +72,14 @@ For example:
 4. See error
 -->
 
-### Description
-<!-- Describe the bug here -->
-
 
 ### Platform and version information
 
 - wxWidgets version <!-- [e.g. 3.2.1] --> you use:
 - wxWidgets port <!-- [e.g. wxMSW, wxGTK, wxOSX] --> you use:
 - OS <!-- [e.g. Windows 10, Ubuntu 22.10, macOS 15] --> and its version:
-
-<!-- For wxGTK only (**remove** this section if not using wxGTK) -->
-+ GTK version: <!-- [e.g. 3.24.5] -->
-+ Which GDK <!-- [X11 or Wayland] --> backend is used:
-+ Current theme: <!-- (If relevant, i.e. for appearance-related problems) -->
+  <!-- For wxGTK only (**remove** this section if not using wxGTK) -->
+  + GTK version: <!-- [e.g. 3.24.5] -->
+  + Which GDK <!-- [X11 or Wayland] --> backend is used:
+  + Desktop environment <!-- [e.g. Gnome or KDE] -->:
+  + Current theme: <!-- (If relevant, i.e. for appearance-related problems) -->

--- a/.github/ISSUE_TEMPLATE/build_problem.md
+++ b/.github/ISSUE_TEMPLATE/build_problem.md
@@ -6,13 +6,31 @@ labels: 'build'
 assignees: ''
 
 ---
+
+### Build System Used
+
 <!--
 
-Please describe exactly how you build wxWidgets, including the full `configure`
-command line and/or `make` command line if relevant.
+Please select the tool you use for building, i.e. check exactly
+one line from those below by putting "x" in between the brackets.
+-->
 
-Please attach the full build log, but feel free to quote the relevant parts of
-it here.
+I build wxWidgets and/or my application using:
+
+- [ ] CMake
+- [ ] configure
+- [ ] mingw32-make with makefile.gcc
+- [ ] MSBuild (Microsoft Visual Studio solution file)
+- [ ] nmake with makefile.vc
+- [ ] Xcode
+
+<!--
+
+For command line based tools, such as configure or CMake,
+please include the full command line used to run them.
+
+Please attach the full build log, but feel free to quote
+the relevant parts of it here.
 
 When using `configure`, please also attach `config.log` file.
 
@@ -28,3 +46,4 @@ When using `configure`, please also attach `config.log` file.
 - wxWidgets port <!-- [e.g. wxMSW, wxGTK, wxOSX] --> you are building:
 - OS <!-- [e.g. Windows 10, Ubuntu 22.10, macOS 15] --> and its version:
 - Compiler <!-- [e.g. MSVS 2022, gcc 12.1] --> being used:
+- Non-default compiler options, if any <!-- e.g. -std=c++26 -->:


### PR DESCRIPTION
What do people think of changing it like this?

Notably, very few people think of submitting stack traces on their own (thanks a lot to those who do!).