### PR TITLE
Add missing accessibility methods to interface

### DIFF
--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -3462,6 +3462,17 @@ public:
     */
     void SetAccessible(wxAccessible* accessible);
 
+    /**
+        Override to create a specific accessible object.
+    */
+    virtual wxAccessible* CreateAccessible();
+
+    /**
+        Returns the accessible object, calling CreateAccessible if necessary.
+        May return NULL, in which case system-provide accessible is used.
+    */
+    wxAccessible* GetOrCreateAccessible();
+
     ///@}
 
 


### PR DESCRIPTION
`wxWindow->CreateAccessible()` and `wxWindow->GetOrCreateAccessible()` are missing from `interface/wx/window.h`.
Therefore these methods are currently not added to wxPython builds.

I have tested with a wxPython build and they can be supported there, once the interface is updated.
(I will submit a wxPython PR for this.)

I think, no `@since ...` need to be added, as the methods are only new for wxPython, not for wxWidgets.