### PR TITLE
Fix removing non-current page from AUI notebook with multiple tab controls

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -210,6 +210,9 @@ public:
 
     void SetRect(const wxRect& rect) { wxAuiTabContainer::SetRect(rect, this); }
 
+    // Internal helper.
+    void DoShowTab(int idx);
+
 protected:
     // choose the default border for this window
     virtual wxBorder GetDefaultBorder() const override { return wxBORDER_NONE; }

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1019,6 +1019,12 @@ wxAuiTabCtrl::~wxAuiTabCtrl()
 {
 }
 
+void wxAuiTabCtrl::DoShowTab(int idx)
+{
+    DoShowHide();
+    MakeTabVisible(idx, this);
+}
+
 void wxAuiTabCtrl::DoEndDragging()
 {
     m_clickPt = wxDefaultPosition;
@@ -2143,8 +2149,7 @@ bool wxAuiNotebook::RemovePage(size_t page_idx)
 
                 // but we still need to show the new active page in this
                 // control, otherwise it wouldn't be updated
-                ctrl->DoShowHide();
-                ctrl->MakeTabVisible(ctrl_idx, ctrl);
+                ctrl->DoShowTab(ctrl_idx);
             }
         }
     }
@@ -3659,9 +3664,7 @@ int wxAuiNotebook::DoModifySelection(size_t n, bool events)
 
             ctrl->SetActivePage(ctrl_idx);
             DoSizing();
-            ctrl->DoShowHide();
-
-            ctrl->MakeTabVisible(ctrl_idx, ctrl);
+            ctrl->DoShowTab(ctrl_idx);
 
             // set fonts
             wxAuiPaneInfoArray& all_panes = m_mgr.GetAllPanes();

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2136,6 +2136,16 @@ bool wxAuiNotebook::RemovePage(size_t page_idx)
             {
                 new_active = ctrl->GetWindowFromIdx(ctrl_idx);
             }
+            else // not deleting the globally active page
+            {
+                // so don't change the current one
+                new_active = active_wnd;
+
+                // but we still need to show the new active page in this
+                // control, otherwise it wouldn't be updated
+                ctrl->DoShowHide();
+                ctrl->MakeTabVisible(ctrl_idx, ctrl);
+            }
         }
     }
     else

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2119,12 +2119,12 @@ bool wxAuiNotebook::RemovePage(size_t page_idx)
 
     if (is_active_in_split)
     {
-        int ctrl_new_page_count = (int)ctrl->GetPageCount();
+        const int ctrl_new_page_count = (int)ctrl->GetPageCount();
 
         if (ctrl_idx >= ctrl_new_page_count)
             ctrl_idx = ctrl_new_page_count-1;
 
-        if (ctrl_idx >= 0 && ctrl_idx < (int)ctrl->GetPageCount())
+        if (ctrl_idx >= 0 && ctrl_idx < ctrl_new_page_count)
         {
             // set new page as active in the tab split
             ctrl->SetActivePage(ctrl_idx);


### PR DESCRIPTION
This fixes #24063 and does some minor cleanup.