### PR TITLE
Avoid resizing `wxAuiToolbar` to the wrong shape in its `Realize()`

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -704,7 +704,7 @@ private:
     // Common part of OnLeaveWindow() and OnCaptureLost().
     void DoResetMouseState();
 
-    wxSize RealizeHelper(wxClientDC& dc, bool horizontal);
+    wxSize RealizeHelper(wxClientDC& dc, wxOrientation orientation);
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_CLASS(wxAuiToolBar);

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -693,7 +693,6 @@ protected:
     bool m_gripperVisible;
     bool m_overflowVisible;
 
-    bool RealizeHelper(wxClientDC& dc, bool horizontal);
     static bool IsPaneValid(long style, const wxAuiPaneInfo& pane);
     bool IsPaneValid(long style) const;
     void SetArtFlags() const;
@@ -704,6 +703,8 @@ protected:
 private:
     // Common part of OnLeaveWindow() and OnCaptureLost().
     void DoResetMouseState();
+
+    wxSize RealizeHelper(wxClientDC& dc, bool horizontal);
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_CLASS(wxAuiToolBar);

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1877,37 +1877,22 @@ bool wxAuiToolBar::Realize()
 
     // calculate hint sizes for both horizontal and vertical
     // in the order that leaves toolbar in correct final state
-    bool retval = false;
     if (m_orientation == wxHORIZONTAL)
     {
-        if (RealizeHelper(dc, false))
-        {
-            m_vertHintSize = GetSize();
-            if (RealizeHelper(dc, true))
-            {
-                m_horzHintSize = GetSize();
-                retval = true;
-            }
-        }
+        m_vertHintSize = RealizeHelper(dc, false);
+        m_horzHintSize = RealizeHelper(dc, true);
     }
     else
     {
-        if (RealizeHelper(dc, true))
-        {
-            m_horzHintSize = GetSize();
-            if (RealizeHelper(dc, false))
-            {
-                m_vertHintSize = GetSize();
-                retval = true;
-            }
-        }
+        m_horzHintSize = RealizeHelper(dc, true);
+        m_vertHintSize = RealizeHelper(dc, false);
     }
 
     Refresh(false);
-    return retval;
+    return true;
 }
 
-bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
+wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
 {
     // Remove old sizer before adding any controls in this tool bar, which are
     // elements of this sizer, to the new sizer below.
@@ -2149,7 +2134,7 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
         m_sizer->SetDimension(0, 0, curSize.x, curSize.y);
     }
 
-    return true;
+    return GetSize();
 }
 
 int wxAuiToolBar::GetOverflowState() const

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1893,24 +1893,19 @@ bool wxAuiToolBar::Realize()
         size = m_vertHintSize;
     }
 
-    // set control size
+    // Remember our minimum size.
     m_minWidth = size.x;
     m_minHeight = size.y;
 
+    // And set control size if we are not forbidden from doing it by the use of
+    // a special flag and if it did actually change.
     wxSize curSize = GetClientSize();
 
-    if ((m_windowStyle & wxAUI_TB_NO_AUTORESIZE) == 0)
+    if ((m_windowStyle & wxAUI_TB_NO_AUTORESIZE) == 0 && (size != curSize))
     {
-        if (size != curSize)
-        {
-            SetClientSize(size);
-        }
-        else
-        {
-            m_sizer->SetDimension(0, 0, curSize.x, curSize.y);
-        }
+        SetClientSize(size);
     }
-    else
+    else // Don't change the size but let the sizer know about available size.
     {
         m_sizer->SetDimension(0, 0, curSize.x, curSize.y);
     }

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1875,17 +1875,44 @@ bool wxAuiToolBar::Realize()
     if (!dc.IsOk())
         return false;
 
-    // calculate hint sizes for both horizontal and vertical
-    // in the order that leaves toolbar in correct final state
+    // calculate hint sizes for both horizontal and vertical orientations and
+    // store the size appropriate for the current orientation in this variable.
+    wxSize size;
     if (m_orientation == wxHORIZONTAL)
     {
         m_vertHintSize = RealizeHelper(dc, wxVERTICAL);
         m_horzHintSize = RealizeHelper(dc, wxHORIZONTAL);
+
+        size = m_horzHintSize;
     }
     else
     {
         m_horzHintSize = RealizeHelper(dc, wxHORIZONTAL);
         m_vertHintSize = RealizeHelper(dc, wxVERTICAL);
+
+        size = m_vertHintSize;
+    }
+
+    // set control size
+    m_minWidth = size.x;
+    m_minHeight = size.y;
+
+    wxSize curSize = GetClientSize();
+
+    if ((m_windowStyle & wxAUI_TB_NO_AUTORESIZE) == 0)
+    {
+        if (size != curSize)
+        {
+            SetClientSize(size);
+        }
+        else
+        {
+            m_sizer->SetDimension(0, 0, curSize.x, curSize.y);
+        }
+    }
+    else
+    {
+        m_sizer->SetDimension(0, 0, curSize.x, curSize.y);
     }
 
     Refresh(false);
@@ -2092,31 +2119,7 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, wxOrientation orientation)
             item.m_sizerItem->SetMinSize(item.m_minSize);
     }
 
-    // set control size
-    wxSize size = m_sizer->GetMinSize();
-    m_minWidth = size.x;
-    m_minHeight = size.y;
-
-    wxSize curSize = GetClientSize();
-
-    if ((m_windowStyle & wxAUI_TB_NO_AUTORESIZE) == 0)
-    {
-        wxSize new_size = GetMinSize();
-        if (new_size != curSize)
-        {
-            SetClientSize(new_size);
-        }
-        else
-        {
-            m_sizer->SetDimension(0, 0, curSize.x, curSize.y);
-        }
-    }
-    else
-    {
-        m_sizer->SetDimension(0, 0, curSize.x, curSize.y);
-    }
-
-    return GetSize();
+    return m_sizer->GetMinSize();
 }
 
 int wxAuiToolBar::GetOverflowState() const

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1412,6 +1412,8 @@ void wxAuiToolBar::SetOrientation(int orientation)
     {
         m_orientation = wxOrientation(orientation);
         SetArtFlags();
+
+        Realize();
     }
 }
 
@@ -2374,7 +2376,7 @@ void wxAuiToolBar::OnIdle(wxIdleEvent& evt)
             if (newOrientation != m_orientation)
             {
                 SetOrientation(newOrientation);
-                Realize();
+
                 if (newOrientation == wxHORIZONTAL)
                 {
                     pane.best_size = GetHintSize(wxAUI_DOCK_TOP);

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1879,20 +1879,20 @@ bool wxAuiToolBar::Realize()
     // in the order that leaves toolbar in correct final state
     if (m_orientation == wxHORIZONTAL)
     {
-        m_vertHintSize = RealizeHelper(dc, false);
-        m_horzHintSize = RealizeHelper(dc, true);
+        m_vertHintSize = RealizeHelper(dc, wxVERTICAL);
+        m_horzHintSize = RealizeHelper(dc, wxHORIZONTAL);
     }
     else
     {
-        m_horzHintSize = RealizeHelper(dc, true);
-        m_vertHintSize = RealizeHelper(dc, false);
+        m_horzHintSize = RealizeHelper(dc, wxHORIZONTAL);
+        m_vertHintSize = RealizeHelper(dc, wxVERTICAL);
     }
 
     Refresh(false);
     return true;
 }
 
-wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
+wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, wxOrientation orientation)
 {
     // Remove old sizer before adding any controls in this tool bar, which are
     // elements of this sizer, to the new sizer below.
@@ -1900,7 +1900,7 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
     m_sizer = nullptr;
 
     // create the new sizer to add toolbar elements to
-    wxBoxSizer* sizer = new wxBoxSizer(horizontal ? wxHORIZONTAL : wxVERTICAL);
+    wxBoxSizer* sizer = new wxBoxSizer(orientation);
 
     // add gripper area
     int separatorSize = m_art->GetElementSize(wxAUI_TBART_SEPARATOR_SIZE);
@@ -2055,7 +2055,7 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
 
 
     // the outside sizer helps us apply the "top" and "bottom" padding
-    wxBoxSizer* outside_sizer = new wxBoxSizer(horizontal ? wxVERTICAL : wxHORIZONTAL);
+    wxBoxSizer* outside_sizer = new wxBoxSizer(orientation ^ wxBOTH);
 
     // add "top" padding
     if (m_topPadding > 0)

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1875,19 +1875,24 @@ bool wxAuiToolBar::Realize()
     if (!dc.IsOk())
         return false;
 
-    // calculate hint sizes for both horizontal and vertical orientations and
+    // calculate hint sizes for both horizontal and vertical orientations if we
+    // can use them, i.e. if the toolbar isn't locked into just one of them, and
     // store the size appropriate for the current orientation in this variable.
     wxSize size;
     if (m_orientation == wxHORIZONTAL)
     {
-        m_vertHintSize = RealizeHelper(dc, wxVERTICAL);
+        if (!HasFlag(wxAUI_TB_HORIZONTAL))
+            m_vertHintSize = RealizeHelper(dc, wxVERTICAL);
+
         m_horzHintSize = RealizeHelper(dc, wxHORIZONTAL);
 
         size = m_horzHintSize;
     }
     else
     {
-        m_horzHintSize = RealizeHelper(dc, wxHORIZONTAL);
+        if (!HasFlag(wxAUI_TB_VERTICAL))
+            m_horzHintSize = RealizeHelper(dc, wxHORIZONTAL);
+
         m_vertHintSize = RealizeHelper(dc, wxVERTICAL);
 
         size = m_vertHintSize;

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1907,10 +1907,8 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
     int gripperSize = m_art->GetElementSize(wxAUI_TBART_GRIPPER_SIZE);
     if (gripperSize > 0 && m_gripperVisible)
     {
-        if (horizontal)
-            m_gripperSizerItem = sizer->Add(gripperSize, 1, 0, wxEXPAND);
-        else
-            m_gripperSizerItem = sizer->Add(1, gripperSize, 0, wxEXPAND);
+        m_gripperSizerItem = sizer->AddSpacer(gripperSize);
+        m_gripperSizerItem->SetFlag(wxEXPAND);
     }
     else
     {
@@ -1920,10 +1918,7 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
     // add "left" padding
     if (m_leftPadding > 0)
     {
-        if (horizontal)
-            sizer->Add(m_leftPadding, 1);
-        else
-            sizer->Add(1, m_leftPadding);
+        sizer->AddSpacer(m_leftPadding);
     }
 
     size_t i, count;
@@ -1969,10 +1964,8 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
 
             case wxITEM_SEPARATOR:
             {
-                if (horizontal)
-                    sizerItem = sizer->Add(separatorSize, 1, 0, wxEXPAND);
-                else
-                    sizerItem = sizer->Add(1, separatorSize, 0, wxEXPAND);
+                sizerItem = sizer->AddSpacer(separatorSize);
+                sizerItem->SetFlag(wxEXPAND);
 
                 // add tool packing
                 if (i+1 < count)
@@ -2039,10 +2032,7 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
     // add "right" padding
     if (m_rightPadding > 0)
     {
-        if (horizontal)
-            sizer->Add(m_rightPadding, 1);
-        else
-            sizer->Add(1, m_rightPadding);
+        sizer->AddSpacer(m_rightPadding);
     }
 
     // add drop down area
@@ -2053,10 +2043,8 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
         int overflow_size = m_art->GetElementSize(wxAUI_TBART_OVERFLOW_SIZE);
         if (overflow_size > 0 && m_overflowVisible)
         {
-            if (horizontal)
-                m_overflowSizerItem = sizer->Add(overflow_size, 1, 0, wxEXPAND);
-            else
-                m_overflowSizerItem = sizer->Add(1, overflow_size, 0, wxEXPAND);
+            m_overflowSizerItem = sizer->AddSpacer(overflow_size);
+            m_overflowSizerItem->SetFlag(wxEXPAND);
             m_overflowSizerItem->SetMinSize(m_overflowSizerItem->GetSize());
         }
         else
@@ -2072,10 +2060,7 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
     // add "top" padding
     if (m_topPadding > 0)
     {
-        if (horizontal)
-            outside_sizer->Add(1, m_topPadding);
-        else
-            outside_sizer->Add(m_topPadding, 1);
+        outside_sizer->AddSpacer(m_topPadding);
     }
 
     // add the sizer that contains all of the toolbar elements
@@ -2084,10 +2069,7 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
     // add "bottom" padding
     if (m_bottomPadding > 0)
     {
-        if (horizontal)
-            outside_sizer->Add(1, m_bottomPadding);
-        else
-            outside_sizer->Add(m_bottomPadding, 1);
+        outside_sizer->AddSpacer(m_bottomPadding);
     }
 
     m_sizer = outside_sizer;

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2097,9 +2097,10 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, wxOrientation orientation)
     m_minWidth = size.x;
     m_minHeight = size.y;
 
+    wxSize curSize = GetClientSize();
+
     if ((m_windowStyle & wxAUI_TB_NO_AUTORESIZE) == 0)
     {
-        wxSize curSize = GetClientSize();
         wxSize new_size = GetMinSize();
         if (new_size != curSize)
         {
@@ -2112,7 +2113,6 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, wxOrientation orientation)
     }
     else
     {
-        wxSize curSize = GetClientSize();
         m_sizer->SetDimension(0, 0, curSize.x, curSize.y);
     }
 


### PR DESCRIPTION
This is mostly done to address #24023 but also contains a few cleanups.