### PR TITLE
Improve native MSW dialog DPI awareness

### DIFF
--- a/include/wx/msw/private/dpiaware.h
+++ b/include/wx/msw/private/dpiaware.h
@@ -15,6 +15,7 @@
 #endif
 
 #include "wx/dynlib.h"
+#include "wx/display.h"
 
 namespace wxMSWImpl
 {
@@ -35,6 +36,9 @@ public:
     AutoSystemDpiAware()
         : m_prevContext(WXDPI_AWARENESS_CONTEXT_UNAWARE)
     {
+        if ( !Needed() )
+            return;
+
         if ( ms_pfnSetThreadDpiAwarenessContext == (SetThreadDpiAwarenessContext_t)-1)
         {
             wxLoadedDLL dllUser32("user32.dll");
@@ -60,6 +64,15 @@ public:
         {
             ms_pfnSetThreadDpiAwarenessContext(m_prevContext);
         }
+    }
+
+    static bool Needed()
+    {
+        // use system-dpi-aware context when there are displays with different DPI
+        bool diferentDPI = false;
+        for ( unsigned i = 1; i < wxDisplay::GetCount() && !diferentDPI; ++i )
+            diferentDPI = wxDisplay(0u).GetPPI() != wxDisplay(i).GetPPI();
+        return diferentDPI;
     }
 
 private:

--- a/include/wx/msw/private/dpiaware.h
+++ b/include/wx/msw/private/dpiaware.h
@@ -16,6 +16,7 @@
 
 #include "wx/dynlib.h"
 #include "wx/display.h"
+#include "wx/sysopt.h"
 
 namespace wxMSWImpl
 {
@@ -68,7 +69,12 @@ public:
 
     static bool Needed()
     {
-        // use system-dpi-aware context when there are displays with different DPI
+        // use system-dpi-aware context when:
+        // - the user did not set an option to force per-monitor context
+        // - there are displays with different DPI
+        if ( wxSystemOptions::GetOptionInt("msw.native-dialogs-pmdpi") == 1 )
+            return false;
+
         bool diferentDPI = false;
         for ( unsigned i = 1; i < wxDisplay::GetCount() && !diferentDPI; ++i )
             diferentDPI = wxDisplay(0u).GetPPI() != wxDisplay(i).GetPPI();

--- a/interface/wx/sysopt.h
+++ b/interface/wx/sysopt.h
@@ -81,6 +81,12 @@
         using it, i.e. this has the same effect as calling
         wxApp::MSWEnableDarkMode(). If set to 2, use dark mode unconditionally,
         as if this function were called with wxApp::DarkMode_Always argument.
+    @flag{msw.native-dialogs-pmdpi}
+        Some native win32 dialogs (like the font and colour pickers) are not
+        per-monitor DPI aware, and wxWidgets will forcefully show them as
+        system DPI aware when there are monitors with different DPI connected.
+        If set to 1, these dialogs will always be shown as per-monitor DPI
+        aware (when enabled in the manifest).
     @endFlagTable
 
 


### PR DESCRIPTION
Only show the native dialogs using system dpi-awereness, when there are displays with different DPI.

And add the `msw.native-dialogs-pmdpi` option to also show the dialogs using per-monitor dpi-awareness when there are displays with different DPI.

I tested many combinations of dpi and on which display the dialog is created, and it seems to always show and return the correct font size. But some more tests would be nice.

See #24121