### PR TITLE
Fix wxAnyButton Current/Normal state under wxQt

### DIFF
--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -158,7 +158,7 @@ wxAnyButton::State wxAnyButton::QtGetCurrentState() const
         return State_Pressed;
     }
 
-    if ( HasCapture() || m_qtPushButton->hasMouseTracking() || m_qtPushButton->underMouse() )
+    if ( HasCapture() || m_qtPushButton->underMouse() )
     {
         return State_Current;
     }


### PR DESCRIPTION
Do not check for hasMouseTracking in QtGetCurrentState as mouse tracking is always enabled in any widget derived from wxQtEventSignalHandler.

This resulted in an QtGetCurrentState reporting State_Current when it should have reported State_Normal i.e. the button showed hovering state when it was actually not hovering.

After the change, button state will show State_Current only if the mouse pointer is actually hovered on the button.

See #24129.