### PR TITLE
Revert "Fix user-visible with AUI tab selection after dragging"

### DIFF
--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2726,10 +2726,7 @@ void wxAuiNotebook::OnTabEndDrag(wxAuiNotebookEvent& evt)
     wxPoint mouse_screen_pt = ::wxGetMousePosition();
     wxPoint mouse_client_pt = ScreenToClient(mouse_screen_pt);
 
-    // Update our selection (it may be updated again below but the code below
-    // can also return without doing anything else and this ensures that the
-    // selection is updated even then).
-    m_curPage = src_tabs->GetActivePage();
+
 
     // check for an external move
     if (m_flags & wxAUI_NB_TAB_EXTERNAL_MOVE)


### PR DESCRIPTION
This reverts commit b1fcf100fff53dad8feac9fea808bc5842fc385a because it doesn't seem to be necessary any more, as the bug reported in #15071 that was fixed by that commit can't be reproduce any longer in the current version and this commit resulted in other bugs, notably #24042 and probably also #24063.