### PR TITLE
Experiment with not defining operators in global scope

### DIFF
--- a/include/wx/bitmap.h
+++ b/include/wx/bitmap.h
@@ -18,6 +18,7 @@
 #include "wx/gdicmn.h"  // for wxBitmapType
 #include "wx/colour.h"
 #include "wx/image.h"
+#include "wx/variant.h"
 
 class WXDLLIMPEXP_FWD_CORE wxBitmap;
 class WXDLLIMPEXP_FWD_CORE wxBitmapHandler;
@@ -27,15 +28,6 @@ class WXDLLIMPEXP_FWD_CORE wxIcon;
 class WXDLLIMPEXP_FWD_CORE wxMask;
 class WXDLLIMPEXP_FWD_CORE wxPalette;
 class WXDLLIMPEXP_FWD_CORE wxPixelDataBase;
-
-// ----------------------------------------------------------------------------
-// wxVariant support
-// ----------------------------------------------------------------------------
-
-#if wxUSE_VARIANT
-#include "wx/variant.h"
-DECLARE_VARIANT_OBJECT_EXPORTED(wxBitmap,WXDLLIMPEXP_CORE)
-#endif
 
 // ----------------------------------------------------------------------------
 // wxMask represents the transparent area of the bitmap
@@ -100,6 +92,9 @@ public:
 
     // Rescale the given bitmap to the requested size.
     static void Rescale(wxBitmap& bmp, const wxSize& sizeNeeded);
+
+    // wxVariant support
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(wxBitmap, WXDLLIMPEXP_CORE);
 };
 
 

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -17,6 +17,7 @@
 class wxBitmapBundleImpl;
 class WXDLLIMPEXP_FWD_CORE wxIconBundle;
 class WXDLLIMPEXP_FWD_CORE wxImageList;
+class WXDLLIMPEXP_FWD_BASE wxVariant;
 class WXDLLIMPEXP_FWD_CORE wxWindow;
 
 // ----------------------------------------------------------------------------
@@ -155,6 +156,15 @@ public:
         return GetImpl() == other.GetImpl();
     }
 
+    // Allow using wxBitmapBundle with wxVariant
+#if wxUSE_VARIANT
+    friend WXDLLIMPEXP_CORE
+    wxBitmapBundle& operator<<(wxBitmapBundle& value, const wxVariant& variant);
+    friend WXDLLIMPEXP_CORE
+    wxVariant& operator<<(wxVariant& variant, const wxBitmapBundle& value);
+#endif // wxUSE_VARIANT
+
+
     // Implementation only from now on.
 
     // Get the bitmap size preferred by the majority of the elements of the
@@ -273,20 +283,5 @@ public:
     // on demand and cache it.
     virtual wxBitmap GetBitmap(const wxSize& size) = 0;
 };
-
-// ----------------------------------------------------------------------------
-// Allow using wxBitmapBundle in wxVariant
-// ----------------------------------------------------------------------------
-
-#if wxUSE_VARIANT
-
-class WXDLLIMPEXP_FWD_BASE wxVariant;
-
-WXDLLIMPEXP_CORE
-wxBitmapBundle& operator<<(wxBitmapBundle& value, const wxVariant& variant);
-WXDLLIMPEXP_CORE
-wxVariant& operator<<(wxVariant& variant, const wxBitmapBundle& value);
-
-#endif // wxUSE_VARIANT
 
 #endif // _WX_BMPBNDL_H_

--- a/include/wx/brush.h
+++ b/include/wx/brush.h
@@ -102,6 +102,8 @@ extern WXDLLIMPEXP_DATA_CORE(wxBrushList*)   wxTheBrushList;
 // to compile without warnings which it would otherwise provoke from some
 // compilers as it compares elements of different enums
 
+#if WXWIN_COMPATIBILITY_3_2
+
 wxDEPRECATED_MSG("use wxBRUSHSTYLE_XXX constants only")
 inline bool operator==(wxBrushStyle s, wxDeprecatedGUIConstants t)
 {
@@ -113,5 +115,7 @@ inline bool operator!=(wxBrushStyle s, wxDeprecatedGUIConstants t)
 {
     return static_cast<int>(s) != static_cast<int>(t);
 }
+
+#endif // WXWIN_COMPATIBILITY_3_2
 
 #endif // _WX_BRUSH_H_BASE_

--- a/include/wx/colour.h
+++ b/include/wx/colour.h
@@ -13,6 +13,7 @@
 
 #include "wx/defs.h"
 #include "wx/gdiobj.h"
+#include "wx/variant.h"
 
 class WXDLLIMPEXP_FWD_CORE wxColour;
 
@@ -52,15 +53,6 @@ const unsigned char wxALPHA_OPAQUE = 0xff;
 // a valid but fully transparent colour
 #define wxTransparentColour wxColour(0, 0, 0, wxALPHA_TRANSPARENT)
 #define wxTransparentColor wxTransparentColour
-
-// ----------------------------------------------------------------------------
-// wxVariant support
-// ----------------------------------------------------------------------------
-
-#if wxUSE_VARIANT
-#include "wx/variant.h"
-DECLARE_VARIANT_OBJECT_EXPORTED(wxColour,WXDLLIMPEXP_CORE)
-#endif
 
 //-----------------------------------------------------------------------------
 // wxColourBase: this class has no data members, just some functions to avoid
@@ -187,6 +179,8 @@ public:
 
     wxColour ChangeLightness(int ialpha) const;
     wxColour& MakeDisabled(unsigned char brightness = 255);
+
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(wxColour, WXDLLIMPEXP_CORE);
 
 protected:
     // Some ports need Init() and while we don't, provide a stub so that the

--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -1278,6 +1278,8 @@ public:
         return wxTimeSpan(*this).Multiply(n);
     }
 
+    friend WXDLLIMPEXP_BASE wxTimeSpan operator*(int n, const wxTimeSpan& ts);
+
         // return this timespan with opposite sign
     wxTimeSpan Negate() const { return wxTimeSpan(-GetValue()); }
         // negate the value of the timespan
@@ -1531,6 +1533,7 @@ public:
     {
         return wxDateSpan(*this).Multiply(n);
     }
+    friend WXDLLIMPEXP_BASE wxDateSpan operator*(int n, const wxDateSpan& ds);
 
     // ds1 == d2 if and only if for every wxDateTime t t + ds1 == t + ds2
     inline bool operator==(const wxDateSpan& ds) const
@@ -2242,22 +2245,6 @@ inline wxDateSpan wxDateSpan::Subtract(const wxDateSpan& other) const
 #undef MILLISECONDS_PER_DAY
 
 #undef MODIFY_AND_RETURN
-
-// ============================================================================
-// binary operators
-// ============================================================================
-
-// ----------------------------------------------------------------------------
-// wxTimeSpan operators
-// ----------------------------------------------------------------------------
-
-wxTimeSpan WXDLLIMPEXP_BASE operator*(int n, const wxTimeSpan& ts);
-
-// ----------------------------------------------------------------------------
-// wxDateSpan
-// ----------------------------------------------------------------------------
-
-wxDateSpan WXDLLIMPEXP_BASE operator*(int n, const wxDateSpan& ds);
 
 // ============================================================================
 // other helper functions

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -782,19 +782,22 @@ typedef short int WXTYPE;
 
 
 #define wxDEFINE_COMPARISON(op, T1, T2, cmp) \
-    inline bool operator op(T1 x, T2 y) { return cmp(x, y, op); }
+    friend bool operator op(T1 x, T2 y) { return cmp(x, y, op); }
 
 #define wxDEFINE_COMPARISON_REV(op, T1, T2, cmp, oprev) \
-    inline bool operator op(T2 y, T1 x) { return cmp(x, y, oprev); }
+    friend bool operator op(T2 y, T1 x) { return cmp(x, y, oprev); }
 
 #define wxDEFINE_COMPARISON_BY_REV(op, T1, T2, oprev) \
-    inline bool operator op(T1 x, T2 y) { return y oprev x; }
+    friend bool operator op(T1 x, T2 y) { return y oprev x; }
 
 /*
     Define all 6 comparison operators (==, !=, <, <=, >, >=) for the given
     types in the specified order. The implementation is provided by the cmp
     macro. Normally wxDEFINE_ALL_COMPARISONS should be used as comparison
     operators are usually symmetric.
+
+    Note that comparison operators are defined as hidden friends and so this
+    macro can only be used inside the class declaration.
  */
 #define wxDEFINE_COMPARISONS(T1, T2, cmp) \
     wxFOR_ALL_COMPARISONS_3(wxDEFINE_COMPARISON, T1, T2, cmp)
@@ -803,6 +806,9 @@ typedef short int WXTYPE;
     Define all 6 comparison operators (==, !=, <, <=, >, >=) for the given
     types in the specified order, implemented in terms of existing operators
     for the reverse order.
+
+    Note that comparison operators are defined as hidden friends and so this
+    macro can only be used inside the class declaration.
  */
 #define wxDEFINE_COMPARISONS_BY_REV(T1, T2) \
     wxFOR_ALL_COMPARISONS_2_REV(wxDEFINE_COMPARISON_BY_REV, T1, T2)

--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -67,14 +67,14 @@ public:
         return !IsSameAs(other);
     }
 
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(wxDataViewIconText, WXDLLIMPEXP_CORE);
+
 private:
     wxString    m_text;
     wxBitmapBundle m_bitmap;
 
     wxDECLARE_DYNAMIC_CLASS(wxDataViewIconText);
 };
-
-DECLARE_VARIANT_OBJECT_EXPORTED(wxDataViewIconText, WXDLLIMPEXP_CORE)
 
 // ----------------------------------------------------------------------------
 // wxDataViewCheckIconText: value class used by wxDataViewCheckIconTextRenderer
@@ -94,13 +94,13 @@ public:
     wxCheckBoxState GetCheckedState() const { return m_checkedState; }
     void SetCheckedState(wxCheckBoxState state) { m_checkedState = state; }
 
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(wxDataViewCheckIconText, WXDLLIMPEXP_CORE);
+
 private:
     wxCheckBoxState m_checkedState;
 
     wxDECLARE_DYNAMIC_CLASS(wxDataViewCheckIconText);
 };
-
-DECLARE_VARIANT_OBJECT_EXPORTED(wxDataViewCheckIconText, WXDLLIMPEXP_CORE)
 
 // ----------------------------------------------------------------------------
 // wxDataViewRendererBase

--- a/include/wx/font.h
+++ b/include/wx/font.h
@@ -671,6 +671,8 @@ extern WXDLLIMPEXP_DATA_CORE(wxFontList*)    wxTheFontList;
 // to compile without warnings which it would otherwise provoke from some
 // compilers as it compares elements of different enums
 
+#if WXWIN_COMPATIBILITY_3_2
+
 wxDEPRECATED_MSG("use wxFONTFAMILY_XXX constants") \
 inline bool operator==(wxFontFamily s, wxDeprecatedGUIConstants t)
     { return static_cast<int>(s) == static_cast<int>(t); }
@@ -689,5 +691,7 @@ inline bool operator==(wxFontWeight s, wxDeprecatedGUIConstants t)
 wxDEPRECATED_MSG("use wxFONTWEIGHT_XXX constants") \
 inline bool operator!=(wxFontWeight s, wxDeprecatedGUIConstants t)
     { return static_cast<int>(s) != static_cast<int>(t); }
+
+#endif // WXWIN_COMPATIBILITY_3_2
 
 #endif // _WX_FONT_H_BASE_

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -295,6 +295,102 @@ public:
     wxSize& operator/=(double i) { x = wxRound(x/i); y = wxRound(y/i); return *this; }
     wxSize& operator*=(double i) { x = wxRound(x*i); y = wxRound(y*i); return *this; }
 
+    friend bool operator==(const wxSize& s1, const wxSize& s2)
+    {
+        return s1.x == s2.x && s1.y == s2.y;
+    }
+
+    friend bool operator!=(const wxSize& s1, const wxSize& s2)
+    {
+        return s1.x != s2.x || s1.y != s2.y;
+    }
+
+    friend wxSize operator+(const wxSize& s1, const wxSize& s2)
+    {
+        return wxSize(s1.x + s2.x, s1.y + s2.y);
+    }
+
+    friend wxSize operator-(const wxSize& s1, const wxSize& s2)
+    {
+        return wxSize(s1.x - s2.x, s1.y - s2.y);
+    }
+
+    friend wxSize operator/(const wxSize& s, int i)
+    {
+        return wxSize(s.x / i, s.y / i);
+    }
+
+    friend wxSize operator*(const wxSize& s, int i)
+    {
+        return wxSize(s.x * i, s.y * i);
+    }
+
+    friend wxSize operator*(int i, const wxSize& s)
+    {
+        return wxSize(s.x * i, s.y * i);
+    }
+
+    friend wxSize operator/(const wxSize& s, unsigned int i)
+    {
+        return wxSize(s.x / i, s.y / i);
+    }
+
+    friend wxSize operator*(const wxSize& s, unsigned int i)
+    {
+        return wxSize(s.x * i, s.y * i);
+    }
+
+    friend wxSize operator*(unsigned int i, const wxSize& s)
+    {
+        return wxSize(s.x * i, s.y * i);
+    }
+
+    friend wxSize operator/(const wxSize& s, long i)
+    {
+        return wxSize(s.x / i, s.y / i);
+    }
+
+    friend wxSize operator*(const wxSize& s, long i)
+    {
+        return wxSize(int(s.x * i), int(s.y * i));
+    }
+
+    friend wxSize operator*(long i, const wxSize& s)
+    {
+        return wxSize(int(s.x * i), int(s.y * i));
+    }
+
+    friend wxSize operator/(const wxSize& s, unsigned long i)
+    {
+        return wxSize(int(s.x / i), int(s.y / i));
+    }
+
+    friend wxSize operator*(const wxSize& s, unsigned long i)
+    {
+        return wxSize(int(s.x * i), int(s.y * i));
+    }
+
+    friend wxSize operator*(unsigned long i, const wxSize& s)
+    {
+        return wxSize(int(s.x * i), int(s.y * i));
+    }
+
+    friend wxSize operator/(const wxSize& s, double i)
+    {
+        return wxSize(wxRound(s.x / i), wxRound(s.y / i));
+    }
+
+    friend wxSize operator*(const wxSize& s, double i)
+    {
+        return wxSize(wxRound(s.x * i), wxRound(s.y * i));
+    }
+
+    friend wxSize operator*(double i, const wxSize& s)
+    {
+        return wxSize(wxRound(s.x * i), wxRound(s.y * i));
+    }
+
+
     void IncTo(const wxSize& sz)
         { if ( sz.x > x ) x = sz.x; if ( sz.y > y ) y = sz.y; }
     void DecTo(const wxSize& sz)
@@ -350,103 +446,6 @@ public:
     int GetY() const { return y; }
 };
 
-inline bool operator==(const wxSize& s1, const wxSize& s2)
-{
-    return s1.x == s2.x && s1.y == s2.y;
-}
-
-inline bool operator!=(const wxSize& s1, const wxSize& s2)
-{
-    return s1.x != s2.x || s1.y != s2.y;
-}
-
-inline wxSize operator+(const wxSize& s1, const wxSize& s2)
-{
-    return wxSize(s1.x + s2.x, s1.y + s2.y);
-}
-
-inline wxSize operator-(const wxSize& s1, const wxSize& s2)
-{
-    return wxSize(s1.x - s2.x, s1.y - s2.y);
-}
-
-inline wxSize operator/(const wxSize& s, int i)
-{
-    return wxSize(s.x / i, s.y / i);
-}
-
-inline wxSize operator*(const wxSize& s, int i)
-{
-    return wxSize(s.x * i, s.y * i);
-}
-
-inline wxSize operator*(int i, const wxSize& s)
-{
-    return wxSize(s.x * i, s.y * i);
-}
-
-inline wxSize operator/(const wxSize& s, unsigned int i)
-{
-    return wxSize(s.x / i, s.y / i);
-}
-
-inline wxSize operator*(const wxSize& s, unsigned int i)
-{
-    return wxSize(s.x * i, s.y * i);
-}
-
-inline wxSize operator*(unsigned int i, const wxSize& s)
-{
-    return wxSize(s.x * i, s.y * i);
-}
-
-inline wxSize operator/(const wxSize& s, long i)
-{
-    return wxSize(s.x / i, s.y / i);
-}
-
-inline wxSize operator*(const wxSize& s, long i)
-{
-    return wxSize(int(s.x * i), int(s.y * i));
-}
-
-inline wxSize operator*(long i, const wxSize& s)
-{
-    return wxSize(int(s.x * i), int(s.y * i));
-}
-
-inline wxSize operator/(const wxSize& s, unsigned long i)
-{
-    return wxSize(int(s.x / i), int(s.y / i));
-}
-
-inline wxSize operator*(const wxSize& s, unsigned long i)
-{
-    return wxSize(int(s.x * i), int(s.y * i));
-}
-
-inline wxSize operator*(unsigned long i, const wxSize& s)
-{
-    return wxSize(int(s.x * i), int(s.y * i));
-}
-
-inline wxSize operator/(const wxSize& s, double i)
-{
-    return wxSize(wxRound(s.x / i), wxRound(s.y / i));
-}
-
-inline wxSize operator*(const wxSize& s, double i)
-{
-    return wxSize(wxRound(s.x * i), wxRound(s.y * i));
-}
-
-inline wxSize operator*(double i, const wxSize& s)
-{
-    return wxSize(wxRound(s.x * i), wxRound(s.y * i));
-}
-
-
-
 // ---------------------------------------------------------------------------
 // Point classes: with real or integer coordinates
 // ---------------------------------------------------------------------------
@@ -474,128 +473,127 @@ public:
     wxRealPoint& operator*=(int i) { x /= i; y /= i; return *this; }
     wxRealPoint& operator/=(double f) { x /= f; y /= f; return *this; }
     wxRealPoint& operator*=(double f) { x *= f; y *= f; return *this; }
+
+    friend bool operator==(const wxRealPoint& p1, const wxRealPoint& p2)
+    {
+        return wxIsSameDouble(p1.x, p2.x) && wxIsSameDouble(p1.y, p2.y);
+    }
+
+    friend bool operator!=(const wxRealPoint& p1, const wxRealPoint& p2)
+    {
+        return !(p1 == p2);
+    }
+
+    friend wxRealPoint operator+(const wxRealPoint& p1, const wxRealPoint& p2)
+    {
+        return wxRealPoint(p1.x + p2.x, p1.y + p2.y);
+    }
+
+    friend wxRealPoint operator-(const wxRealPoint& p1, const wxRealPoint& p2)
+    {
+        return wxRealPoint(p1.x - p2.x, p1.y - p2.y);
+    }
+
+    friend wxRealPoint operator+(const wxRealPoint& pt, const wxSize& sz)
+    {
+        return wxRealPoint(pt.x + sz.GetWidth(), pt.y + sz.GetHeight());
+    }
+
+    friend wxRealPoint operator-(const wxRealPoint& pt, const wxSize& sz)
+    {
+        return wxRealPoint(pt.x - sz.GetWidth(), pt.y - sz.GetHeight());
+    }
+
+    friend wxRealPoint operator+(const wxSize& sz, const wxRealPoint& pt)
+    {
+        return wxRealPoint(sz.GetWidth() + pt.x, sz.GetHeight() + pt.y);
+    }
+
+    friend wxRealPoint operator-(const wxSize& sz, const wxRealPoint& pt)
+    {
+        return wxRealPoint(sz.GetWidth() - pt.x, sz.GetHeight() - pt.y);
+    }
+
+    friend wxRealPoint operator-(const wxRealPoint& pt)
+    {
+        return wxRealPoint(-pt.x, -pt.y);
+    }
+
+    friend wxRealPoint operator/(const wxRealPoint& p, int i)
+    {
+        return wxRealPoint(p.x / i, p.y / i);
+    }
+
+    friend wxRealPoint operator*(const wxRealPoint& p, int i)
+    {
+        return wxRealPoint(p.x * i, p.y * i);
+    }
+
+    friend wxRealPoint operator*(int i, const wxRealPoint& p)
+    {
+        return wxRealPoint(p.x * i, p.y * i);
+    }
+
+    friend wxRealPoint operator/(const wxRealPoint& p, unsigned int i)
+    {
+        return wxRealPoint(p.x / i, p.y / i);
+    }
+
+    friend wxRealPoint operator*(const wxRealPoint& p, unsigned int i)
+    {
+        return wxRealPoint(p.x * i, p.y * i);
+    }
+
+    friend wxRealPoint operator*(unsigned int i, const wxRealPoint& p)
+    {
+        return wxRealPoint(p.x * i, p.y * i);
+    }
+
+    friend wxRealPoint operator/(const wxRealPoint& p, long i)
+    {
+        return wxRealPoint(p.x / i, p.y / i);
+    }
+
+    friend wxRealPoint operator*(const wxRealPoint& p, long i)
+    {
+        return wxRealPoint(p.x * i, p.y * i);
+    }
+
+    friend wxRealPoint operator*(long i, const wxRealPoint& p)
+    {
+        return wxRealPoint(p.x * i, p.y * i);
+    }
+
+    friend wxRealPoint operator/(const wxRealPoint& p, unsigned long i)
+    {
+        return wxRealPoint(p.x / i, p.y / i);
+    }
+
+    friend wxRealPoint operator*(const wxRealPoint& p, unsigned long i)
+    {
+        return wxRealPoint(p.x * i, p.y * i);
+    }
+
+    friend wxRealPoint operator*(unsigned long i, const wxRealPoint& p)
+    {
+        return wxRealPoint(p.x * i, p.y * i);
+    }
+
+    friend wxRealPoint operator/(const wxRealPoint& p, double f)
+    {
+        return wxRealPoint(p.x / f, p.y / f);
+    }
+
+    friend wxRealPoint operator*(const wxRealPoint& p, double f)
+    {
+        return wxRealPoint(p.x * f, p.y * f);
+    }
+
+    friend wxRealPoint operator*(double f, const wxRealPoint& p)
+    {
+        return wxRealPoint(p.x * f, p.y * f);
+    }
 };
-
-
-inline bool operator==(const wxRealPoint& p1, const wxRealPoint& p2)
-{
-    return wxIsSameDouble(p1.x, p2.x) && wxIsSameDouble(p1.y, p2.y);
-}
-
-inline bool operator!=(const wxRealPoint& p1, const wxRealPoint& p2)
-{
-    return !(p1 == p2);
-}
-
-inline wxRealPoint operator+(const wxRealPoint& p1, const wxRealPoint& p2)
-{
-    return wxRealPoint(p1.x + p2.x, p1.y + p2.y);
-}
-
-inline wxRealPoint operator-(const wxRealPoint& p1, const wxRealPoint& p2)
-{
-    return wxRealPoint(p1.x - p2.x, p1.y - p2.y);
-}
-
-inline wxRealPoint operator+(const wxRealPoint& pt, const wxSize& sz)
-{
-    return wxRealPoint(pt.x + sz.GetWidth(), pt.y + sz.GetHeight());
-}
-
-inline wxRealPoint operator-(const wxRealPoint& pt, const wxSize& sz)
-{
-    return wxRealPoint(pt.x - sz.GetWidth(), pt.y - sz.GetHeight());
-}
-
-inline wxRealPoint operator+(const wxSize& sz, const wxRealPoint& pt)
-{
-    return wxRealPoint(sz.GetWidth() + pt.x, sz.GetHeight() + pt.y);
-}
-
-inline wxRealPoint operator-(const wxSize& sz, const wxRealPoint& pt)
-{
-    return wxRealPoint(sz.GetWidth() - pt.x, sz.GetHeight() - pt.y);
-}
-
-inline wxRealPoint operator-(const wxRealPoint& pt)
-{
-    return wxRealPoint(-pt.x, -pt.y);
-}
-
-inline wxRealPoint operator/(const wxRealPoint& p, int i)
-{
-    return wxRealPoint(p.x / i, p.y / i);
-}
-
-inline wxRealPoint operator*(const wxRealPoint& p, int i)
-{
-    return wxRealPoint(p.x * i, p.y * i);
-}
-
-inline wxRealPoint operator*(int i, const wxRealPoint& p)
-{
-    return wxRealPoint(p.x * i, p.y * i);
-}
-
-inline wxRealPoint operator/(const wxRealPoint& p, unsigned int i)
-{
-    return wxRealPoint(p.x / i, p.y / i);
-}
-
-inline wxRealPoint operator*(const wxRealPoint& p, unsigned int i)
-{
-    return wxRealPoint(p.x * i, p.y * i);
-}
-
-inline wxRealPoint operator*(unsigned int i, const wxRealPoint& p)
-{
-    return wxRealPoint(p.x * i, p.y * i);
-}
-
-inline wxRealPoint operator/(const wxRealPoint& p, long i)
-{
-    return wxRealPoint(p.x / i, p.y / i);
-}
-
-inline wxRealPoint operator*(const wxRealPoint& p, long i)
-{
-    return wxRealPoint(p.x * i, p.y * i);
-}
-
-inline wxRealPoint operator*(long i, const wxRealPoint& p)
-{
-    return wxRealPoint(p.x * i, p.y * i);
-}
-
-inline wxRealPoint operator/(const wxRealPoint& p, unsigned long i)
-{
-    return wxRealPoint(p.x / i, p.y / i);
-}
-
-inline wxRealPoint operator*(const wxRealPoint& p, unsigned long i)
-{
-    return wxRealPoint(p.x * i, p.y * i);
-}
-
-inline wxRealPoint operator*(unsigned long i, const wxRealPoint& p)
-{
-    return wxRealPoint(p.x * i, p.y * i);
-}
-
-inline wxRealPoint operator/(const wxRealPoint& p, double f)
-{
-    return wxRealPoint(p.x / f, p.y / f);
-}
-
-inline wxRealPoint operator*(const wxRealPoint& p, double f)
-{
-    return wxRealPoint(p.x * f, p.y * f);
-}
-
-inline wxRealPoint operator*(double f, const wxRealPoint& p)
-{
-    return wxRealPoint(p.x * f, p.y * f);
-}
 
 
 // ----------------------------------------------------------------------------
@@ -625,6 +623,129 @@ public:
     wxPoint& operator/=(double f) { x = wxRound(x/f); y = wxRound(y/f); return *this; }
     wxPoint& operator*=(double f) { x = wxRound(x*f); y = wxRound(y*f); return *this; }
 
+    // comparison
+    friend bool operator==(const wxPoint& p1, const wxPoint& p2)
+    {
+        return p1.x == p2.x && p1.y == p2.y;
+    }
+
+    friend bool operator!=(const wxPoint& p1, const wxPoint& p2)
+    {
+        return !(p1 == p2);
+    }
+
+
+    // arithmetic operations (component wise)
+    friend wxPoint operator+(const wxPoint& p1, const wxPoint& p2)
+    {
+        return wxPoint(p1.x + p2.x, p1.y + p2.y);
+    }
+
+    friend wxPoint operator-(const wxPoint& p1, const wxPoint& p2)
+    {
+        return wxPoint(p1.x - p2.x, p1.y - p2.y);
+    }
+
+    friend wxPoint operator+(const wxPoint& p, const wxSize& s)
+    {
+        return wxPoint(p.x + s.x, p.y + s.y);
+    }
+
+    friend wxPoint operator-(const wxPoint& p, const wxSize& s)
+    {
+        return wxPoint(p.x - s.x, p.y - s.y);
+    }
+
+    friend wxPoint operator+(const wxSize& s, const wxPoint& p)
+    {
+        return wxPoint(p.x + s.x, p.y + s.y);
+    }
+
+    friend wxPoint operator-(const wxSize& s, const wxPoint& p)
+    {
+        return wxPoint(s.x - p.x, s.y - p.y);
+    }
+
+    friend wxPoint operator-(const wxPoint& p)
+    {
+        return wxPoint(-p.x, -p.y);
+    }
+
+    friend wxPoint operator/(const wxPoint& p, int i)
+    {
+        return wxPoint(p.x / i, p.y / i);
+    }
+
+    friend wxPoint operator*(const wxPoint& p, int i)
+    {
+        return wxPoint(p.x * i, p.y * i);
+    }
+
+    friend wxPoint operator*(int i, const wxPoint& p)
+    {
+        return wxPoint(p.x * i, p.y * i);
+    }
+
+    friend wxPoint operator/(const wxPoint& p, unsigned int i)
+    {
+        return wxPoint(p.x / i, p.y / i);
+    }
+
+    friend wxPoint operator*(const wxPoint& p, unsigned int i)
+    {
+        return wxPoint(p.x * i, p.y * i);
+    }
+
+    friend wxPoint operator*(unsigned int i, const wxPoint& p)
+    {
+        return wxPoint(p.x * i, p.y * i);
+    }
+
+    friend wxPoint operator/(const wxPoint& p, long i)
+    {
+        return wxPoint(p.x / i, p.y / i);
+    }
+
+    friend wxPoint operator*(const wxPoint& p, long i)
+    {
+        return wxPoint(int(p.x * i), int(p.y * i));
+    }
+
+    friend wxPoint operator*(long i, const wxPoint& p)
+    {
+        return wxPoint(int(p.x * i), int(p.y * i));
+    }
+
+    friend wxPoint operator/(const wxPoint& p, unsigned long i)
+    {
+        return wxPoint(p.x / i, p.y / i);
+    }
+
+    friend wxPoint operator*(const wxPoint& p, unsigned long i)
+    {
+        return wxPoint(int(p.x * i), int(p.y * i));
+    }
+
+    friend wxPoint operator*(unsigned long i, const wxPoint& p)
+    {
+        return wxPoint(int(p.x * i), int(p.y * i));
+    }
+
+    friend wxPoint operator/(const wxPoint& p, double f)
+    {
+        return wxPoint(wxRound(p.x / f), wxRound(p.y / f));
+    }
+
+    friend wxPoint operator*(const wxPoint& p, double f)
+    {
+        return wxPoint(int(p.x * f), int(p.y * f));
+    }
+
+    friend wxPoint operator*(double f, const wxPoint& p)
+    {
+        return wxPoint(int(p.x * f), int(p.y * f));
+    }
+
     // check if both components are set/initialized
     bool IsFullySpecified() const { return x != wxDefaultCoord && y != wxDefaultCoord; }
 
@@ -638,129 +759,6 @@ public:
     }
 };
 
-
-// comparison
-inline bool operator==(const wxPoint& p1, const wxPoint& p2)
-{
-    return p1.x == p2.x && p1.y == p2.y;
-}
-
-inline bool operator!=(const wxPoint& p1, const wxPoint& p2)
-{
-    return !(p1 == p2);
-}
-
-
-// arithmetic operations (component wise)
-inline wxPoint operator+(const wxPoint& p1, const wxPoint& p2)
-{
-    return wxPoint(p1.x + p2.x, p1.y + p2.y);
-}
-
-inline wxPoint operator-(const wxPoint& p1, const wxPoint& p2)
-{
-    return wxPoint(p1.x - p2.x, p1.y - p2.y);
-}
-
-inline wxPoint operator+(const wxPoint& p, const wxSize& s)
-{
-    return wxPoint(p.x + s.x, p.y + s.y);
-}
-
-inline wxPoint operator-(const wxPoint& p, const wxSize& s)
-{
-    return wxPoint(p.x - s.x, p.y - s.y);
-}
-
-inline wxPoint operator+(const wxSize& s, const wxPoint& p)
-{
-    return wxPoint(p.x + s.x, p.y + s.y);
-}
-
-inline wxPoint operator-(const wxSize& s, const wxPoint& p)
-{
-    return wxPoint(s.x - p.x, s.y - p.y);
-}
-
-inline wxPoint operator-(const wxPoint& p)
-{
-    return wxPoint(-p.x, -p.y);
-}
-
-inline wxPoint operator/(const wxPoint& p, int i)
-{
-    return wxPoint(p.x / i, p.y / i);
-}
-
-inline wxPoint operator*(const wxPoint& p, int i)
-{
-    return wxPoint(p.x * i, p.y * i);
-}
-
-inline wxPoint operator*(int i, const wxPoint& p)
-{
-    return wxPoint(p.x * i, p.y * i);
-}
-
-inline wxPoint operator/(const wxPoint& p, unsigned int i)
-{
-    return wxPoint(p.x / i, p.y / i);
-}
-
-inline wxPoint operator*(const wxPoint& p, unsigned int i)
-{
-    return wxPoint(p.x * i, p.y * i);
-}
-
-inline wxPoint operator*(unsigned int i, const wxPoint& p)
-{
-    return wxPoint(p.x * i, p.y * i);
-}
-
-inline wxPoint operator/(const wxPoint& p, long i)
-{
-    return wxPoint(p.x / i, p.y / i);
-}
-
-inline wxPoint operator*(const wxPoint& p, long i)
-{
-    return wxPoint(int(p.x * i), int(p.y * i));
-}
-
-inline wxPoint operator*(long i, const wxPoint& p)
-{
-    return wxPoint(int(p.x * i), int(p.y * i));
-}
-
-inline wxPoint operator/(const wxPoint& p, unsigned long i)
-{
-    return wxPoint(p.x / i, p.y / i);
-}
-
-inline wxPoint operator*(const wxPoint& p, unsigned long i)
-{
-    return wxPoint(int(p.x * i), int(p.y * i));
-}
-
-inline wxPoint operator*(unsigned long i, const wxPoint& p)
-{
-    return wxPoint(int(p.x * i), int(p.y * i));
-}
-
-inline wxPoint operator/(const wxPoint& p, double f)
-{
-    return wxPoint(wxRound(p.x / f), wxRound(p.y / f));
-}
-
-inline wxPoint operator*(const wxPoint& p, double f)
-{
-    return wxPoint(int(p.x * f), int(p.y * f));
-}
-
-inline wxPoint operator*(double f, const wxPoint& p)
-{
-    return wxPoint(int(p.x * f), int(p.y * f));
-}
 
 WX_DECLARE_LIST_WITH_DECL(wxPoint, wxPointList, class WXDLLIMPEXP_CORE);
 
@@ -888,9 +886,24 @@ public:
 
     // like Union() but don't ignore empty rectangles
     wxRect& operator+=(const wxRect& rect);
+    friend WXDLLIMPEXP_CORE wxRect operator+(const wxRect& r1, const wxRect& r2);
 
     // intersections of two rectangles not testing for empty rectangles
     wxRect& operator*=(const wxRect& rect);
+    friend WXDLLIMPEXP_CORE wxRect operator*(const wxRect& r1, const wxRect& r2);
+
+    // compare rectangles
+    friend bool operator==(const wxRect& r1, const wxRect& r2)
+    {
+        return (r1.x == r2.x) && (r1.y == r2.y) &&
+               (r1.width == r2.width) && (r1.height == r2.height);
+    }
+
+    friend bool operator!=(const wxRect& r1, const wxRect& r2)
+    {
+        return !(r1 == r2);
+    }
+
 
     // centre this rectangle in the given (usually, but not necessarily,
     // larger) one
@@ -919,24 +932,6 @@ public:
     int x, y, width, height;
 };
 
-
-// compare rectangles
-inline bool operator==(const wxRect& r1, const wxRect& r2)
-{
-    return (r1.x == r2.x) && (r1.y == r2.y) &&
-           (r1.width == r2.width) && (r1.height == r2.height);
-}
-
-inline bool operator!=(const wxRect& r1, const wxRect& r2)
-{
-    return !(r1 == r2);
-}
-
-// like Union() but don't treat empty rectangles specially
-WXDLLIMPEXP_CORE wxRect operator+(const wxRect& r1, const wxRect& r2);
-
-// intersections of two rectangles
-WXDLLIMPEXP_CORE wxRect operator*(const wxRect& r1, const wxRect& r2);
 
 // define functions which couldn't be defined above because of declarations
 // order

--- a/include/wx/generic/icon.h
+++ b/include/wx/generic/icon.h
@@ -51,6 +51,8 @@ public:
     // ctors, assignment operators...), but it's ok to have such function
     void CopyFromBitmap(const wxBitmap& bmp);
 
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(wxIcon, WXDLLIMPEXP_CORE);
+
 private:
     wxDECLARE_DYNAMIC_CLASS(wxIcon);
 };

--- a/include/wx/geometry.h
+++ b/include/wx/geometry.h
@@ -71,6 +71,60 @@ public :
     inline bool operator==(const wxPoint2DInt& pt) const;
     inline bool operator!=(const wxPoint2DInt& pt) const;
 
+    friend wxPoint2DInt operator+(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
+    {
+        return wxPoint2DInt( pt1.m_x + pt2.m_x , pt1.m_y + pt2.m_y );
+    }
+
+    friend wxPoint2DInt operator-(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
+    {
+        return wxPoint2DInt( pt1.m_x - pt2.m_x , pt1.m_y - pt2.m_y );
+    }
+
+
+    friend wxPoint2DInt operator*(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
+    {
+        return wxPoint2DInt( pt1.m_x * pt2.m_x , pt1.m_y * pt2.m_y );
+    }
+
+    friend wxPoint2DInt operator*(wxInt32 n , const wxPoint2DInt& pt)
+    {
+        return wxPoint2DInt( pt.m_x * n , pt.m_y * n );
+    }
+
+    friend wxPoint2DInt operator*(wxDouble n , const wxPoint2DInt& pt)
+    {
+        return wxPoint2DInt( static_cast<wxInt32>(pt.m_x * n) ,
+            static_cast<wxInt32>(pt.m_y * n) );
+    }
+
+    friend wxPoint2DInt operator*(const wxPoint2DInt& pt , wxInt32 n)
+    {
+        return wxPoint2DInt( pt.m_x * n , pt.m_y * n );
+    }
+
+    friend wxPoint2DInt operator*(const wxPoint2DInt& pt , wxDouble n)
+    {
+        return wxPoint2DInt( static_cast<wxInt32>(pt.m_x * n) ,
+            static_cast<wxInt32>(pt.m_y * n) );
+    }
+
+    friend wxPoint2DInt operator/(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
+    {
+        return wxPoint2DInt( pt1.m_x / pt2.m_x , pt1.m_y / pt2.m_y );
+    }
+
+    friend wxPoint2DInt operator/(const wxPoint2DInt& pt , wxInt32 n)
+    {
+        return wxPoint2DInt( pt.m_x / n , pt.m_y / n );
+    }
+
+    friend wxPoint2DInt operator/(const wxPoint2DInt& pt , wxDouble n)
+    {
+        return wxPoint2DInt( static_cast<wxInt32>(pt.m_x / n) ,
+            static_cast<wxInt32>(pt.m_y / n) );
+    }
+
 #if wxUSE_STREAMS
     void WriteTo( wxDataOutputStream &stream ) const;
     void ReadFrom( wxDataInputStream &stream );
@@ -79,17 +133,6 @@ public :
     wxInt32 m_x;
     wxInt32 m_y;
 };
-
-inline wxPoint2DInt operator+(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2);
-inline wxPoint2DInt operator-(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2);
-inline wxPoint2DInt operator*(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2);
-inline wxPoint2DInt operator*(wxInt32 n , const wxPoint2DInt& pt);
-inline wxPoint2DInt operator*(wxDouble n , const wxPoint2DInt& pt);
-inline wxPoint2DInt operator*(const wxPoint2DInt& pt , wxInt32 n);
-inline wxPoint2DInt operator*(const wxPoint2DInt& pt , wxDouble n);
-inline wxPoint2DInt operator/(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2);
-inline wxPoint2DInt operator/(const wxPoint2DInt& pt , wxInt32 n);
-inline wxPoint2DInt operator/(const wxPoint2DInt& pt , wxDouble n);
 
 inline wxPoint2DInt::wxPoint2DInt()
 {
@@ -209,60 +252,6 @@ inline bool wxPoint2DInt::operator!=(const wxPoint2DInt& pt) const
     return m_x != pt.m_x || m_y != pt.m_y;
 }
 
-inline wxPoint2DInt operator+(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
-{
-    return wxPoint2DInt( pt1.m_x + pt2.m_x , pt1.m_y + pt2.m_y );
-}
-
-inline wxPoint2DInt operator-(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
-{
-    return wxPoint2DInt( pt1.m_x - pt2.m_x , pt1.m_y - pt2.m_y );
-}
-
-
-inline wxPoint2DInt operator*(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
-{
-    return wxPoint2DInt( pt1.m_x * pt2.m_x , pt1.m_y * pt2.m_y );
-}
-
-inline wxPoint2DInt operator*(wxInt32 n , const wxPoint2DInt& pt)
-{
-    return wxPoint2DInt( pt.m_x * n , pt.m_y * n );
-}
-
-inline wxPoint2DInt operator*(wxDouble n , const wxPoint2DInt& pt)
-{
-    return wxPoint2DInt( static_cast<wxInt32>(pt.m_x * n) ,
-        static_cast<wxInt32>(pt.m_y * n) );
-}
-
-inline wxPoint2DInt operator*(const wxPoint2DInt& pt , wxInt32 n)
-{
-    return wxPoint2DInt( pt.m_x * n , pt.m_y * n );
-}
-
-inline wxPoint2DInt operator*(const wxPoint2DInt& pt , wxDouble n)
-{
-    return wxPoint2DInt( static_cast<wxInt32>(pt.m_x * n) ,
-        static_cast<wxInt32>(pt.m_y * n) );
-}
-
-inline wxPoint2DInt operator/(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
-{
-    return wxPoint2DInt( pt1.m_x / pt2.m_x , pt1.m_y / pt2.m_y );
-}
-
-inline wxPoint2DInt operator/(const wxPoint2DInt& pt , wxInt32 n)
-{
-    return wxPoint2DInt( pt.m_x / n , pt.m_y / n );
-}
-
-inline wxPoint2DInt operator/(const wxPoint2DInt& pt , wxDouble n)
-{
-    return wxPoint2DInt( static_cast<wxInt32>(pt.m_x / n) ,
-        static_cast<wxInt32>(pt.m_y / n) );
-}
-
 // wxPoint2Ds represent a point or a vector in a 2d coordinate system
 
 class WXDLLIMPEXP_CORE wxPoint2DDouble
@@ -307,20 +296,60 @@ public :
     inline bool operator==(const wxPoint2DDouble& pt) const;
     inline bool operator!=(const wxPoint2DDouble& pt) const;
 
+    friend wxPoint2DDouble operator+(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
+    {
+        return wxPoint2DDouble( pt1.m_x + pt2.m_x , pt1.m_y + pt2.m_y );
+    }
+
+    friend wxPoint2DDouble operator-(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
+    {
+        return wxPoint2DDouble( pt1.m_x - pt2.m_x , pt1.m_y - pt2.m_y );
+    }
+
+
+    friend wxPoint2DDouble operator*(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
+    {
+        return wxPoint2DDouble( pt1.m_x * pt2.m_x , pt1.m_y * pt2.m_y );
+    }
+
+    friend wxPoint2DDouble operator*(wxDouble n , const wxPoint2DDouble& pt)
+    {
+        return wxPoint2DDouble( pt.m_x * n , pt.m_y * n );
+    }
+
+    friend wxPoint2DDouble operator*(wxInt32 n , const wxPoint2DDouble& pt)
+    {
+        return wxPoint2DDouble( pt.m_x * n , pt.m_y * n );
+    }
+
+    friend wxPoint2DDouble operator*(const wxPoint2DDouble& pt , wxDouble n)
+    {
+        return wxPoint2DDouble( pt.m_x * n , pt.m_y * n );
+    }
+
+    friend wxPoint2DDouble operator*(const wxPoint2DDouble& pt , wxInt32 n)
+    {
+        return wxPoint2DDouble( pt.m_x * n , pt.m_y * n );
+    }
+
+    friend wxPoint2DDouble operator/(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
+    {
+        return wxPoint2DDouble( pt1.m_x / pt2.m_x , pt1.m_y / pt2.m_y );
+    }
+
+    friend wxPoint2DDouble operator/(const wxPoint2DDouble& pt , wxDouble n)
+    {
+        return wxPoint2DDouble( pt.m_x / n , pt.m_y / n );
+    }
+
+    friend wxPoint2DDouble operator/(const wxPoint2DDouble& pt , wxInt32 n)
+    {
+        return wxPoint2DDouble( pt.m_x / n , pt.m_y / n );
+    }
+
     wxDouble m_x;
     wxDouble m_y;
 };
-
-inline wxPoint2DDouble operator+(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2);
-inline wxPoint2DDouble operator-(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2);
-inline wxPoint2DDouble operator*(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2);
-inline wxPoint2DDouble operator*(wxDouble n , const wxPoint2DDouble& pt);
-inline wxPoint2DDouble operator*(wxInt32 n , const wxPoint2DDouble& pt);
-inline wxPoint2DDouble operator*(const wxPoint2DDouble& pt , wxDouble n);
-inline wxPoint2DDouble operator*(const wxPoint2DDouble& pt , wxInt32 n);
-inline wxPoint2DDouble operator/(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2);
-inline wxPoint2DDouble operator/(const wxPoint2DDouble& pt , wxDouble n);
-inline wxPoint2DDouble operator/(const wxPoint2DDouble& pt , wxInt32 n);
 
 inline wxPoint2DDouble::wxPoint2DDouble()
 {
@@ -424,57 +453,6 @@ inline bool wxPoint2DDouble::operator==(const wxPoint2DDouble& pt) const
 inline bool wxPoint2DDouble::operator!=(const wxPoint2DDouble& pt) const
 {
     return !(*this == pt);
-}
-
-inline wxPoint2DDouble operator+(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
-{
-    return wxPoint2DDouble( pt1.m_x + pt2.m_x , pt1.m_y + pt2.m_y );
-}
-
-inline wxPoint2DDouble operator-(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
-{
-    return wxPoint2DDouble( pt1.m_x - pt2.m_x , pt1.m_y - pt2.m_y );
-}
-
-
-inline wxPoint2DDouble operator*(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
-{
-    return wxPoint2DDouble( pt1.m_x * pt2.m_x , pt1.m_y * pt2.m_y );
-}
-
-inline wxPoint2DDouble operator*(wxDouble n , const wxPoint2DDouble& pt)
-{
-    return wxPoint2DDouble( pt.m_x * n , pt.m_y * n );
-}
-
-inline wxPoint2DDouble operator*(wxInt32 n , const wxPoint2DDouble& pt)
-{
-    return wxPoint2DDouble( pt.m_x * n , pt.m_y * n );
-}
-
-inline wxPoint2DDouble operator*(const wxPoint2DDouble& pt , wxDouble n)
-{
-    return wxPoint2DDouble( pt.m_x * n , pt.m_y * n );
-}
-
-inline wxPoint2DDouble operator*(const wxPoint2DDouble& pt , wxInt32 n)
-{
-    return wxPoint2DDouble( pt.m_x * n , pt.m_y * n );
-}
-
-inline wxPoint2DDouble operator/(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
-{
-    return wxPoint2DDouble( pt1.m_x / pt2.m_x , pt1.m_y / pt2.m_y );
-}
-
-inline wxPoint2DDouble operator/(const wxPoint2DDouble& pt , wxDouble n)
-{
-    return wxPoint2DDouble( pt.m_x / n , pt.m_y / n );
-}
-
-inline wxPoint2DDouble operator/(const wxPoint2DDouble& pt , wxInt32 n)
-{
-    return wxPoint2DDouble( pt.m_x / n , pt.m_y / n );
 }
 
 // wxRect2Ds are an axis-aligned rectangles, each side of the rect is parallel to the x- or m_y- axis. The rectangle is either defined by the

--- a/include/wx/icon.h
+++ b/include/wx/icon.h
@@ -11,7 +11,7 @@
 #define _WX_ICON_H_BASE_
 
 #include "wx/iconloc.h"
-
+#include "wx/variant.h"
 
 // a more readable way to tell
 #define wxICON_SCREEN_DEPTH     (-1)
@@ -56,16 +56,6 @@
 #ifndef wxICON_DIFFERENT_FROM_BITMAP
     #define wxICON_IS_BITMAP
 #endif
-
-//-----------------------------------------------------------------------------
-// wxVariant support
-//-----------------------------------------------------------------------------
-
-#if wxUSE_VARIANT
-#include "wx/variant.h"
-DECLARE_VARIANT_OBJECT_EXPORTED(wxIcon,WXDLLIMPEXP_CORE)
-#endif
-
 
 #endif
     // _WX_ICON_H_BASE_

--- a/include/wx/image.h
+++ b/include/wx/image.h
@@ -18,6 +18,7 @@
 #include "wx/gdicmn.h"
 #include "wx/hashmap.h"
 #include "wx/arrstr.h"
+#include "wx/variant.h"
 
 #if wxUSE_STREAMS
 #  include "wx/stream.h"
@@ -97,15 +98,6 @@ const unsigned char wxIMAGE_ALPHA_OPAQUE = 0xff;
 class WXDLLIMPEXP_FWD_CORE wxImageHandler;
 class WXDLLIMPEXP_FWD_CORE wxImage;
 class WXDLLIMPEXP_FWD_CORE wxPalette;
-
-//-----------------------------------------------------------------------------
-// wxVariant support
-//-----------------------------------------------------------------------------
-
-#if wxUSE_VARIANT
-#include "wx/variant.h"
-DECLARE_VARIANT_OBJECT_EXPORTED(wxImage,WXDLLIMPEXP_CORE)
-#endif
 
 //-----------------------------------------------------------------------------
 // wxImageHandler
@@ -593,6 +585,9 @@ public:
 
     static HSVValue RGBtoHSV(const RGBValue& rgb);
     static RGBValue HSVtoRGB(const HSVValue& hsv);
+
+    // wxVariant support
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(wxImage, WXDLLIMPEXP_CORE);
 
 protected:
     static wxList   sm_handlers;

--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -197,6 +197,8 @@ public:
         { return wxLongLongNative(m_ll + ll.m_ll); }
     wxLongLongNative& operator+=(const wxLongLongNative& ll)
         { m_ll += ll.m_ll; return *this; }
+    friend wxLongLongNative operator+(long l, const wxLongLongNative& ll)
+        { return ll + l; }
 
     wxLongLongNative operator+(const wxLongLong_t ll) const
         { return wxLongLongNative(m_ll + ll); }
@@ -221,6 +223,10 @@ public:
         { return wxLongLongNative(m_ll - ll.m_ll); }
     wxLongLongNative& operator-=(const wxLongLongNative& ll)
         { m_ll -= ll.m_ll; return *this; }
+    friend wxLongLongNative operator-(long l, const wxLongLongNative& ll)
+    {
+        return wxLongLongNative(l) - ll;
+    }
 
     wxLongLongNative operator-(const wxLongLong_t ll) const
         { return wxLongLongNative(m_ll - ll); }
@@ -313,6 +319,13 @@ public:
         { return m_ll >= ll.m_ll; }
     bool operator>=(long l) const
         { return m_ll >= l; }
+
+    friend bool operator<(long l, const wxLongLongNative& ll) { return ll > l; }
+    friend bool operator>(long l, const wxLongLongNative& ll) { return ll < l; }
+    friend bool operator<=(long l, const wxLongLongNative& ll) { return ll >= l; }
+    friend bool operator>=(long l, const wxLongLongNative& ll) { return ll <= l; }
+    friend bool operator==(long l, const wxLongLongNative& ll) { return ll == l; }
+    friend bool operator!=(long l, const wxLongLongNative& ll) { return ll != l; }
 
     // miscellaneous
 
@@ -421,6 +434,8 @@ public:
         { return wxULongLongNative(m_ll + ll.m_ll); }
     wxULongLongNative& operator+=(const wxULongLongNative& ll)
         { m_ll += ll.m_ll; return *this; }
+    friend wxULongLongNative operator+(unsigned long l, const wxULongLongNative& ull)
+        { return ull + l; }
 
     wxULongLongNative operator+(const wxULongLong_t ll) const
         { return wxULongLongNative(m_ll + ll); }
@@ -440,6 +455,10 @@ public:
         { return wxULongLongNative(m_ll - ll.m_ll); }
     wxULongLongNative& operator-=(const wxULongLongNative& ll)
         { m_ll -= ll.m_ll; return *this; }
+    friend wxULongLongNative operator-(unsigned long l, const wxULongLongNative& ull)
+    {
+        return wxULongLongNative(l - ull.m_ll);
+    }
 
     wxULongLongNative operator-(const wxULongLong_t ll) const
         { return wxULongLongNative(m_ll - ll); }
@@ -532,6 +551,13 @@ public:
         { return m_ll >= ll.m_ll; }
     bool operator>=(unsigned long l) const
         { return m_ll >= l; }
+
+    friend bool operator<(unsigned long l, const wxULongLongNative& ull) { return ull > l; }
+    friend bool operator>(unsigned long l, const wxULongLongNative& ull) { return ull < l; }
+    friend bool operator<=(unsigned long l, const wxULongLongNative& ull) { return ull >= l; }
+    friend bool operator>=(unsigned long l, const wxULongLongNative& ull) { return ull <= l; }
+    friend bool operator==(unsigned long l, const wxULongLongNative& ull) { return ull == l; }
+    friend bool operator!=(unsigned long l, const wxULongLongNative& ull) { return ull != l; }
 
     // miscellaneous
 
@@ -696,6 +722,8 @@ public:
     wxLongLongWx operator+(long l) const;
     wxLongLongWx& operator+=(long l);
 
+    friend wxLongLongWx operator+(long l, const wxLongLongWx& ll) { return ll + l; }
+
         // pre increment operator
     wxLongLongWx& operator++();
 
@@ -709,6 +737,10 @@ public:
         // subtraction
     wxLongLongWx operator-(const wxLongLongWx& ll) const;
     wxLongLongWx& operator-=(const wxLongLongWx& ll);
+    friend wxLongLongWx operator-(long l, const wxLongLongWx& ll)
+    {
+        return wxLongLongWx(l) - ll;
+    }
 
         // pre decrement operator
     wxLongLongWx& operator--();
@@ -760,6 +792,13 @@ public:
 
     bool operator<=(long l) const { return *this < l || *this == l; }
     bool operator>=(long l) const { return *this > l || *this == l; }
+
+    friend bool operator<(long l, const wxLongLongWx& ll) { return ll > l; }
+    friend bool operator>(long l, const wxLongLongWx& ll) { return ll < l; }
+    friend bool operator<=(long l, const wxLongLongWx& ll) { return ll >= l; }
+    friend bool operator>=(long l, const wxLongLongWx& ll) { return ll <= l; }
+    friend bool operator==(long l, const wxLongLongWx& ll) { return ll == l; }
+    friend bool operator!=(long l, const wxLongLongWx& ll) { return ll != l; }
 
     // multiplication
     wxLongLongWx operator*(const wxLongLongWx& ll) const;
@@ -920,6 +959,8 @@ public:
     wxULongLongWx& operator+=(const wxULongLongWx& ll);
     wxULongLongWx operator+(unsigned long l) const;
     wxULongLongWx& operator+=(unsigned long l);
+    friend wxULongLongWx operator+(unsigned long l, const wxULongLongWx& ull)
+        { return ull + l; }
 
         // pre increment operator
     wxULongLongWx& operator++();
@@ -930,6 +971,13 @@ public:
         // subtraction
     wxLongLongWx operator-(const wxULongLongWx& ll) const;
     wxULongLongWx& operator-=(const wxULongLongWx& ll);
+
+    friend wxLongLongWx operator-(unsigned long l, const wxULongLongWx& ull)
+    {
+        const wxULongLongWx ret = wxULongLongWx(l) - ull;
+        return wxLongLongWx((wxInt32)ret.GetHi(),ret.GetLo());
+    }
+
 
         // pre decrement operator
     wxULongLongWx& operator--();
@@ -976,6 +1024,13 @@ public:
 
     bool operator<=(unsigned long l) const { return *this < l || *this == l; }
     bool operator>=(unsigned long l) const { return *this > l || *this == l; }
+
+    friend bool operator<(unsigned long l, const wxULongLongWx& ull) { return ull > l; }
+    friend bool operator>(unsigned long l, const wxULongLongWx& ull) { return ull < l; }
+    friend bool operator<=(unsigned long l, const wxULongLongWx& ull) { return ull >= l; }
+    friend bool operator>=(unsigned long l, const wxULongLongWx& ull) { return ull <= l; }
+    friend bool operator==(unsigned long l, const wxULongLongWx& ull) { return ull == l; }
+    friend bool operator!=(unsigned long l, const wxULongLongWx& ull) { return ull != l; }
 
     // multiplication
     wxULongLongWx operator*(const wxULongLongWx& ll) const;
@@ -1030,38 +1085,6 @@ private:
 };
 
 #endif // wxUSE_LONGLONG_WX
-
-// ----------------------------------------------------------------------------
-// binary operators
-// ----------------------------------------------------------------------------
-
-inline bool operator<(long l, const wxLongLong& ll) { return ll > l; }
-inline bool operator>(long l, const wxLongLong& ll) { return ll < l; }
-inline bool operator<=(long l, const wxLongLong& ll) { return ll >= l; }
-inline bool operator>=(long l, const wxLongLong& ll) { return ll <= l; }
-inline bool operator==(long l, const wxLongLong& ll) { return ll == l; }
-inline bool operator!=(long l, const wxLongLong& ll) { return ll != l; }
-
-inline wxLongLong operator+(long l, const wxLongLong& ll) { return ll + l; }
-inline wxLongLong operator-(long l, const wxLongLong& ll)
-{
-    return wxLongLong(l) - ll;
-}
-
-inline bool operator<(unsigned long l, const wxULongLong& ull) { return ull > l; }
-inline bool operator>(unsigned long l, const wxULongLong& ull) { return ull < l; }
-inline bool operator<=(unsigned long l, const wxULongLong& ull) { return ull >= l; }
-inline bool operator>=(unsigned long l, const wxULongLong& ull) { return ull <= l; }
-inline bool operator==(unsigned long l, const wxULongLong& ull) { return ull == l; }
-inline bool operator!=(unsigned long l, const wxULongLong& ull) { return ull != l; }
-
-inline wxULongLong operator+(unsigned long l, const wxULongLong& ull) { return ull + l; }
-
-inline wxLongLong operator-(unsigned long l, const wxULongLong& ull)
-{
-    const wxULongLong ret = wxULongLong(l) - ull;
-    return wxLongLong((wxInt32)ret.GetHi(),ret.GetLo());
-}
 
 #if wxUSE_LONGLONG_NATIVE && wxUSE_STREAMS
 

--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -834,7 +834,14 @@ public:
     class wxTextOutputStream& operator<<(class wxTextOutputStream&, const wxLongLongWx&);
     friend WXDLLIMPEXP_BASE
     class wxTextInputStream& operator>>(class wxTextInputStream&, wxLongLongWx&);
-#endif
+
+#if wxUSE_LONGLONG_NATIVE
+    friend WXDLLIMPEXP_BASE
+    class wxTextOutputStream &operator<<(class wxTextOutputStream &stream, wxLongLong_t value);
+    friend WXDLLIMPEXP_BASE
+    class wxTextInputStream &operator>>(class wxTextInputStream &stream, wxLongLong_t &value);
+#endif // wxUSE_LONGLONG_NATIVE
+#endif // wxUSE_STREAMS
 
 private:
     // long is at least 32 bits, so represent our 64bit number as 2 longs
@@ -1066,7 +1073,14 @@ public:
     class wxTextOutputStream& operator<<(class wxTextOutputStream&, const wxULongLongWx&);
     friend WXDLLIMPEXP_BASE
     class wxTextInputStream& operator>>(class wxTextInputStream&, wxULongLongWx&);
-#endif
+
+#if wxUSE_LONGLONG_NATIVE
+    friend WXDLLIMPEXP_BASE
+    class wxTextOutputStream &operator<<(class wxTextOutputStream &stream, wxULongLong_t value);
+    friend WXDLLIMPEXP_BASE
+    class wxTextInputStream &operator>>(class wxTextInputStream &stream, wxULongLong_t &value);
+#endif // wxUSE_LONGLONG_NATIVE
+#endif // wxUSE_STREAMS
 
 private:
     // long is at least 32 bits, so represent our 64bit number as 2 longs
@@ -1085,16 +1099,6 @@ private:
 };
 
 #endif // wxUSE_LONGLONG_WX
-
-#if wxUSE_LONGLONG_NATIVE && wxUSE_STREAMS
-
-WXDLLIMPEXP_BASE class wxTextOutputStream &operator<<(class wxTextOutputStream &stream, wxULongLong_t value);
-WXDLLIMPEXP_BASE class wxTextOutputStream &operator<<(class wxTextOutputStream &stream, wxLongLong_t value);
-
-WXDLLIMPEXP_BASE class wxTextInputStream &operator>>(class wxTextInputStream &stream, wxULongLong_t &value);
-WXDLLIMPEXP_BASE class wxTextInputStream &operator>>(class wxTextInputStream &stream, wxLongLong_t &value);
-
-#endif
 
 // ----------------------------------------------------------------------------
 // Specialize numeric_limits<> for our long long wrapper classes.

--- a/include/wx/msw/icon.h
+++ b/include/wx/msw/icon.h
@@ -77,6 +77,8 @@ public:
     // ctors, assignment operators...), but it's ok to have such function
     void CopyFromBitmap(const wxBitmap& bmp);
 
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(wxIcon, WXDLLIMPEXP_CORE);
+
 protected:
     virtual wxGDIImageRefData *CreateData() const override
     {

--- a/include/wx/pen.h
+++ b/include/wx/pen.h
@@ -133,6 +133,8 @@ extern WXDLLIMPEXP_DATA_CORE(wxPenList*)   wxThePenList;
 // to compile without warnings which it would otherwise provoke from some
 // compilers as it compares elements of different enums
 
+#if WXWIN_COMPATIBILITY_3_2
+
 wxDEPRECATED_MSG("use wxPENSTYLE_XXX constants")
 inline bool operator==(wxPenStyle s, wxDeprecatedGUIConstants t)
 {
@@ -144,5 +146,7 @@ inline bool operator!=(wxPenStyle s, wxDeprecatedGUIConstants t)
 {
     return static_cast<int>(s) != static_cast<int>(t);
 }
+
+#endif // WXWIN_COMPATIBILITY_3_2
 
 #endif // _WX_PEN_H_BASE_

--- a/include/wx/propgrid/advprops.h
+++ b/include/wx/propgrid/advprops.h
@@ -113,6 +113,8 @@ public:
             Init( cpv.m_type, cpv.m_colour );
     }
 
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(wxColourPropertyValue, WXDLLIMPEXP_PROPGRID);
+
 private:
     wxDECLARE_DYNAMIC_CLASS(wxColourPropertyValue);
 };
@@ -120,8 +122,6 @@ private:
 
 bool WXDLLIMPEXP_PROPGRID
 operator==(const wxColourPropertyValue&, const wxColourPropertyValue&);
-
-DECLARE_VARIANT_OBJECT_EXPORTED(wxColourPropertyValue, WXDLLIMPEXP_PROPGRID)
 
 // -----------------------------------------------------------------------
 

--- a/include/wx/sharedptr.h
+++ b/include/wx/sharedptr.h
@@ -110,6 +110,18 @@ public:
     bool unique()   const    { return (m_ref ? m_ref->m_count == 1 : true); }
     long use_count() const   { return (m_ref ? (long)m_ref->m_count : 0); }
 
+    template <class U>
+    friend bool operator == (wxSharedPtr<T> const &a, wxSharedPtr<U> const &b )
+    {
+        return a.get() == b.get();
+    }
+
+    template <class U>
+    friend bool operator != (wxSharedPtr<T> const &a, wxSharedPtr<U> const &b )
+    {
+        return a.get() != b.get();
+    }
+
 private:
 
     struct reftype
@@ -153,17 +165,5 @@ private:
         }
     }
 };
-
-template <class T, class U>
-bool operator == (wxSharedPtr<T> const &a, wxSharedPtr<U> const &b )
-{
-    return a.get() == b.get();
-}
-
-template <class T, class U>
-bool operator != (wxSharedPtr<T> const &a, wxSharedPtr<U> const &b )
-{
-    return a.get() != b.get();
-}
 
 #endif // _WX_SHAREDPTR_H_

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -864,6 +864,8 @@ public:
 
       iterator operator+(ptrdiff_t n) const
         { return iterator(str(), wxStringOperations::AddToIter(m_cur, n)); }
+      friend iterator operator+(ptrdiff_t n, iterator i)
+        { return i + n; }
       iterator operator-(ptrdiff_t n) const
         { return iterator(str(), wxStringOperations::AddToIter(m_cur, -n)); }
 
@@ -918,6 +920,8 @@ public:
 
       const_iterator operator+(ptrdiff_t n) const
         { return const_iterator(str(), wxStringOperations::AddToIter(m_cur, n)); }
+      friend const_iterator operator+(ptrdiff_t n, const_iterator i)
+        { return i + n; }
       const_iterator operator-(ptrdiff_t n) const
         { return const_iterator(str(), wxStringOperations::AddToIter(m_cur, -n)); }
 
@@ -961,6 +965,8 @@ public:
 
       iterator operator+(ptrdiff_t n) const
         { return iterator(wxStringOperations::AddToIter(m_cur, n)); }
+      friend iterator operator+(ptrdiff_t n, iterator i)
+        { return i + n; }
       iterator operator-(ptrdiff_t n) const
         { return iterator(wxStringOperations::AddToIter(m_cur, -n)); }
 
@@ -996,6 +1002,8 @@ public:
 
       const_iterator operator+(ptrdiff_t n) const
         { return const_iterator(wxStringOperations::AddToIter(m_cur, n)); }
+      friend const_iterator operator+(ptrdiff_t n, const_iterator i)
+        { return i + n; }
       const_iterator operator-(ptrdiff_t n) const
         { return const_iterator(wxStringOperations::AddToIter(m_cur, -n)); }
 
@@ -1087,6 +1095,8 @@ public:
 
       reverse_iterator_impl operator+(ptrdiff_t n) const
         { return reverse_iterator_impl(m_cur - n); }
+      friend iterator operator+(ptrdiff_t n, reverse_iterator_impl i)
+        { return i + n; }
       reverse_iterator_impl operator-(ptrdiff_t n) const
         { return reverse_iterator_impl(m_cur + n); }
       reverse_iterator_impl operator+=(ptrdiff_t n)
@@ -3759,17 +3769,6 @@ private:
   friend class wxStringInternalBuffer;
   friend class wxStringInternalBufferLength;
 };
-
-// string iterator operators that satisfy STL Random Access Iterator
-// requirements:
-inline wxString::iterator operator+(ptrdiff_t n, wxString::iterator i)
-  { return i + n; }
-inline wxString::const_iterator operator+(ptrdiff_t n, wxString::const_iterator i)
-  { return i + n; }
-inline wxString::reverse_iterator operator+(ptrdiff_t n, wxString::reverse_iterator i)
-  { return i + n; }
-inline wxString::const_reverse_iterator operator+(ptrdiff_t n, wxString::const_reverse_iterator i)
-  { return i + n; }
 
 #define wxGetEmptyString() wxString()
 

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -291,6 +291,13 @@ public:
         return p - cs.AsWChar();
     }
 
+#if wxUSE_STD_IOSTREAM
+  friend WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxCStrData&);
+#if defined(HAVE_WOSTREAM)
+  friend WXDLLIMPEXP_BASE std::wostream& operator<<(std::wostream&, const wxCStrData&);
+#endif  // defined(HAVE_WOSTREAM)
+#endif  // wxUSE_STD_IOSTREAM
+
 private:
     // the wxString this object was returned for
     const wxString *m_str;
@@ -3626,6 +3633,13 @@ public:
   wxString& operator+=(unsigned char ch) { return *this += wxUniChar(ch); }
   wxString& operator+=(wchar_t ch) { return *this += wxUniChar(ch); }
 
+#if wxUSE_STD_IOSTREAM
+  friend WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxString&);
+#if defined(HAVE_WOSTREAM)
+  friend WXDLLIMPEXP_BASE std::wostream& operator<<(std::wostream&, const wxString&);
+#endif  // defined(HAVE_WOSTREAM)
+#endif  // wxUSE_STD_IOSTREAM
+
 private:
   #if !wxUSE_UTF8_LOCALE_ONLY
   int DoPrintfWchar(const wxChar *format, ...);
@@ -4157,27 +4171,6 @@ namespace std
 // ---------------------------------------------------------------------------
 // Implementation only from here until the end of file
 // ---------------------------------------------------------------------------
-
-#if wxUSE_STD_IOSTREAM
-
-#include "wx/iosfwrap.h"
-
-WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxString&);
-WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxCStrData&);
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxScopedCharBuffer&);
-#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-WXDLLIMPEXP_BASE std::ostream& operator<<(std::ostream&, const wxScopedWCharBuffer&);
-
-#if defined(HAVE_WOSTREAM)
-
-WXDLLIMPEXP_BASE std::wostream& operator<<(std::wostream&, const wxString&);
-WXDLLIMPEXP_BASE std::wostream& operator<<(std::wostream&, const wxCStrData&);
-WXDLLIMPEXP_BASE std::wostream& operator<<(std::wostream&, const wxScopedWCharBuffer&);
-
-#endif  // defined(HAVE_WOSTREAM)
-
-#endif  // wxUSE_STD_IOSTREAM
 
 // ---------------------------------------------------------------------------
 // wxCStrData implementation

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -261,6 +261,36 @@ public:
     // "*(c_str() + 2)" work
     inline wxUniChar operator*() const;
 
+    // we also need to provide the operators for comparison with wxCStrData to
+    // resolve ambiguity between operator(const wxChar *,const wxString &) and
+    // operator(const wxChar *, const wxChar *) for "p == s.c_str()"
+    //
+    // notice that these are (shallow) pointer comparisons, not (deep) string ones
+#define wxCMP_CHAR_CSTRDATA(p, s, op) p op s.AsChar()
+#define wxCMP_WCHAR_CSTRDATA(p, s, op) p op s.AsWChar()
+
+    wxDEFINE_ALL_COMPARISONS(const wchar_t *, const wxCStrData&, wxCMP_WCHAR_CSTRDATA)
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    wxDEFINE_ALL_COMPARISONS(const char *, const wxCStrData&, wxCMP_CHAR_CSTRDATA)
+#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
+
+#undef wxCMP_CHAR_CSTRDATA
+#undef wxCMP_WCHAR_CSTRDATA
+
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    // we need to define those to allow "size_t pos = p - s.c_str()" where p is
+    // some pointer into the string
+    friend size_t operator-(const char *p, const wxCStrData& cs)
+    {
+        return p - cs.AsChar();
+    }
+#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
+
+    friend size_t operator-(const wchar_t *p, const wxCStrData& cs)
+    {
+        return p - cs.AsWChar();
+    }
+
 private:
     // the wxString this object was returned for
     const wxString *m_str;
@@ -2019,6 +2049,33 @@ public:
   friend wxString WXDLLIMPEXP_BASE operator+(const wchar_t *pwz,
                                              const wxString& string);
 
+  friend wxString operator+(const wxString& string, wxUniCharRef ch)
+      { return string + (wxUniChar)ch; }
+  friend wxString operator+(const wxString& string, char ch)
+      { return string + wxUniChar(ch); }
+  friend wxString operator+(const wxString& string, wchar_t ch)
+      { return string + wxUniChar(ch); }
+  friend wxString operator+(wxUniCharRef ch, const wxString& string)
+      { return (wxUniChar)ch + string; }
+  friend wxString operator+(char ch, const wxString& string)
+      { return wxUniChar(ch) + string; }
+  friend wxString operator+(wchar_t ch, const wxString& string)
+      { return wxUniChar(ch) + string; }
+
+
+  friend wxString operator+(const wxString& string, const wxScopedWCharBuffer& buf)
+      { return string + (const wchar_t *)buf; }
+  friend wxString operator+(const wxScopedWCharBuffer& buf, const wxString& string)
+      { return (const wchar_t *)buf + string; }
+
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+  friend wxString operator+(const wxString& string, const wxScopedCharBuffer& buf)
+      { return string + (const char *)buf; }
+  friend wxString operator+(const wxScopedCharBuffer& buf, const wxString& string)
+      { return (const char *)buf + string; }
+#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
+
+
   // stream-like functions
       // insert an int into string
   wxString& operator<<(int i)
@@ -2113,6 +2170,83 @@ public:
     { return IsSameAs(wxUniChar(c), compareWithCase); }
   bool IsSameAs(int c, bool compareWithCase = true) const
     { return IsSameAs(wxUniChar(c), compareWithCase); }
+
+    // comparison operators: these are always case sensitive
+
+    // With C strings (narrow and wide):
+
+  #define wxCMP_WXCHAR_STRING(p, s, op) 0 op s.Cmp(p)
+
+  wxDEFINE_ALL_COMPARISONS(const wchar_t *, const wxString&, wxCMP_WXCHAR_STRING)
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+  wxDEFINE_ALL_COMPARISONS(const char *, const wxString&, wxCMP_WXCHAR_STRING)
+#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
+
+  #undef wxCMP_WXCHAR_STRING
+
+    // With wxString itself and related types.
+  friend bool operator==(const wxString& s1, const wxString& s2)
+      { return s1.IsSameAs(s2); }
+  friend bool operator!=(const wxString& s1, const wxString& s2)
+      { return !s1.IsSameAs(s2); }
+  friend bool operator< (const wxString& s1, const wxString& s2)
+      { return s1.Cmp(s2) < 0; }
+  friend bool operator> (const wxString& s1, const wxString& s2)
+      { return s1.Cmp(s2) >  0; }
+  friend bool operator<=(const wxString& s1, const wxString& s2)
+      { return s1.Cmp(s2) <= 0; }
+  friend bool operator>=(const wxString& s1, const wxString& s2)
+      { return s1.Cmp(s2) >= 0; }
+
+  friend bool operator==(const wxString& s1, const wxCStrData& s2)
+      { return s1 == s2.AsString(); }
+  friend bool operator==(const wxCStrData& s1, const wxString& s2)
+      { return s1.AsString() == s2; }
+  friend bool operator!=(const wxString& s1, const wxCStrData& s2)
+      { return s1 != s2.AsString(); }
+  friend bool operator!=(const wxCStrData& s1, const wxString& s2)
+      { return s1.AsString() != s2; }
+
+  friend bool operator==(const wxString& s1, const wxScopedWCharBuffer& s2)
+      { return (s1.Cmp((const wchar_t *)s2) == 0); }
+  friend bool operator==(const wxScopedWCharBuffer& s1, const wxString& s2)
+      { return (s2.Cmp((const wchar_t *)s1) == 0); }
+  friend bool operator!=(const wxString& s1, const wxScopedWCharBuffer& s2)
+      { return (s1.Cmp((const wchar_t *)s2) != 0); }
+  friend bool operator!=(const wxScopedWCharBuffer& s1, const wxString& s2)
+      { return (s2.Cmp((const wchar_t *)s1) != 0); }
+
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+  friend bool operator==(const wxString& s1, const wxScopedCharBuffer& s2)
+      { return (s1.Cmp((const char *)s2) == 0); }
+  friend bool operator==(const wxScopedCharBuffer& s1, const wxString& s2)
+      { return (s2.Cmp((const char *)s1) == 0); }
+  friend bool operator!=(const wxString& s1, const wxScopedCharBuffer& s2)
+      { return (s1.Cmp((const char *)s2) != 0); }
+  friend bool operator!=(const wxScopedCharBuffer& s1, const wxString& s2)
+      { return (s2.Cmp((const char *)s1) != 0); }
+#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
+
+    // comparison with char
+  friend bool operator==(const wxUniChar& c, const wxString& s) { return s.IsSameAs(c); }
+  friend bool operator==(const wxUniCharRef& c, const wxString& s) { return s.IsSameAs(c); }
+  friend bool operator==(char c, const wxString& s) { return s.IsSameAs(c); }
+  friend bool operator==(wchar_t c, const wxString& s) { return s.IsSameAs(c); }
+  friend bool operator==(int c, const wxString& s) { return s.IsSameAs(c); }
+  friend bool operator==(const wxString& s, const wxUniChar& c) { return s.IsSameAs(c); }
+  friend bool operator==(const wxString& s, const wxUniCharRef& c) { return s.IsSameAs(c); }
+  friend bool operator==(const wxString& s, char c) { return s.IsSameAs(c); }
+  friend bool operator==(const wxString& s, wchar_t c) { return s.IsSameAs(c); }
+  friend bool operator!=(const wxUniChar& c, const wxString& s) { return !s.IsSameAs(c); }
+  friend bool operator!=(const wxUniCharRef& c, const wxString& s) { return !s.IsSameAs(c); }
+  friend bool operator!=(char c, const wxString& s) { return !s.IsSameAs(c); }
+  friend bool operator!=(wchar_t c, const wxString& s) { return !s.IsSameAs(c); }
+  friend bool operator!=(int c, const wxString& s) { return !s.IsSameAs(c); }
+  friend bool operator!=(const wxString& s, const wxUniChar& c) { return !s.IsSameAs(c); }
+  friend bool operator!=(const wxString& s, const wxUniCharRef& c) { return !s.IsSameAs(c); }
+  friend bool operator!=(const wxString& s, char c) { return !s.IsSameAs(c); }
+  friend bool operator!=(const wxString& s, wchar_t c) { return !s.IsSameAs(c); }
+
 
   // simple sub-string extraction
       // return substring starting at nFirst of length nCount (or till the end
@@ -3637,37 +3771,6 @@ inline wxString::reverse_iterator operator+(ptrdiff_t n, wxString::reverse_itera
 inline wxString::const_reverse_iterator operator+(ptrdiff_t n, wxString::const_reverse_iterator i)
   { return i + n; }
 
-// notice that even though for many compilers the friend declarations above are
-// enough, from the point of view of C++ standard we must have the declarations
-// here as friend ones are not injected in the enclosing namespace and without
-// them the code fails to compile with conforming compilers such as xlC or g++4
-wxString WXDLLIMPEXP_BASE operator+(const wxString& string1, const wxString& string2);
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-wxString WXDLLIMPEXP_BASE operator+(const wxString& string, const char *psz);
-#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-wxString WXDLLIMPEXP_BASE operator+(const wxString& string, const wchar_t *pwz);
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-wxString WXDLLIMPEXP_BASE operator+(const char *psz, const wxString& string);
-#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-wxString WXDLLIMPEXP_BASE operator+(const wchar_t *pwz, const wxString& string);
-
-wxString WXDLLIMPEXP_BASE operator+(const wxString& string, wxUniChar ch);
-wxString WXDLLIMPEXP_BASE operator+(wxUniChar ch, const wxString& string);
-
-inline wxString operator+(const wxString& string, wxUniCharRef ch)
-    { return string + (wxUniChar)ch; }
-inline wxString operator+(const wxString& string, char ch)
-    { return string + wxUniChar(ch); }
-inline wxString operator+(const wxString& string, wchar_t ch)
-    { return string + wxUniChar(ch); }
-inline wxString operator+(wxUniCharRef ch, const wxString& string)
-    { return (wxUniChar)ch + string; }
-inline wxString operator+(char ch, const wxString& string)
-    { return wxUniChar(ch) + string; }
-inline wxString operator+(wchar_t ch, const wxString& string)
-    { return wxUniChar(ch) + string; }
-
-
 #define wxGetEmptyString() wxString()
 
 // ----------------------------------------------------------------------------
@@ -4005,95 +4108,9 @@ public:
 
 
 // ---------------------------------------------------------------------------
-// wxString comparison functions: operator versions are always case sensitive
+// wxString iterators comparisons
 // ---------------------------------------------------------------------------
 
-// comparison with C-style narrow and wide strings.
-#define wxCMP_WXCHAR_STRING(p, s, op) 0 op s.Cmp(p)
-
-wxDEFINE_ALL_COMPARISONS(const wchar_t *, const wxString&, wxCMP_WXCHAR_STRING)
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-wxDEFINE_ALL_COMPARISONS(const char *, const wxString&, wxCMP_WXCHAR_STRING)
-#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-
-#undef wxCMP_WXCHAR_STRING
-
-inline bool operator==(const wxString& s1, const wxString& s2)
-    { return s1.IsSameAs(s2); }
-inline bool operator!=(const wxString& s1, const wxString& s2)
-    { return !s1.IsSameAs(s2); }
-inline bool operator< (const wxString& s1, const wxString& s2)
-    { return s1.Cmp(s2) < 0; }
-inline bool operator> (const wxString& s1, const wxString& s2)
-    { return s1.Cmp(s2) >  0; }
-inline bool operator<=(const wxString& s1, const wxString& s2)
-    { return s1.Cmp(s2) <= 0; }
-inline bool operator>=(const wxString& s1, const wxString& s2)
-    { return s1.Cmp(s2) >= 0; }
-
-inline bool operator==(const wxString& s1, const wxCStrData& s2)
-    { return s1 == s2.AsString(); }
-inline bool operator==(const wxCStrData& s1, const wxString& s2)
-    { return s1.AsString() == s2; }
-inline bool operator!=(const wxString& s1, const wxCStrData& s2)
-    { return s1 != s2.AsString(); }
-inline bool operator!=(const wxCStrData& s1, const wxString& s2)
-    { return s1.AsString() != s2; }
-
-inline bool operator==(const wxString& s1, const wxScopedWCharBuffer& s2)
-    { return (s1.Cmp((const wchar_t *)s2) == 0); }
-inline bool operator==(const wxScopedWCharBuffer& s1, const wxString& s2)
-    { return (s2.Cmp((const wchar_t *)s1) == 0); }
-inline bool operator!=(const wxString& s1, const wxScopedWCharBuffer& s2)
-    { return (s1.Cmp((const wchar_t *)s2) != 0); }
-inline bool operator!=(const wxScopedWCharBuffer& s1, const wxString& s2)
-    { return (s2.Cmp((const wchar_t *)s1) != 0); }
-
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-inline bool operator==(const wxString& s1, const wxScopedCharBuffer& s2)
-    { return (s1.Cmp((const char *)s2) == 0); }
-inline bool operator==(const wxScopedCharBuffer& s1, const wxString& s2)
-    { return (s2.Cmp((const char *)s1) == 0); }
-inline bool operator!=(const wxString& s1, const wxScopedCharBuffer& s2)
-    { return (s1.Cmp((const char *)s2) != 0); }
-inline bool operator!=(const wxScopedCharBuffer& s1, const wxString& s2)
-    { return (s2.Cmp((const char *)s1) != 0); }
-#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-
-inline wxString operator+(const wxString& string, const wxScopedWCharBuffer& buf)
-    { return string + (const wchar_t *)buf; }
-inline wxString operator+(const wxScopedWCharBuffer& buf, const wxString& string)
-    { return (const wchar_t *)buf + string; }
-
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-inline wxString operator+(const wxString& string, const wxScopedCharBuffer& buf)
-    { return string + (const char *)buf; }
-inline wxString operator+(const wxScopedCharBuffer& buf, const wxString& string)
-    { return (const char *)buf + string; }
-#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-
-// comparison with char
-inline bool operator==(const wxUniChar& c, const wxString& s) { return s.IsSameAs(c); }
-inline bool operator==(const wxUniCharRef& c, const wxString& s) { return s.IsSameAs(c); }
-inline bool operator==(char c, const wxString& s) { return s.IsSameAs(c); }
-inline bool operator==(wchar_t c, const wxString& s) { return s.IsSameAs(c); }
-inline bool operator==(int c, const wxString& s) { return s.IsSameAs(c); }
-inline bool operator==(const wxString& s, const wxUniChar& c) { return s.IsSameAs(c); }
-inline bool operator==(const wxString& s, const wxUniCharRef& c) { return s.IsSameAs(c); }
-inline bool operator==(const wxString& s, char c) { return s.IsSameAs(c); }
-inline bool operator==(const wxString& s, wchar_t c) { return s.IsSameAs(c); }
-inline bool operator!=(const wxUniChar& c, const wxString& s) { return !s.IsSameAs(c); }
-inline bool operator!=(const wxUniCharRef& c, const wxString& s) { return !s.IsSameAs(c); }
-inline bool operator!=(char c, const wxString& s) { return !s.IsSameAs(c); }
-inline bool operator!=(wchar_t c, const wxString& s) { return !s.IsSameAs(c); }
-inline bool operator!=(int c, const wxString& s) { return !s.IsSameAs(c); }
-inline bool operator!=(const wxString& s, const wxUniChar& c) { return !s.IsSameAs(c); }
-inline bool operator!=(const wxString& s, const wxUniCharRef& c) { return !s.IsSameAs(c); }
-inline bool operator!=(const wxString& s, char c) { return !s.IsSameAs(c); }
-inline bool operator!=(const wxString& s, wchar_t c) { return !s.IsSameAs(c); }
-
-
-// wxString iterators comparisons
 inline bool wxString::const_iterator::operator==(const iterator& i) const
     { return *this == const_iterator(i); }
 inline bool wxString::const_iterator::operator!=(const iterator& i) const
@@ -4119,22 +4136,6 @@ inline bool wxString::iterator::operator<=(const const_iterator& i) const
     { return i >= *this; }
 inline bool wxString::iterator::operator>=(const const_iterator& i) const
     { return i <= *this; }
-
-// we also need to provide the operators for comparison with wxCStrData to
-// resolve ambiguity between operator(const wxChar *,const wxString &) and
-// operator(const wxChar *, const wxChar *) for "p == s.c_str()"
-//
-// notice that these are (shallow) pointer comparisons, not (deep) string ones
-#define wxCMP_CHAR_CSTRDATA(p, s, op) p op s.AsChar()
-#define wxCMP_WCHAR_CSTRDATA(p, s, op) p op s.AsWChar()
-
-wxDEFINE_ALL_COMPARISONS(const wchar_t *, const wxCStrData&, wxCMP_WCHAR_CSTRDATA)
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-wxDEFINE_ALL_COMPARISONS(const char *, const wxCStrData&, wxCMP_CHAR_CSTRDATA)
-#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-
-#undef wxCMP_CHAR_CSTRDATA
-#undef wxCMP_WCHAR_CSTRDATA
 
 // ----------------------------------------------------------------------------
 // Implement hashing using C++11 std::hash<>.
@@ -4262,24 +4263,6 @@ inline wxUniChar wxCStrData::operator[](size_t n) const
     // NB: we intentionally use operator[] and not at() here because the former
     //     works for the terminating NUL while the latter does not
     return (*m_str)[m_offset + n];
-}
-
-// ----------------------------------------------------------------------------
-// more wxCStrData operators
-// ----------------------------------------------------------------------------
-
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-// we need to define those to allow "size_t pos = p - s.c_str()" where p is
-// some pointer into the string
-inline size_t operator-(const char *p, const wxCStrData& cs)
-{
-    return p - cs.AsChar();
-}
-#endif // wxNO_IMPLICIT_WXSTRING_ENCODING
-
-inline size_t operator-(const wchar_t *p, const wxCStrData& cs)
-{
-    return p - cs.AsWChar();
 }
 
 // ----------------------------------------------------------------------------

--- a/include/wx/unichar.h
+++ b/include/wx/unichar.h
@@ -162,6 +162,9 @@ public:
 #undef wxDEFINE_UNICHAR_OPERATOR
 #undef wxDEFINE_UNCHAR_CMP_WITH_INT
 
+    wxDEFINE_COMPARISONS_BY_REV(char, const wxUniChar&)
+    wxDEFINE_COMPARISONS_BY_REV(wchar_t, const wxUniChar&)
+
     // this is needed for expressions like 'Z'-c
     int operator-(const wxUniChar& c) const { return m_value - c.m_value; }
     int operator-(char c) const { return m_value - From8bit(c); }
@@ -290,12 +293,23 @@ public:
 #undef wxDEFINE_UNICHARREF_OPERATOR
 #undef wxDEFINE_UNICHARREF_CMP_WITH_INT
 
+    // Comparison operators for the case when wxUniChar(Ref) is the second
+    // operand implemented in terms of member comparison functions
+    wxDEFINE_COMPARISONS_BY_REV(char, const wxUniCharRef&)
+    wxDEFINE_COMPARISONS_BY_REV(wchar_t, const wxUniCharRef&)
+
+    wxDEFINE_COMPARISONS_BY_REV(const wxUniChar&, const wxUniCharRef&)
+
     // for expressions like c-'A':
     int operator-(const wxUniCharRef& c) const { return UniChar() - c.UniChar(); }
     int operator-(const wxUniChar& c) const { return UniChar() - c; }
     int operator-(char c) const { return UniChar() - c; }
     int operator-(unsigned char c) const { return UniChar() - c; }
     int operator-(wchar_t c) const { return UniChar() - c; }
+    friend int operator-(char c1, const wxUniCharRef& c2) { return -(c2 - c1); }
+    friend int operator-(const wxUniChar& c1, const wxUniCharRef& c2) { return -(c2 - c1); }
+    friend int operator-(wchar_t c1, const wxUniCharRef& c2) { return -(c2 - c1); }
+
 
 private:
 #if wxUSE_UNICODE_UTF8
@@ -364,22 +378,5 @@ void swap(wxUniCharRef&& lhs, wxUniCharRef&& rhs)
     lhs = rhs;
     rhs = tmp;
 }
-
-
-// Comparison operators for the case when wxUniChar(Ref) is the second operand
-// implemented in terms of member comparison functions
-
-wxDEFINE_COMPARISONS_BY_REV(char, const wxUniChar&)
-wxDEFINE_COMPARISONS_BY_REV(char, const wxUniCharRef&)
-
-wxDEFINE_COMPARISONS_BY_REV(wchar_t, const wxUniChar&)
-wxDEFINE_COMPARISONS_BY_REV(wchar_t, const wxUniCharRef&)
-
-wxDEFINE_COMPARISONS_BY_REV(const wxUniChar&, const wxUniCharRef&)
-
-// for expressions like c-'A':
-inline int operator-(char c1, const wxUniCharRef& c2) { return -(c2 - c1); }
-inline int operator-(const wxUniChar& c1, const wxUniCharRef& c2) { return -(c2 - c1); }
-inline int operator-(wchar_t c1, const wxUniCharRef& c2) { return -(c2 - c1); }
 
 #endif /* _WX_UNICHAR_H_ */

--- a/include/wx/variant.h
+++ b/include/wx/variant.h
@@ -470,13 +470,29 @@ REGISTER_WXANY_CONVERSION(T, CLASSNAME)
 
 #endif // wxUSE_ANY/!wxUSE_ANY
 
+// Note: these macros must be used inside "classname" declaration.
+#define wxDECLARE_VARIANT_OBJECT(classname) \
+    wxDECLARE_VARIANT_OBJECT_EXPORTED(classname, wxEMPTY_PARAMETER_VALUE)
 
+#define wxDECLARE_VARIANT_OBJECT_EXPORTED(classname,expdecl) \
+    friend expdecl classname& operator<<(classname &object, const wxVariant &variant); \
+    friend expdecl wxVariant& operator<<(wxVariant &variant, const classname &object)
+
+// These macros are deprecated, consider using wxDECLARE_VARIANT_OBJECT() above
+// instead.
 #define DECLARE_VARIANT_OBJECT(classname) \
     DECLARE_VARIANT_OBJECT_EXPORTED(classname, wxEMPTY_PARAMETER_VALUE)
 
 #define DECLARE_VARIANT_OBJECT_EXPORTED(classname,expdecl) \
 expdecl classname& operator << ( classname &object, const wxVariant &variant ); \
 expdecl wxVariant& operator << ( wxVariant &variant, const classname &object );
+
+// These macros use "wx" prefix and require a semicolon after them for
+// consistency with the rest of wx macros, but are otherwise the same as the
+// older IMPLEMENT_VARIANT_XXX macros.
+#define wxIMPLEMENT_VARIANT_OBJECT(classname) \
+    IMPLEMENT_VARIANT_OBJECT_EXPORTED(classname, wxEMPTY_PARAMETER_VALUE) \
+    struct wxDummyVariantStructFwdDecl /* to force a semicolon */
 
 #define IMPLEMENT_VARIANT_OBJECT(classname) \
     IMPLEMENT_VARIANT_OBJECT_EXPORTED(classname, wxEMPTY_PARAMETER_VALUE)
@@ -578,6 +594,13 @@ bool classname##VariantData::Eq(wxVariantData& data) const \
 
 extern wxVariant WXDLLIMPEXP_BASE wxNullVariant;
 
-#endif // wxUSE_VARIANT
+#else // !wxUSE_VARIANT
+
+// Define these macros to allow using them without checking for wxUSE_VARIANT
+// and simply do nothing in them in this case.
+#define wxDECLARE_VARIANT_OBJECT(classname)
+#define wxDECLARE_VARIANT_OBJECT_EXPORTED(classname,expdecl)
+
+#endif // wxUSE_VARIANT/!wxUSE_VARIANT
 
 #endif // _WX_VARIANT_H_

--- a/include/wx/windowid.h
+++ b/include/wx/windowid.h
@@ -74,6 +74,57 @@ public:
         return *this;
     }
 
+    // comparison operators
+    friend bool operator==(const wxWindowIDRef& lhs, const wxWindowIDRef& rhs)
+    {
+        return lhs.GetValue() == rhs.GetValue();
+    }
+
+    friend bool operator==(const wxWindowIDRef& lhs, int rhs)
+    {
+        return lhs.GetValue() == rhs;
+    }
+
+    friend bool operator==(const wxWindowIDRef& lhs, long rhs)
+    {
+        return lhs.GetValue() == rhs;
+    }
+
+    friend bool operator==(int lhs, const wxWindowIDRef& rhs)
+    {
+        return rhs == lhs;
+    }
+
+    friend bool operator==(long lhs, const wxWindowIDRef& rhs)
+    {
+        return rhs == lhs;
+    }
+
+    friend bool operator!=(const wxWindowIDRef& lhs, const wxWindowIDRef& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bool operator!=(const wxWindowIDRef& lhs, int rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bool operator!=(const wxWindowIDRef& lhs, long rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bool operator!=(int lhs, const wxWindowIDRef& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bool operator!=(long lhs, const wxWindowIDRef& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
     // access to the stored id value
     wxWindowID GetValue() const
     {
@@ -113,57 +164,6 @@ private:
 
     wxWindowID m_id;
 };
-
-// comparison operators
-inline bool operator==(const wxWindowIDRef& lhs, const wxWindowIDRef& rhs)
-{
-    return lhs.GetValue() == rhs.GetValue();
-}
-
-inline bool operator==(const wxWindowIDRef& lhs, int rhs)
-{
-    return lhs.GetValue() == rhs;
-}
-
-inline bool operator==(const wxWindowIDRef& lhs, long rhs)
-{
-    return lhs.GetValue() == rhs;
-}
-
-inline bool operator==(int lhs, const wxWindowIDRef& rhs)
-{
-    return rhs == lhs;
-}
-
-inline bool operator==(long lhs, const wxWindowIDRef& rhs)
-{
-    return rhs == lhs;
-}
-
-inline bool operator!=(const wxWindowIDRef& lhs, const wxWindowIDRef& rhs)
-{
-    return !(lhs == rhs);
-}
-
-inline bool operator!=(const wxWindowIDRef& lhs, int rhs)
-{
-    return !(lhs == rhs);
-}
-
-inline bool operator!=(const wxWindowIDRef& lhs, long rhs)
-{
-    return !(lhs == rhs);
-}
-
-inline bool operator!=(int lhs, const wxWindowIDRef& rhs)
-{
-    return !(lhs == rhs);
-}
-
-inline bool operator!=(long lhs, const wxWindowIDRef& rhs)
-{
-    return !(lhs == rhs);
-}
 
 // ----------------------------------------------------------------------------
 // wxIdManager

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -200,44 +200,41 @@ public:
     /**
         @name Miscellaneous operators
 
-        Note that these operators are documented as class members
-        (to make them easier to find) but, as their prototype shows,
-        they are implemented as global operators; note that this is
-        transparent to the user but it helps to understand why the
-        following functions are documented to take the wxPoint they
-        operate on as an explicit argument.
+        Note that binary operators are defined as friend functions inside this
+        class, making them accessible via argument-dependent lookup, but hidden
+        otherwise.
     */
     ///@{
     wxRealPoint& operator=(const wxRealPoint& pt);
 
-    bool operator ==(const wxRealPoint& p1, const wxRealPoint& p2);
-    bool operator !=(const wxRealPoint& p1, const wxRealPoint& p2);
+    friend bool operator ==(const wxRealPoint& p1, const wxRealPoint& p2);
+    friend bool operator !=(const wxRealPoint& p1, const wxRealPoint& p2);
 
-    wxRealPoint operator +(const wxRealPoint& p1, const wxRealPoint& p2);
-    wxRealPoint operator -(const wxRealPoint& p1, const wxRealPoint& p2);
+    friend wxRealPoint operator +(const wxRealPoint& p1, const wxRealPoint& p2);
+    friend wxRealPoint operator -(const wxRealPoint& p1, const wxRealPoint& p2);
 
     wxRealPoint& operator +=(const wxRealPoint& pt);
     wxRealPoint& operator -=(const wxRealPoint& pt);
 
-    wxRealPoint operator +(const wxRealPoint& pt, const wxSize& sz);
-    wxRealPoint operator -(const wxRealPoint& pt, const wxSize& sz);
-    wxRealPoint operator +(const wxSize& sz, const wxRealPoint& pt);
-    wxRealPoint operator -(const wxSize& sz, const wxRealPoint& pt);
+    friend wxRealPoint operator +(const wxRealPoint& pt, const wxSize& sz);
+    friend wxRealPoint operator -(const wxRealPoint& pt, const wxSize& sz);
+    friend wxRealPoint operator +(const wxSize& sz, const wxRealPoint& pt);
+    friend wxRealPoint operator -(const wxSize& sz, const wxRealPoint& pt);
 
     wxRealPoint& operator +=(const wxSize& sz);
     wxRealPoint& operator -=(const wxSize& sz);
 
-    wxRealPoint operator -(const wxRealPoint& pt);
+    friend wxRealPoint operator -(const wxRealPoint& pt);
 
-    wxRealPoint operator /(const wxRealPoint& sz, int divisor);
-    wxRealPoint operator *(const wxRealPoint& sz, int factor);
-    wxRealPoint operator *(int factor, const wxRealPoint& pt);
+    friend wxRealPoint operator /(const wxRealPoint& sz, int divisor);
+    friend wxRealPoint operator *(const wxRealPoint& sz, int factor);
+    friend wxRealPoint operator *(int factor, const wxRealPoint& pt);
     wxRealPoint& operator /=(int divisor);
     wxRealPoint& operator *=(int factor);
 
-    wxRealPoint operator /(const wxRealPoint& pt, double divisor);
-    wxRealPoint operator *(const wxRealPoint& pt, double factor);
-    wxRealPoint operator *(double factor, const wxRealPoint& pt);
+    friend wxRealPoint operator /(const wxRealPoint& pt, double divisor);
+    friend wxRealPoint operator *(const wxRealPoint& pt, double factor);
+    friend wxRealPoint operator *(double factor, const wxRealPoint& pt);
     wxRealPoint& operator /=(double divisor);
     wxRealPoint& operator *=(double factor);
     ///@}
@@ -608,13 +605,13 @@ public:
     /**
         Inequality operator.
     */
-    bool operator !=(const wxRect& r1, const wxRect& r2);
+    friend bool operator !=(const wxRect& r1, const wxRect& r2);
 
     ///@{
     /**
         Like Union(), but doesn't treat empty rectangles specially.
     */
-    wxRect operator +(const wxRect& r1, const wxRect& r2);
+    friend wxRect operator +(const wxRect& r1, const wxRect& r2);
     wxRect& operator +=(const wxRect& r);
     ///@}
 
@@ -622,7 +619,7 @@ public:
     /**
         Returns the intersection of two rectangles (which may be empty).
     */
-    wxRect operator *(const wxRect& r1, const wxRect& r2);
+    friend wxRect operator *(const wxRect& r1, const wxRect& r2);
     wxRect& operator *=(const wxRect& r);
     ///@}
 
@@ -634,7 +631,7 @@ public:
     /**
         Equality operator.
     */
-    bool operator ==(const wxRect& r1, const wxRect& r2);
+    friend bool operator ==(const wxRect& r1, const wxRect& r2);
 
     /**
         Height member.
@@ -712,44 +709,41 @@ public:
     /**
         @name Miscellaneous operators
 
-        Note that these operators are documented as class members
-        (to make them easier to find) but, as their prototype shows,
-        they are implemented as global operators; note that this is
-        transparent to the user but it helps to understand why the
-        following functions are documented to take the wxPoint they
-        operate on as an explicit argument.
+        Note that binary operators are defined as friend functions inside this
+        class, making them accessible via argument-dependent lookup, but hidden
+        otherwise.
     */
     ///@{
     wxPoint& operator=(const wxPoint& pt);
 
-    bool operator ==(const wxPoint& p1, const wxPoint& p2);
-    bool operator !=(const wxPoint& p1, const wxPoint& p2);
+    friend bool operator ==(const wxPoint& p1, const wxPoint& p2);
+    friend bool operator !=(const wxPoint& p1, const wxPoint& p2);
 
-    wxPoint operator +(const wxPoint& p1, const wxPoint& p2);
-    wxPoint operator -(const wxPoint& p1, const wxPoint& p2);
+    friend wxPoint operator +(const wxPoint& p1, const wxPoint& p2);
+    friend wxPoint operator -(const wxPoint& p1, const wxPoint& p2);
 
     wxPoint& operator +=(const wxPoint& pt);
     wxPoint& operator -=(const wxPoint& pt);
 
-    wxPoint operator +(const wxPoint& pt, const wxSize& sz);
-    wxPoint operator -(const wxPoint& pt, const wxSize& sz);
-    wxPoint operator +(const wxSize& sz, const wxPoint& pt);
-    wxPoint operator -(const wxSize& sz, const wxPoint& pt);
+    friend wxPoint operator +(const wxPoint& pt, const wxSize& sz);
+    friend wxPoint operator -(const wxPoint& pt, const wxSize& sz);
+    friend wxPoint operator +(const wxSize& sz, const wxPoint& pt);
+    friend wxPoint operator -(const wxSize& sz, const wxPoint& pt);
 
     wxPoint& operator +=(const wxSize& sz);
     wxPoint& operator -=(const wxSize& sz);
 
     wxPoint operator -(const wxPoint& pt);
 
-    wxPoint operator /(const wxPoint& sz, int divisor);
-    wxPoint operator *(const wxPoint& sz, int factor);
-    wxPoint operator *(int factor, const wxPoint& sz);
+    friend wxPoint operator /(const wxPoint& sz, int divisor);
+    friend wxPoint operator *(const wxPoint& sz, int factor);
+    friend wxPoint operator *(int factor, const wxPoint& sz);
     wxPoint& operator /=(int divisor);
     wxPoint& operator *=(int factor);
 
-    wxPoint operator /(const wxPoint& pt, double divisor);
-    wxPoint operator *(const wxPoint& pt, double factor);
-    wxPoint operator *(double factor, const wxPoint& pt);
+    friend wxPoint operator /(const wxPoint& pt, double divisor);
+    friend wxPoint operator *(const wxPoint& pt, double factor);
+    friend wxPoint operator *(double factor, const wxPoint& pt);
     wxPoint& operator /=(double divisor);
     wxPoint& operator *=(double factor);
     ///@}
@@ -1117,12 +1111,9 @@ public:
         Sizes can be added to or subtracted from each other or divided or
         multiplied by a number.
 
-        Note that these operators are documented as class members
-        (to make them easier to find) but, as their prototype shows,
-        they are implemented as global operators; note that this is
-        transparent to the user but it helps to understand why the
-        following functions are documented to take the wxSize they
-        operate on as an explicit argument.
+        Note that binary operators are defined as friend functions inside this
+        class, making them accessible via argument-dependent lookup, but hidden
+        otherwise.
 
         Also note that using @c double factor may result in rounding errors,
         as wxSize always stores @c int coordinates and the result is always
@@ -1131,20 +1122,20 @@ public:
     ///@{
     wxSize& operator=(const wxSize& sz);
 
-    bool operator ==(const wxSize& s1, const wxSize& s2);
-    bool operator !=(const wxSize& s1, const wxSize& s2);
+    friend bool operator ==(const wxSize& s1, const wxSize& s2);
+    friend bool operator !=(const wxSize& s1, const wxSize& s2);
 
-    wxSize operator +(const wxSize& s1, const wxSize& s2);
-    wxSize operator -(const wxSize& s1, const wxSize& s2);
+    friend wxSize operator +(const wxSize& s1, const wxSize& s2);
+    friend wxSize operator -(const wxSize& s1, const wxSize& s2);
     wxSize& operator +=(const wxSize& sz);
     wxSize& operator -=(const wxSize& sz);
 
-    wxSize operator /(const wxSize& sz, int factor);
-    wxSize operator /(const wxSize& sz, double factor);
-    wxSize operator *(const wxSize& sz, int factor);
-    wxSize operator *(const wxSize& sz, double factor);
-    wxSize operator *(int factor, const wxSize& sz);
-    wxSize operator *(double factor, const wxSize& sz);
+    friend wxSize operator /(const wxSize& sz, int factor);
+    friend wxSize operator /(const wxSize& sz, double factor);
+    friend wxSize operator *(const wxSize& sz, int factor);
+    friend wxSize operator *(const wxSize& sz, double factor);
+    friend wxSize operator *(int factor, const wxSize& sz);
+    friend wxSize operator *(double factor, const wxSize& sz);
     wxSize& operator /=(int factor);
     wxSize& operator /=(double factor);
     wxSize& operator *=(int factor);

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -911,12 +911,12 @@ public:
     /**
         Concatenation: returns a new string equal to the concatenation of the operands.
     */
-    wxString operator +(const wxString& x, const wxString& y);
+    friend wxString operator +(const wxString& x, const wxString& y);
 
     /**
         @overload
     */
-    wxString operator +(const wxString& x, wxUniChar y);
+    friend wxString operator +(const wxString& x, wxUniChar y);
 
     wxString& operator<<(const wxString& s);
     wxString& operator<<(const char* psz);
@@ -1014,6 +1014,54 @@ public:
         @see Cmp(), CmpNoCase()
     */
     bool IsSameAs(wxUniChar ch, bool caseSensitive = true) const;
+
+    ///@{
+    /**
+        Comparison operator for string types.
+    */
+    friend bool operator==(const wxString& s1, const wxString& s2);
+    friend bool operator!=(const wxString& s1, const wxString& s2);
+    friend bool operator< (const wxString& s1, const wxString& s2);
+    friend bool operator> (const wxString& s1, const wxString& s2);
+    friend bool operator<=(const wxString& s1, const wxString& s2);
+    friend bool operator>=(const wxString& s1, const wxString& s2);
+    friend bool operator==(const wxString& s1, const wxCStrData& s2);
+    friend bool operator==(const wxCStrData& s1, const wxString& s2);
+    friend bool operator!=(const wxString& s1, const wxCStrData& s2);
+    friend bool operator!=(const wxCStrData& s1, const wxString& s2);
+    friend bool operator==(const wxString& s1, const wxWCharBuffer& s2);
+    friend bool operator==(const wxWCharBuffer& s1, const wxString& s2);
+    friend bool operator!=(const wxString& s1, const wxWCharBuffer& s2);
+    friend bool operator!=(const wxWCharBuffer& s1, const wxString& s2);
+    friend bool operator==(const wxString& s1, const wxCharBuffer& s2);
+    friend bool operator==(const wxCharBuffer& s1, const wxString& s2);
+    friend bool operator!=(const wxString& s1, const wxCharBuffer& s2);
+    friend bool operator!=(const wxCharBuffer& s1, const wxString& s2);
+    ///@}
+
+    ///@{
+    /**
+        Comparison operators char types.
+    */
+    friend bool operator==(const wxUniChar& c, const wxString& s);
+    friend bool operator==(const wxUniCharRef& c, const wxString& s);
+    friend bool operator==(char c, const wxString& s);
+    friend bool operator==(wchar_t c, const wxString& s);
+    friend bool operator==(int c, const wxString& s);
+    friend bool operator==(const wxString& s, const wxUniChar& c);
+    friend bool operator==(const wxString& s, const wxUniCharRef& c);
+    friend bool operator==(const wxString& s, char c);
+    friend bool operator==(const wxString& s, wchar_t c);
+    friend bool operator!=(const wxUniChar& c, const wxString& s);
+    friend bool operator!=(const wxUniCharRef& c, const wxString& s);
+    friend bool operator!=(char c, const wxString& s);
+    friend bool operator!=(wchar_t c, const wxString& s);
+    friend bool operator!=(int c, const wxString& s);
+    friend bool operator!=(const wxString& s, const wxUniChar& c);
+    friend bool operator!=(const wxString& s, const wxUniCharRef& c);
+    friend bool operator!=(const wxString& s, char c);
+    friend bool operator!=(const wxString& s, wchar_t c);
+    ///@}
 
     /**
         Returns @true if the string contents matches a mask containing '*' and '?'.
@@ -1998,54 +2046,6 @@ public:
 };
 
 
-
-///@{
-/**
-    Comparison operator for string types.
-*/
-inline bool operator==(const wxString& s1, const wxString& s2);
-inline bool operator!=(const wxString& s1, const wxString& s2);
-inline bool operator< (const wxString& s1, const wxString& s2);
-inline bool operator> (const wxString& s1, const wxString& s2);
-inline bool operator<=(const wxString& s1, const wxString& s2);
-inline bool operator>=(const wxString& s1, const wxString& s2);
-inline bool operator==(const wxString& s1, const wxCStrData& s2);
-inline bool operator==(const wxCStrData& s1, const wxString& s2);
-inline bool operator!=(const wxString& s1, const wxCStrData& s2);
-inline bool operator!=(const wxCStrData& s1, const wxString& s2);
-inline bool operator==(const wxString& s1, const wxWCharBuffer& s2);
-inline bool operator==(const wxWCharBuffer& s1, const wxString& s2);
-inline bool operator!=(const wxString& s1, const wxWCharBuffer& s2);
-inline bool operator!=(const wxWCharBuffer& s1, const wxString& s2);
-inline bool operator==(const wxString& s1, const wxCharBuffer& s2);
-inline bool operator==(const wxCharBuffer& s1, const wxString& s2);
-inline bool operator!=(const wxString& s1, const wxCharBuffer& s2);
-inline bool operator!=(const wxCharBuffer& s1, const wxString& s2);
-///@}
-
-///@{
-/**
-    Comparison operators char types.
-*/
-inline bool operator==(const wxUniChar& c, const wxString& s);
-inline bool operator==(const wxUniCharRef& c, const wxString& s);
-inline bool operator==(char c, const wxString& s);
-inline bool operator==(wchar_t c, const wxString& s);
-inline bool operator==(int c, const wxString& s);
-inline bool operator==(const wxString& s, const wxUniChar& c);
-inline bool operator==(const wxString& s, const wxUniCharRef& c);
-inline bool operator==(const wxString& s, char c);
-inline bool operator==(const wxString& s, wchar_t c);
-inline bool operator!=(const wxUniChar& c, const wxString& s);
-inline bool operator!=(const wxUniCharRef& c, const wxString& s);
-inline bool operator!=(char c, const wxString& s);
-inline bool operator!=(wchar_t c, const wxString& s);
-inline bool operator!=(int c, const wxString& s);
-inline bool operator!=(const wxString& s, const wxUniChar& c);
-inline bool operator!=(const wxString& s, const wxUniCharRef& c);
-inline bool operator!=(const wxString& s, char c);
-inline bool operator!=(const wxString& s, wchar_t c);
-///@}
 
 /**
     The global wxString instance of an empty string.

--- a/interface/wx/variant.h
+++ b/interface/wx/variant.h
@@ -42,21 +42,24 @@
     required.
 
     Note that as of wxWidgets 2.7.1, wxVariant is
-    @ref overview_refcount "reference counted". Additionally, the convenience
-    macros DECLARE_VARIANT_OBJECT() and IMPLEMENT_VARIANT_OBJECT() were added
-    so that adding (limited) support for conversion to and from wxVariant can
-    be very easily implemented without modifying either wxVariant or the class
-    to be stored by wxVariant. Since assignment operators cannot be declared
-    outside the class, the shift left operators are used like this:
+    @ref overview_refcount "reference counted".
+
+    Convenience macros wxDECLARE_VARIANT_OBJECT() and wxIMPLEMENT_VARIANT_OBJECT()
+    allow easily adding support for conversion to and from wxVariant to custom
+    classes. The first of these macros must be used inside the class declaration
+    and the second one outside of it in the implementation file, e.g.
 
     @code
     // in the header file
-    DECLARE_VARIANT_OBJECT(MyClass)
+    class MyClass : public wxObject {
+        ...
+        wxDECLARE_VARIANT_OBJECT(MyClass);
+    };
 
     // in the implementation file
-    IMPLEMENT_VARIANT_OBJECT(MyClass)
+    wxIMPLEMENT_VARIANT_OBJECT(MyClass);
 
-    // in the user code
+    // and then objects of MyClass can be used with wxVariant like this:
     wxVariant variant;
     MyClass value;
     variant << value;
@@ -78,6 +81,11 @@
     - wxIcon
     - wxBitmap
     - wxBitmapBundle
+
+    @note There also are legacy versions of the above macros without `wx`
+        prefix, working in a slightly different way. Please use the new
+        versions in the new code and consider replacing any existing use of
+        the legacy macros with the new ones.
 
     Note that as of wxWidgets 2.9.0, wxVariantData no longer inherits from
     wxObject and wxVariant no longer uses the type-unsafe wxList class for list

--- a/interface/wx/variant.h
+++ b/interface/wx/variant.h
@@ -73,12 +73,11 @@
     wxObject itself. By default, wxWidgets already implements the shift
     operator conversion for a few of its drawing related classes:
 
-    @code
-    IMPLEMENT_VARIANT_OBJECT(wxColour)
-    IMPLEMENT_VARIANT_OBJECT(wxImage)
-    IMPLEMENT_VARIANT_OBJECT(wxIcon)
-    IMPLEMENT_VARIANT_OBJECT(wxBitmap)
-    @endcode
+    - wxColour
+    - wxImage
+    - wxIcon
+    - wxBitmap
+    - wxBitmapBundle
 
     Note that as of wxWidgets 2.9.0, wxVariantData no longer inherits from
     wxObject and wxVariant no longer uses the type-unsafe wxList class for list

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -169,17 +169,29 @@ std::ostream& operator<<(std::ostream& os, const wxString& str)
     return os << str.c_str();
 }
 
-std::ostream& operator<<(std::ostream& os, const wxScopedCharBuffer& str)
+std::ostream&
+wxPrivate::OutputCharBuffer(std::ostream& os, const char* str)
+{
+    return os << str;
+}
+
+std::ostream& operator<<(std::ostream& os, const wxCharBuffer& str)
 {
     return os << str.data();
 }
 
-std::ostream& operator<<(std::ostream& os, const wxScopedWCharBuffer& str)
+std::ostream&
+wxPrivate::OutputWCharBuffer(std::ostream& os, const wchar_t* wstr)
 {
     // There is no way to write wide character data to std::ostream directly,
     // but we need to define this operator for compatibility, as we provided it
     // since basically always, even if it never worked correctly before. So do
     // the only reasonable thing and output it as UTF-8.
+    return os << wxConvWhateverWorks.cWC2MB(wstr);
+}
+
+std::ostream& operator<<(std::ostream& os, const wxWCharBuffer& str)
+{
     return os << wxConvWhateverWorks.cWC2MB(str.data());
 }
 
@@ -195,7 +207,13 @@ std::wostream& operator<<(std::wostream& wos, const wxCStrData& str)
     return wos << str.AsWChar();
 }
 
-std::wostream& operator<<(std::wostream& wos, const wxScopedWCharBuffer& str)
+std::wostream&
+wxPrivate::OutputWCharBuffer(std::wostream& wos, const wchar_t* wstr)
+{
+    return wos << wstr;
+}
+
+std::wostream& operator<<(std::wostream& wos, const wxWCharBuffer& str)
 {
     return wos << str.data();
 }


### PR DESCRIPTION
Try using "hidden friend" idiom instead.

If this works, we should extend to all the other operators currently defined in global scope.

To get an idea of the scope of the problem:

```console
$ echo "#include <wx/gdicmn.h>\nstruct S{}; bool foo() { S s1, s2; return s1 == s2; }" | g++ -fsyntax-only -Wall `wx-config --cxxflags --libs base,core` -x c++ -
<stdin>: In function ‘bool foo()’:
<stdin>:2:46: error: no match for ‘operator==’ (operand types are ‘S’ and ‘S’)
wx/include/wx/defs.h:791:17: note: candidate: ‘bool operator==(char, const wxUniChar&)’
  791 |     inline bool operator op(T1 x, T2 y) { return y oprev x; }
      |                 ^~~~~~~~
... 420 more lines of similar output snipped ...
```

I.e. there is a clear error message (on 2 lines) and then **424** lines of junk due to global operators defined in wx headers.
