### PR TITLE
Make some WidgetsPages scrollable in the widgets sample

### DIFF
--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -39,6 +39,7 @@
 #include "wx/stattext.h"
 #include "wx/dc.h"
 #include "wx/dcmemory.h"
+#include "wx/scrolwin.h"
 #include "wx/sizer.h"
 #include "wx/icon.h"
 #include "wx/dir.h"
@@ -339,7 +340,8 @@ void BitmapComboBoxWidgetsPage::CreateContent()
     sizerLeft->Add( sizerOptions, wxSizerFlags().Expand().Border(wxTOP, 2));
 
     // middle pane
-    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change wxBitmapComboBox contents");
+    auto scrolMidl = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(420, -1));
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, scrolMidl, "&Change wxBitmapComboBox contents");
     wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_ContainerTests, "Run &tests");
@@ -377,6 +379,8 @@ void BitmapComboBoxWidgetsPage::CreateContent()
 
     btn = new wxButton(sizerMiddleBox, BitmapComboBoxPage_Clear, "&Clear");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    scrolMidl->SetSizer(sizerMiddle);
+    scrolMidl->SetScrollRate(10, 10);
 
 #if wxUSE_IMAGE
     wxInitAllImageHandlers();
@@ -402,7 +406,7 @@ void BitmapComboBoxWidgetsPage::CreateContent()
 
     // the 3 panes panes compose the window
     sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 5, wxGROW | wxALL, 10);
+    sizerTop->Add(scrolMidl, 5, wxGROW | wxALL, 10);
     sizerTop->Add(sizerRight, 4, wxGROW | (wxALL & ~wxRIGHT), 10);
 
     // final initializations

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include "wx/artprov.h"
+#include "wx/scrolwin.h"
 #include "wx/sizer.h"
 #include "wx/dcmemory.h"
 #include "wx/commandlinkbutton.h"
@@ -249,7 +250,8 @@ void ButtonWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    auto scrolLeft = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(580, -1));
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "&Set style");
     wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     m_chkBitmapOnly = CreateCheckBoxAndAddToSizer(sizerLeft, "&Bitmap only", wxID_ANY, sizerLeftBox);
@@ -349,6 +351,8 @@ void ButtonWidgetsPage::CreateContent()
 
     wxButton *btn = new wxButton(sizerLeftBox, ButtonPage_Reset, "&Reset");
     sizerLeft->Add(btn, wxSizerFlags().CentreHorizontal().TripleBorder(wxALL));
+    scrolLeft->SetSizer(sizerLeft);
+    scrolLeft->SetScrollRate(10, 10);
 
     // middle pane
     wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Operations");
@@ -378,7 +382,7 @@ void ButtonWidgetsPage::CreateContent()
     m_sizerButton->SetMinSize(FromDIP(150), 0);
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft,
+    sizerTop->Add(scrolLeft,
                   wxSizerFlags(0).Expand().DoubleBorder(wxALL & ~wxLEFT));
     sizerTop->Add(sizerMiddle,
                   wxSizerFlags(1).Expand().DoubleBorder(wxALL));

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -35,6 +35,7 @@
     #include "wx/textctrl.h"
 #endif
 
+#include "wx/scrolwin.h"
 #include "wx/sizer.h"
 
 #include "itemcontainer.h"
@@ -268,7 +269,8 @@ void ComboboxWidgetsPage::CreateContent()
         "drop down",
     };
 
-    wxStaticBoxSizer *sizerLeftTop = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    auto scrolLeft = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(200, -1));
+    wxStaticBoxSizer *sizerLeftTop = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "&Set style");
     wxStaticBox* const sizerLeftTopBox = sizerLeftTop->GetStaticBox();
 
     m_radioKind = new wxRadioBox(sizerLeftTopBox, wxID_ANY, "Combobox &kind:",
@@ -287,7 +289,7 @@ void ComboboxWidgetsPage::CreateContent()
     sizerLeftTop->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
     // lower left pane
-    wxStaticBoxSizer *sizerLeftBottom = new wxStaticBoxSizer(wxVERTICAL, this, "&Popup");
+    wxStaticBoxSizer *sizerLeftBottom = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "&Popup");
     wxStaticBox* const sizerLeftBottomBox = sizerLeftBottom->GetStaticBox();
 
     sizerLeftBottom->Add(new wxButton(sizerLeftBottomBox, ComboPage_Popup, "&Show"),
@@ -297,12 +299,15 @@ void ComboboxWidgetsPage::CreateContent()
 
 
     wxSizer *sizerLeft = new wxBoxSizer(wxVERTICAL);
-    sizerLeft->Add(sizerLeftTop);
+    sizerLeft->Add(sizerLeftTop, wxSizerFlags().Centre());
     sizerLeft->AddSpacer(10);
     sizerLeft->Add(sizerLeftBottom, wxSizerFlags().Expand());
+    scrolLeft->SetSizer(sizerLeft);
+    scrolLeft->SetScrollRate(10, 10);
 
     // middle pane
-    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change combobox contents");
+    auto scrolMidl = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(420, -1));
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, scrolMidl, "&Change combobox contents");
     wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxSizer *sizerRow;
@@ -380,7 +385,8 @@ void ComboboxWidgetsPage::CreateContent()
 
     btn = new wxButton(sizerMiddleBox, ComboPage_ContainerTests, "Run &tests");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
-
+    scrolMidl->SetSizer(sizerMiddle);
+    scrolMidl->SetScrollRate(10, 10);
 
 
     // right pane
@@ -401,8 +407,8 @@ void ComboboxWidgetsPage::CreateContent()
     m_sizerCombo = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 1, wxGROW | wxALL, 10);
+    sizerTop->Add(scrolLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
+    sizerTop->Add(scrolMidl, 1, wxGROW | wxALL, 10);
     sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
 
     // final initializations

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -34,6 +34,7 @@
     #include "wx/filedlg.h"
 #endif
 
+#include "wx/scrolwin.h"
 #include "wx/generic/dirctrlg.h"
 
 #include "wx/wupdlock.h"
@@ -177,7 +178,8 @@ void DirCtrlWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "Dir control details");
+    auto scrolLeft = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(300, -1));
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "Dir control details");
     wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     sizerLeft->Add( CreateSizerWithTextAndButton( DirCtrlPage_SetPath , "Set &path", wxID_ANY, &m_path, sizerLeftBox),
@@ -206,6 +208,8 @@ void DirCtrlWidgetsPage::CreateContent()
 
     wxButton *btn = new wxButton(sizerFiltersBox, DirCtrlPage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    scrolLeft->SetSizer(sizerLeft);
+    scrolLeft->SetScrollRate(10, 10);
 
     // keep consistency between enum and labels of radiobox
     wxCOMPILE_TIME_ASSERT( stdPathMax == WXSIZEOF(stdPaths), EnumForRadioBoxMismatch);
@@ -226,7 +230,7 @@ void DirCtrlWidgetsPage::CreateContent()
     );
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, (wxALL & ~wxLEFT), 10);
+    sizerTop->Add(scrolLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
     sizerTop->Add(m_radioStdPath, 0, wxGROW | wxALL , 10);
     sizerTop->Add(m_dirCtrl, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
 

--- a/samples/widgets/filectrl.cpp
+++ b/samples/widgets/filectrl.cpp
@@ -29,6 +29,7 @@
 
 #include "wx/filectrl.h"
 
+#include "wx/scrolwin.h"
 #include "wx/wupdlock.h"
 #include "wx/filename.h"
 
@@ -158,29 +159,31 @@ void FileCtrlWidgetsPage::CreateContent()
     // left pane
     wxSizer *sizerLeft = new wxBoxSizer( wxVERTICAL );
 
+    auto scrolLeft = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(300, -1));
+
     static const wxString mode[] = { "open", "save" };
-    m_radioFileCtrlMode = new wxRadioBox( this, wxID_ANY, "wxFileCtrl mode",
+    m_radioFileCtrlMode = new wxRadioBox( scrolLeft, wxID_ANY, "wxFileCtrl mode",
                                           wxDefaultPosition, wxDefaultSize,
                                           WXSIZEOF( mode ), mode );
 
     sizerLeft->Add( m_radioFileCtrlMode,
                     0, wxALL | wxEXPAND , 5 );
 
-    sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetDirectory , "Set &directory", wxID_ANY, &m_dir ),
+    sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetDirectory , "Set &directory", wxID_ANY, &m_dir, scrolLeft ),
                     0, wxALL | wxEXPAND , 5 );
-    sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetPath , "Set &path", wxID_ANY, &m_path ),
+    sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetPath , "Set &path", wxID_ANY, &m_path, scrolLeft ),
                     0, wxALL | wxEXPAND , 5 );
-    sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetFilename , "Set &filename", wxID_ANY, &m_filename ),
+    sizerLeft->Add( CreateSizerWithTextAndButton( FileCtrlPage_SetFilename , "Set &filename", wxID_ANY, &m_filename, scrolLeft ),
                     0, wxALL | wxEXPAND , 5 );
 
-    wxStaticBoxSizer *sizerFlags = new wxStaticBoxSizer( wxVERTICAL, this, "&Flags");
+    wxStaticBoxSizer *sizerFlags = new wxStaticBoxSizer( wxVERTICAL, scrolLeft, "&Flags");
     wxStaticBox* const sizerFlagsBox = sizerFlags->GetStaticBox();
 
     m_chkMultiple   = CreateCheckBoxAndAddToSizer( sizerFlags, "wxFC_MULTIPLE", wxID_ANY, sizerFlagsBox );
     m_chkNoShowHidden   = CreateCheckBoxAndAddToSizer( sizerFlags, "wxFC_NOSHOWHIDDEN", wxID_ANY, sizerFlagsBox );
     sizerLeft->Add( sizerFlags, wxSizerFlags().Expand().Border() );
 
-    wxStaticBoxSizer *sizerFilters = new wxStaticBoxSizer( wxVERTICAL, this, "&Filters");
+    wxStaticBoxSizer *sizerFilters = new wxStaticBoxSizer( wxVERTICAL, scrolLeft, "&Filters");
     wxStaticBox* const sizerFiltersBox = sizerFilters->GetStaticBox();
 
     m_fltr[0] = CreateCheckBoxAndAddToSizer( sizerFilters, wxString::Format("all files (%s)|%s",
@@ -189,8 +192,10 @@ void FileCtrlWidgetsPage::CreateContent()
     m_fltr[2] = CreateCheckBoxAndAddToSizer( sizerFilters, "PNG images (*.png)|*.png", wxID_ANY, sizerFiltersBox );
     sizerLeft->Add( sizerFilters, wxSizerFlags().Expand().Border() );
 
-    wxButton *btn = new wxButton( this, FileCtrlPage_Reset, "&Reset" );
+    wxButton *btn = new wxButton( scrolLeft, FileCtrlPage_Reset, "&Reset" );
     sizerLeft->Add( btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15 );
+    scrolLeft->SetSizer(sizerLeft);
+    scrolLeft->SetScrollRate(10, 10);
 
     // right pane
     m_fileCtrl = new wxFileCtrl(
@@ -204,8 +209,8 @@ void FileCtrlWidgetsPage::CreateContent()
                      wxDefaultSize
                  );
 
-    // the 3 panes panes compose the window
-    sizerTop->Add( sizerLeft, 0, ( wxALL & ~wxLEFT ), 10 );
+    // the 2 panes compose the window
+    sizerTop->Add( scrolLeft, 0, wxGROW | ( wxALL & ~wxLEFT ), 10 );
     sizerTop->Add( m_fileCtrl, 1, wxGROW | ( wxALL & ~wxRIGHT ), 10 );
 
     // final initializations

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -36,6 +36,7 @@
     #include "wx/textctrl.h"
 #endif
 
+#include "wx/scrolwin.h"
 #include "wx/sizer.h"
 
 #include "wx/checklst.h"
@@ -274,7 +275,8 @@ void ListboxWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // left pane
-    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set listbox parameters");
+    auto scrolLeft = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(260, -1));
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "&Set listbox parameters");
     wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     m_chkVScroll = CreateCheckBoxAndAddToSizer
@@ -327,9 +329,12 @@ void ListboxWidgetsPage::CreateContent()
 
     wxButton *btn = new wxButton(sizerLeftBox, ListboxPage_Reset, "&Reset");
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    scrolLeft->SetSizer(sizerLeft);
+    scrolLeft->SetScrollRate(10, 10);
 
     // middle pane
-    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change listbox contents");
+    auto scrolMidl = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(420, -1));
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, scrolMidl, "&Change listbox contents");
     wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
@@ -386,6 +391,8 @@ void ListboxWidgetsPage::CreateContent()
 
     btn = new wxButton(sizerMiddleBox, ListboxPage_ContainerTests, "Run &tests");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    scrolMidl->SetSizer(sizerMiddle);
+    scrolMidl->SetScrollRate(10, 10);
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
@@ -398,8 +405,8 @@ void ListboxWidgetsPage::CreateContent()
     m_sizerLbox = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 1, wxGROW | wxALL, 10);
+    sizerTop->Add(scrolLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
+    sizerTop->Add(scrolMidl, 1, wxGROW | wxALL, 10);
     sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
 
     // final initializations

--- a/samples/widgets/odcombobox.cpp
+++ b/samples/widgets/odcombobox.cpp
@@ -37,6 +37,7 @@
 
 #include "wx/dc.h"
 #include "wx/dcmemory.h"
+#include "wx/scrolwin.h"
 #include "wx/sizer.h"
 #include "wx/odcombo.h"
 
@@ -329,7 +330,8 @@ void ODComboboxWidgetsPage::CreateContent()
     wxSizer *sizerLeft = new wxBoxSizer(wxVERTICAL);
 
     // left pane - style box
-    wxStaticBoxSizer *sizerStyle = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    auto scrolLeft = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(200, -1));
+    wxStaticBoxSizer *sizerStyle = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "&Set style");
     wxStaticBox* const sizerStyleBox = sizerStyle->GetStaticBox();
 
     m_chkSort = CreateCheckBoxAndAddToSizer(sizerStyle, "&Sort items", wxID_ANY, sizerStyleBox);
@@ -347,7 +349,7 @@ void ODComboboxWidgetsPage::CreateContent()
     sizerLeft->Add(sizerStyle, wxSizerFlags().Expand());
 
     // left pane - popup adjustment box
-    wxStaticBoxSizer *sizerPopupPos = new wxStaticBoxSizer(wxVERTICAL, this, "Adjust &popup");
+    wxStaticBoxSizer *sizerPopupPos = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "Adjust &popup");
     wxStaticBox* const sizerPopupPosBox = sizerPopupPos->GetStaticBox();
 
     sizerRow = CreateSizerWithTextAndLabel("Min. Width:",
@@ -369,7 +371,7 @@ void ODComboboxWidgetsPage::CreateContent()
     sizerLeft->Add(sizerPopupPos, wxSizerFlags().Expand().Border(wxTOP, 2));
 
     // left pane - button adjustment box
-    wxStaticBoxSizer *sizerButtonPos = new wxStaticBoxSizer(wxVERTICAL, this, "Adjust &button");
+    wxStaticBoxSizer *sizerButtonPos = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "Adjust &button");
     wxStaticBox* const sizerButtonPosBox = sizerButtonPos->GetStaticBox();
 
     sizerRow = CreateSizerWithTextAndLabel("Width:",
@@ -396,9 +398,12 @@ void ODComboboxWidgetsPage::CreateContent()
     m_chkAlignbutleft = CreateCheckBoxAndAddToSizer(sizerButtonPos, "Align Left", wxID_ANY, sizerButtonPosBox);
 
     sizerLeft->Add(sizerButtonPos, wxSizerFlags().Expand().Border(wxTOP, 2));
+    scrolLeft->SetSizer(sizerLeft);
+    scrolLeft->SetScrollRate(10, 10);
 
     // middle pane
-    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, this, "&Change combobox contents");
+    auto scrolMidl = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(420, -1));
+    wxStaticBoxSizer *sizerMiddle = new wxStaticBoxSizer(wxVERTICAL, scrolMidl, "&Change combobox contents");
     wxStaticBox* const sizerMiddleBox = sizerMiddle->GetStaticBox();
 
     btn = new wxButton(sizerMiddleBox, ODComboPage_ContainerTests, "Run &tests");
@@ -459,6 +464,8 @@ void ODComboboxWidgetsPage::CreateContent()
 
     btn = new wxButton(sizerMiddleBox, ODComboPage_Clear, "&Clear");
     sizerMiddle->Add(btn, 0, wxALL | wxGROW, 5);
+    scrolMidl->SetSizer(sizerMiddle);
+    scrolMidl->SetScrollRate(10, 10);
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
@@ -472,8 +479,8 @@ void ODComboboxWidgetsPage::CreateContent()
     m_sizerCombo = sizerRight; // save it to modify it later
 
     // the 3 panes panes compose the window
-    sizerTop->Add(sizerLeft, 4, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 5, wxGROW | wxALL, 10);
+    sizerTop->Add(scrolLeft, 4, wxGROW | (wxALL & ~wxLEFT), 10);
+    sizerTop->Add(scrolMidl, 5, wxGROW | wxALL, 10);
     sizerTop->Add(sizerRight, 4, wxGROW | (wxALL & ~wxRIGHT), 10);
 
     // final initializations

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -36,6 +36,7 @@
     #include "wx/msgdlg.h"
 #endif
 
+#include "wx/scrolwin.h"
 #include "wx/sizer.h"
 
 #include "widgets.h"
@@ -295,7 +296,7 @@ private:
 
             case wxTE_HT_UNKNOWN:
                 x = y = -1;
-                where = "nowhere near";
+                where = "nowhere near, wxDefaultPosition, wxSize(120, -1)";
                 break;
 
             case wxTE_HT_BEFORE:
@@ -417,7 +418,8 @@ void TextWidgetsPage::CreateContent()
         "multi line",
     };
 
-    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, this, "&Set textctrl parameters");
+    auto scrolLeft = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(260, -1));
+    wxStaticBoxSizer *sizerLeft = new wxStaticBoxSizer(wxVERTICAL, scrolLeft, "&Set textctrl parameters");
     wxStaticBox* const sizerLeftBox = sizerLeft->GetStaticBox();
 
     m_radioTextLines = new wxRadioBox(sizerLeftBox, wxID_ANY, "&Number of lines:",
@@ -496,9 +498,12 @@ void TextWidgetsPage::CreateContent()
     wxButton *btn = new wxButton(sizerLeftBox, TextPage_Reset, "&Reset");
     sizerLeft->Add(2, 2, 0, wxGROW | wxALL, 1); // spacer
     sizerLeft->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
+    scrolLeft->SetSizer(sizerLeft);
+    scrolLeft->SetScrollRate(10, 10);
 
     // middle pane
-    wxStaticBoxSizer *sizerMiddleUp = new wxStaticBoxSizer(wxVERTICAL, this, "&Change contents:");
+    auto scrolMidl = new wxScrolledWindow(this, wxID_ANY, wxDefaultPosition, wxSize(420, -1));
+    wxStaticBoxSizer *sizerMiddleUp = new wxStaticBoxSizer(wxVERTICAL, scrolMidl, "&Change contents:");
     wxStaticBox* const sizerMiddleUpBox = sizerMiddleUp->GetStaticBox();
 
     btn = new wxButton(sizerMiddleUpBox, TextPage_Set, "&Set text value");
@@ -519,7 +524,7 @@ void TextWidgetsPage::CreateContent()
     btn = new wxButton(sizerMiddleUpBox, TextPage_StreamRedirector, "St&ream redirection");
     sizerMiddleUp->Add(btn, 0, wxALL | wxGROW, 1);
 
-    wxStaticBoxSizer *sizerMiddleDown = new wxStaticBoxSizer(wxVERTICAL, this, "&Info:");
+    wxStaticBoxSizer *sizerMiddleDown = new wxStaticBoxSizer(wxVERTICAL, scrolMidl, "&Info:");
     wxStaticBox* const sizerMiddleDownBox = sizerMiddleDown->GetStaticBox();
 
     m_textPosCur = CreateInfoText(sizerMiddleDownBox);
@@ -605,6 +610,8 @@ void TextWidgetsPage::CreateContent()
     wxSizer *sizerMiddle = new wxBoxSizer(wxVERTICAL);
     sizerMiddle->Add(sizerMiddleUp, 0, wxGROW);
     sizerMiddle->Add(sizerMiddleDown, 1, wxGROW | wxTOP, 5);
+    scrolMidl->SetSizer(sizerMiddle);
+    scrolMidl->SetScrollRate(10, 10);
 
     // right pane
     m_sizerText = new wxStaticBoxSizer(wxHORIZONTAL, this, "&Text:");
@@ -614,8 +621,8 @@ void TextWidgetsPage::CreateContent()
 
     // the 3 panes panes compose the upper part of the window
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
-    sizerTop->Add(sizerLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
-    sizerTop->Add(sizerMiddle, 0, wxGROW | wxALL, 10);
+    sizerTop->Add(scrolLeft, 0, wxGROW | (wxALL & ~wxLEFT), 10);
+    sizerTop->Add(scrolMidl, 0, wxGROW | wxALL, 10);
     sizerTop->Add(m_sizerText, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
 
     SetSizer(sizerTop);

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -380,6 +380,8 @@ bool WidgetsApp::OnInit()
     title += "wxGTK";
 #elif defined(__WXMAC__)
     title += "wxMAC";
+#elif defined(__WXQT__)
+    title += "wxQt";
 #else
     title += "wxWidgets";
 #endif


### PR DESCRIPTION
Under some ports, `wxQt` specifically, the left and middle panes of certain `WidgetsPages` must be scrollable. Otherwise, some properties will not be accessible at all.

These changes are still useful for the other ports too. especially when the window is not maximized.

_I found this very handy when working on this PR #24135._

### Here is some screenshots:

Under KDE **without** this patch:
![widgets_qt_old](https://github.com/wxWidgets/wxWidgets/assets/7704771/a0c5bdeb-60f9-4944-be20-dfb436349e9d)

Under KDE **with** this patch:
![widgets_qt](https://github.com/wxWidgets/wxWidgets/assets/7704771/4caa5070-c984-4cf6-8f37-63ad15c021a2)


Under Win10 with this patch:
![widgets](https://github.com/wxWidgets/wxWidgets/assets/7704771/1978741e-d900-42c0-89b7-ee73fa40a222)


