### PR TITLE
OSX keep old activation for out-of-bundle executables

### DIFF
--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -109,7 +109,12 @@ void wxBell()
         }
 
         if ( activate ) {
-            [[NSRunningApplication currentApplication] activateWithOptions: NSApplicationActivateIgnoringOtherApps];
+            if ( [NSApp activationPolicy] == NSApplicationActivationPolicyAccessory ) {
+                [[NSRunningApplication currentApplication] activateWithOptions: NSApplicationActivateIgnoringOtherApps];
+            }
+            else {
+                [NSApp activateIgnoringOtherApps: YES];
+            }
         }
     }
 }


### PR DESCRIPTION
see #24056 and #23893 (latter resolved in #24003)