### PR TITLE
Make WidgetsPage pages scrollable in the widgets sample

### DIFF
--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -374,7 +374,7 @@ void ButtonWidgetsPage::CreateContent()
 #endif
 
     // right pane
-    m_sizerButton = new wxBoxSizer(wxHORIZONTAL);
+    m_sizerButton = new wxBoxSizer(wxVERTICAL);
     m_sizerButton->SetMinSize(FromDIP(150), 0);
 
     // the 3 panes panes compose the window
@@ -612,7 +612,7 @@ void ButtonWidgetsPage::CreateButton()
 
     m_sizerButton->AddStretchSpacer();
     m_sizerButton->Add(m_button, wxSizerFlags().Centre().Border());
-    m_sizerButton->AddStretchSpacer();
+    m_sizerButton->AddStretchSpacer(2);
 
     m_sizerButton->Layout();
 }

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -259,6 +259,15 @@ void ComboboxWidgetsPage::CreateContent()
     wxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
 
     // upper left pane
+    wxStaticBoxSizer *sizerLeftTop = new wxStaticBoxSizer(wxVERTICAL, this, "&Popup");
+    wxStaticBox* const sizerLeftTopBox = sizerLeftTop->GetStaticBox();
+
+    sizerLeftTop->Add(new wxButton(sizerLeftTopBox, ComboPage_Popup, "&Show"),
+                         wxSizerFlags().Border().Centre());
+    sizerLeftTop->Add(new wxButton(sizerLeftTopBox, ComboPage_Dismiss, "&Hide"),
+                         wxSizerFlags().Border().Centre());
+
+    // lower left pane
 
     // should be in sync with ComboKind_XXX values
     static const wxString kinds[] =
@@ -268,32 +277,23 @@ void ComboboxWidgetsPage::CreateContent()
         "drop down",
     };
 
-    wxStaticBoxSizer *sizerLeftTop = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
-    wxStaticBox* const sizerLeftTopBox = sizerLeftTop->GetStaticBox();
+    wxStaticBoxSizer *sizerLeftBottom = new wxStaticBoxSizer(wxVERTICAL, this, "&Set style");
+    wxStaticBox* const sizerLeftBottomBox = sizerLeftBottom->GetStaticBox();
 
-    m_radioKind = new wxRadioBox(sizerLeftTopBox, wxID_ANY, "Combobox &kind:",
+    m_radioKind = new wxRadioBox(sizerLeftBottomBox, wxID_ANY, "Combobox &kind:",
                                  wxDefaultPosition, wxDefaultSize,
                                  WXSIZEOF(kinds), kinds,
                                  1, wxRA_SPECIFY_COLS);
 
-    m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeftTop, "&Sort items", wxID_ANY, sizerLeftTopBox);
-    m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerLeftTop, "&Read only", wxID_ANY, sizerLeftTopBox);
-    m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerLeftTop, "Process &Enter", wxID_ANY, sizerLeftTopBox);
+    m_chkSort = CreateCheckBoxAndAddToSizer(sizerLeftBottom, "&Sort items", wxID_ANY, sizerLeftBottomBox);
+    m_chkReadonly = CreateCheckBoxAndAddToSizer(sizerLeftBottom, "&Read only", wxID_ANY, sizerLeftBottomBox);
+    m_chkProcessEnter = CreateCheckBoxAndAddToSizer(sizerLeftBottom, "Process &Enter", wxID_ANY, sizerLeftBottomBox);
 
-    sizerLeftTop->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
-    sizerLeftTop->Add(m_radioKind, 0, wxGROW | wxALL, 5);
+    sizerLeftBottom->Add(5, 5, 0, wxGROW | wxALL, 5); // spacer
+    sizerLeftBottom->Add(m_radioKind, 0, wxGROW | wxALL, 5);
 
-    wxButton *btn = new wxButton(sizerLeftTopBox, ComboPage_Reset, "&Reset");
-    sizerLeftTop->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
-
-    // lower left pane
-    wxStaticBoxSizer *sizerLeftBottom = new wxStaticBoxSizer(wxVERTICAL, this, "&Popup");
-    wxStaticBox* const sizerLeftBottomBox = sizerLeftBottom->GetStaticBox();
-
-    sizerLeftBottom->Add(new wxButton(sizerLeftBottomBox, ComboPage_Popup, "&Show"),
-                         wxSizerFlags().Border().Centre());
-    sizerLeftBottom->Add(new wxButton(sizerLeftBottomBox, ComboPage_Dismiss, "&Hide"),
-                         wxSizerFlags().Border().Centre());
+    wxButton *btn = new wxButton(sizerLeftBottomBox, ComboPage_Reset, "&Reset");
+    sizerLeftBottom->Add(btn, 0, wxALIGN_CENTRE_HORIZONTAL | wxALL, 15);
 
 
     wxSizer *sizerLeft = new wxBoxSizer(wxVERTICAL);

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -771,7 +771,8 @@ void WidgetsFrame::OnPageChanged(WidgetsBookCtrlEvent& event)
     {
         wxWindowUpdateLocker noUpdates(curPage);
         curPage->CreateContent();
-        curPage->Layout();
+        curPage->SetScrollRate(10, 10);
+        curPage->FitInside();
 
         ConnectToWidgetEvents();
     }
@@ -1321,10 +1322,9 @@ WidgetsPageInfo *WidgetsPage::ms_widgetPages = nullptr;
 WidgetsPage::WidgetsPage(WidgetsBookCtrl *book,
                          wxImageList *imaglist,
                          const char *const icon[])
-           : wxPanel(book, wxID_ANY,
+           : wxScrolledWindow(book, wxID_ANY,
                      wxDefaultPosition, wxDefaultSize,
-                     wxCLIP_CHILDREN |
-                     wxTAB_TRAVERSAL)
+                     wxCLIP_CHILDREN | wxTAB_TRAVERSAL)
 {
     imaglist->Add(wxBitmap(wxImage(icon).Scale(ICON_SIZE, ICON_SIZE)));
 }

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -46,7 +46,7 @@ class WXDLLIMPEXP_FWD_CORE WidgetsBookCtrl;
 
 class WidgetsPageInfo;
 
-#include "wx/panel.h"
+#include "wx/scrolwin.h"
 #include "wx/vector.h"
 
 // INTRODUCING NEW PAGES DON'T FORGET TO ADD ENTRIES TO 'WidgetsCategories'
@@ -119,7 +119,7 @@ struct WidgetAttributes
     long m_defaultFlags;
 };
 
-class WidgetsPage : public wxPanel
+class WidgetsPage : public wxScrolledWindow
 {
 public:
     WidgetsPage(WidgetsBookCtrl *book,


### PR DESCRIPTION
Because some pages in the sample contain too much content to fit entirely in the visible area of the page. Under `wxQt` port, this is true regardless of the state of the window (whether it is maximized or not) some content remains hidden and inaccessible.

`ButtonWidgetsPage` and `ComboboxWidgetsPage` are also fixed after the changes made here:

![widgets_sample_button](https://github.com/wxWidgets/wxWidgets/assets/7704771/f99035c9-08bd-44a8-9c9e-f63ee408a849)

![widgets_sample_combobox](https://github.com/wxWidgets/wxWidgets/assets/7704771/2a2438e0-addf-4ede-b866-0b60db3ac71a)


