### PR TITLE
Add missing method doc for wxSizerFlags

### DIFF
--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -1534,6 +1534,12 @@ public:
     wxSizerFlags& DoubleBorder(int direction = wxALL);
 
     /**
+        Sets the border in left and right directions having the default
+        border size.
+    */
+    wxSizerFlags& HorzBorder();
+
+    /**
         Sets the border in left and right directions having twice the default
         border size.
     */


### PR DESCRIPTION
Interface documentation for wxSizerFlags was missing doc for wxSizerFlags::HorzBorder().
This PR fixes that.