### PR TITLE
Add wxRibbonBar::GetPageById()

### DIFF
--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -125,6 +125,7 @@ public:
     bool SetActivePage(wxRibbonPage* page);
     int GetActivePage() const;
     wxRibbonPage* GetPage(int n);
+    wxRibbonPage* GetPageById(wxWindowID id);
     size_t GetPageCount() const;
     bool DismissExpandedPanel();
     int GetPageNumber(wxRibbonPage* page) const;

--- a/interface/wx/ribbon/bar.h
+++ b/interface/wx/ribbon/bar.h
@@ -304,6 +304,15 @@ public:
     wxRibbonPage* GetPage(int n);
 
     /**
+        Get a page by window ID.
+
+        @NULL will be returned if no page with the ID is found.
+
+        @since 3.3.0
+    */
+    wxRibbonPage* GetPageById(wxWindowID id);
+
+    /**
         Get the number of pages in this bar.
 
         @since 2.9.4

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -316,6 +316,16 @@ wxRibbonPage* wxRibbonBar::GetPage(int n)
     return m_pages.Item(n).page;
 }
 
+wxRibbonPage* wxRibbonBar::GetPageById(wxWindowID id)
+{
+    for (auto& page : m_pages)
+    {
+        if (page.page->GetId() == id)
+            return page.page;
+    }
+    return nullptr;
+}
+
 size_t wxRibbonBar::GetPageCount() const
 {
     return m_pages.GetCount();


### PR DESCRIPTION
To find a page by ID currently you have to do a recursive `FindWindow` (which would also look at the child Panel windows). This function allows for finding a page by ID more elegantly.

Also, I have to admit that I initially thought `GetPage()` expected an ID (not an index), so having this function makes the overall API a little more clear (IMO).