### PR TITLE
interface/wx/gdicmn.h: correct wxRealPoint and wxPoint types for documentation

### DIFF
--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -227,11 +227,11 @@ public:
     wxRealPoint& operator +=(const wxSize& sz);
     wxRealPoint& operator -=(const wxSize& sz);
 
-    wxSize operator /(const wxRealPoint& sz, int factor);
-    wxSize operator *(const wxRealPoint& sz, int factor);
-    wxSize operator *(int factor, const wxSize& sz);
-    wxSize& operator /=(int factor);
-    wxSize& operator *=(int factor);
+    wxRealPoint operator /(const wxRealPoint& sz, int factor);
+    wxRealPoint operator *(const wxRealPoint& sz, int factor);
+    wxRealPoint operator *(int factor, const wxRealPoint& sz);
+    wxRealPoint& operator /=(int factor);
+    wxRealPoint& operator *=(int factor);
     ///@}
 
     /**
@@ -731,11 +731,11 @@ public:
     wxPoint& operator +=(const wxSize& sz);
     wxPoint& operator -=(const wxSize& sz);
 
-    wxSize operator /(const wxPoint& sz, int factor);
-    wxSize operator *(const wxPoint& sz, int factor);
-    wxSize operator *(int factor, const wxSize& sz);
-    wxSize& operator /=(int factor);
-    wxSize& operator *=(int factor);
+    wxPoint operator /(const wxPoint& sz, int factor);
+    wxPoint operator *(const wxPoint& sz, int factor);
+    wxPoint operator *(int factor, const wxPoint& sz);
+    wxPoint& operator /=(int factor);
+    wxPoint& operator *=(int factor);
     ///@}
 
 


### PR DESCRIPTION
As is described in #23804, the documented types for the overloaded operators of `wxRealPoint` and `wxPoint` are wrong, probably because they were copied from `wxSize`

_Originally posted by @vadz in https://github.com/wxWidgets/wxWidgets/issues/23804#issuecomment-1693282079_:
> I see, thanks, the return types are indeed wrong (due to copy-and-paste probably). If you can please make a PR fixing `interface/wx/gdicmn.h` it would be welcome, TIA!

This is *that* pull request.

---

Since I'm looking at this, I noticed that the `operator/` and `operator*`, are overloaded for `int`, `unsigned int, `long`, and `unsigned long` but only the `int` is documented. I'm guessing that this is on purpose to avoid extra verbose documentation but if not, those can be added.