### PR TITLE
Fix wxEVT_SET_CURSOR handling under wxQt

### DIFF
--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -167,7 +167,7 @@ public:
 
     static void QtStoreWindowPointer( QWidget *widget, const wxWindowQt *window );
     static wxWindowQt *QtRetrieveWindowPointer( const QWidget *widget );
-    static void QtSendSetCursorEvent(wxWindowQt* win, wxPoint posClient);
+    static void QtSendSetCursorEvent(wxWindowQt* win, const wxPoint& posClient);
 
 #if wxUSE_ACCEL
     virtual void QtHandleShortcut ( int command );

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -284,7 +284,7 @@ void wxWindowQt::QtSendSetCursorEvent(wxWindowQt* win, const wxPoint& posClient)
         event.SetId(win->GetId());
         event.SetEventObject(win);
 
-        bool processedEvtSetCursor = win->HandleWindowEvent(event);
+        const bool processedEvtSetCursor = win->HandleWindowEvent(event);
         if ( processedEvtSetCursor && event.HasCursor() )
         {
             win->SetCursor( event.GetCursor() );

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -274,27 +274,33 @@ static const char WINDOW_POINTER_PROPERTY_NAME[] = "wxWindowPointer";
 }
 
 /* static */
-void wxWindowQt::QtSendSetCursorEvent(wxWindowQt* win, wxPoint posScreen)
+void wxWindowQt::QtSendSetCursorEvent(wxWindowQt* win, const wxPoint& posClient)
 {
-    wxWindowQt* w = win;
-    for ( ;; )
-    {
-        const wxPoint posClient = w->ScreenToClient(posScreen);
-        wxSetCursorEvent event(posClient.x, posClient.y);
-        event.SetEventObject(w);
+    const wxRect rect(win->GetClientAreaOrigin(), win->GetClientSize());
 
-        const bool processedEvtSetCursor = w->ProcessWindowEvent(event);
+    if ( rect.Contains(posClient) )
+    {
+        wxSetCursorEvent event( posClient.x , posClient.y );
+        event.SetId(win->GetId());
+        event.SetEventObject(win);
+
+        bool processedEvtSetCursor = win->HandleWindowEvent(event);
         if ( processedEvtSetCursor && event.HasCursor() )
         {
-            win->SetCursor(event.GetCursor());
-            return;
+            win->SetCursor( event.GetCursor() );
         }
+        else
+        {
+            // Notice that GetCursor() can return an invalid cursor even if the window already
+            // has a valid cursor set at the Qt level. Don't override it if this is the case.
+            const bool hasCursor = win->GetHandle()->testAttribute(Qt::WA_SetCursor);
 
-        w = w->GetParent();
-        if ( w == nullptr )
-            break;
+            if ( !hasCursor || (!wxIsBusy() && !win->GetParent()) )
+            {
+                win->SetCursor( *wxSTANDARD_CURSOR );
+            }
+        }
     }
-    win->SetCursor(wxCursor(wxCURSOR_ARROW));
 }
 
 static wxWindowQt *s_capturedWindow = nullptr;
@@ -1689,7 +1695,7 @@ bool wxWindowQt::QtHandleMouseEvent ( QWidget *handler, QMouseEvent *event )
             ProcessWindowEvent( e );
         }
 
-        QtSendSetCursorEvent(this, wxQtConvertPoint( event->globalPos()));
+        QtSendSetCursorEvent(this, mousePos);
     }
 
     m_mouseInside = mouseInside;

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -287,7 +287,7 @@ void wxWindowQt::QtSendSetCursorEvent(wxWindowQt* win, const wxPoint& posClient)
         const bool processedEvtSetCursor = win->HandleWindowEvent(event);
         if ( processedEvtSetCursor && event.HasCursor() )
         {
-            win->SetCursor( event.GetCursor() );
+            win->SetCursor(event.GetCursor());
         }
         else
         {


### PR DESCRIPTION
Really fix `wxSetCursorEvent` handling for `wxAUI` done in commit f608b34 (Send set cursor events whenever there is mouse movement) without breaking the other controls, i.e. `wxSplitterWindow`, `wxHeaderCtrl` and `wxGrid`.

Also pass the mouse position by const reference to `QtSendSetCursorEvent()`.