### PR TITLE
Document CEF_RUNTIME_LIBRARY_FLAG switch for building CEF

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -506,11 +506,36 @@ if(wxUSE_GUI)
             message(WARNING "WebviewChromium libcef_dll_wrapper can only be built with MSVC... disabled")
             wx_option_force_value(wxUSE_WEBVIEW_CHROMIUM OFF)
         endif()
-        if(wxUSE_WEBVIEW_CHROMIUM AND CMAKE_CXX_STANDARD LESS 17)
-            # We shouldn't disable this option as it's disabled by default and
-            # if it is on, it means that CEF is meant to be used, but we can't
-            # continue neither as libcef_dll_wrapper will fail to build.
-            message(FATAL_ERROR "WebviewChromium requires at least C++17 but configured to use C++${CMAKE_CXX_STANDARD}")
+        if(wxUSE_WEBVIEW_CHROMIUM)
+            # Check for C++17 support as it's required by CEF: we trust
+            # CMAKE_CXX_STANDARD if it is defined, but we need to compile a
+            # test program if it is not because the compiler could be
+            # supporting C++17 anyway.
+            if (DEFINED CMAKE_CXX_STANDARD)
+                if (CMAKE_CXX_STANDARD GREATER_EQUAL 17)
+                    set(wxHAVE_CXX17 ON)
+                endif()
+            else()
+                check_cxx_source_compiles("
+                    #if defined(_MSVC_LANG)
+                        #if _MSVC_LANG < 201703L
+                            #error C++17 support is required
+                        #endif
+                    #elif __cplusplus < 201703L
+                        #error C++17 support is required
+                    #endif
+                    int main() {
+                        [[maybe_unused]] auto unused = 17;
+                    }"
+                    wxHAVE_CXX17)
+            endif()
+
+            if (NOT wxHAVE_CXX17)
+                # We shouldn't disable this option as it's disabled by default and
+                # if it is on, it means that CEF is meant to be used, but we can't
+                # continue neither as libcef_dll_wrapper will fail to build.
+                message(FATAL_ERROR "WebviewChromium requires at least C++17 but configured to use C++${CMAKE_CXX_STANDARD}")
+            endif()
         endif()
     endif()
 

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -533,8 +533,18 @@ if(wxUSE_GUI)
             if (NOT wxHAVE_CXX17)
                 # We shouldn't disable this option as it's disabled by default and
                 # if it is on, it means that CEF is meant to be used, but we can't
-                # continue neither as libcef_dll_wrapper will fail to build.
-                message(FATAL_ERROR "WebviewChromium requires at least C++17 but configured to use C++${CMAKE_CXX_STANDARD}")
+                # continue neither as libcef_dll_wrapper will fail to build
+                # (actually it may still succeed with CEF v116 which provided
+                # its own stand-in for std::in_place used in CEF headers, but
+                # not with the later versions, so just fail instead of trying
+                # to detect CEF version here, as even v116 officially only
+                # supports C++17 anyhow).
+                if (DEFINED CMAKE_CXX_STANDARD)
+                    set(cxx17_error_details "configured to use C++${CMAKE_CXX_STANDARD}")
+                else()
+                    set(cxx17_error_details "the compiler doesn't support C++17 by default and CMAKE_CXX_STANDARD is not set")
+                endif()
+                message(FATAL_ERROR "WebviewChromium requires at least C++17 but ${cxx17_error_details}")
             endif()
         endif()
     endif()

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -506,11 +506,11 @@ if(wxUSE_GUI)
             message(WARNING "WebviewChromium libcef_dll_wrapper can only be built with MSVC... disabled")
             wx_option_force_value(wxUSE_WEBVIEW_CHROMIUM OFF)
         endif()
-        if(wxUSE_WEBVIEW_CHROMIUM AND CMAKE_CXX_STANDARD LESS 14)
+        if(wxUSE_WEBVIEW_CHROMIUM AND CMAKE_CXX_STANDARD LESS 17)
             # We shouldn't disable this option as it's disabled by default and
             # if it is on, it means that CEF is meant to be used, but we can't
             # continue neither as libcef_dll_wrapper will fail to build.
-            message(FATAL_ERROR "WebviewChromium requires at least C++14 but configured to use C++${CMAKE_CXX_STANDARD}")
+            message(FATAL_ERROR "WebviewChromium requires at least C++17 but configured to use C++${CMAKE_CXX_STANDARD}")
         endif()
     endif()
 

--- a/build/cmake/lib/webview_chromium/CMakeLists.txt
+++ b/build/cmake/lib/webview_chromium/CMakeLists.txt
@@ -59,7 +59,6 @@ set(USE_SANDBOX OFF)    # Disable usage of sandbox on windows
 add_subdirectory(${CEF_ROOT} ${CEF_BUILD_DIR} EXCLUDE_FROM_ALL)
 set_target_properties(libcef_dll_wrapper PROPERTIES
     FOLDER "Third Party Libraries"
-    COMPILE_FLAGS     "-Wno-extra"
     OUTPUT_NAME "libcef_dll_wrapper"
 )
 
@@ -68,6 +67,8 @@ if(MSVC)
     get_target_property(cef_compile_options libcef_dll_wrapper COMPILE_OPTIONS)
     string(REGEX REPLACE "/MTd?;" "" cef_compile_options "${cef_compile_options}")
     set_target_properties(libcef_dll_wrapper PROPERTIES COMPILE_OPTIONS "${cef_compile_options}")
+else()
+    set_target_properties(libcef_dll_wrapper PROPERTIES COMPILE_OPTIONS "-Wno-extra")
 endif()
 
 add_library(libcef SHARED IMPORTED GLOBAL)

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -613,7 +613,8 @@ check_type_size(ssize_t SSIZE_T)
 
 test_big_endian(WORDS_BIGENDIAN)
 
-if(wxUSE_WEBVIEW_CHROMIUM)
+# For generators using build type, ensure that wxHAVE_CEF_DEBUG matches it.
+if(wxUSE_WEBVIEW_CHROMIUM AND DEFINED CMAKE_BUILD_TYPE)
     string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
     if(${build_type} STREQUAL DEBUG)
         set(wxHAVE_CEF_DEBUG ON)

--- a/build/msw/wx_webview.vcxproj
+++ b/build/msw/wx_webview.vcxproj
@@ -152,6 +152,7 @@
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE=1;_CRT_NON_CONFORMING_SWPRINTFS=1;_SCL_SECURE_NO_WARNINGS=1;__WXMSW__;_UNICODE;WXBUILDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -187,6 +188,7 @@
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE=1;_CRT_NON_CONFORMING_SWPRINTFS=1;_SCL_SECURE_NO_WARNINGS=1;__WXMSW__;_UNICODE;WXBUILDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -225,6 +227,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <StringPooling>true</StringPooling>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE=1;_CRT_NON_CONFORMING_SWPRINTFS=1;_SCL_SECURE_NO_WARNINGS=1;__WXMSW__;NDEBUG;_UNICODE;WXBUILDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -262,6 +265,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE=1;_CRT_NON_CONFORMING_SWPRINTFS=1;_SCL_SECURE_NO_WARNINGS=1;__WXMSW__;NDEBUG;_UNICODE;WXBUILDING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -298,6 +302,7 @@
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE=1;_CRT_NON_CONFORMING_SWPRINTFS=1;_SCL_SECURE_NO_WARNINGS=1;__WXMSW__;_UNICODE;WXBUILDING;WXDLLNAME=$(TargetName);WXUSINGDLL;WXMAKINGDLL_WEBVIEW;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -339,6 +344,7 @@
       <WarningLevel>Level4</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;_CRT_SECURE_NO_DEPRECATE=1;_CRT_NON_CONFORMING_SWPRINTFS=1;_SCL_SECURE_NO_WARNINGS=1;__WXMSW__;_UNICODE;WXBUILDING;WXDLLNAME=$(TargetName);WXUSINGDLL;WXMAKINGDLL_WEBVIEW;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -380,6 +386,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE=1;_CRT_NON_CONFORMING_SWPRINTFS=1;_SCL_SECURE_NO_WARNINGS=1;__WXMSW__;NDEBUG;_UNICODE;WXBUILDING;WXDLLNAME=$(TargetName);WXUSINGDLL;WXMAKINGDLL_WEBVIEW;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -424,6 +431,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE=1;_CRT_NON_CONFORMING_SWPRINTFS=1;_SCL_SECURE_NO_WARNINGS=1;__WXMSW__;NDEBUG;_UNICODE;WXBUILDING;WXDLLNAME=$(TargetName);WXUSINGDLL;WXMAKINGDLL_WEBVIEW;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/interface/wx/webview_chromium.h
+++ b/interface/wx/webview_chromium.h
@@ -47,11 +47,16 @@
     2. Unpack the archive into `3rdparty/cef` directory under wxWidgets source
     directory.
     3. Build `libcef_dll_wrapper` using the instructions provided in the CEF
-    distribution, but, in short, just by using `cmake` to do it. Please note
-    that if you use `-DCMAKE_BUILD_TYPE=Debug` under Unix when building it, you
-    need to pass `--enable-cef_debug` option to wxWidgets configure to avoid
-    mismatches between various definitions in the wrapper itself and in
-    wxWidgets.
+    distribution, which basically means using `cmake` to do it. Please note:
+        * Under Windows you must use `-DCEF_RUNTIME_LIBRARY_FLAG=/MD` option
+          to match the default wxWidgets build configuration.
+        * Under Unix remember that if you use `-DCMAKE_BUILD_TYPE=Debug` when
+          building it, you need to pass `--enable-cef_debug` option to
+          wxWidgets configure to avoid mismatches between various definitions
+          in the wrapper itself and in wxWidgets.
+        * Under all platforms you may want to use `-DCEF_USE_SANDBOX=OFF`
+          option to avoid linking with the sandbox library which is not
+          provided in the "Minimal Distribution" if you don't use this feature.
     4. Copy the static library binary in the platform-dependent location:
       - Under MSW, copy `libcefl_dll_wrapper.lib` file to either
       `3rdparty/cef/Release` or `3rdparty/cef/Debug` depending on the build


### PR DESCRIPTION
This must match the options used when building wx itself.

Also mention CEF_USE_SANDBOX while discussing CEF build options.

---

@MaartenBent I think that CMake might want to use this option when configuring CEF instead of using `REGEX_REPLACE` on compile options, but I didn't change `build/cmake/lib/webview_chromium/CMakeLists.txt` myself because I might be missing some reason for which it wouldn't work.