### PR TITLE
Make wxSTAY_ON_TOP TLWs transient for parent too in wxGTK

### DIFF
--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -737,7 +737,8 @@ bool wxTopLevelWindowGTK::Create( wxWindow *parent,
     wxWindow *topParent = wxGetTopLevelParent(m_parent);
     if (topParent && (((GTK_IS_WINDOW(topParent->m_widget)) &&
                        (GetExtraStyle() & wxTOPLEVEL_EX_DIALOG)) ||
-                       (style & wxFRAME_FLOAT_ON_PARENT)))
+                       (style & wxFRAME_FLOAT_ON_PARENT) ||
+                       (style & wxSTAY_ON_TOP)))
     {
         gtk_window_set_transient_for( GTK_WINDOW(m_widget),
                                       GTK_WINDOW(topParent->m_widget) );


### PR DESCRIPTION
Normally such windows should be remain on top of all the other windows, but at least under Wayland they do not, so make them at least remain on top of their parent window -- which should do no harm anyhow and might do some good (by allowing the WM to associate them with the correct window) even if they do stay on top of everything.

----

@paulcor Any objections to merging this? Without it, `wxBusyInfo` window can get hidden beyond its parent, at least under Wayland. I could change its code to use `wxFRAME_FLOAT_ON_PARENT`, of course, but it looks like this would be the desired behaviour for any `wxSTAY_ON_TOP` window, wouldn't it?