### PR TITLE
Improve `wxFileConfig` XDG compliance

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -168,6 +168,10 @@ Currently the following symbols exist:
     implemented in a generic way, using a critical section.}
 @itemdef{wxHAS_BITMAPTOGGLEBUTTON, Defined in @c wx/tglbtn.h if
     wxBitmapToggleButton class is available in addition to wxToggleButton.}
+@itemdef{wxHAS_CONFIG_AS_FILECONFIG, Defined if wxConfig is defined as
+    wxFileConfig. This constant is available since wxWidgets 3.3.0.}
+@itemdef{wxHAS_CONFIG_AS_REGCONFIG, Defined if wxConfig is defined as
+    wxRegConfig. This constant is available since wxWidgets 3.3.0.}
 @itemdef{wxHAS_CONFIG_TEMPLATE_RW, Defined if the currently used compiler
     supports template Read() and Write() methods in wxConfig.}
 @itemdef{wxHAS_DEPRECATED_ATTR, Defined if C++14 @c [[deprecated]] attribute is

--- a/include/wx/confbase.h
+++ b/include/wx/confbase.h
@@ -62,7 +62,8 @@ enum
     wxCONFIG_USE_GLOBAL_FILE = 2,
     wxCONFIG_USE_RELATIVE_PATH = 4,
     wxCONFIG_USE_NO_ESCAPE_CHARACTERS = 8,
-    wxCONFIG_USE_SUBDIR = 16
+    wxCONFIG_USE_SUBDIR = 16,
+    wxCONFIG_USE_XDG = 32
 };
 
 // ----------------------------------------------------------------------------

--- a/include/wx/config.h
+++ b/include/wx/config.h
@@ -23,9 +23,11 @@
 #if defined(__WINDOWS__) && wxUSE_CONFIG_NATIVE
     #include "wx/msw/regconf.h"
     #define wxConfig  wxRegConfig
+    #define wxHAS_CONFIG_AS_REGCONFIG
 #else // either we're under Unix or wish to always use config files
     #include "wx/fileconf.h"
     #define wxConfig wxFileConfig
+    #define wxHAS_CONFIG_AS_FILECONFIG
 #endif
 
 #endif // wxUSE_CONFIG

--- a/include/wx/fileconf.h
+++ b/include/wx/fileconf.h
@@ -123,6 +123,22 @@ public:
       return GetLocalFile(szFile, style).GetFullPath();
   }
 
+  // Function to migrate, i.e. move, an existing local config file to another
+  // location. Old and new style determine the existing and new file paths.
+  struct MigrationResult
+  {
+      // If empty, it means the old file wasn't found and nothing was done.
+      wxString oldPath;
+
+      // The name of the new file.
+      wxString newPath;
+
+      // If empty, means the file was successfully migrated.
+      wxString error;
+  };
+  static MigrationResult
+  MigrateLocalFile(const wxString& name, int newStyle, int oldStyle = 0);
+
   // ctor & dtor
     // New constructor: one size fits all. Specify wxCONFIG_USE_LOCAL_FILE or
     // wxCONFIG_USE_GLOBAL_FILE to say which files should be used.

--- a/include/wx/stdpaths.h
+++ b/include/wx/stdpaths.h
@@ -184,6 +184,10 @@ public:
 
     bool UsesAppInfo(int info) const { return (m_usedAppInfo & info) != 0; }
 
+    // append application information determined by m_usedAppInfo to dir
+    wxString AppendAppInfo(const wxString& dir) const;
+
+
     void SetFileLayout(FileLayout layout)
     {
         m_fileLayout = layout;
@@ -202,10 +206,6 @@ protected:
     // append the path component, with a leading path separator if a
     // path separator or dot (.) is not already at the end of dir
     static wxString AppendPathComponent(const wxString& dir, const wxString& component);
-
-    // append application information determined by m_usedAppInfo to dir
-    wxString AppendAppInfo(const wxString& dir) const;
-
 
     // combination of AppInfo_XXX flags used by AppendAppInfo()
     int m_usedAppInfo;

--- a/include/wx/stdpaths.h
+++ b/include/wx/stdpaths.h
@@ -186,6 +186,7 @@ public:
     bool UsesAppInfo(int info) const { return (m_usedAppInfo & info) != 0; }
 
     // append application information determined by m_usedAppInfo to dir
+    wxNODISCARD
     wxString AppendAppInfo(const wxString& dir) const;
 
 

--- a/include/wx/stdpaths.h
+++ b/include/wx/stdpaths.h
@@ -51,6 +51,7 @@ public:
     enum Dir
     {
         Dir_Cache,
+        Dir_Config,
         Dir_Documents,
         Dir_Desktop,
         Dir_Downloads,

--- a/interface/wx/config.h
+++ b/interface/wx/config.h
@@ -6,14 +6,41 @@
 /////////////////////////////////////////////////////////////////////////////
 
 
-// Flags for constructor style parameter
+/// Flags for wxConfig constructor style parameter.
 enum
 {
     wxCONFIG_USE_LOCAL_FILE = 1,
     wxCONFIG_USE_GLOBAL_FILE = 2,
     wxCONFIG_USE_RELATIVE_PATH = 4,
     wxCONFIG_USE_NO_ESCAPE_CHARACTERS = 8,
-    wxCONFIG_USE_SUBDIR = 16
+
+    /**
+        Use subdirectory for the local configuration file location.
+
+        Specifying this flag changes the default local configuration file
+        location to `~/.appname/appname.conf`. Please note that this path is
+        _not_ affected by layout set using wxStandardPaths::SetFileLayout() and
+        it is recommended to use wxCONFIG_USE_XDG flag in addition to this file
+        on contemporary Linux systems.
+
+        @since 2.8.2
+     */
+    wxCONFIG_USE_SUBDIR = 16,
+
+    /**
+        Use XDG-compliant file location on Unix systems.
+
+        If wxCONFIG_USE_SUBDIR is not specified, using this flag has the same
+        effect as calling wxStandardPaths::SetFileLayout() with
+        wxStandardPaths::FileLayout_XDG, i.e. it changes the default local
+        configuration file location to `~/.config/appname.conf`.
+
+        In combination with wxCONFIG_USE_SUBDIR, this flag changes the default
+        configuration file location to ~/.config/appname/appname.conf`.
+
+        @since 3.3.0
+     */
+    wxCONFIG_USE_XDG = 32
 };
 
 
@@ -296,14 +323,16 @@ public:
             @n For wxFileConfig you can also add @c wxCONFIG_USE_RELATIVE_PATH by
             logically or'ing it to either of the _FILE options to tell
             wxFileConfig to use relative instead of absolute paths.
-            @n On non-VMS Unix systems, the default local configuration file is
-            "~/.appname". However, this path may be also used as user data
+            @n On Unix-like systems, the default local configuration file is
+            `~/.appname` unless wxStandardPaths::SetFileLayout() is called with
+            wxStandardPaths::FileLayout_XDG parameter in which case the default
+            becomes `~/.config/appname.conf`.
+            @n Note that this default path may be also used as user data
             directory (see wxStandardPaths::GetUserDataDir()) if the
-            application has several data files. In this case
-            @c wxCONFIG_USE_SUBDIR flag, which changes the default local
-            configuration file to "~/.appname/appname" should be used. Notice
-            that this flag is ignored if @a localFilename is provided.
-            @c wxCONFIG_USE_SUBDIR is new since wxWidgets version 2.8.2.
+            application has several data files. In this case it is recommended
+            to use ::wxCONFIG_USE_XDG flag (available since wxWidgets 3.3.0)
+            and/or older ::wxCONFIG_USE_SUBDIR (available since 2.8.2) to
+            change the default local configuration file location.
             @n For wxFileConfig, you can also add
             @c wxCONFIG_USE_NO_ESCAPE_CHARACTERS which will turn off character
             escaping for the values of entries stored in the config file: for

--- a/interface/wx/config.h
+++ b/interface/wx/config.h
@@ -57,7 +57,9 @@ enum
     with the registry under Windows or text-based config files under Unix.
     To make writing the portable code even easier, wxWidgets provides a typedef
     wxConfig which is mapped onto the native wxConfigBase implementation on the
-    given platform: i.e. wxRegConfig under Windows and wxFileConfig otherwise.
+    given platform: i.e. wxRegConfig under Windows (in this case
+    `wxHAS_CONFIG_AS_REGCONFIG` preprocessor symbol is defined) and
+    wxFileConfig otherwise (in this case `wxHAS_CONFIG_AS_FILECONFIG` is).
 
     See @ref overview_config for a description of all features of this class.
 

--- a/interface/wx/fileconf.h
+++ b/interface/wx/fileconf.h
@@ -18,6 +18,24 @@
     used explicitly if you want to use files and not the registry even under
     Windows.
 
+    @section fileconf_paths Configuration Files Paths
+
+    The default path for local (or user) configuration file is `~/.appname`,
+    i.e. it is stored directly in the user home directory. This default
+    path is backwards-compatible but not recommended any more and it is advised
+    to call wxStandardPaths::SetFileLayout() with
+    wxStandardPaths::FileLayout_XDG parameter to change the default path to
+    `~/.config/appname.conf`.
+
+    Alternatively, it is possible to specify ::wxCONFIG_USE_XDG flag in the
+    style parameter of the constructor to use this XDG-compliant path without
+    changing the global file layout.
+
+    And for the programs using multiple configuration files it is recommended
+    to use both ::wxCONFIG_USE_XDG and ::wxCONFIG_USE_SUBDIR which change the
+    default file path to `~/.config/appname/appname.conf` -- and allow the
+    program to store other files in the same `~/.config/appname` directory.
+
     @library{wxbase}
     @category{cfg}
 
@@ -71,8 +89,8 @@ public:
         parameter in the constructor.
 
         @a style has the same meaning as in @ref wxConfigBase::wxConfigBase "wxConfig constructor"
-        and can contain any combination of styles but only wxCONFIG_USE_SUBDIR bit is
-        examined by this function.
+        and can contain any combination of styles but only wxCONFIG_USE_SUBDIR
+        and wxCONFIG_USE_XDG are really used by this function.
 
         Notice that this function cannot be used if @a basename is already a full path name.
     */

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -80,6 +80,18 @@ public:
         Dir_Cache,
 
         /**
+            Directory containing configuration information.
+
+            Example return values:
+            - Unix: `~/.config`
+            - Windows: `C:\Users\username\AppData\Roaming`
+            - Mac: @c `~/Library/Preferences`
+
+            @since 3.3.0
+        */
+        Dir_Config,
+
+        /**
             Directory containing user documents.
 
             Example return values:
@@ -384,8 +396,8 @@ public:
         - Mac: @c ~/Library/Preferences
 
         Only use this method if you have a single configuration file to put in this
-        directory, otherwise GetUserDataDir() is more appropriate as the latter
-        adds @c appinfo to the path, unlike this function.
+        directory, otherwise calling AppendAppInfo() with the value returned by
+        GetDir() with wxStandardPaths::Dir_Config is more appropriate.
     */
     virtual wxString GetUserConfigDir() const;
 

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -376,11 +376,19 @@ public:
     virtual wxString GetUserConfigDir() const;
 
     /**
-        Return the directory for the user-dependent application data files:
+        Return the directory for the user-dependent application data files.
+
+        The returned path is:
+
         - Unix: @c ~/.appinfo
         - Windows: @c "C:\Users\username\AppData\Roaming\appinfo" or
                    @c "C:\Documents and Settings\username\Application Data\appinfo"
         - Mac: @c "~/Library/Application Support/appinfo"
+
+        Please note that under Unix this function return value doesn't depend
+        on the file layout, and so returns a possibly unexpected value when
+        wxStandardPaths::FileLayout_XDG is used. Consider using GetUserDir()
+        instead if you use XDG layout, as this function does respect it.
     */
     virtual wxString GetUserDataDir() const;
 

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -196,6 +196,20 @@ public:
     };
 
     /**
+        Append application and/or vendor name to the given directory.
+
+        By default, appends the subdirectory with the application name, as
+        returned by wxApp::GetAppName(), to the given directory.
+
+        This behaviour is affected by UseAppInfo(), e.g. if this function is
+        called with `AppInfo_VendorName` then the vendor name would be appended
+        instead of the application name.
+
+        @since 3.3.0
+    */
+    wxString AppendAppInfo(const wxString& dir) const;
+
+    /**
         MSW-specific function undoing the effect of IgnoreAppSubDir() calls.
 
         After a call to this function the program directory will be exactly the
@@ -512,6 +526,8 @@ public:
             `AppInfo_AppName | AppInfo_VendorName`.
 
         By default, only the application name is used.
+
+        @see AppendAppInfo()
 
         @since 2.9.0
     */

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -37,6 +37,9 @@
     #include "wx/msgdlg.h"
 #endif
 
+#include "wx/config.h"
+#include "wx/stdpaths.h"
+
 #include "wx/sysopt.h"
 #include "wx/bookctrl.h"
 #include "wx/treebook.h"
@@ -141,6 +144,30 @@ public:
 #if USE_LOG
         m_logTarget = nullptr;
 #endif // USE_LOG
+
+#ifdef wxHAS_CONFIG_AS_FILECONFIG
+        // We want to put our config file (implicitly created for persistent
+        // controls settings) in XDG-compliant location, so we want to change
+        // the default file layout, but before doing this migrate any existing
+        // config files to the new location as the previous versions of this
+        // sample didn't use XDG layout.
+        const auto
+            res = wxFileConfig::MigrateLocalFile("widgets", wxCONFIG_USE_XDG);
+        if ( !res.oldPath.empty() )
+        {
+            if ( res.error.empty() )
+            {
+                wxLogMessage("Config file was migrated from \"%s\" to \"%s\"",
+                             res.oldPath, res.newPath);
+            }
+            else
+            {
+                wxLogWarning("Migrating old config failed: %s.", res.error);
+            }
+        }
+
+        wxStandardPaths::Get().SetFileLayout(wxStandardPaths::FileLayout_XDG);
+#endif // wxHAS_CONFIG_AS_FILECONFIG
     }
     WidgetsApp(const WidgetsApp&) = delete;
     WidgetsApp& operator=(const WidgetsApp&) = delete;

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -56,12 +56,13 @@ bool          wxConfigBase::ms_bAutoCreate = true;
 
 wxConfigBase *wxAppTraitsBase::CreateConfig()
 {
-    return new
-    #if defined(__WINDOWS__) && wxUSE_CONFIG_NATIVE
-        wxRegConfig(wxTheApp->GetAppName(), wxTheApp->GetVendorName());
-    #else // either we're under Unix or wish to use files even under Windows
-        wxFileConfig(wxTheApp->GetAppName());
-    #endif
+#if defined(wxHAS_CONFIG_AS_REGCONFIG)
+    return new wxRegConfig(wxTheApp->GetAppName(), wxTheApp->GetVendorName());
+#elif defined(wxHAS_CONFIG_AS_FILECONFIG)
+    return new wxFileConfig(wxTheApp->GetAppName());
+#else
+    #error No wxConfig implementation defined.
+#endif
 }
 
 // ----------------------------------------------------------------------------

--- a/src/common/fileconf.cpp
+++ b/src/common/fileconf.cpp
@@ -247,8 +247,6 @@ wxString wxFileConfig::GetGlobalDir()
 
 wxString wxFileConfig::GetLocalDir(int style)
 {
-    wxUnusedVar(style);
-
     wxStandardPathsBase& stdp = wxStandardPaths::Get();
 
     // it so happens that user data directory is a subdirectory of user config

--- a/src/common/fileconf.cpp
+++ b/src/common/fileconf.cpp
@@ -247,7 +247,7 @@ wxString wxFileConfig::GetGlobalDir()
 
 wxString wxFileConfig::GetLocalDir(int style)
 {
-    wxStandardPathsBase& stdp = wxStandardPaths::Get();
+    const wxStandardPathsBase& stdp = wxStandardPaths::Get();
 
     if ( style & wxCONFIG_USE_XDG )
     {
@@ -271,14 +271,14 @@ wxString wxFileConfig::GetLocalDir(int style)
 
 wxFileName wxFileConfig::GetGlobalFile(const wxString& szFile)
 {
-    wxStandardPathsBase& stdp = wxStandardPaths::Get();
+    const wxStandardPathsBase& stdp = wxStandardPaths::Get();
 
     return wxFileName(GetGlobalDir(), stdp.MakeConfigFileName(szFile));
 }
 
 wxFileName wxFileConfig::GetLocalFile(const wxString& szFile, int style)
 {
-    wxStandardPathsBase& stdp = wxStandardPaths::Get();
+    const wxStandardPathsBase& stdp = wxStandardPaths::Get();
 
     // If the config file is located in a subdirectory, we always use an
     // extension for it, but we use just the leading dot if it is located

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -488,14 +488,18 @@ static void DoCommonPostCleanup()
 
 void wxEntryCleanup()
 {
-    DoCommonPreCleanup();
-
-
     // delete the application object
     if ( wxTheApp )
     {
         wxTheApp->CleanUp();
+    }
 
+    // It's important to call this after wxApp::CleanUp() as it can log some
+    // messages that will be flushed inside DoCommonPreCleanup().
+    DoCommonPreCleanup();
+
+    if ( wxTheApp )
+    {
         // reset the global pointer to it to nullptr before destroying it as in
         // some circumstances this can result in executing the code using
         // wxTheApp and using half-destroyed object is no good

--- a/src/msw/stdpaths.cpp
+++ b/src/msw/stdpaths.cpp
@@ -189,6 +189,9 @@ wxString wxStandardPaths::GetUserDir(Dir userDir) const
         case Dir_Cache:
             csidl = CSIDL_LOCAL_APPDATA;
             break;
+        case Dir_Config:
+            csidl = CSIDL_APPDATA;
+            break;
         case Dir_Desktop:
             csidl = CSIDL_DESKTOPDIRECTORY;
             break;

--- a/src/osx/cocoa/stdpaths.mm
+++ b/src/osx/cocoa/stdpaths.mm
@@ -101,11 +101,17 @@ wxStandardPaths::GetLocalizedResourcesDir(const wxString& lang,
 
 wxString wxStandardPaths::GetUserDir(Dir userDir) const
 {
+    wxString subdir;
+
     NSSearchPathDirectory dirType;
     switch (userDir)
     {
         case Dir_Cache:
             dirType = NSCachesDirectory;
+            break;
+        case Dir_Config:
+            dirType = NSLibraryDirectory;
+            subdir = "/Preferences";
             break;
         case Dir_Desktop:
             dirType = NSDesktopDirectory;
@@ -127,7 +133,7 @@ wxString wxStandardPaths::GetUserDir(Dir userDir) const
             break;
     }
     
-    return GetFMDirectory(dirType, NSUserDomainMask);
+    return GetFMDirectory(dirType, NSUserDomainMask) + subdir;
 }
 
 wxString

--- a/src/unix/stdpaths.cpp
+++ b/src/unix/stdpaths.cpp
@@ -274,7 +274,11 @@ wxString wxStandardPaths::GetUserDir(Dir userDir) const
         return cacheDir;
     }
 
-    const wxFileName dirsFile(GetXDGConfigHome(), wxS("user-dirs.dirs"));
+    const wxString configDir = GetXDGConfigHome();
+    if (userDir == Dir_Config)
+        return configDir;
+
+    const wxFileName dirsFile(configDir, wxS("user-dirs.dirs"));
     if ( dirsFile.FileExists() )
     {
         wxString userDirId;


### PR DESCRIPTION
The main goal here is to allow easily creating config files in `~/.config/appname` instead of using ~/.appname` directory for them as `wxCONFIG_USE_SUBDIR` does now. Unfortunately achieving this is not that simple without breaking backwards compatibility -- which is something we really can't do here as this would break all the existing applications that wouldn't find their config files any longer.

So add a new `wxCONFIG_USE_XDG` flag which can be used to explicitly opt-in the new behaviour.

Also add `Dir_Config` which can be used to retrieve this directory location for code not using `wxFileConfig` too.

Also includes some other related cleanup.