### PR TITLE
Flush wxLogGui before showing a modal dialog

### DIFF
--- a/include/wx/generic/logg.h
+++ b/include/wx/generic/logg.h
@@ -52,8 +52,14 @@ private:
 class WXDLLIMPEXP_CORE wxLogGui : public wxLog
 {
 public:
-    // ctor
+    // ctor has a side effect of installing a custom modal hook flushing the
+    // logs before showing any modal dialog: we do this to avoid showing the
+    // log dialog while another modal dialog is showing or, even worse, only
+    // after it is dismissed
     wxLogGui();
+
+    // dtor removes the modal hook
+    virtual ~wxLogGui();
 
     // show all messages that were logged since the last Flush()
     virtual void Flush() override;

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -372,6 +372,10 @@ public:
         When it is called from the other threads it simply calls Flush() on the
         currently active log target, so it mostly makes sense to do this if a
         thread has its own logger set with SetThreadActiveTarget().
+
+        Note that when using the default log target, this method is called
+        automatically before showing any modal dialog, in order to prevent
+        showing several modal dialogs one after another.
     */
     static void FlushActive();
 


### PR DESCRIPTION
This ensures that any messages passed to wxLogError() or other functions are shown before wxMessageBox() that could be referring to them instead of it happening while the message box is shown (most ports, including wxGTK) or only after it is dismissed (wxMSW).

Closes #24228.