### PR TITLE
Improve C++ standard handling in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,6 @@ endif()
 
 project(wxWidgets VERSION ${wxVERSION} LANGUAGES ${wxLANGUAGES})
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 include(build/cmake/main.cmake)
 
 # Set the default startup project for Visual Studio

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -10,6 +10,25 @@
 
 if(DEFINED wxBUILD_CXX_STANDARD AND NOT wxBUILD_CXX_STANDARD STREQUAL COMPILER_DEFAULT)
     set(CMAKE_CXX_STANDARD ${wxBUILD_CXX_STANDARD})
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+else()
+    # If the standard is not set explicitly, check whether we can use C++11
+    # without any special options.
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("
+        #include <vector>
+        int main() {
+            std::vector<int> v{1,2,3};
+            for (auto& n : v)
+                --n;
+            return v[0];
+        }"
+        wxHAVE_CXX11)
+    if(NOT wxHAVE_CXX11)
+        # If not, request it explicitly and let CMake check if it's supported.
+        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    endif()
 endif()
 
 if(MSVC)

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -46,8 +46,6 @@ endif()
 # support setting the C++ standard, present it an option to the user
 if(DEFINED CMAKE_CXX_STANDARD)
     set(wxCXX_STANDARD_DEFAULT ${CMAKE_CXX_STANDARD})
-elseif(APPLE)
-    set(wxCXX_STANDARD_DEFAULT 11)
 else()
     set(wxCXX_STANDARD_DEFAULT COMPILER_DEFAULT)
 endif()

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -110,7 +110,7 @@ function(wx_check_cxx_source_compiles code res_var)
     cmake_pop_check_state()
 endfunction()
 
-# wx_check_cxx_source_compiles(<code> <var> [headers...])
+# wx_check_c_source_compiles(<code> <var> [headers...])
 function(wx_check_c_source_compiles code res_var)
     set(src)
     foreach(header ${ARGN})


### PR DESCRIPTION
I had to move things around to allow me to use `wx_check_cxx_source_compiles()` in `init.cmake`, please let me know if there is a better way to do this.