### PR TITLE
Misc mac fixes

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -221,7 +221,7 @@ public :
     virtual void                controlTextDidChange();
 
     virtual void                AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical) override;
-    virtual void                UseClippingView(bool clip) override;
+    virtual void                UseClippingView() override;
     virtual WXWidget            GetContainer() const override { return m_osxClipView ? m_osxClipView : m_osxView; }
 
 protected:

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -368,7 +368,7 @@ public :
     // scrolling views need a clip subview that acts as parent for native children
     // (except for the scollbars) which are children of the view itself
     virtual void        AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical);
-    virtual void        UseClippingView(bool clip);
+    virtual void        UseClippingView();
 
     // returns native view which acts as a parent for native children
     virtual WXWidget    GetContainer() const;

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -224,7 +224,7 @@ public:
     // returns true if children have to clipped to the content area
     // (e.g., scrolled windows)
     bool                MacClipChildren() const { return m_clipChildren ; }
-    void                MacSetClipChildren( bool clip );
+    void                MacSetClipChildren();
 
     // returns true if the grandchildren need to be clipped to the children's content area
     // (e.g., splitter windows)

--- a/include/wx/platform.h
+++ b/include/wx/platform.h
@@ -455,6 +455,9 @@
 #        ifndef MAC_OS_X_VERSION_10_16
 #           define MAC_OS_X_VERSION_10_16 101600
 #        endif
+         /*
+            Note that since macOS 11 there is no more "X" in the names.
+          */
 #        ifndef MAC_OS_VERSION_11_0
 #           define MAC_OS_VERSION_11_0 110000
 #        endif

--- a/include/wx/scrolwin.h
+++ b/include/wx/scrolwin.h
@@ -439,7 +439,7 @@ public:
         m_targetWindow = this;
 
 #ifdef __WXMAC__
-        this->MacSetClipChildren(true);
+        this->MacSetClipChildren();
 #endif
 
         // by default, we're scrollable in both directions (but if one of the

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -1023,19 +1023,18 @@ wxString wxAppTraitsBase::GetAssertStackTrace()
 
             if ( !name.empty() )
             {
-                m_stackTrace << wxString::Format(wxT("%-40s"), name.c_str());
+                m_stackTrace << wxString::Format("%-80s", name);
             }
             else
             {
-                m_stackTrace << wxString::Format(wxT("%p"), frame.GetAddress());
+                m_stackTrace << wxString::Format("%-80p", frame.GetAddress());
             }
 
             if ( frame.HasSourceLocation() )
             {
-                m_stackTrace << wxT('\t')
-                             << frame.GetFileName()
-                             << wxT(':')
-                             << frame.GetLine();
+                m_stackTrace << wxString::Format("%s:%zu",
+                                                 frame.GetFileName(),
+                                                 frame.GetLine());
             }
 
             m_stackTrace << wxT('\n');

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5641,7 +5641,7 @@ bool wxDataViewCtrl::Create(wxWindow *parent,
     SetInitialSize(size);
 
 #ifdef __WXMAC__
-    MacSetClipChildren( true );
+    MacSetClipChildren();
 #endif
 
     m_clientArea = new wxDataViewMainWindow( this, wxID_ANY );

--- a/src/generic/laywin.cpp
+++ b/src/generic/laywin.cpp
@@ -50,7 +50,7 @@ void wxSashLayoutWindow::Init()
     m_orientation = wxLAYOUT_HORIZONTAL;
     m_alignment = wxLAYOUT_TOP;
 #ifdef __WXMAC__
-    MacSetClipChildren( true ) ;
+    MacSetClipChildren() ;
 #endif
 }
 

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -444,7 +444,7 @@ void wxScrollHelperBase::DoSetTargetWindow(wxWindow *target)
 {
     m_targetWindow = target;
 #ifdef __WXMAC__
-    target->MacSetClipChildren( true ) ;
+    target->MacSetClipChildren() ;
 #endif
 
     // install the event handler which will intercept the events we're

--- a/src/generic/vscroll.cpp
+++ b/src/generic/vscroll.cpp
@@ -435,7 +435,7 @@ void wxVarScrollHelperBase::DoSetTargetWindow(wxWindow *target)
 {
     m_targetWindow = target;
 #ifdef __WXMAC__
-    target->MacSetClipChildren( true ) ;
+    target->MacSetClipChildren() ;
 #endif
 
     // install the event handler which will intercept the events we're

--- a/src/osx/cocoa/renderer.mm
+++ b/src/osx/cocoa/renderer.mm
@@ -618,7 +618,7 @@ void wxRendererMac::ApplyMacControlFlags(wxWindow* win, NSCell* cell, int flags)
         size = NSSmallControlSize;
     else if (win->GetWindowVariant() == wxWINDOW_VARIANT_MINI || (win->GetParent() && win->GetParent()->GetWindowVariant() == wxWINDOW_VARIANT_MINI))
         size = NSMiniControlSize;
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_11_0
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_11_0
     else if (win->GetWindowVariant() == wxWINDOW_VARIANT_LARGE|| (win->GetParent() && win->GetParent()->GetWindowVariant() == wxWINDOW_VARIANT_LARGE))
     {
         if (WX_IS_MACOS_AVAILABLE(11, 0))

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -4077,7 +4077,7 @@ void wxWidgetCocoaImpl::AdjustClippingView(wxScrollBar* horizontal, wxScrollBar*
     }
 }
 
-void wxWidgetCocoaImpl::UseClippingView(bool clip)
+void wxWidgetCocoaImpl::UseClippingView()
 {
    wxWindow* peer = m_wxPeer;
 

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -261,11 +261,11 @@ wxWindowMac::~wxWindowMac()
     delete GetPeer() ;
 }
 
-void wxWindowMac::MacSetClipChildren( bool clip )
+void wxWindowMac::MacSetClipChildren()
 {
-    m_clipChildren = clip ;
+    m_clipChildren = true ;
     if ( m_peer )
-        m_peer->UseClippingView(clip);
+        m_peer->UseClippingView();
 }
 
 WXWidget wxWindowMac::GetHandle() const
@@ -394,7 +394,7 @@ bool wxWindowMac::Create(wxWindowMac *parent,
         SetPeer(wxWidgetImpl::CreateUserPane( this, parent, id, pos, size , style, GetExtraStyle() ));
         MacPostControlCreate(pos, size) ;
         if ( m_clipChildren )
-            m_peer->UseClippingView(m_clipChildren);
+            m_peer->UseClippingView();
     }
 
     wxWindowCreateEvent event((wxWindow*)this);
@@ -2715,7 +2715,7 @@ void wxWidgetImpl::AdjustClippingView(wxScrollBar* WXUNUSED(horizontal), wxScrol
 {
 }
 
-void wxWidgetImpl::UseClippingView(bool WXUNUSED(clip))
+void wxWidgetImpl::UseClippingView()
 {
 }
 


### PR DESCRIPTION
Some minor changes to get rid of a few warnings in Mac build using older SDK.

Stefan, do you agree with removing `bool clip`? I could just suppress the warning about it being unused, if you think it's useful to keep it, but as it doesn't do anything, I'd prefer to remove it to make things more clear.