### PR TITLE
Update binaries.md mentioning the build subdirectory and the location…

### DIFF
--- a/docs/msw/binaries.md
+++ b/docs/msw/binaries.md
@@ -35,7 +35,7 @@ All binaries are available at:
 https://www.wxwidgets.org/downloads#v3.2.4_msw
 
 Once you have the files you need, unzip all of them into the same directory, for
-example `c:\wx\3.2.4`. You should have only include and lib subdirectories under
+example `c:\wx\3.2.4`. You should have the file `wxidgets.props` plus include, lib and build subdirectories under
 it, nothing else. To avoid hard-coding this path into your projects, define
 `wxwin` environment variable containing it: although it's a little known fact,
 all versions of MSVC support environment variable expansion in the C++ projects


### PR DESCRIPTION
… of wxwidgets.props

This very important document says 'You should have only include and lib subdirectories under it, nothing else'. This is not true. You also have a build subdirectory, (just as well as without it nothing further will work), and the vital wxwidgets.props file. The next paragraph says 'simply add the provided wxwidgets.props file...' and this was initially mysterious to me as I messed things up the first time and the instructions did not give a clue as to where the file might be and in fact misled me as they said the location where it should be was supposed to be empty bar two subdirectories.

I think this page might be one of the most important in the wxWidgets docs. It's easy to waste a day or more trying to get started with wxWidgets on Windows. This page provides the absolute best and easiest path if the user is lucky enough to find it and it is vital to make it as accurate as possible.