### PR TITLE
Disable swap interval in GLX wxGLCanvas implementation too

### DIFF
--- a/include/wx/unix/glx11.h
+++ b/include/wx/unix/glx11.h
@@ -99,6 +99,8 @@ public:
 private:
     GLXFBConfig *m_fbc;
     void* m_vi;
+
+    bool m_swapIntervalSet = false;
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
We need to do it when using XWayland for the same reasons as we had to do it in the EGL version when using either XWayland or Wayland directly: without this, we can block for up to 1 second in glXSwapBuffers() if the window is hidden, see #23512.

Closes #24163.