### PR TITLE
Add missing default constructor of wxFileDialog on MSW

### DIFF
--- a/include/wx/msw/filedlg.h
+++ b/include/wx/msw/filedlg.h
@@ -19,6 +19,7 @@ class wxFileDialogMSWData;
 class WXDLLIMPEXP_CORE wxFileDialog: public wxFileDialogBase
 {
 public:
+    wxFileDialog() = default;
     wxFileDialog(wxWindow *parent,
                  const wxString& message = wxASCII_STR(wxFileSelectorPromptStr),
                  const wxString& defaultDir = wxEmptyString,


### PR DESCRIPTION
There is the contructor on other backends but not MSW.