### PR TITLE
add wxNativeContainerWindow to wxTopLevelWindows

### DIFF
--- a/src/msw/nativewin.cpp
+++ b/src/msw/nativewin.cpp
@@ -111,6 +111,8 @@ bool wxNativeContainerWindow::Create(wxNativeContainerWindowHandle hwnd)
     // inherit the other attributes we can from the native HWND
     AdoptAttributesFromHWND();
 
+    wxTopLevelWindows.Append(this);
+
     return true;
 }
 


### PR DESCRIPTION
to ensure that wxDialog::ShowModal() disables wxNativeContainerWindow
