### PR TITLE
Fix missing semicolon

### DIFF
--- a/interface/wx/listbox.h
+++ b/interface/wx/listbox.h
@@ -165,7 +165,7 @@ public:
     /**
         return true if the listbox allows multiple selection
     */
-    bool HasMultipleSelection() const
+    bool HasMultipleSelection() const;
 
     /**
         Deselects an item in the list box.


### PR DESCRIPTION
Missing semicolon on latest method addition causes doxygen parsing issues which in turn causes problems for dependent projects like wxRuby and wxPython.