### PR TITLE
more convenient API for wxGenericValidator + wxLB_SINGLE

### DIFF
--- a/include/wx/valgen.h
+++ b/include/wx/valgen.h
@@ -52,6 +52,8 @@ public:
     wxGenericValidator(double* val);
         // wxColourPickerCtrl
     wxGenericValidator(wxColour* val);
+        // wxCheckBox
+    wxGenericValidator(wxCheckBoxState* val);
 
     wxGenericValidator(const wxGenericValidator& copyFrom);
 
@@ -88,6 +90,7 @@ protected:
     float*      m_pFloat;
     double*     m_pDouble;
     wxColour*   m_pColour;
+    wxCheckBoxState* m_pCheckBoxState;
 
 private:
     wxDECLARE_CLASS(wxGenericValidator);

--- a/include/wx/valgen.h
+++ b/include/wx/valgen.h
@@ -33,6 +33,7 @@ public:
         // wxCheckBox, wxRadioButton, wx(Bitmap)ToggleButton
     wxGenericValidator(bool* val);
         // wxChoice, wxGauge, wxRadioBox, wxScrollBar, wxSlider, wxSpinButton
+        // single-selection wxListBox
     wxGenericValidator(int* val);
         // wxComboBox, wxTextCtrl, wxButton, wxStaticText (read-only)
     wxGenericValidator(wxString* val);

--- a/include/wx/valgen.h
+++ b/include/wx/valgen.h
@@ -16,6 +16,7 @@
 
 class WXDLLIMPEXP_FWD_BASE wxDateTime;
 class WXDLLIMPEXP_FWD_BASE wxFileName;
+class WXDLLIMPEXP_FWD_CORE wxColour;
 
 // ----------------------------------------------------------------------------
 // wxGenericValidator performs data transfer between many standard controls and
@@ -49,6 +50,8 @@ public:
     wxGenericValidator(float* val);
         // wxTextCtrl
     wxGenericValidator(double* val);
+        // wxColourPickerCtrl
+    wxGenericValidator(wxColour* val);
 
     wxGenericValidator(const wxGenericValidator& copyFrom);
 
@@ -84,6 +87,7 @@ protected:
     wxFileName* m_pFileName;
     float*      m_pFloat;
     double*     m_pDouble;
+    wxColour*   m_pColour;
 
 private:
     wxDECLARE_CLASS(wxGenericValidator);

--- a/interface/wx/listbox.h
+++ b/interface/wx/listbox.h
@@ -163,6 +163,11 @@ public:
     ///@}
 
     /**
+        return true if the listbox allows multiple selection
+    */
+    bool HasMultipleSelection() const
+
+    /**
         Deselects an item in the list box.
 
         @param n

--- a/interface/wx/valgen.h
+++ b/interface/wx/valgen.h
@@ -23,6 +23,7 @@
 
     @since 3.2.5
     A wxLB_SINGLE wxListBox can also use an int.  wxColourPickerCtrl support.
+    A 3-state wxCheckBox can use wxCheckBoxState.
 
     For more information, please see @ref overview_validator.
 

--- a/interface/wx/valgen.h
+++ b/interface/wx/valgen.h
@@ -15,7 +15,7 @@
     - wxButton, wxRadioButton, wxToggleButton, wxBitmapToggleButton, wxSpinButton
     - wxCheckBox, wxRadioBox, wxComboBox, wxListBox, wxCheckListBox
     - wxGauge, wxSlider, wxScrollBar, wxChoice, wxStaticText
-    - wxSpinCtrl, wxTextCtrl, wxColourPickerCtrl
+    - wxSpinCtrl, wxTextCtrl, wxColourPickerCtrl (since wxWidgets 3.3.0 or later).
 
     It checks the type of the window and uses an appropriate type for it.
     For example, wxButton and wxTextCtrl transfer data to and from a

--- a/interface/wx/valgen.h
+++ b/interface/wx/valgen.h
@@ -21,6 +21,9 @@
     For example, wxButton and wxTextCtrl transfer data to and from a
     wxString variable; wxListBox uses a wxArrayInt; wxCheckBox uses a boolean.
 
+    @since 3.2.5
+    A wxLB_SINGLE wxListBox can also use an int.
+
     For more information, please see @ref overview_validator.
 
     @library{wxcore}

--- a/interface/wx/valgen.h
+++ b/interface/wx/valgen.h
@@ -15,14 +15,14 @@
     - wxButton, wxRadioButton, wxToggleButton, wxBitmapToggleButton, wxSpinButton
     - wxCheckBox, wxRadioBox, wxComboBox, wxListBox, wxCheckListBox
     - wxGauge, wxSlider, wxScrollBar, wxChoice, wxStaticText
-    - wxSpinCtrl, wxTextCtrl
+    - wxSpinCtrl, wxTextCtrl, wxColourPickerCtrl
 
     It checks the type of the window and uses an appropriate type for it.
     For example, wxButton and wxTextCtrl transfer data to and from a
     wxString variable; wxListBox uses a wxArrayInt; wxCheckBox uses a boolean.
 
     @since 3.2.5
-    A wxLB_SINGLE wxListBox can also use an int.
+    A wxLB_SINGLE wxListBox can also use an int.  wxColourPickerCtrl support.
 
     For more information, please see @ref overview_validator.
 

--- a/src/common/valgen.cpp
+++ b/src/common/valgen.cpp
@@ -377,6 +377,17 @@ bool wxGenericValidator::TransferToWindow()
 
             return true;
         }
+        else if (m_pInt)
+        {
+            wxCHECK_MSG(
+                !(pControl->GetWindowStyle() & (wxLB_MULTIPLE || wxLB_EXTENDED)),
+                false,
+                "multi-select control requires wxArrayInt"
+            );
+            pControl->Check(*m_pInt);
+
+            return true;
+        }
         else
             return false;
     } else
@@ -397,6 +408,17 @@ bool wxGenericValidator::TransferToWindow()
             count = m_pArrayInt->GetCount();
             for ( i = 0 ; i < count; i++ )
                 pControl->SetSelection(m_pArrayInt->Item(i));
+
+            return true;
+        }
+        else if (m_pInt)
+        {
+            wxCHECK_MSG(
+                !(pControl->GetWindowStyle() & (wxLB_MULTIPLE || wxLB_EXTENDED)),
+                false,
+                "multi-select control requires wxArrayInt"
+            );
+            pControl->SetSelection(*m_pInt);
 
             return true;
         }
@@ -654,6 +676,26 @@ bool wxGenericValidator::TransferFromWindow()
 
             return true;
         }
+        else if (m_pInt)
+        {
+            wxCHECK_MSG(
+                !(pControl->GetWindowStyle()& (wxLB_MULTIPLE || wxLB_EXTENDED)),
+                false,
+                "multi-select control requires wxArrayInt"
+            );
+
+            size_t i,
+                count = pControl->GetCount();
+            for ( i = 0; i < count; i++ )
+            {
+                if (pControl->IsChecked(i))
+                {
+                    *m_pInt = i;
+                }
+            }
+
+            return true;
+        }
         else
             return false;
     } else
@@ -675,6 +717,18 @@ bool wxGenericValidator::TransferFromWindow()
                 if (pControl->IsSelected(i))
                     m_pArrayInt->Add(i);
             }
+
+            return true;
+        }
+        else if (m_pInt)
+        {
+            wxCHECK_MSG(
+                !(pControl->GetWindowStyle() & (wxLB_MULTIPLE || wxLB_EXTENDED)),
+                false,
+                "multi-select control requires wxArrayInt"
+            );
+
+            *m_pInt = pControl->GetSelection();
 
             return true;
         }

--- a/src/common/valgen.cpp
+++ b/src/common/valgen.cpp
@@ -380,7 +380,7 @@ bool wxGenericValidator::TransferToWindow()
         else if (m_pInt)
         {
             wxCHECK_MSG(
-                !(pControl->GetWindowStyle() & (wxLB_MULTIPLE || wxLB_EXTENDED)),
+                !pControl->HasMultipleSelection(),
                 false,
                 "multi-select control requires wxArrayInt"
             );
@@ -414,7 +414,7 @@ bool wxGenericValidator::TransferToWindow()
         else if (m_pInt)
         {
             wxCHECK_MSG(
-                !(pControl->GetWindowStyle() & (wxLB_MULTIPLE || wxLB_EXTENDED)),
+                !pControl->HasMultipleSelection(),
                 false,
                 "multi-select control requires wxArrayInt"
             );
@@ -679,7 +679,7 @@ bool wxGenericValidator::TransferFromWindow()
         else if (m_pInt)
         {
             wxCHECK_MSG(
-                !(pControl->GetWindowStyle()& (wxLB_MULTIPLE || wxLB_EXTENDED)),
+                !pControl->HasMultipleSelection(),
                 false,
                 "multi-select control requires wxArrayInt"
             );
@@ -723,7 +723,7 @@ bool wxGenericValidator::TransferFromWindow()
         else if (m_pInt)
         {
             wxCHECK_MSG(
-                !(pControl->GetWindowStyle() & (wxLB_MULTIPLE || wxLB_EXTENDED)),
+                !pControl->HasMultipleSelection(),
                 false,
                 "multi-select control requires wxArrayInt"
             );

--- a/src/common/valgen.cpp
+++ b/src/common/valgen.cpp
@@ -108,6 +108,12 @@ wxGenericValidator::wxGenericValidator(wxColour* val)
     m_pColour = val;
 }
 
+wxGenericValidator::wxGenericValidator(wxCheckBoxState* val)
+{
+    Initialize();
+    m_pCheckBoxState = val;
+}
+
 wxGenericValidator::wxGenericValidator(const wxGenericValidator& val)
     : wxValidator()
 {
@@ -129,6 +135,7 @@ bool wxGenericValidator::Copy(const wxGenericValidator& val)
     m_pFloat = val.m_pFloat;
     m_pDouble = val.m_pDouble;
     m_pColour = val.m_pColour;
+    m_pCheckBoxState = val.m_pCheckBoxState;
 
     return true;
 }
@@ -147,6 +154,11 @@ bool wxGenericValidator::TransferToWindow()
         if (m_pBool)
         {
             pControl->SetValue(*m_pBool);
+            return true;
+        }
+        else if (m_pCheckBoxState && pControl->Is3State())
+        {
+            pControl->Set3StateValue(*m_pCheckBoxState);
             return true;
         }
     } else
@@ -469,6 +481,11 @@ bool wxGenericValidator::TransferFromWindow()
         if (m_pBool)
         {
             *m_pBool = pControl->GetValue() ;
+            return true;
+        }
+        else if (m_pCheckBoxState && pControl->Is3State())
+        {
+            *m_pCheckBoxState = pControl->Get3StateValue();
             return true;
         }
     } else
@@ -794,6 +811,7 @@ void wxGenericValidator::Initialize()
     m_pFloat = nullptr;
     m_pDouble = nullptr;
     m_pColour = nullptr;
+    m_pCheckBoxState = nullptr;
 }
 
 #endif // wxUSE_VALIDATORS

--- a/src/common/valgen.cpp
+++ b/src/common/valgen.cpp
@@ -41,6 +41,9 @@
 #if wxUSE_TOGGLEBTN
     #include "wx/tglbtn.h"
 #endif
+#if wxUSE_COLOURPICKERCTRL
+    #include <wx/clrpicker.h>
+#endif
 #include "wx/filename.h"
 
 #include "wx/valgen.h"
@@ -99,6 +102,12 @@ wxGenericValidator::wxGenericValidator(double *val)
     m_pDouble = val;
 }
 
+wxGenericValidator::wxGenericValidator(wxColour* val)
+{
+    Initialize();
+    m_pColour = val;
+}
+
 wxGenericValidator::wxGenericValidator(const wxGenericValidator& val)
     : wxValidator()
 {
@@ -119,6 +128,7 @@ bool wxGenericValidator::Copy(const wxGenericValidator& val)
     m_pFileName = val.m_pFileName;
     m_pFloat = val.m_pFloat;
     m_pDouble = val.m_pDouble;
+    m_pColour = val.m_pColour;
 
     return true;
 }
@@ -419,6 +429,20 @@ bool wxGenericValidator::TransferToWindow()
                 "multi-select control requires wxArrayInt"
             );
             pControl->SetSelection(*m_pInt);
+
+            return true;
+        }
+    } else
+#endif
+
+    // colour controls
+#if wxUSE_COLOURPICKERCTRL
+    if (wxDynamicCast(m_validatorWindow, wxColourPickerCtrl))
+    {
+        wxColourPickerCtrl* pControl = (wxColourPickerCtrl*)m_validatorWindow;
+        if (m_pColour)
+        {
+            pControl->SetColour(*m_pColour);
 
             return true;
         }
@@ -734,6 +758,19 @@ bool wxGenericValidator::TransferFromWindow()
         }
     } else
 #endif
+#if wxUSE_COLOURPICKERCTRL
+        if (wxDynamicCast(m_validatorWindow, wxColourPickerCtrl))
+        {
+            wxColourPickerCtrl* pControl = (wxColourPickerCtrl*)m_validatorWindow;
+            if (m_pColour)
+            {
+                *m_pColour = pControl->GetColour();
+
+                return true;
+            }
+        }
+        else
+#endif
 
     // unrecognized control, or bad pointer
         return false;
@@ -756,6 +793,7 @@ void wxGenericValidator::Initialize()
     m_pFileName = nullptr;
     m_pFloat = nullptr;
     m_pDouble = nullptr;
+    m_pColour = nullptr;
 }
 
 #endif // wxUSE_VALIDATORS

--- a/src/common/valgen.cpp
+++ b/src/common/valgen.cpp
@@ -42,7 +42,7 @@
     #include "wx/tglbtn.h"
 #endif
 #if wxUSE_COLOURPICKERCTRL
-    #include <wx/clrpicker.h>
+    #include "wx/clrpicker.h"
 #endif
 #include "wx/filename.h"
 


### PR DESCRIPTION
For a single-selection wxListBox, using an int to transfer data to/from wxGenericValidator is more convenient than wxArrayInt.