### PR TITLE
Can't uniconize window while hidden on MSW

### DIFF
--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -708,7 +708,7 @@ bool wxTopLevelWindowMSW::IsMaximized() const
 
 void wxTopLevelWindowMSW::Iconize(bool iconize)
 {
-    if ( iconize == MSWIsIconized() )
+    if ( iconize == IsIconized() )
     {
         // Do nothing, in particular don't restore non-iconized windows when
         // Iconize(false) is called as this would wrongly un-maximize them.


### PR DESCRIPTION
I once fixed this years ago in #14539, but while updating my application from wxWidgets 2.9.5 to 3.2 found that it has reappeared in some circumstances.

#### Steps to Reproduce

Apply the following patch to the “minimal” sample. Choose any of the four “Test” items added to the File menu (“Test Hide-Minimize-Show-Restore”, …) and watch as the named four actions are performed at intervals of two seconds.

<details><summary>uniconize-hidden-sample.patch</summary>

```diff
diff --git a/samples/minimal/minimal.cpp b/samples/minimal/minimal.cpp
index 5f32257c6b..7d44f19f12 100644
--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -62,9 +62,13 @@ public:
 
     // event handlers (these functions should _not_ be virtual)
     void OnQuit(wxCommandEvent& event);
+    void OnTest(wxCommandEvent & event);
+    void OnTestTimer(wxTimerEvent & event);
     void OnAbout(wxCommandEvent& event);
 
 private:
+    wxTimer testTimer;
+    int testState;
     // any class wishing to process wxWidgets events must use this macro
     wxDECLARE_EVENT_TABLE();
 };
@@ -78,6 +82,10 @@ enum
 {
     // menu items
     Minimal_Quit = wxID_EXIT,
+    Minimal_Test1 = wxID_HIGHEST + 1,
+    Minimal_Test2,
+    Minimal_Test3,
+    Minimal_Test4,
 
     // it is important for the id corresponding to the "About" command to have
     // this standard value as otherwise it won't be handled properly under Mac
@@ -95,6 +103,8 @@ enum
 wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(Minimal_Quit,  MyFrame::OnQuit)
     EVT_MENU(Minimal_About, MyFrame::OnAbout)
+    EVT_MENU_RANGE(Minimal_Test1, Minimal_Test4, MyFrame::OnTest)
+    EVT_TIMER(wxID_ANY, MyFrame::OnTestTimer)
 wxEND_EVENT_TABLE()
 
 // Create a new application object: this macro will allow wxWidgets to create
@@ -152,6 +162,10 @@ MyFrame::MyFrame(const wxString& title)
     wxMenu *helpMenu = new wxMenu;
     helpMenu->Append(Minimal_About, "&About\tF1", "Show about dialog");
 
+    fileMenu->Append(Minimal_Test1, "Test Hide-Minimize-Show-Restore");
+    fileMenu->Append(Minimal_Test2, "Test Minimize-Hide-Restore-Show");
+    fileMenu->Append(Minimal_Test3, "Test Hide-Minimize-Restore-Show");
+    fileMenu->Append(Minimal_Test4, "Test Minimize-Hide-Show-Restore");
     fileMenu->Append(Minimal_Quit, "E&xit\tAlt-X", "Quit this program");
 
     // now append the freshly created menu to the menu bar...
@@ -175,6 +189,8 @@ MyFrame::MyFrame(const wxString& title)
     CreateStatusBar(2);
     SetStatusText("Welcome to wxWidgets!");
 #endif // wxUSE_STATUSBAR
+
+    testTimer.SetOwner(this);
 }
 
 
@@ -185,6 +201,37 @@ void MyFrame::OnQuit(wxCommandEvent& WXUNUSED(event))
     // true is to force the frame to close
     Close(true);
 }
+ 
+void MyFrame::OnTest(wxCommandEvent& event)
+{
+    testState = 10*(event.GetId() - Minimal_Test1);
+    testTimer.Start(2000, wxTIMER_CONTINUOUS);
+}
+
+void MyFrame::OnTestTimer(wxTimerEvent& WXUNUSED(event))
+{
+    switch (testState++) {
+        case  0: Show(false);       break;
+        case  1: Iconize(true);     break;
+        case  2: Show(true);        break;
+        case  3: Iconize(false);    testTimer.Stop(); break;
+
+        case 10: Iconize(true);     break;
+        case 11: Show(false);       break;
+        case 12: Iconize(false);    break;
+        case 13: Show(true);        testTimer.Stop(); break;
+
+        case 20: Show(false);       break;
+        case 21: Iconize(true);     break;
+        case 22: Iconize(false);    break;
+        case 23: Show(true);        testTimer.Stop(); break;
+
+        case 30: Iconize(true);     break;
+        case 31: Show(false);       break;
+        case 32: Show(true);        break;
+        case 33: Iconize(false);    testTimer.Stop(); break;
+    }
+}
 
 void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
 {
```
</details>

#### Expected result

At the end of all four tests, the window should be visible and unminimized, since “shown” is set to true and “iconized” to false.

#### Actual result

At the end of the third test, _Hide-Minimize-Restore-Show_, the window is visible (in the task bar) but still minimized.

#### Proposed fix

`wxTopLevelWindowMSW::Iconize()` calls `::IsIconic()` (indirectly) to determine whether to do anything at all. Apparently that can return either `true` or `false` on a hidden window depending on whether it was iconized at the time it was hidden, even though Windows in other respects does not distinguish these states. However, what we are actually interested in at that time is not whether the window is iconized from the point of view of Windows, but from the point of view of wxWidgets, because that determines whether we need to update `m_showCmd`. Therefore replace the call to `MSWIsIconized()` by `IsIconized()`, which considers `m_showCmd` when the window is hidden.