### PR TITLE
Fix crash in DoShowMultipleLogMessages() with  wxUSE_LOG_DIALOG set to 0

### DIFF
--- a/src/generic/logg.cpp
+++ b/src/generic/logg.cpp
@@ -266,7 +266,7 @@ wxLogGui::DoShowMultipleLogMessages(const wxArrayString& messages,
     const size_t nMsgCount = messages.size();
     message.reserve(nMsgCount*100);
     for ( size_t n = nMsgCount; n > 0; n-- ) {
-        message << m_aMessages[n - 1] << wxT("\n");
+        message << messages[n - 1] << wxT("\n");
     }
 
     DoShowSingleLogMessage(message, title, style);


### PR DESCRIPTION
This PR fixes a crash when `DoShowMultipleLogMessages()` is called with `wxUSE_LOG_DIALOG` set to 0. The code after the #else statement gets the size of the `wxArrayString` but then instead of accessing that array, it tried to access the `m_aMessages` array which is empty, resulting in a crash in the C runtime. This one-line commit simply gets the strings from the correct array.

I was able to verify the fix in an application I have that has wxUSE_LOG_DIALOG set to 0 and a situation where 26 warnings were in the array passed to DoShowMultipleLogMessages(). It works fine with this change.
