### PR TITLE
Fix typing error in interface def.

### DIFF
--- a/interface/wx/propgrid/props.h
+++ b/interface/wx/propgrid/props.h
@@ -218,7 +218,7 @@ public:
     virtual wxString ValueToString(wxVariant& value,
                                    wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const;
     virtual bool StringToValue(wxVariant& variant, const wxString& text,
-                               wxPGPropValFormatFlagsflags = wxPGPropValFormatFlags::Null) const;
+                               wxPGPropValFormatFlags flags = wxPGPropValFormatFlags::Null) const;
     virtual bool ValidateValue( wxVariant& value,
                                 wxPGValidationInfo& validationInfo ) const;
     virtual bool IntToValue(wxVariant& variant, int number,


### PR DESCRIPTION
missing whitespace between arg type and name