### PR TITLE
resolve FTBFS seen with autoconf 2.72 / build: add missing AC_PROG_EGREP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7960,6 +7960,7 @@ dnl MAKE_SET will be replaced with "MAKE=..." or nothing if make sets MAKE
 dnl itself (this macro is required if SUBDIRS variable is used in Makefile.am
 dnl - and we do use it)
 AC_PROG_MAKE_SET
+AC_PROG_EGREP
 
 
 AC_CONFIG_HEADERS([lib/wx/include/${TOOLCHAIN_FULLNAME}/wx/setup.h:setup.h.in])


### PR DESCRIPTION
configure.ac uses $EGREP at some point, but as it never called AC_PROG_EGREP, this can expand to nothing. Down the line, this causes misconstruction of the SUBDIRS variable and tests/Makefile is never produced (so observed on autoconf 2.72).

```
./configure --host=i586-suse-linux-gnu --build=i586-suse-linux-gnu --program-prefix= --disable-dependency-tracking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin --sbindir=/usr/sbin --sysconfdir=/etc --datadir=/usr/share --includedir=/usr/include --libdir=/usr/lib --libexecdir=/usr/libexec --localstatedir=/var --sharedstatedir=/var/lib --mandir=/usr/share/man --infodir=/usr/share/info --enable-vendor=suse --with-gtk=2 --enable-unicode --with-opengl --with-libmspack --with-sdl --enable-ipv6 --enable-mediactrl --enable-optimise --enable-repro-build --disable-glcanvasegl --enable-webrequest --enable-stl --enable-plugins
...
[   20s] checking whether catch.hpp file exists... yes
[   20s] ./configure: line 48269: -v: command not found
[   20s] ./configure: line 48269: -v: command not found
[   20s] ./configure: line 48269: -v: command not found
[   20s] configure: creating ./config.status
[   20s] config.status: creating lib/wx/config/gtk2-unicode-3.2
…
[   22s] config.status: creating samples/animate/Makefile
[   22s] config.status: creating samples/Makefile
[   22s] config.status: creating lib/wx/include/gtk2-unicode-3.2/wx/setup.h
[   22s] config.status: executing wx-config commands
```

autoconf 2.72 changelog even has a mention of it:

```
+  This change might break configure scripts that expected probes for
+  ‘grep’ and/or the C preprocessor to happen as a side effect of an
+  unrelated operation.  Such scripts can be fixed by adding
+  AC_PROG_EGREP and/or AC_PROG_CPP in an appropriate place.
```