### PR TITLE
Fix W String conversion

### DIFF
--- a/src/msw/dir.cpp
+++ b/src/msw/dir.cpp
@@ -75,7 +75,7 @@ CheckFoundMatch(const FIND_STRUCT* finddata, const wxString& filter)
     if ( filter.empty() )
         return true;
 
-    return ::PathMatchSpec(finddata->cFileName, filter) == TRUE;
+    return ::PathMatchSpec(finddata->cFileName, filter.t_str()) == TRUE;
 }
 
 inline bool


### PR DESCRIPTION
when enabling wxUSE_STD_STRING_CONV_IN_WXSTRING, w_char * operator is removed, force conversion with t_str().