### PR TITLE
Restore ToCDouble compatibility with leading spaces/+ characters and hex

### DIFF
--- a/tests/strings/strings.cpp
+++ b/tests/strings/strings.cpp
@@ -829,16 +829,16 @@ TEST_CASE("StringToDouble", "[wxString]")
     }
 
     CHECK( wxString("inf").ToCDouble(&d) );
-    CHECK( isinf(d) );
-    
+    CHECK( std::isinf(d) );
+
     CHECK( wxString("INFINITY").ToCDouble(&d) );
-    CHECK( isinf(d) );
+    CHECK( std::isinf(d) );
 
     CHECK( wxString("nan").ToCDouble(&d) );
-    CHECK( isnan(d) );
-    
+    CHECK( std::isnan(d) );
+
     CHECK( wxString("NAN").ToCDouble(&d) );
-    CHECK( isnan(d) );
+    CHECK( std::isnan(d) );
 
 
     // test ToDouble() now:
@@ -888,16 +888,16 @@ TEST_CASE("StringToDouble", "[wxString]")
     }
 
     CHECK( wxString("inf").ToDouble(&d) );
-    CHECK( isinf(d) );
-    
+    CHECK( std::isinf(d) );
+
     CHECK( wxString("INFINITY").ToDouble(&d) );
-    CHECK( isinf(d) );
+    CHECK( std::isinf(d) );
 
     CHECK( wxString("nan").ToDouble(&d) );
-    CHECK( isnan(d) );
-    
+    CHECK( std::isnan(d) );
+
     CHECK( wxString("NAN").ToDouble(&d) );
-    CHECK( isnan(d) );
+    CHECK( std::isnan(d) );
 }
 
 TEST_CASE("StringFromDouble", "[wxString]")

--- a/tests/strings/strings.cpp
+++ b/tests/strings/strings.cpp
@@ -804,6 +804,17 @@ TEST_CASE("StringToDouble", "[wxString]")
         { wxT("--1"), 0, false },
         { wxT("-3E-5"), -3E-5, true },
         { wxT("-3E-abcde5"), 0, false },
+
+        { wxT(" 1"), 1, true },
+        { wxT(" .1"), .1, true },
+        { wxT(" -1.2"), -1.2, true },
+
+        // printf can output + in a valid double/float string
+        { wxT("+1"), 1, true },
+        { wxT("+.1"), 0.1, true },
+        { wxT("++1"), 0, false },
+
+        { wxT("0X1.BC70A3D70A3D7p+6"), 111.11, true },
     };
 
     // test ToCDouble() first:
@@ -816,6 +827,18 @@ TEST_CASE("StringToDouble", "[wxString]")
         if ( ld.ok )
             CHECK( d == ld.value );
     }
+
+    CHECK( wxString("inf").ToCDouble(&d) );
+    CHECK( isinf(d) );
+    
+    CHECK( wxString("INFINITY").ToCDouble(&d) );
+    CHECK( isinf(d) );
+
+    CHECK( wxString("nan").ToCDouble(&d) );
+    CHECK( isnan(d) );
+    
+    CHECK( wxString("NAN").ToCDouble(&d) );
+    CHECK( isnan(d) );
 
 
     // test ToDouble() now:
@@ -844,6 +867,16 @@ TEST_CASE("StringToDouble", "[wxString]")
         { wxT("--1"), 0, false },
         { wxT("-3E-5"), -3E-5, true },
         { wxT("-3E-abcde5"), 0, false },
+
+        { wxT(" 1"), 1, true },
+        { wxT(" ,1"), .1, true },
+
+        // printf can output + in a valid double/float string
+        { wxT("+1"), 1, true },
+        { wxT("+,1"), 0.1, true },
+        { wxT("++1"), 0, false },
+
+        { wxT("0X1,BC70A3D70A3D7P+6"), 111.11, true },
     };
 
     for ( n = 0; n < WXSIZEOF(doubleData2); n++ )
@@ -853,6 +886,18 @@ TEST_CASE("StringToDouble", "[wxString]")
         if ( ld.ok )
             CHECK( d == ld.value );
     }
+
+    CHECK( wxString("inf").ToDouble(&d) );
+    CHECK( isinf(d) );
+    
+    CHECK( wxString("INFINITY").ToDouble(&d) );
+    CHECK( isinf(d) );
+
+    CHECK( wxString("nan").ToDouble(&d) );
+    CHECK( isnan(d) );
+    
+    CHECK( wxString("NAN").ToDouble(&d) );
+    CHECK( isnan(d) );
 }
 
 TEST_CASE("StringFromDouble", "[wxString]")


### PR DESCRIPTION
The previous ToCDouble() function accepted leading spaces, a starting + sign, and hex strings. std::from_chars() does not accept spaces or +, and requires a special flag to convert hex strings.

Sample strings that didn't work before can be seen in the new test cases. I also added test cases for infinity/nan, since they are also strings that should be ensured are supported.