### PR TITLE
Fix testsuite failures on s390x

### DIFF
--- a/tests/file/filetest.cpp
+++ b/tests/file/filetest.cpp
@@ -153,6 +153,7 @@ TEST_CASE("wxFile::Special", "[file][linux][special-file]")
     CHECK( fileProc.ReadAll(&s) );
     CHECK( !s.empty() );
 
+    if ( wxFile::Exists("/sys/power/state") ) {
     // All files in /sys have the size of one kernel page, even if they don't
     // have that much data in them.
     const long pageSize = sysconf(_SC_PAGESIZE);
@@ -163,6 +164,7 @@ TEST_CASE("wxFile::Special", "[file][linux][special-file]")
     CHECK( fileSys.ReadAll(&s) );
     CHECK( !s.empty() );
     CHECK( s.length() < pageSize );
+    }
 }
 
 #endif // __LINUX__

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -1040,9 +1040,11 @@ TEST_CASE("wxFileName::GetSizeSpecial", "[filename][linux][special-file]")
     INFO( "size of /proc/kcore=" << size );
     CHECK( size > 0 );
 
+    if ( wxFile::Exists("/sys/power/state") ) {
     // All files in /sys are one page in size, irrespectively of the size of
     // their actual contents.
     CHECK( wxFileName::GetSize("/sys/power/state") == sysconf(_SC_PAGESIZE) );
+    }
 }
 
 #endif // __LINUX__

--- a/tests/textfile/textfiletest.cpp
+++ b/tests/textfile/textfiletest.cpp
@@ -348,6 +348,7 @@ TEST_CASE("wxTextFile::Special", "[textfile][linux][special-file]")
         CHECK( f.GetLineCount() > 1 );
     }
 
+    if ( wxFile::Exists("/sys/power/state") ) {
     SECTION("/sys")
     {
         wxTextFile f;
@@ -355,6 +356,7 @@ TEST_CASE("wxTextFile::Special", "[textfile][linux][special-file]")
         REQUIRE( f.GetLineCount() == 1 );
         INFO( "/sys/power/state contains \"" << f[0] << "\"" );
         CHECK( (f[0].find("mem") != wxString::npos || f[0].find("disk") != wxString::npos) );
+    }
     }
 }
 


### PR DESCRIPTION
Upon ``make check``, we observe:

	./textfile/textfiletest.cpp:351
	...............................................................................

	./textfile/textfiletest.cpp:354: FAILED:
	  CHECK( f.Open("/sys/power/state") )
	with expansion:
	  false

	./textfile/textfiletest.cpp:355: FAILED:
	  REQUIRE( f.GetLineCount() == 1 )
	with expansion:
	  0 == 1