### PR TITLE
Fix memory leak when calling wxInitialize(void)

### DIFF
--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -210,9 +210,9 @@ void wxInitData::InitIfNecessary(int argcIn, wchar_t** argvIn)
     // elsewhere, but it is also possible to call a wide-char initialization
     // function (wxInitialize(), wxEntryStart() or wxEntry() itself) directly,
     // so we need to support this case too.
-    if ( argc )
+    if ( argc || !argcIn )
     {
-        // Already initialized, nothing to do.
+        // Already initialized or nothing to do.
         return;
     }
 


### PR DESCRIPTION
We still allocated argv arrays when argc was 0, but didn't free them in this case.

Fix this by just not bothering to allocate them.