### PR TITLE
Add wxXmlParseError structure, update wxXmlDocument::Load() to optionally use it

### DIFF
--- a/include/wx/xml/xml.h
+++ b/include/wx/xml/xml.h
@@ -20,6 +20,7 @@
 #include "wx/list.h"
 #include "wx/textbuf.h"
 #include "wx/versioninfo.h"
+#include "wx/filefn.h"
 
 #include <memory>
 

--- a/include/wx/xml/xml.h
+++ b/include/wx/xml/xml.h
@@ -222,6 +222,16 @@ enum wxXmlDocumentLoadFlag
     wxXMLDOC_KEEP_WHITESPACE_NODES = 1
 };
 
+// Create an instance of this and pass it to wxXmlDocument::Load()
+// to get detailed error information in case of failure. Values
+// are set to -1 if no error occurred.
+struct wxXmlParseError
+{
+    wxString message;
+    int line;
+    int column;
+    int byte_offset;
+};
 
 // This class holds XML data/document as parsed by XML parser.
 
@@ -238,8 +248,8 @@ public:
 
     // Parses .xml file and loads data. Returns TRUE on success, FALSE
     // otherwise.
-    bool Load(const wxString& filename, int flags = wxXMLDOC_NONE);
-    bool Load(wxInputStream& stream, int flags = wxXMLDOC_NONE);
+    bool Load(const wxString& filename, int flags = wxXMLDOC_NONE, wxXmlParseError* err_details = nullptr);
+    bool Load(wxInputStream& stream, int flags = wxXMLDOC_NONE, wxXmlParseError* err_details = nullptr);
 
     // Saves document as .xml file.
     virtual bool Save(const wxString& filename, int indentstep = 2) const;

--- a/include/wx/xml/xml.h
+++ b/include/wx/xml/xml.h
@@ -223,14 +223,13 @@ enum wxXmlDocumentLoadFlag
 };
 
 // Create an instance of this and pass it to wxXmlDocument::Load()
-// to get detailed error information in case of failure. Values
-// are set to -1 if no error occurred.
+// to get detailed error information in case of failure.
 struct wxXmlParseError
 {
     wxString message;
-    int line;
-    int column;
-    int byte_offset;
+    int line = 0;
+    int column = 0;
+    wxFileOffset offset = 0;
 };
 
 // This class holds XML data/document as parsed by XML parser.
@@ -248,8 +247,8 @@ public:
 
     // Parses .xml file and loads data. Returns TRUE on success, FALSE
     // otherwise.
-    bool Load(const wxString& filename, int flags = wxXMLDOC_NONE, wxXmlParseError* err_details = nullptr);
-    bool Load(wxInputStream& stream, int flags = wxXMLDOC_NONE, wxXmlParseError* err_details = nullptr);
+    bool Load(const wxString& filename, int flags = wxXMLDOC_NONE, wxXmlParseError* err = nullptr);
+    bool Load(wxInputStream& stream, int flags = wxXMLDOC_NONE, wxXmlParseError* err = nullptr);
 
     // Saves document as .xml file.
     virtual bool Save(const wxString& filename, int indentstep = 2) const;

--- a/include/wx/xml/xml.h
+++ b/include/wx/xml/xml.h
@@ -287,7 +287,7 @@ public:
 
     static wxVersionInfo GetLibraryVersionInfo();
 
-#ifdef WXWIN_COMPATIBILITY_3_2
+#if WXWIN_COMPATIBILITY_3_2
     wxDEPRECATED_MSG("Remove encoding parameter from the call")
     wxXmlDocument(const wxString& filename,
                   const wxString& WXUNUSED(encoding))

--- a/interface/wx/xml/xml.h
+++ b/interface/wx/xml/xml.h
@@ -849,19 +849,19 @@ public:
 
         Returns true on success, false otherwise.
 
-       @since 3.3.0
+        @since 3.3.0
     */
     bool Load(const wxString& filename, int flags = wxXMLDOC_NONE,
-              wxXmlParseError* err_details = nullptr);
+              wxXmlParseError* err = nullptr);
 
     /**
         Like Load(const wxString&, int) but takes the data from given input
         stream.
 
-       @since 3.3.0
+        @since 3.3.0
 */
     bool Load(wxInputStream& stream, int flags = wxXMLDOC_NONE,
-              wxXmlParseError* err_details = nullptr);
+              wxXmlParseError* err = nullptr);
 
     /**
         Saves XML tree creating a file named with given string.

--- a/interface/wx/xml/xml.h
+++ b/interface/wx/xml/xml.h
@@ -557,6 +557,23 @@ enum wxXmlDocumentLoadFlag
 };
 
 
+/**
+
+  Pass this structure to wxXmlDocument::Load() to get more information
+  if an error occurred during XML parsing.
+
+  @since 3.3.0
+
+ */
+
+struct wxXmlParseError
+{
+    wxString message;   ///< Error description
+    int line;           ///< Line number where error occurred
+    int column;         ///< Column number where error occurred
+    int byte_offset;    ///< Byte offset where error occurred
+};
+
 
 /**
     @class wxXmlDocument
@@ -827,15 +844,24 @@ public:
         less memory however makes impossible to recreate exactly the loaded text with a
         Save() call later. Read the initial description of this class for more info.
 
+        Create an wxXmlParseError object and pass it to this function to get more
+        information if an error occurred during XML parsing.
+
         Returns true on success, false otherwise.
+
+       @since 3.3.0
     */
-    bool Load(const wxString& filename, int flags = wxXMLDOC_NONE);
+    bool Load(const wxString& filename, int flags = wxXMLDOC_NONE,
+              wxXmlParseError* err_details = nullptr);
 
     /**
         Like Load(const wxString&, int) but takes the data from given input
         stream.
-    */
-    bool Load(wxInputStream& stream, int flags = wxXMLDOC_NONE);
+
+       @since 3.3.0
+*/
+    bool Load(wxInputStream& stream, int flags = wxXMLDOC_NONE,
+              wxXmlParseError* err_details = nullptr);
 
     /**
         Saves XML tree creating a file named with given string.


### PR DESCRIPTION
This PR declares a `wxXmlParseError` structure and adds an optional pointer to this structure to both versions of wxXmlDocument::Load(). If a parsing error occurs, this structure will be filled in with a descriptive message and the line, column and byte offset where the error occurred.

Note that this also fixes a bug in xml.h where `#ifdef WXWIN_COMPATIBILITY_3_2` was used to call the deprecated functions instead of `#if WXWIN_COMPATIBILITY_3_2` which allows setup to use `#define WXWIN_COMPATIBILITY_3_2 0`.

Closes #24167