### PR TITLE
Add support for %F (ISO 8601 date) format specifier to wxDateTime

### DIFF
--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -337,7 +337,7 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
     bool isPercent = false;
 
     // We also can't use strftime() if we use non standard specifier: either
-    // our own extension "%l" or one of POSIX specifiers not supported when
+    // our own extension "%l" or one of C99/POSIX specifiers not supported when
     // using MinGW, see https://sourceforge.net/p/mingw-w64/bugs/793/
     for ( wxString::const_iterator p = format.begin();
           canUseStrftime && p != format.end();
@@ -355,6 +355,7 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
         {
             case 'l':
 #ifdef __MINGW32__
+            case 'F':
             case 'g':
             case 'G':
             case 'V':

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -580,6 +580,10 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
                     res += wxString::Format(fmt, tm.mday);
                     break;
 
+                case wxT('F'):      // ISO 8601 date
+                    res += wxString::Format(wxT("%04d-%02d-%02d"), tm.year, tm.mon + 1, tm.mday);
+                    break;
+
                 case wxT('g'):      // 2-digit week-based year
                     res += wxString::Format(fmt, GetWeekBasedYear() % 100);
                     break;
@@ -1227,6 +1231,22 @@ wxDateTime::ParseFormat(const wxString& date,
                 // do it later - assume ok for now
                 haveDay = true;
                 mday = (wxDateTime_t)num;
+                break;
+
+            case wxT('F'):       // ISO 8601 date
+                {
+                    wxDateTime dt = ParseFormatAt(input, end, wxS("%Y-%m-%d"));
+                    if ( !dt.IsValid() )
+                        return false;
+
+                    const Tm tm = dt.GetTm();
+
+                    year = tm.year;
+                    mon = tm.mon;
+                    mday = tm.mday;
+
+                    haveDay = haveMon = haveYear = true;
+                }
                 break;
 
             case wxT('H'):       // hour in 24h format (00-23)

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -337,8 +337,8 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
     bool isPercent = false;
 
     // We also can't use strftime() if we use non standard specifier: either
-    // our own extension "%l" or one of "%g", "%G", "%V", "%z" which are POSIX
-    // but not supported under Windows.
+    // our own extension "%l" or one of POSIX specifiers not supported when
+    // using MinGW, see https://sourceforge.net/p/mingw-w64/bugs/793/
     for ( wxString::const_iterator p = format.begin();
           canUseStrftime && p != format.end();
           ++p )
@@ -354,12 +354,12 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
         switch ( (*p).GetValue() )
         {
             case 'l':
-#ifdef __WINDOWS__
+#ifdef __MINGW32__
             case 'g':
             case 'G':
             case 'V':
             case 'z':
-#endif // __WINDOWS__
+#endif // __MINGW32__
                 canUseStrftime = false;
                 break;
         }

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -684,6 +684,7 @@ void DateTimeTestCase::TestTimeFormat()
        { CompareYear, "Date is %x, time is %X" }, // %x could use 2 digits
        { CompareTime, "Time is %H:%M:%S or %I:%M:%S %p" },
        { CompareNone, "The day of year: %j, the week of year: %W" },
+       { CompareDate, "ISO date using short form: %F" },
        { CompareDate, "ISO date without separators: %Y%m%d" },
        { CompareBoth, "RFC 2822 string: %Y-%m-%d %H:%M:%S.%l %z" },
 


### PR DESCRIPTION
Recognize it when formatting and parsing dates.

Closes #24173.