### PR TITLE
cleaning up wxPoint and wxRealPoint arithmetic operators

### DIFF
--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -469,6 +469,9 @@ public:
 
     wxRealPoint& operator+=(const wxSize& s) { x += s.GetWidth(); y += s.GetHeight(); return *this; }
     wxRealPoint& operator-=(const wxSize& s) { x -= s.GetWidth(); y -= s.GetHeight(); return *this; }
+
+    wxRealPoint& operator/=(int i) { x *= i; y *= i; return *this; }
+    wxRealPoint& operator*=(int i) { x /= i; y /= i; return *this; }
 };
 
 
@@ -591,6 +594,9 @@ public:
 
     wxPoint& operator+=(const wxSize& s) { x += s.GetWidth(); y += s.GetHeight(); return *this; }
     wxPoint& operator-=(const wxSize& s) { x -= s.GetWidth(); y -= s.GetHeight(); return *this; }
+
+    wxPoint& operator/=(int i) { x /= i, y /= i; return *this; }
+    wxPoint& operator*=(int i) { x *= i, y *= i; return *this; }
 
     // check if both components are set/initialized
     bool IsFullySpecified() const { return x != wxDefaultCoord && y != wxDefaultCoord; }

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -738,6 +738,11 @@ inline wxPoint operator*(unsigned long i, const wxPoint& p)
     return wxPoint(int(p.x * i), int(p.y * i));
 }
 
+inline wxPoint operator/(const wxPoint& p, double f)
+{
+    return wxPoint(wxRound(p.x / f), wxRound(p.y / f));
+}
+
 inline wxPoint operator*(const wxPoint& p, double f)
 {
     return wxPoint(int(p.x * f), int(p.y * f));
@@ -746,11 +751,6 @@ inline wxPoint operator*(const wxPoint& p, double f)
 inline wxPoint operator*(double f, const wxPoint& p)
 {
     return wxPoint(int(p.x * f), int(p.y * f));
-}
-
-inline wxPoint operator/(const wxPoint& p, double f)
-{
-    return wxPoint(wxRound(p.x / f), wxRound(p.y / f));
 }
 
 WX_DECLARE_LIST_WITH_DECL(wxPoint, wxPointList, class WXDLLIMPEXP_CORE);

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -470,8 +470,6 @@ public:
     wxRealPoint& operator+=(const wxSize& s) { x += s.GetWidth(); y += s.GetHeight(); return *this; }
     wxRealPoint& operator-=(const wxSize& s) { x -= s.GetWidth(); y -= s.GetHeight(); return *this; }
 
-    wxRealPoint& operator+=(double f) { x += f; y += f; return *this; }
-    wxRealPoint& operator-=(double f) { x -= f; y -= f; return *this; }
     wxRealPoint& operator/=(int i) { x *= i; y *= i; return *this; }
     wxRealPoint& operator*=(int i) { x /= i; y /= i; return *this; }
     wxRealPoint& operator/=(double f) { x /= f; y /= f; return *this; }
@@ -522,26 +520,6 @@ inline wxRealPoint operator-(const wxSize& sz, const wxRealPoint& pt)
 inline wxRealPoint operator-(const wxRealPoint& pt)
 {
     return wxRealPoint(-pt.x, -pt.y);
-}
-
-inline wxRealPoint operator+(const wxRealPoint& pt, double f)
-{
-  return wxRealPoint(pt.x + f, pt.y + f);
-}
-
-inline wxRealPoint operator-(const wxRealPoint& pt, double f)
-{
-  return wxRealPoint(pt.x - f, pt.y - f);
-}
-
-inline wxRealPoint operator+(double f, const wxRealPoint& pt)
-{
-  return wxRealPoint(f + pt.x, f + pt.y);
-}
-
-inline wxRealPoint operator-(double f, const wxRealPoint& pt)
-{
-  return wxRealPoint(f - pt.x, f - pt.y);
 }
 
 inline wxRealPoint operator/(const wxRealPoint& p, int i)
@@ -642,8 +620,6 @@ public:
     wxPoint& operator+=(const wxSize& s) { x += s.GetWidth(); y += s.GetHeight(); return *this; }
     wxPoint& operator-=(const wxSize& s) { x -= s.GetWidth(); y -= s.GetHeight(); return *this; }
 
-    wxPoint& operator+=(int i) { x += i; y += i; return *this; }
-    wxPoint& operator-=(int i) { x -= i; y -= i; return *this; }
     wxPoint& operator/=(int i) { x /= i, y /= i; return *this; }
     wxPoint& operator*=(int i) { x *= i, y *= i; return *this; }
     wxPoint& operator*=(double f) { x = wxRound(x*f); y = wxRound(y*f); return *this; }
@@ -709,26 +685,6 @@ inline wxPoint operator-(const wxSize& s, const wxPoint& p)
 inline wxPoint operator-(const wxPoint& p)
 {
     return wxPoint(-p.x, -p.y);
-}
-
-inline wxPoint operator+(const wxPoint& pt, int i)
-{
-  return wxPoint(pt.x + i, pt.y + i);
-}
-
-inline wxPoint operator-(const wxPoint& pt, int i)
-{
-  return wxPoint(pt.x - i, pt.y - i);
-}
-
-inline wxPoint operator+(int i, const wxPoint& pt)
-{
-  return wxPoint(i + pt.x, i + pt.y);
-}
-
-inline wxPoint operator-(int i, const wxPoint& pt)
-{
-  return wxPoint(i - pt.x, i - pt.y);
 }
 
 inline wxPoint operator/(const wxPoint& p, int i)

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -494,74 +494,74 @@ inline wxRealPoint operator-(const wxRealPoint& p1, const wxRealPoint& p2)
 }
 
 
-inline wxRealPoint operator/(const wxRealPoint& s, int i)
+inline wxRealPoint operator/(const wxRealPoint& p, int i)
 {
-    return wxRealPoint(s.x / i, s.y / i);
+    return wxRealPoint(p.x / i, p.y / i);
 }
 
-inline wxRealPoint operator*(const wxRealPoint& s, int i)
+inline wxRealPoint operator*(const wxRealPoint& p, int i)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * i, p.y * i);
 }
 
-inline wxRealPoint operator*(int i, const wxRealPoint& s)
+inline wxRealPoint operator*(int i, const wxRealPoint& p)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * i, p.y * i);
 }
 
-inline wxRealPoint operator/(const wxRealPoint& s, unsigned int i)
+inline wxRealPoint operator/(const wxRealPoint& p, unsigned int i)
 {
-    return wxRealPoint(s.x / i, s.y / i);
+    return wxRealPoint(p.x / i, p.y / i);
 }
 
-inline wxRealPoint operator*(const wxRealPoint& s, unsigned int i)
+inline wxRealPoint operator*(const wxRealPoint& p, unsigned int i)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * i, p.y * i);
 }
 
-inline wxRealPoint operator*(unsigned int i, const wxRealPoint& s)
+inline wxRealPoint operator*(unsigned int i, const wxRealPoint& p)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * i, p.y * i);
 }
 
-inline wxRealPoint operator/(const wxRealPoint& s, long i)
+inline wxRealPoint operator/(const wxRealPoint& p, long i)
 {
-    return wxRealPoint(s.x / i, s.y / i);
+    return wxRealPoint(p.x / i, p.y / i);
 }
 
-inline wxRealPoint operator*(const wxRealPoint& s, long i)
+inline wxRealPoint operator*(const wxRealPoint& p, long i)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * i, p.y * i);
 }
 
-inline wxRealPoint operator*(long i, const wxRealPoint& s)
+inline wxRealPoint operator*(long i, const wxRealPoint& p)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * i, p.y * i);
 }
 
-inline wxRealPoint operator/(const wxRealPoint& s, unsigned long i)
+inline wxRealPoint operator/(const wxRealPoint& p, unsigned long i)
 {
-    return wxRealPoint(s.x / i, s.y / i);
+    return wxRealPoint(p.x / i, p.y / i);
 }
 
-inline wxRealPoint operator*(const wxRealPoint& s, unsigned long i)
+inline wxRealPoint operator*(const wxRealPoint& p, unsigned long i)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * i, p.y * i);
 }
 
-inline wxRealPoint operator*(unsigned long i, const wxRealPoint& s)
+inline wxRealPoint operator*(unsigned long i, const wxRealPoint& p)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * i, p.y * i);
 }
 
-inline wxRealPoint operator*(const wxRealPoint& s, double i)
+inline wxRealPoint operator*(const wxRealPoint& p, double f)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * f, p.y * f);
 }
 
-inline wxRealPoint operator*(double i, const wxRealPoint& s)
+inline wxRealPoint operator*(double f, const wxRealPoint& p)
 {
-    return wxRealPoint(s.x * i, s.y * i);
+    return wxRealPoint(p.x * f, p.y * f);
 }
 
 inline wxRealPoint operator/(const wxRealPoint& p, double f)
@@ -654,74 +654,74 @@ inline wxPoint operator-(const wxPoint& p)
     return wxPoint(-p.x, -p.y);
 }
 
-inline wxPoint operator/(const wxPoint& s, int i)
+inline wxPoint operator/(const wxPoint& p, int i)
 {
-    return wxPoint(s.x / i, s.y / i);
+    return wxPoint(p.x / i, p.y / i);
 }
 
-inline wxPoint operator*(const wxPoint& s, int i)
+inline wxPoint operator*(const wxPoint& p, int i)
 {
-    return wxPoint(s.x * i, s.y * i);
+    return wxPoint(p.x * i, p.y * i);
 }
 
-inline wxPoint operator*(int i, const wxPoint& s)
+inline wxPoint operator*(int i, const wxPoint& p)
 {
-    return wxPoint(s.x * i, s.y * i);
+    return wxPoint(p.x * i, p.y * i);
 }
 
-inline wxPoint operator/(const wxPoint& s, unsigned int i)
+inline wxPoint operator/(const wxPoint& p, unsigned int i)
 {
-    return wxPoint(s.x / i, s.y / i);
+    return wxPoint(p.x / i, p.y / i);
 }
 
-inline wxPoint operator*(const wxPoint& s, unsigned int i)
+inline wxPoint operator*(const wxPoint& p, unsigned int i)
 {
-    return wxPoint(s.x * i, s.y * i);
+    return wxPoint(p.x * i, p.y * i);
 }
 
-inline wxPoint operator*(unsigned int i, const wxPoint& s)
+inline wxPoint operator*(unsigned int i, const wxPoint& p)
 {
-    return wxPoint(s.x * i, s.y * i);
+    return wxPoint(p.x * i, p.y * i);
 }
 
-inline wxPoint operator/(const wxPoint& s, long i)
+inline wxPoint operator/(const wxPoint& p, long i)
 {
-    return wxPoint(s.x / i, s.y / i);
+    return wxPoint(p.x / i, p.y / i);
 }
 
-inline wxPoint operator*(const wxPoint& s, long i)
+inline wxPoint operator*(const wxPoint& p, long i)
 {
-    return wxPoint(int(s.x * i), int(s.y * i));
+    return wxPoint(int(p.x * i), int(p.y * i));
 }
 
-inline wxPoint operator*(long i, const wxPoint& s)
+inline wxPoint operator*(long i, const wxPoint& p)
 {
-    return wxPoint(int(s.x * i), int(s.y * i));
+    return wxPoint(int(p.x * i), int(p.y * i));
 }
 
-inline wxPoint operator/(const wxPoint& s, unsigned long i)
+inline wxPoint operator/(const wxPoint& p, unsigned long i)
 {
-    return wxPoint(s.x / i, s.y / i);
+    return wxPoint(p.x / i, p.y / i);
 }
 
-inline wxPoint operator*(const wxPoint& s, unsigned long i)
+inline wxPoint operator*(const wxPoint& p, unsigned long i)
 {
-    return wxPoint(int(s.x * i), int(s.y * i));
+    return wxPoint(int(p.x * i), int(p.y * i));
 }
 
-inline wxPoint operator*(unsigned long i, const wxPoint& s)
+inline wxPoint operator*(unsigned long i, const wxPoint& p)
 {
-    return wxPoint(int(s.x * i), int(s.y * i));
+    return wxPoint(int(p.x * i), int(p.y * i));
 }
 
-inline wxPoint operator*(const wxPoint& s, double i)
+inline wxPoint operator*(const wxPoint& p, double f)
 {
-    return wxPoint(int(s.x * i), int(s.y * i));
+    return wxPoint(int(p.x * f), int(p.y * f));
 }
 
-inline wxPoint operator*(double i, const wxPoint& s)
+inline wxPoint operator*(double f, const wxPoint& p)
 {
-    return wxPoint(int(s.x * i), int(s.y * i));
+    return wxPoint(int(p.x * f), int(p.y * f));
 }
 
 inline wxPoint operator/(const wxPoint& p, double f)

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -490,12 +490,30 @@ inline wxRealPoint operator+(const wxRealPoint& p1, const wxRealPoint& p2)
     return wxRealPoint(p1.x + p2.x, p1.y + p2.y);
 }
 
-
 inline wxRealPoint operator-(const wxRealPoint& p1, const wxRealPoint& p2)
 {
     return wxRealPoint(p1.x - p2.x, p1.y - p2.y);
 }
 
+inline wxRealPoint operator+(const wxRealPoint& pt, const wxSize& sz)
+{
+    return wxRealPoint(pt.x + sz.GetWidth(), pt.y + sz.GetHeight());
+}
+
+inline wxRealPoint operator-(const wxRealPoint& pt, const wxSize& sz)
+{
+    return wxRealPoint(pt.x - sz.GetWidth(), pt.y - sz.GetHeight());
+}
+
+inline wxRealPoint operator+(const wxSize& sz, const wxRealPoint& pt)
+{
+    return wxRealPoint(sz.GetWidth() + pt.x, sz.GetHeight() + pt.y);
+}
+
+inline wxRealPoint operator-(const wxSize& sz, const wxRealPoint& pt)
+{
+    return wxRealPoint(sz.GetWidth() - pt.x, sz.GetHeight() - pt.y);
+}
 
 inline wxRealPoint operator/(const wxRealPoint& p, int i)
 {

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -580,6 +580,11 @@ inline wxRealPoint operator*(unsigned long i, const wxRealPoint& p)
     return wxRealPoint(p.x * i, p.y * i);
 }
 
+inline wxRealPoint operator/(const wxRealPoint& p, double f)
+{
+    return wxRealPoint(p.x / f, p.y / f);
+}
+
 inline wxRealPoint operator*(const wxRealPoint& p, double f)
 {
     return wxRealPoint(p.x * f, p.y * f);
@@ -588,11 +593,6 @@ inline wxRealPoint operator*(const wxRealPoint& p, double f)
 inline wxRealPoint operator*(double f, const wxRealPoint& p)
 {
     return wxRealPoint(p.x * f, p.y * f);
-}
-
-inline wxRealPoint operator/(const wxRealPoint& p, double f)
-{
-    return wxRealPoint(p.x / f, p.y / f);
 }
 
 

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -470,8 +470,12 @@ public:
     wxRealPoint& operator+=(const wxSize& s) { x += s.GetWidth(); y += s.GetHeight(); return *this; }
     wxRealPoint& operator-=(const wxSize& s) { x -= s.GetWidth(); y -= s.GetHeight(); return *this; }
 
+    wxRealPoint& operator+=(double f) { x += f; y += f; return *this; }
+    wxRealPoint& operator-=(double f) { x -= f; y -= f; return *this; }
     wxRealPoint& operator/=(int i) { x *= i; y *= i; return *this; }
     wxRealPoint& operator*=(int i) { x /= i; y /= i; return *this; }
+    wxRealPoint& operator/=(double f) { x /= f; y /= f; return *this; }
+    wxRealPoint& operator*=(double f) { x *= f; y *= f; return *this; }
 };
 
 
@@ -518,6 +522,26 @@ inline wxRealPoint operator-(const wxSize& sz, const wxRealPoint& pt)
 inline wxRealPoint operator-(const wxRealPoint& pt)
 {
     return wxRealPoint(-pt.x, -pt.y);
+}
+
+inline wxRealPoint operator+(const wxRealPoint& pt, double f)
+{
+  return wxRealPoint(pt.x + f, pt.y + f);
+}
+
+inline wxRealPoint operator-(const wxRealPoint& pt, double f)
+{
+  return wxRealPoint(pt.x - f, pt.y - f);
+}
+
+inline wxRealPoint operator+(double f, const wxRealPoint& pt)
+{
+  return wxRealPoint(f + pt.x, f + pt.y);
+}
+
+inline wxRealPoint operator-(double f, const wxRealPoint& pt)
+{
+  return wxRealPoint(f - pt.x, f - pt.y);
 }
 
 inline wxRealPoint operator/(const wxRealPoint& p, int i)
@@ -618,8 +642,12 @@ public:
     wxPoint& operator+=(const wxSize& s) { x += s.GetWidth(); y += s.GetHeight(); return *this; }
     wxPoint& operator-=(const wxSize& s) { x -= s.GetWidth(); y -= s.GetHeight(); return *this; }
 
+    wxPoint& operator+=(int i) { x += i; y += i; return *this; }
+    wxPoint& operator-=(int i) { x -= i; y -= i; return *this; }
     wxPoint& operator/=(int i) { x /= i, y /= i; return *this; }
     wxPoint& operator*=(int i) { x *= i, y *= i; return *this; }
+    wxPoint& operator*=(double f) { x = wxRound(x*f); y = wxRound(y*f); return *this; }
+    wxPoint& operator/=(double f) { x = wxRound(x/f); y = wxRound(y/f); return *this; }
 
     // check if both components are set/initialized
     bool IsFullySpecified() const { return x != wxDefaultCoord && y != wxDefaultCoord; }
@@ -681,6 +709,26 @@ inline wxPoint operator-(const wxSize& s, const wxPoint& p)
 inline wxPoint operator-(const wxPoint& p)
 {
     return wxPoint(-p.x, -p.y);
+}
+
+inline wxPoint operator+(const wxPoint& pt, int i)
+{
+  return wxPoint(pt.x + i, pt.y + i);
+}
+
+inline wxPoint operator-(const wxPoint& pt, int i)
+{
+  return wxPoint(pt.x - i, pt.y - i);
+}
+
+inline wxPoint operator+(int i, const wxPoint& pt)
+{
+  return wxPoint(i + pt.x, i + pt.y);
+}
+
+inline wxPoint operator-(int i, const wxPoint& pt)
+{
+  return wxPoint(i - pt.x, i - pt.y);
 }
 
 inline wxPoint operator/(const wxPoint& p, int i)

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -515,6 +515,11 @@ inline wxRealPoint operator-(const wxSize& sz, const wxRealPoint& pt)
     return wxRealPoint(sz.GetWidth() - pt.x, sz.GetHeight() - pt.y);
 }
 
+inline wxRealPoint operator-(const wxRealPoint& pt)
+{
+    return wxRealPoint(-pt.x, -pt.y);
+}
+
 inline wxRealPoint operator/(const wxRealPoint& p, int i)
 {
     return wxRealPoint(p.x / i, p.y / i);

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -227,6 +227,8 @@ public:
     wxRealPoint& operator +=(const wxSize& sz);
     wxRealPoint& operator -=(const wxSize& sz);
 
+    wxRealPoint operator -(const wxRealPoint& pt);
+
     wxRealPoint operator /(const wxRealPoint& sz, int divisor);
     wxRealPoint operator *(const wxRealPoint& sz, int factor);
     wxRealPoint operator *(int factor, const wxRealPoint& pt);

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -235,9 +235,9 @@ public:
     wxRealPoint& operator /=(int divisor);
     wxRealPoint& operator *=(int factor);
 
+    wxRealPoint operator /(const wxRealPoint& pt, double divisor);
     wxRealPoint operator *(const wxRealPoint& pt, double factor);
     wxRealPoint operator *(double factor, const wxRealPoint& pt);
-    wxRealPoint operator /(const wxRealPoint& pt, double divisor);
     ///@}
 
     /**

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -229,13 +229,6 @@ public:
 
     wxRealPoint operator -(const wxRealPoint& pt);
 
-    wxRealPoint operator +(const wxRealPoint& pt, double a);
-    wxRealPoint operator -(const wxRealPoint& pt, double a);
-    wxRealPoint operator +(double a, const wxRealPoint& pt);
-    wxRealPoint operator -(double a, const wxRealPoint& pt);
-    wxRealPoint& operator +=(double a);
-    wxRealPoint& operator -=(double a);
-
     wxRealPoint operator /(const wxRealPoint& sz, int divisor);
     wxRealPoint operator *(const wxRealPoint& sz, int factor);
     wxRealPoint operator *(int factor, const wxRealPoint& pt);
@@ -747,13 +740,6 @@ public:
     wxPoint& operator -=(const wxSize& sz);
 
     wxPoint operator -(const wxPoint& pt);
-
-    wxPoint operator +(const wxPoint& pt, int a);
-    wxPoint operator -(const wxPoint& pt, int a);
-    wxPoint operator +(int a, const wxPoint& pt);
-    wxPoint operator -(int a, const wxPoint& pt);
-    wxPoint& operator +=(int a);
-    wxPoint& operator -=(int a);
 
     wxPoint operator /(const wxPoint& sz, int divisor);
     wxPoint operator *(const wxPoint& sz, int factor);

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -229,6 +229,13 @@ public:
 
     wxRealPoint operator -(const wxRealPoint& pt);
 
+    wxRealPoint operator +(const wxRealPoint& pt, double a);
+    wxRealPoint operator -(const wxRealPoint& pt, double a);
+    wxRealPoint operator +(double a, const wxRealPoint& pt);
+    wxRealPoint operator -(double a, const wxRealPoint& pt);
+    wxRealPoint& operator +=(double a);
+    wxRealPoint& operator -=(double a);
+
     wxRealPoint operator /(const wxRealPoint& sz, int divisor);
     wxRealPoint operator *(const wxRealPoint& sz, int factor);
     wxRealPoint operator *(int factor, const wxRealPoint& pt);
@@ -238,6 +245,8 @@ public:
     wxRealPoint operator /(const wxRealPoint& pt, double divisor);
     wxRealPoint operator *(const wxRealPoint& pt, double factor);
     wxRealPoint operator *(double factor, const wxRealPoint& pt);
+    wxRealPoint& operator /=(double divisor);
+    wxRealPoint& operator *=(double factor);
     ///@}
 
     /**
@@ -739,6 +748,13 @@ public:
 
     wxPoint operator -(const wxPoint& pt);
 
+    wxPoint operator +(const wxPoint& pt, int a);
+    wxPoint operator -(const wxPoint& pt, int a);
+    wxPoint operator +(int a, const wxPoint& pt);
+    wxPoint operator -(int a, const wxPoint& pt);
+    wxPoint& operator +=(int a);
+    wxPoint& operator -=(int a);
+
     wxPoint operator /(const wxPoint& sz, int divisor);
     wxPoint operator *(const wxPoint& sz, int factor);
     wxPoint operator *(int factor, const wxPoint& sz);
@@ -748,6 +764,8 @@ public:
     wxPoint operator /(const wxPoint& pt, double divisor);
     wxPoint operator *(const wxPoint& pt, double factor);
     wxPoint operator *(double factor, const wxPoint& pt);
+    wxPoint& operator /=(double divisor);
+    wxPoint& operator *=(double factor);
     ///@}
 
 

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -233,6 +233,8 @@ public:
     wxRealPoint& operator /=(int divisor);
     wxRealPoint& operator *=(int factor);
 
+    wxRealPoint operator *(const wxRealPoint& pt, double factor);
+    wxRealPoint operator *(double factor, const wxRealPoint& pt);
     wxRealPoint operator /(const wxRealPoint& pt, double divisor);
     ///@}
 
@@ -733,6 +735,8 @@ public:
     wxPoint& operator +=(const wxSize& sz);
     wxPoint& operator -=(const wxSize& sz);
 
+    wxPoint operator -(const wxPoint& pt);
+
     wxPoint operator /(const wxPoint& sz, int divisor);
     wxPoint operator *(const wxPoint& sz, int factor);
     wxPoint operator *(int factor, const wxPoint& sz);
@@ -740,6 +744,8 @@ public:
     wxPoint& operator *=(int factor);
 
     wxPoint operator /(const wxPoint& pt, double divisor);
+    wxPoint operator *(const wxPoint& pt, double factor);
+    wxPoint operator *(double factor, const wxPoint& pt);
     ///@}
 
 

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -227,13 +227,13 @@ public:
     wxRealPoint& operator +=(const wxSize& sz);
     wxRealPoint& operator -=(const wxSize& sz);
 
-    wxRealPoint operator /(const wxRealPoint& sz, int factor);
+    wxRealPoint operator /(const wxRealPoint& sz, int divisor);
     wxRealPoint operator *(const wxRealPoint& sz, int factor);
-    wxRealPoint operator *(int factor, const wxRealPoint& sz);
-    wxRealPoint& operator /=(int factor);
+    wxRealPoint operator *(int factor, const wxRealPoint& pt);
+    wxRealPoint& operator /=(int divisor);
     wxRealPoint& operator *=(int factor);
 
-    wxRealPoint operator /(const wxRealPoint& pt, double factor);
+    wxRealPoint operator /(const wxRealPoint& pt, double divisor);
     ///@}
 
     /**
@@ -733,13 +733,13 @@ public:
     wxPoint& operator +=(const wxSize& sz);
     wxPoint& operator -=(const wxSize& sz);
 
-    wxPoint operator /(const wxPoint& sz, int factor);
+    wxPoint operator /(const wxPoint& sz, int divisor);
     wxPoint operator *(const wxPoint& sz, int factor);
     wxPoint operator *(int factor, const wxPoint& sz);
-    wxPoint& operator /=(int factor);
+    wxPoint& operator /=(int divisor);
     wxPoint& operator *=(int factor);
 
-    wxPoint operator /(const wxPoint& pt, double factor);
+    wxPoint operator /(const wxPoint& pt, double divisor);
     ///@}
 
 

--- a/tests/geometry/point.cpp
+++ b/tests/geometry/point.cpp
@@ -51,6 +51,52 @@ TEST_CASE("wxPoint::Operators", "[point]")
     p6 = p2; p6 -= s;
     CHECK( p3 == p5 );
     CHECK( p4 == p6 );
+
+    // Test arithmetic compound assignment operators with scalars
+    wxPoint p7(2, 4);
+    p7 += 2;
+    CHECK( p7.x == 4 );
+    CHECK( p7.y == 6 );
+    p7 -= 1;
+    CHECK( p7.x == 3 );
+    CHECK( p7.y == 5 );
+    p7 /= 2;  // chosen to check results truncate
+    CHECK( p7.x == 1 );
+    CHECK( p7.y == 2 );
+    p7 *= 2;
+    CHECK( p7.x == 2 );
+    CHECK( p7.y == 4 );
+    p7 *= 3.2;  // chosen so that x and y rounds down and up respectively
+    CHECK( p7.x == 6 );
+    CHECK( p7.y == 13 );
+    p7 /= 1.1;  // chosen so that x and y rounds up and down respectively
+    CHECK( p7.x == 5 );
+    CHECK( p7.y == 12 );
+
+    // Test arithmetic compound assignment operators with wxSizes
+    wxSize s1(2, 3);
+    p7 += s1;
+    CHECK( p7.x == 7 );
+    CHECK( p7.y == 15 );
+    wxSize s2(3, 4);
+    p7 -= s2;
+    CHECK( p7.x == 4 );
+    CHECK( p7.y == 11 );
+
+    // Test arithmetic with scalars
+    wxRealPoint p8;
+    p8 = p1 + 2;
+    CHECK( p8.x == 3 );
+    CHECK( p8.y == 4 );
+    p8 = p1 - 2;
+    CHECK( p8.x == -1 );
+    CHECK( p8.y == 0 );
+    p8 = 1 + p1;
+    CHECK( p8.x == 2 );
+    CHECK( p8.y == 3 );
+    p8 = 5 - p1;
+    CHECK( p8.x == 4 );
+    CHECK( p8.y == 3 );
 }
 
 TEST_CASE("wxRealPoint::Operators", "[point]")
@@ -66,4 +112,44 @@ TEST_CASE("wxRealPoint::Operators", "[point]")
     CHECK( p4.x == Approx(p6.x) );
     CHECK( p4.y == Approx(p6.y) );
     CHECK( p3.x != Approx(p4.x) );
+
+    // Test arithmetic compound assignment operators with scalars
+    wxRealPoint p7(2.0, 4.0);
+    p7 += 2.0;
+    CHECK( p7.x == Approx(4.0) );
+    CHECK( p7.y == Approx(6.0) );
+    p7 -= 1.0;
+    CHECK( p7.x == Approx(3.0) );
+    CHECK( p7.y == Approx(5.0) );
+    p7 /= 2.0;
+    CHECK( p7.x == Approx(1.5) );
+    CHECK( p7.y == Approx(2.5) );
+    p7 *= 3.0;
+    CHECK( p7.x == Approx(4.5) );
+    CHECK( p7.y == Approx(7.5) );
+
+    // Test arithmetic compound assignment operators with wxSizes
+    wxSize s1(2, 3);
+    p7 += s1;
+    CHECK( p7.x == Approx(6.5) );
+    CHECK( p7.y == Approx(10.5) );
+    wxSize s2(3, 4);
+    p7 -= s2;
+    CHECK( p7.x == Approx(3.5) );
+    CHECK( p7.y == Approx(6.5) );
+
+    // Test arithmetic with scalars
+    wxRealPoint p8;
+    p8 = p1 + 2.0;
+    CHECK( p8.x == Approx(3.2) );
+    CHECK( p8.y == Approx(5.4) );
+    p8 = p1 - 0.5;
+    CHECK( p8.x == Approx(0.7) );
+    CHECK( p8.y == Approx(2.9) );
+    p8 = 1.0 + p1;
+    CHECK( p8.x == Approx(2.2) );
+    CHECK( p8.y == Approx(4.4) );
+    p8 = 5.0 - p1;
+    CHECK( p8.x == Approx(3.8) );
+    CHECK( p8.y == Approx(1.6) );
 }

--- a/tests/geometry/point.cpp
+++ b/tests/geometry/point.cpp
@@ -53,13 +53,7 @@ TEST_CASE("wxPoint::Operators", "[point]")
     CHECK( p4 == p6 );
 
     // Test arithmetic compound assignment operators with scalars
-    wxPoint p7(2, 4);
-    p7 += 2;
-    CHECK( p7.x == 4 );
-    CHECK( p7.y == 6 );
-    p7 -= 1;
-    CHECK( p7.x == 3 );
-    CHECK( p7.y == 5 );
+    wxPoint p7(3, 5);
     p7 /= 2;  // chosen to check results truncate
     CHECK( p7.x == 1 );
     CHECK( p7.y == 2 );
@@ -82,21 +76,6 @@ TEST_CASE("wxPoint::Operators", "[point]")
     p7 -= s2;
     CHECK( p7.x == 4 );
     CHECK( p7.y == 11 );
-
-    // Test arithmetic with scalars
-    wxRealPoint p8;
-    p8 = p1 + 2;
-    CHECK( p8.x == 3 );
-    CHECK( p8.y == 4 );
-    p8 = p1 - 2;
-    CHECK( p8.x == -1 );
-    CHECK( p8.y == 0 );
-    p8 = 1 + p1;
-    CHECK( p8.x == 2 );
-    CHECK( p8.y == 3 );
-    p8 = 5 - p1;
-    CHECK( p8.x == 4 );
-    CHECK( p8.y == 3 );
 }
 
 TEST_CASE("wxRealPoint::Operators", "[point]")
@@ -114,13 +93,7 @@ TEST_CASE("wxRealPoint::Operators", "[point]")
     CHECK( p3.x != Approx(p4.x) );
 
     // Test arithmetic compound assignment operators with scalars
-    wxRealPoint p7(2.0, 4.0);
-    p7 += 2.0;
-    CHECK( p7.x == Approx(4.0) );
-    CHECK( p7.y == Approx(6.0) );
-    p7 -= 1.0;
-    CHECK( p7.x == Approx(3.0) );
-    CHECK( p7.y == Approx(5.0) );
+    wxRealPoint p7(3.0, 5.0);
     p7 /= 2.0;
     CHECK( p7.x == Approx(1.5) );
     CHECK( p7.y == Approx(2.5) );
@@ -137,19 +110,4 @@ TEST_CASE("wxRealPoint::Operators", "[point]")
     p7 -= s2;
     CHECK( p7.x == Approx(3.5) );
     CHECK( p7.y == Approx(6.5) );
-
-    // Test arithmetic with scalars
-    wxRealPoint p8;
-    p8 = p1 + 2.0;
-    CHECK( p8.x == Approx(3.2) );
-    CHECK( p8.y == Approx(5.4) );
-    p8 = p1 - 0.5;
-    CHECK( p8.x == Approx(0.7) );
-    CHECK( p8.y == Approx(2.9) );
-    p8 = 1.0 + p1;
-    CHECK( p8.x == Approx(2.2) );
-    CHECK( p8.y == Approx(4.4) );
-    p8 = 5.0 - p1;
-    CHECK( p8.x == Approx(3.8) );
-    CHECK( p8.y == Approx(1.6) );
 }


### PR DESCRIPTION
While fixing #24185 I came across a bunch of oddities on the arithmetic operators for `wxPoint` and `wxRealPoint`. I fixed them in a series of 8 commits so they can be reviewed independent of each other (although because they're all touching the same code, cherry picking individual ones will likely require manual fixing of conflicts). My main issues were:

1. not all documented operators were implemented so I implemented them (there is an alternative case to be made about removing them from the documentation instead of implementing them) (done in 8ccbd7e9 and 66e7d0bc)
2. some of the implemented operators were not documented (done in 8638db50)
3. I expected `wxPoint` and `wxRealPoint` to have the same set of operators implemented but that was not the case (done in 11c30341 )

I also made a few other commits that move and rename a few internal parts with the goal of making the fixes above cleaner (see 9a5d2ffa, b9b0cce4, and 1097fe6a).

And in the end, I also added a few arithmetic operators with scalars and their corresponding compound assignment operators that seem obvious to me and added their corresponding new tests (see 475af673 - this also adds tests for compound assignment operators with `wxSize` so if you choose not to merge this specific commit consider cherry pick those specific tests).