### PR TITLE
Add native wxOverlay implementation under wxQt

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5534,7 +5534,8 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS =  \
 	monodll_qt_treectrl.o \
 	monodll_paletteg.o \
 	monodll_qt_datectrl.o \
-	monodll_qt_timectrl.o
+	monodll_qt_timectrl.o \
+	monodll_qt_overlay.o
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS)
 @COND_PLATFORM_UNIX_1@__QT_PLATFORM_SRC_OBJECTS = \
 @COND_PLATFORM_UNIX_1@	monodll_unix_dialup.o monodll_unix_joystick.o \
@@ -7297,7 +7298,8 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_1 =  \
 	monolib_qt_treectrl.o \
 	monolib_paletteg.o \
 	monolib_qt_datectrl.o \
-	monolib_qt_timectrl.o
+	monolib_qt_timectrl.o \
+	monolib_qt_overlay.o
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_1)
 @COND_PLATFORM_UNIX_1@__QT_PLATFORM_SRC_OBJECTS_1 = \
 @COND_PLATFORM_UNIX_1@	monolib_unix_dialup.o monolib_unix_joystick.o \
@@ -9212,7 +9214,8 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_2 =  \
 	coredll_qt_treectrl.o \
 	coredll_paletteg.o \
 	coredll_qt_datectrl.o \
-	coredll_qt_timectrl.o
+	coredll_qt_timectrl.o \
+	coredll_qt_overlay.o
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_2)
 @COND_PLATFORM_UNIX_1@__QT_PLATFORM_SRC_OBJECTS_2 = \
 @COND_PLATFORM_UNIX_1@	coredll_unix_dialup.o coredll_unix_joystick.o \
@@ -10703,7 +10706,8 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_3 =  \
 	corelib_qt_treectrl.o \
 	corelib_paletteg.o \
 	corelib_qt_datectrl.o \
-	corelib_qt_timectrl.o
+	corelib_qt_timectrl.o \
+	corelib_qt_overlay.o
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_3)
 @COND_PLATFORM_UNIX_1@__QT_PLATFORM_SRC_OBJECTS_3 = \
 @COND_PLATFORM_UNIX_1@	corelib_unix_dialup.o corelib_unix_joystick.o \
@@ -15802,6 +15806,9 @@ monodll_qt_datectrl.o: $(srcdir)/src/qt/datectrl.cpp $(MONODLL_ODEP)
 monodll_qt_timectrl.o: $(srcdir)/src/qt/timectrl.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/qt/timectrl.cpp
 
+monodll_qt_overlay.o: $(srcdir)/src/qt/overlay.cpp $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/qt/overlay.cpp
+
 monodll_mdig.o: $(srcdir)/src/generic/mdig.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/mdig.cpp
 
@@ -20544,6 +20551,9 @@ monolib_qt_datectrl.o: $(srcdir)/src/qt/datectrl.cpp $(MONOLIB_ODEP)
 
 monolib_qt_timectrl.o: $(srcdir)/src/qt/timectrl.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/qt/timectrl.cpp
+
+monolib_qt_overlay.o: $(srcdir)/src/qt/overlay.cpp $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/qt/overlay.cpp
 
 monolib_mdig.o: $(srcdir)/src/generic/mdig.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/mdig.cpp
@@ -25966,6 +25976,9 @@ coredll_qt_datectrl.o: $(srcdir)/src/qt/datectrl.cpp $(COREDLL_ODEP)
 coredll_qt_timectrl.o: $(srcdir)/src/qt/timectrl.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/qt/timectrl.cpp
 
+coredll_qt_overlay.o: $(srcdir)/src/qt/overlay.cpp $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/qt/overlay.cpp
+
 coredll_mdig.o: $(srcdir)/src/generic/mdig.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/mdig.cpp
 
@@ -29682,6 +29695,9 @@ corelib_qt_datectrl.o: $(srcdir)/src/qt/datectrl.cpp $(CORELIB_ODEP)
 
 corelib_qt_timectrl.o: $(srcdir)/src/qt/timectrl.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/qt/timectrl.cpp
+
+corelib_qt_overlay.o: $(srcdir)/src/qt/overlay.cpp $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/qt/overlay.cpp
 
 corelib_mdig.o: $(srcdir)/src/generic/mdig.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/mdig.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -477,6 +477,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/generic/paletteg.cpp
     src/qt/datectrl.cpp
     src/qt/timectrl.cpp
+    src/qt/overlay.cpp
 </set>
 
 <set var="MEDIA_QT_SRC" hints="files">

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -390,6 +390,7 @@ set(QT_SRC
     src/generic/paletteg.cpp
     src/qt/datectrl.cpp
     src/qt/timectrl.cpp
+    src/qt/overlay.cpp
 )
 
 set(MEDIA_QT_SRC

--- a/build/files
+++ b/build/files
@@ -379,6 +379,7 @@ QT_SRC=
     src/qt/msgdlg.cpp
     src/qt/nonownedwnd.cpp
     src/qt/notebook.cpp
+    src/qt/overlay.cpp
     src/qt/pen.cpp
     src/qt/popupwin.cpp
     src/qt/printdlg.cpp

--- a/include/wx/private/overlay.h
+++ b/include/wx/private/overlay.h
@@ -21,6 +21,8 @@
 #elif defined(__WXGTK3__)
     #define wxHAS_NATIVE_OVERLAY 1
     #define wxHAS_GENERIC_OVERLAY 1
+#elif defined(__WXQT__)
+    #define wxHAS_NATIVE_OVERLAY 1
 #else
     #define wxHAS_GENERIC_OVERLAY 1
 #endif

--- a/include/wx/qt/dcclient.h
+++ b/include/wx/qt/dcclient.h
@@ -22,6 +22,12 @@ public:
 
     ~wxWindowDCImpl();
 
+protected:
+    std::unique_ptr<QPicture> m_pict;
+
+    // @true if m_qtPainter is owned by the window, @false otherwise (default).
+    bool m_isWindowPainter = false;
+
 private:
     wxDECLARE_CLASS(wxWindowDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxWindowDCImpl);
@@ -34,20 +40,18 @@ public:
     wxClientDCImpl( wxDC *owner );
     wxClientDCImpl( wxDC *owner, wxWindow *win );
 
-    ~wxClientDCImpl();
 private:
-    std::unique_ptr<QPicture> m_pict;
-
     wxDECLARE_CLASS(wxClientDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxClientDCImpl);
 };
 
 
-class WXDLLIMPEXP_CORE wxPaintDCImpl : public wxWindowDCImpl
+class WXDLLIMPEXP_CORE wxPaintDCImpl : public wxClientDCImpl
 {
 public:
     wxPaintDCImpl( wxDC *owner );
     wxPaintDCImpl( wxDC *owner, wxWindow *win );
+
 private:
     wxDECLARE_CLASS(wxPaintDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxPaintDCImpl);

--- a/include/wx/qt/dcclient.h
+++ b/include/wx/qt/dcclient.h
@@ -22,9 +22,6 @@ public:
 
     ~wxWindowDCImpl();
 
-protected:
-    wxWindow *m_window;
-
 private:
     wxDECLARE_CLASS(wxWindowDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxWindowDCImpl);

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -152,7 +152,7 @@ public:
 
     // wxQt implementation internals:
 
-    // Caller maintains ownership of pict - window will NOT delete it
+    // Takes ownership of pict - window will delete it
     void QtSetPicture( QPicture* pict );
 
     QPainter *QtGetPainter();
@@ -244,7 +244,7 @@ private:
 
     bool QtSetBackgroundStyle();
 
-    QPicture *m_qtPicture;                                   // not owned
+    std::unique_ptr<QPicture> m_qtPicture;                   // owned by this window
     std::unique_ptr<QPainter> m_qtPainter;                   // always allocated
 
     bool m_mouseInside;

--- a/samples/caret/caret.cpp
+++ b/samples/caret/caret.cpp
@@ -419,7 +419,7 @@ void MyCanvas::OnPaint( wxPaintEvent &WXUNUSED(event) )
             wxChar ch = CharAt(x, y);
             if ( !ch )
                 ch = ' ';
-#ifdef __WXOSX__
+#if defined(__WXOSX__) || defined(__WXQT__)
             dc.DrawText(ch, m_xMargin + x * m_widthChar,
                         m_yMargin + y * m_heightChar );
 #else
@@ -427,9 +427,8 @@ void MyCanvas::OnPaint( wxPaintEvent &WXUNUSED(event) )
 #endif
         }
 
-#ifndef __WXOSX__
-        dc.DrawText( line, m_xMargin, m_yMargin + y * m_heightChar );
-#endif
+        if ( !line.empty() )
+            dc.DrawText( line, m_xMargin, m_yMargin + y * m_heightChar );
     }
 }
 

--- a/src/qt/dcscreen.cpp
+++ b/src/qt/dcscreen.cpp
@@ -11,16 +11,22 @@
 #include "wx/dcscreen.h"
 #include "wx/qt/dcscreen.h"
 
-#include <QtWidgets/QDesktopWidget>
-#include <QtGui/QScreen>
 #include <QtWidgets/QApplication>
+#include <QtWidgets/QDesktopWidget>
+#include <QtGui/QPainter>
+#include <QtGui/QPicture>
 #include <QtGui/QPixmap>
+#include <QtGui/QScreen>
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxScreenDCImpl, wxQtDCImpl);
 
 wxScreenDCImpl::wxScreenDCImpl( wxScreenDC *owner )
     : wxWindowDCImpl( owner )
 {
+    m_pict.reset(new QPicture());
+    m_ok = m_qtPainter->begin( m_pict.get() );
+
+    QtPreparePainter();
 }
 
 wxScreenDCImpl::~wxScreenDCImpl( )

--- a/src/qt/overlay.cpp
+++ b/src/qt/overlay.cpp
@@ -1,0 +1,145 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        src/qt/overlay.cpp
+// Author:      Ali Kettab
+// Created:     2023-11-01
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#include "wx/wxprec.h"
+
+#ifdef __WXQT__
+
+#include "wx/private/overlay.h"
+#include "wx/dc.h"
+#include "wx/window.h"
+
+#include <QtGui/QGuiApplication>
+#include <QtGui/QPainter>
+#include <QtGui/QPicture>
+#include <QtGui/QScreen>
+#include <QtWidgets/QWidget>
+
+// Inspired by QRubberBand implementation
+
+class wxOverlayWindow : public QWidget
+{
+public:
+    explicit wxOverlayWindow(QWidget* parent)
+        : QWidget(parent, parent ? Qt::Widget : Qt::ToolTip)
+    {
+        if ( !parent )
+            setAttribute(Qt::WA_TranslucentBackground);
+        setAttribute(Qt::WA_TransparentForMouseEvents);
+        setAttribute(Qt::WA_NoSystemBackground);
+        setAttribute(Qt::WA_WState_ExplicitShowHide);
+        setVisible(false);
+    }
+
+    void SetPicture(QPicture& pict)
+    {
+        m_pict.swap(pict);
+        update();
+    }
+
+private:
+
+    QPicture m_pict;
+
+    virtual void paintEvent(QPaintEvent* WXUNUSED(event)) override
+    {
+        QPainter painter(this);
+        m_pict.play(&painter);
+    }
+};
+
+class wxOverlayImpl: public wxOverlay::Impl
+{
+public:
+    wxOverlayImpl() = default;
+    ~wxOverlayImpl();
+
+    virtual bool IsOk() override;
+    virtual void Init(wxDC*, int, int, int, int) override;
+    virtual void BeginDrawing(wxDC* dc) override;
+    virtual void EndDrawing(wxDC* dc) override;
+    virtual void Clear(wxDC* dc) override;
+    virtual void Reset() override;
+
+    wxWindow*        m_target  = nullptr;
+    wxOverlayWindow* m_overlay = nullptr;
+};
+
+wxOverlay::Impl* wxOverlay::Create()
+{
+    return new wxOverlayImpl;
+}
+
+
+wxOverlayImpl::~wxOverlayImpl()
+{
+    if ( m_target && !m_target->IsBeingDeleted() )
+    {
+        if ( m_overlay )
+            wxDELETE(m_overlay);
+    }
+}
+
+bool wxOverlayImpl::IsOk()
+{
+    return m_overlay != nullptr;
+}
+
+void wxOverlayImpl::Init(wxDC* dc, int , int , int , int )
+{
+    wxASSERT_MSG( !IsOk() , "You cannot Init an overlay twice" );
+
+    wxCHECK_RET( dc, "Invalid dc for wxOverlay" );
+
+    m_target = dc->GetWindow();
+
+    m_overlay = new wxOverlayWindow(m_target ? m_target->GetHandle() : nullptr);
+}
+
+void wxOverlayImpl::BeginDrawing(wxDC* WXUNUSED(dc))
+{
+    wxCHECK_RET( IsOk(), "wxOverlay not initialized" );
+
+    QRect qtRect = m_target ? m_target->GetHandle()->rect()
+                            : qGuiApp->primaryScreen()->geometry();
+
+    m_overlay->setGeometry( qtRect );
+    m_overlay->show();
+    m_overlay->raise();
+}
+
+void wxOverlayImpl::EndDrawing(wxDC* dc)
+{
+    wxCHECK_RET( dc, "Invalid dc for wxOverlay" );
+
+    auto painter = static_cast<QPainter*>(dc->GetHandle());
+    auto picture = dynamic_cast<QPicture*>(painter->device());
+
+    if ( picture && !picture->isNull() )
+    {
+        // take over the picture and draw it on the overlay window
+        m_overlay->SetPicture(*picture);
+    }
+}
+
+void wxOverlayImpl::Clear(wxDC* WXUNUSED(dc))
+{
+    // Already cleared by wxQt
+}
+
+void wxOverlayImpl::Reset()
+{
+    if ( m_overlay )
+    {
+        if ( m_target )
+            m_overlay->hide();
+        else
+            wxDELETE(m_overlay);
+    }
+}
+
+#endif // __WXQT__

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -276,7 +276,6 @@ void wxWindowQt::Init()
     m_horzScrollBar = nullptr;
     m_vertScrollBar = nullptr;
 
-    m_qtPicture = nullptr;
     m_qtPainter.reset(new QPainter());
 
     m_mouseInside = false;
@@ -1315,7 +1314,7 @@ bool wxWindowQt::QtHandlePaintEvent ( QWidget *handler, QPaintEvent *event )
         {
             bool handled;
 
-            if ( m_qtPicture == nullptr )
+            if ( !m_qtPicture )
             {
                 // Real paint event (not for wxClientDC), prepare the background
                 switch ( GetBackgroundStyle() )
@@ -1382,7 +1381,7 @@ bool wxWindowQt::QtHandlePaintEvent ( QWidget *handler, QPaintEvent *event )
                 // Data from wxClientDC, paint it
                 m_qtPicture->play( m_qtPainter.get() );
                 // Reset picture
-                m_qtPicture->setData( nullptr, 0 );
+                m_qtPicture.reset();
                 handled = true;
             }
 
@@ -1788,7 +1787,7 @@ QScrollArea *wxWindowQt::QtGetScrollBarsContainer() const
 
 void wxWindowQt::QtSetPicture( QPicture* pict )
 {
-    m_qtPicture = pict;
+    m_qtPicture.reset(pict);
 }
 
 QPainter *wxWindowQt::QtGetPainter()


### PR DESCRIPTION
As well as various fixes to `wx{Client,Window,Screen}DC`

Note that `wxQt` uses `wxGenericDragImage` and still **doesn't work** even with this PR.
But if we change [RedrawImage](https://github.com/wxWidgets/wxWidgets/blob/978fa7ed06fbba9901912d8c416a91459ce59133/src/generic/dragimgg.cpp#L390) to use `wxClientDC/wxScreenDC` constructed as temporary stack objects then everything works well. As I am not sure how to proceed to make the needed changes, I'll open an issue to record that, sorry!