### PR TITLE
Add bullet number and style support to MSW wxTextCtrol via wxTextAttr

### DIFF
--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -373,12 +373,18 @@ public:
 
     /**
         Returns the bullet number.
+
+        For wxTextCtrl, is implemented under wxMSW.
+        Also implemented in wxRichTextCtrl.
     */
     int GetBulletNumber() const;
 
     /**
         Returns the bullet style.
         See ::wxTextAttrBulletStyle for a list of available styles.
+
+        For wxTextCtrl, is implemented under wxMSW.
+        Also implemented in wxRichTextCtrl.
     */
     int GetBulletStyle() const;
 
@@ -609,11 +615,17 @@ public:
 
     /**
         Returns @true if the attribute object specifies a bullet number.
+
+        For wxTextCtrl, is implemented under wxMSW.
+        Also implemented in wxRichTextCtrl.
     */
     bool HasBulletNumber() const;
 
     /**
         Returns @true if the attribute object specifies a bullet style.
+
+        For wxTextCtrl, is implemented under wxMSW.
+        Also implemented in wxRichTextCtrl.
     */
     bool HasBulletStyle() const;
 
@@ -836,14 +848,25 @@ public:
 
     /**
         Sets the bullet number.
+
+        For wxTextCtrl, is implemented under wxMSW.
+        Also implemented in wxRichTextCtrl.
     */
     void SetBulletNumber(int n);
 
     /**
         Sets the bullet style.
 
-        The ::wxTextAttrBulletStyle enumeration values are all supported,
+        For wxTextCtrl, is implemented under wxMSW.
+        Also implemented in wxRichTextCtrl.
+
+        For wxRichTextCtrl, the ::wxTextAttrBulletStyle enumeration values are all supported,
         except for wxTEXT_ATTR_BULLET_STYLE_BITMAP.
+
+        For wxTextCtrl under wxMSW, the ::wxTextAttrBulletStyle enumeration values are all supported,
+        except for wxTEXT_ATTR_BULLET_STYLE_BITMAP, wxTEXT_ATTR_BULLET_STYLE_OUTLINE,
+        wxTEXT_ATTR_BULLET_STYLE_ALIGN_LEFT, wxTEXT_ATTR_BULLET_STYLE_ALIGN_RIGHT,
+        wxTEXT_ATTR_BULLET_STYLE_ALIGN_CENTRE, and wxTEXT_ATTR_BULLET_STYLE_CONTINUATION.
     */
     void SetBulletStyle(int style);
 

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -3212,6 +3212,44 @@ bool wxTextCtrl::MSWSetParaFormat(const wxTextAttr& style, long start, long end)
         // Convert from 1/10 mm to TWIPS
         pf.dySpaceBefore = (int) (((double) style.GetParagraphSpacingBefore()) * mm2twips / 10.0) ;
     }
+
+    if ( style.HasBulletStyle() )
+    {
+        pf.dwMask |= PFM_NUMBERINGSTYLE;
+        pf.dwMask |= PFM_NUMBERING;
+
+        // number/bullet formats
+        if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_NONE) != 0)
+            pf.wNumbering = 0;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_STANDARD) != 0)
+            pf.wNumbering = PFN_BULLET;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_ARABIC) != 0)
+            pf.wNumbering = PFN_ARABIC;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_LETTERS_LOWER) != 0)
+            pf.wNumbering = PFN_LCLETTER;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_LETTERS_UPPER) != 0)
+            pf.wNumbering = PFN_UCLETTER;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_ROMAN_LOWER) != 0)
+            pf.wNumbering = PFN_LCROMAN;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_ROMAN_UPPER) != 0)
+            pf.wNumbering = PFN_UCROMAN;
+
+        // number display
+        if ( style.HasBulletNumber() )
+        {
+            pf.dwMask |= PFM_NUMBERINGSTART;
+            pf.wNumberingStart = style.GetBulletNumber();
+            pf.wNumberingStyle = PFNS_NEWNUMBER;
+        }
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_RIGHT_PARENTHESIS) != 0)
+            pf.wNumberingStyle = PFNS_PAREN;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_PARENTHESES) != 0)
+            pf.wNumberingStyle = PFNS_PARENS;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_PERIOD) != 0)
+            pf.wNumberingStyle = PFNS_PERIOD;
+        else if ((style.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_STANDARD) != 0)
+            pf.wNumberingStyle = PFNS_PLAIN;
+    }
 #endif // wxUSE_RICHEDIT2
 
 #if wxUSE_RICHEDIT2


### PR DESCRIPTION
Adds bullet support to `wxTextCtrl` under MSW using `wxTextAttr` objects. I mapped all the `wxTextAttrBulletStyle` values that are available in `PARAFORMAT2` and tested under Windows 10 & 11.

One API quirk is that because `wNumberingStyle` only takes one value, setting the number will override styles like parentheses and periods.