### PR TITLE
Fix double negatives used with 'neither'

### DIFF
--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2796,7 +2796,7 @@ void wxStaticBoxSizer::RepositionChildren(const wxSize& minSize)
     wxPoint old_pos( m_position );
 
     // If we didn't have any sibling children so far, but we don't have any
-    // real children neither, chances are that they could have been added, so
+    // real children either, chances are that they could have been added, so
     // check for this (but if we do have real children, don't bother doing
     // anything as this would result in extra overhead for every re-layout).
     if ( !m_hasNonBoxChildren && m_staticBox->GetChildren().empty() )

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1594,7 +1594,7 @@ bool SkipOptPrefixAndSetBase(int& base, const char*& start, const char* end)
     while ( wxSafeIsspace(*start) )
         ++start;
 
-    // Also skip optional "+" which std::from_chars() doesn't accept neither.
+    // Also skip optional "+" which std::from_chars() doesn't accept either.
     if ( *start == '+' )
         ++start;
 

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3215,7 +3215,7 @@ static void wxGtkTreeCellDataFunc( GtkTreeViewColumn *WXUNUSED(column),
         // Ignore the return value of PrepareForItem() here, if it returns
         // false because GetValue() didn't return anything, we still want to
         // keep this cell visible, as otherwise it wouldn't be possible to edit
-        // it neither, and we do want to allow editing empty cells.
+        // it either, and we do want to allow editing empty cells.
         cell->PrepareForItem(wx_model, item, column);
     }
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -270,7 +270,7 @@ bool wxListCtrl::Create(wxWindow *parent,
 
         // We also need to explicitly set the background colour as the value
         // returned by GetBackgroundColour() by default doesn't match the
-        // actually used colour neither when using dark mode.
+        // actually used colour either when using dark mode.
         SetBackgroundColour(defAttrs.colBg);
     }
     else

--- a/src/msw/thread.cpp
+++ b/src/msw/thread.cpp
@@ -737,7 +737,7 @@ wxThreadInternal::WaitForTerminate(wxCriticalSection& cs,
 
         case STATE_EXITED:
             // We don't need to wait for the thread to exit if it already did,
-            // but doing it does no harm neither and it's a rare case not worth
+            // but doing it does no harm either and it's a rare case not worth
             // optimizing for.
             //
             // Just ensure we don't call OnDelete() again as we may have

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -542,7 +542,7 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
         if ( exstyle & WS_EX_TOPMOST )
             break;
 
-        // Children of such windows as this doesn't work neither (see #23078).
+        // Children of such windows as this doesn't work either (see #23078).
         wxWindow* const tlw = wxGetTopLevelParent(this);
         if ( tlw && tlw->HasFlag(wxSTAY_ON_TOP) )
             break;


### PR DESCRIPTION
Replace most 'neither' words introduced after
66916c7 (Fix double negatives used with 'neither' in docs and comments, Mon Aug 15 16:36:37 2022 +0300) with 'either'.

All changes are to comments only.