### PR TITLE
Improve wxAUI hint window appearance

### DIFF
--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -485,8 +485,6 @@ public:
     virtual void ShowHint(const wxRect& rect);
     virtual void HideHint();
 
-    void OnHintActivate(wxActivateEvent& event);
-
 public:
 
     // deprecated -- please use SetManagedWindow()

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -134,7 +134,9 @@ enum wxAuiManagerOption
            appearing partially transparent hint.
     @style{wxAUI_MGR_RECTANGLE_HINT}
            The possible location for docking is indicated by a rectangular
-           outline.
+           outline. Note that this flag doesn't work, i.e. doesn't show any
+           hint in wxGTK and wxOSX, please use one of the hint flags above
+           instead.
     @style{wxAUI_MGR_HINT_FADE}
            The translucent area where the pane could be docked appears gradually.
     @style{wxAUI_MGR_NO_VENETIAN_BLINDS_FADE}

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -852,7 +852,8 @@ void wxAuiManager::UpdateHintWindowConfig()
                                          wxFRAME_NO_TASKBAR |
                                          wxNO_BORDER);
 
-            m_hintWnd->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT));
+            // We can set the background of the frame itself directly.
+            auto bgWnd = m_hintWnd;
         #elif defined(__WXMAC__)
             // Using a miniframe with float and tool styles keeps the parent
             // frame activated and highlighted as such...
@@ -863,15 +864,10 @@ void wxAuiManager::UpdateHintWindowConfig()
             m_hintWnd->Bind(wxEVT_ACTIVATE, &wxAuiManager::OnHintActivate, this);
 
             // Can't set the bg colour of a Frame in wxMac
-            wxPanel* p = new wxPanel(m_hintWnd);
-
-            // The default wxSYS_COLOUR_ACTIVECAPTION colour is a light silver
-            // color that is really hard to see, especially transparent.
-            // Until a better system color is decided upon we'll just use
-            // blue.
-            p->SetBackgroundColour(*wxBLUE);
+            wxPanel* bgWnd = new wxPanel(m_hintWnd);
         #endif
 
+        bgWnd->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT));
     }
     else
     {

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -851,7 +851,14 @@ void wxAuiManager::UpdateHintWindowConfig()
                                      wxFRAME_NO_TASKBAR |
                                      wxNO_BORDER);
         #ifdef __WXMAC__
-            m_hintWnd->Bind(wxEVT_ACTIVATE, &wxAuiManager::OnHintActivate, this);
+            // Do nothing so this event isn't handled in the base handlers.
+
+            // Letting the hint window activate without this handler can lead to
+            // weird behaviour on Mac where the menu is switched out to the top
+            // window's menu in MDI applications when it shouldn't be. So since
+            // we don't want user interaction with the hint window anyway, we just
+            // prevent it from activating here.
+            m_hintWnd->Bind(wxEVT_ACTIVATE, [](wxActivateEvent&) {});
         #endif
 
         m_hintWnd->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT));
@@ -3413,18 +3420,6 @@ void wxAuiManager::HideHint()
         m_lastHint = wxRect();
     }
 }
-
-void wxAuiManager::OnHintActivate(wxActivateEvent& WXUNUSED(event))
-{
-    // Do nothing so this event isn't handled in the base handlers.
-
-    // Letting the hint window activate without this handler can lead to
-    // weird behaviour on Mac where the menu is switched out to the top
-    // window's menu in MDI applications when it shouldn't be. So since
-    // we don't want user interaction with the hint window anyway, we just
-    // prevent it from activating here.
-}
-
 
 
 void wxAuiManager::StartPaneDrag(wxWindow* pane_window,

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3311,13 +3311,15 @@ void wxAuiManager::ShowHint(const wxRect& rect)
             return;
         m_lastHint = rect;
 
-        m_hintFadeAmt = m_hintFadeMax;
-
+        // Decide if we want to fade in the hint and set it to the end value if
+        // we don't.
         if ((m_flags & wxAUI_MGR_HINT_FADE)
             && !((m_flags & wxAUI_MGR_VENETIAN_BLINDS_HINT) &&
                  (m_flags & wxAUI_MGR_NO_VENETIAN_BLINDS_FADE))
             )
             m_hintFadeAmt = 0;
+        else
+            m_hintFadeAmt = m_hintFadeMax;
 
         m_hintWnd->SetSize(rect);
         m_hintWnd->SetTransparent(m_hintFadeAmt);

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -852,7 +852,7 @@ void wxAuiManager::UpdateHintWindowConfig()
                                          wxFRAME_NO_TASKBAR |
                                          wxNO_BORDER);
 
-            m_hintWnd->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_ACTIVECAPTION));
+            m_hintWnd->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT));
         #elif defined(__WXMAC__)
             // Using a miniframe with float and tool styles keeps the parent
             // frame activated and highlighted as such...

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -844,20 +844,13 @@ void wxAuiManager::UpdateHintWindowConfig()
     if ((m_flags & wxAUI_MGR_TRANSPARENT_HINT) && can_do_transparent)
     {
         // Make a window to use for a transparent hint
-        #ifndef __WXMAC__
-            m_hintWnd = new wxFrame(m_frame, wxID_ANY, wxEmptyString,
-                                     wxDefaultPosition, wxSize(1,1),
-                                         wxFRAME_TOOL_WINDOW |
-                                         wxFRAME_FLOAT_ON_PARENT |
-                                         wxFRAME_NO_TASKBAR |
-                                         wxNO_BORDER);
-        #else // Mac
-            // Using a miniframe with float and tool styles keeps the parent
-            // frame activated and highlighted as such...
-            m_hintWnd = new wxMiniFrame(m_frame, wxID_ANY, wxEmptyString,
-                                         wxDefaultPosition, wxSize(1,1),
-                                         wxFRAME_FLOAT_ON_PARENT
-                                         | wxFRAME_TOOL_WINDOW );
+        m_hintWnd = new wxFrame(m_frame, wxID_ANY, wxEmptyString,
+                                 wxDefaultPosition, wxSize(1,1),
+                                     wxFRAME_TOOL_WINDOW |
+                                     wxFRAME_FLOAT_ON_PARENT |
+                                     wxFRAME_NO_TASKBAR |
+                                     wxNO_BORDER);
+        #ifdef __WXMAC__
             m_hintWnd->Bind(wxEVT_ACTIVATE, &wxAuiManager::OnHintActivate, this);
         #endif
 

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3298,7 +3298,7 @@ void wxAuiManager::OnHintFadeTimer(wxTimerEvent& WXUNUSED(event))
         return;
     }
 
-    m_hintFadeAmt += 4;
+    m_hintFadeAmt++;
     m_hintWnd->SetTransparent(m_hintFadeAmt);
 }
 
@@ -3339,7 +3339,7 @@ void wxAuiManager::ShowHint(const wxRect& rect)
         {
             // start fade in timer
             m_hintFadeTimer.SetOwner(this);
-            m_hintFadeTimer.Start(5);
+            m_hintFadeTimer.Start(15);
             Bind(wxEVT_TIMER, &wxAuiManager::OnHintFadeTimer, this,
                  m_hintFadeTimer.GetId());
         }

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -844,7 +844,7 @@ void wxAuiManager::UpdateHintWindowConfig()
     if ((m_flags & wxAUI_MGR_TRANSPARENT_HINT) && can_do_transparent)
     {
         // Make a window to use for a transparent hint
-        #if defined(__WXMSW__) || defined(__WXGTK__) || defined(__WXQT__)
+        #ifndef __WXMAC__
             m_hintWnd = new wxFrame(m_frame, wxID_ANY, wxEmptyString,
                                      wxDefaultPosition, wxSize(1,1),
                                          wxFRAME_TOOL_WINDOW |
@@ -854,7 +854,7 @@ void wxAuiManager::UpdateHintWindowConfig()
 
             // We can set the background of the frame itself directly.
             auto bgWnd = m_hintWnd;
-        #elif defined(__WXMAC__)
+        #else // Mac
             // Using a miniframe with float and tool styles keeps the parent
             // frame activated and highlighted as such...
             m_hintWnd = new wxMiniFrame(m_frame, wxID_ANY, wxEmptyString,

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3314,7 +3314,7 @@ void wxAuiManager::ShowHint(const wxRect& rect)
         m_hintFadeAmt = m_hintFadeMax;
 
         if ((m_flags & wxAUI_MGR_HINT_FADE)
-            && !((wxDynamicCast(m_hintWnd, wxPseudoTransparentFrame)) &&
+            && !((m_flags & wxAUI_MGR_VENETIAN_BLINDS_HINT) &&
                  (m_flags & wxAUI_MGR_NO_VENETIAN_BLINDS_FADE))
             )
             m_hintFadeAmt = 0;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -851,9 +851,6 @@ void wxAuiManager::UpdateHintWindowConfig()
                                          wxFRAME_FLOAT_ON_PARENT |
                                          wxFRAME_NO_TASKBAR |
                                          wxNO_BORDER);
-
-            // We can set the background of the frame itself directly.
-            auto bgWnd = m_hintWnd;
         #else // Mac
             // Using a miniframe with float and tool styles keeps the parent
             // frame activated and highlighted as such...
@@ -862,12 +859,9 @@ void wxAuiManager::UpdateHintWindowConfig()
                                          wxFRAME_FLOAT_ON_PARENT
                                          | wxFRAME_TOOL_WINDOW );
             m_hintWnd->Bind(wxEVT_ACTIVATE, &wxAuiManager::OnHintActivate, this);
-
-            // Can't set the bg colour of a Frame in wxMac
-            wxPanel* bgWnd = new wxPanel(m_hintWnd);
         #endif
 
-        bgWnd->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT));
+        m_hintWnd->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT));
     }
     else
     {


### PR DESCRIPTION
This is mostly about making it (much) more noticeable under wxGTK (#23987), but also improves a couple of other things and, noticeably, makes the fade in of the hint window actually noticeable.

I'm not even sure if I like it myself, personally, but it seems wrong to have code whose effect is completely unnoticeable, so if anybody doesn't like the new behaviour, I think we need to either remove support for fade in completely or, if anybody complains about this too, make it configurable. OTOH anybody who preferred the old behaviour could just turn off `wxAUI_MGR_HINT_FADE`.