### PR TITLE
Fix wxSystem() when used from C++

### DIFF
--- a/include/wx/wxcrtbase.h
+++ b/include/wx/wxcrtbase.h
@@ -509,7 +509,12 @@ WXDLLIMPEXP_BASE wchar_t * wxCRT_GetenvW(const wchar_t *name);
 #endif
 
 
+#ifdef __cplusplus
+#include <cstdlib>
+#define wxCRT_SystemA               std::system
+#else /* !C++ */
 #define wxCRT_SystemA               system
+#endif /* C++ */
 #ifdef wxHAVE_TCHAR_SUPPORT
     #define  wxCRT_SystemW          _wsystem
 #endif


### PR DESCRIPTION
Use `std::system()` instead of `system()` when used from C++, to avoid the compiler thinking we could be talking about `boost::system`.

Seen in BambuStudio with wxWidgets 3.2.4.

```
[380/471] Building CXX object src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/HttpServer.cpp.o FAILED: src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/HttpServer.cpp.o /run/ccache/bin/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_CHRONO_NO_LIB -DBOOST_DATE_TIME_NO_LIB -DBOOST_FILESYSTEM_NO_LIB -DBOOST_IOSTREAMS_NO_LIB -DBOOST_LOCALE_NO_LIB -DBOOST_LOG_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_NO_LIB -DCURL_STATICLIB -DGLEW_STATIC -DLIBNEST2D_GEOMETRIES_libslic3r -DLIBNEST2D_OPTIMIZER_nlopt -DLIBNEST2D_STATIC -DLIBNEST2D_THREADING_tbb -DOPENSSL_CERT_OVERRIDE -DOPENVDB_OPENEXR_STATICLIB -DOPENVDB_STATICLIB -DSLIC3R_CURRENTLY_COMPILING_GUI_MODULE -DSLIC3R_GUI -DTBB_USE_CAPTURED_EXCEPTION=0 -DUNICODE -DUSE_TBB -DWXINTL_NO_GETTEXT_MACRO -D_FILE_OFFSET_BITS=64 -D_UNICODE -D__WXGTK3__ -D__WXGTK__ -DwxDEBUG_LEVEL=0 -DwxNO_UNSAFE_WXSTRING_CONV -DwxUSE_UNICODE -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/run/build/BambuStudio/src -I/run/build/BambuStudio/build/src/platform -I/run/build/BambuStudio/src/hidapi/include -I/run/build/BambuStudio/src/slic3r/Utils -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/cairo -I/usr/include/gdk-pixbuf-2.0 -I/run/build/BambuStudio/deps/build/destdir/usr/local/include/freetype2 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/atk-1.0 -I/usr/include/blkid -I/usr/include/libmount -I/usr/include/sysprof-6 -I/run/build/BambuStudio/deps/build/destdir/usr/local/include/libpng16 -I/usr/include/pixman-1 -I/usr/include/gio-unix-2.0 -I/usr/include/fribidi -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/gstreamer-1.0 -I/run/build/BambuStudio/build/src/libslic3r -I/run/build/BambuStudio/deps/build/destdir/usr/local/include/opencascade -I/run/build/BambuStudio/src/libnest2d/include -I/run/build/BambuStudio/src/miniz -I/run/build/BambuStudio/src/glu-libtess/include -I/run/build/BambuStudio/src/clipper2/Clipper2Lib/include -I/run/build/BambuStudio/src/minilzo -isystem /run/build/BambuStudio/src/eigen -isystem /run/build/BambuStudio/src/libigl -isystem /run/build/BambuStudio/deps/build/destdir/usr/local/lib/wx/include/gtk3-unicode-static-3.2 -isystem /run/build/BambuStudio/deps/build/destdir/usr/local/include/wx-3.2 -isystem /run/build/BambuStudio/deps/build/destdir/usr/local/include -isystem /run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78 -isystem /run/build/BambuStudio/deps/build/destdir/usr/local/include/OpenEXR -std=gnu++20 -fext-numeric-literals -Wall -Wno-reorder -pthread -O3 -DNDEBUG -std=gnu++17 -fPIC -fsigned-char -Werror=return-type -Wno-ignored-attributes -Wno-unknown-pragmas -DOPENVDB_ABI_VERSION_NUMBER=8 -MD -MT src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/HttpServer.cpp.o -MF src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/HttpServer.cpp.o.d -o src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/HttpServer.cpp.o -c /run/build/BambuStudio/src/slic3r/GUI/HttpServer.cpp In file included from /run/build/BambuStudio/deps/build/destdir/usr/local/include/wx-3.2/wx/string.h:36,
                 from /run/build/BambuStudio/src/slic3r/GUI/ImGuiWrapper.hpp:9,
                 from /run/build/BambuStudio/src/slic3r/GUI/GUI_App.hpp:6,
                 from /run/build/BambuStudio/src/slic3r/GUI/HttpServer.cpp:4:
/run/build/BambuStudio/deps/build/destdir/usr/local/include/wx-3.2/wx/wxcrt.h: In function ‘int wxSystem(const wxString&)’: /run/build/BambuStudio/deps/build/destdir/usr/local/include/wx-3.2/wx/wxcrt.h:1037:51: error: reference to ‘system’ is ambiguous
 1037 | inline int wxSystem(const wxString& str) { return wxCRT_SystemA(str.mb_str()); }
      |                                                   ^~~~~~~~~~~~~
In file included from /run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78/boost/system/detail/error_code.hpp:13,
                 from /run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78/boost/system/error_code.hpp:13,
                 from /run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78/boost/beast/core/error.hpp:14,
                 from /run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78/boost/beast/core/detail/bind_handler.hpp:13,
                 from /run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78/boost/beast/core/bind_handler.hpp:14,
                 from /run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78/boost/beast/core/async_base.hpp:14,
                 from /run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78/boost/beast/core.hpp:15,
                 from /run/build/BambuStudio/src/slic3r/GUI/HttpServer.hpp:8,
                 from /run/build/BambuStudio/src/slic3r/GUI/HttpServer.cpp:2:
/run/build/BambuStudio/deps/build/destdir/usr/local/include/boost-1_78/boost/system/is_error_code_enum.hpp:16:11: note: candidates are: ‘namespace boost::system { }’
   16 | namespace system
      |           ^~~~~~
In file included from /usr/include/c++/13.2.0/cstdlib:79,
                 from /run/build/BambuStudio/src/slic3r/GUI/HttpServer.cpp:1:
/usr/include/stdlib.h:923:12: note:                 ‘int system(const char*)’
  923 | extern int system (const char *__command) __wur;
      |            ^~~~~~
```

Let me know if you want me to submit a patch for the `master` branch as well.