### PR TITLE
Fix confusing argument names in wxPersistentWindow docs

### DIFF
--- a/interface/wx/persist/dataview.h
+++ b/interface/wx/persist/dataview.h
@@ -39,4 +39,4 @@ public:
 };
 
 /// Overload allowing persistence adapter creation for wxDataViewCtrl objects.
-wxPersistentObject *wxCreatePersistentObject(wxDataViewCtrl *book);
+wxPersistentObject *wxCreatePersistentObject(wxDataViewCtrl *control);

--- a/interface/wx/persist/toplevel.h
+++ b/interface/wx/persist/toplevel.h
@@ -21,10 +21,10 @@ public:
     /**
         Constructor.
 
-        @param topwin
+        @param tlw
             The associated window.
      */
-    wxPersistentTLW(wxTopLevelWindow *topwin);
+    wxPersistentTLW(wxTopLevelWindow *tlw);
 
     /**
         Save the current window geometry.
@@ -39,4 +39,4 @@ public:
 
 /// Overload allowing persistence adapter creation for wxTopLevelWindow-derived
 /// objects.
-wxPersistentObject *wxCreatePersistentObject(wxTopLevelWindow *book);
+wxPersistentObject *wxCreatePersistentObject(wxTopLevelWindow *tlw);


### PR DESCRIPTION
Use the same argument name as in the actual code in the class constructor as well as the convenience function, instead of wrongly copypasted "book".

See also 33de6dc (Fix confusing wxPersistentTLW ctor argument name, 2023-12-22).