### PR TITLE
Fixed wxFileSystemWatcher iterator out of bounds crash

### DIFF
--- a/src/msw/fswatcher.cpp
+++ b/src/msw/fswatcher.cpp
@@ -349,6 +349,8 @@ void wxIOCPThread::ProcessNativeEvents(wxVector<wxEventProcessingData>& events)
             }
             wxFileSystemWatcherEvent event(flags, oldpath, newpath);
             SendEvent(event);
+            if ( it == events.end() )
+                break;
         }
         // all other events
         else


### PR DESCRIPTION
I ran into a crash issue with wxFileSystemWatcher (wxMSW). This crash is hard to reproduce, it only occurs for me when the directory being watched is on a network share. But this could be very environment specific due to network latency etc.

However from the code the bug in wxIOCPThread::ProcessNativeEvents is obvious. The problem occurs when somehow a file rename event does not have a second entry in the events vector (there should be one containing the new path). Below the comment '// newpath should be in the next entry. what if there isn't?', ++it is called and it is checked against events.end(). However when the code returns to the for loop, ++it is called again and the application crashes due to it being past events.end().

Solution is to check gain for the event.end() and break the for loop when required.