### PR TITLE
Add support for hidden panels in ribbon

### DIFF
--- a/src/ribbon/page.cpp
+++ b/src/ribbon/page.cpp
@@ -918,7 +918,7 @@ bool wxRibbonPage::ExpandPanels(wxOrientation direction, int maximum_amount)
                   node = node->GetNext(), ++panel_size )
         {
             wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
-            if(panel == nullptr)
+            if(panel == nullptr || !panel->IsShown())
             {
                 continue;
             }
@@ -1018,7 +1018,7 @@ bool wxRibbonPage::CollapsePanels(wxOrientation direction, int minimum_amount)
                       node = node->GetNext(), ++panel_size )
             {
                 wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
-                if(panel == largest_panel)
+                if(panel == largest_panel && panel->IsShown())
                 {
                     largest_panel_size = panel_size;
                     break;
@@ -1033,7 +1033,7 @@ bool wxRibbonPage::CollapsePanels(wxOrientation direction, int minimum_amount)
                       node = node->GetNext(), ++panel_size )
             {
                 wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
-                if(panel == nullptr)
+                if(panel == nullptr || !panel->IsShown())
                 {
                     continue;
                 }
@@ -1109,7 +1109,7 @@ bool wxRibbonPage::DismissExpandedPanel()
               node = node->GetNext() )
     {
         wxRibbonPanel* panel = wxDynamicCast(node->GetData(), wxRibbonPanel);
-        if(panel == nullptr)
+        if(panel == nullptr || !panel->IsShown())
         {
             continue;
         }

--- a/src/ribbon/panel.cpp
+++ b/src/ribbon/panel.cpp
@@ -342,6 +342,10 @@ bool wxRibbonPanel::IsSizingContinuous() const
 // Finds the best width and height given the parent's width and height
 wxSize wxRibbonPanel::GetBestSizeForParentSize(const wxSize& parentSize) const
 {
+    if (!IsShown())
+    {
+        return wxSize(0, 0);
+    }
     if (GetChildren().GetCount() == 1)
     {
         wxWindow* win = GetChildren().GetFirst()->GetData();
@@ -561,6 +565,10 @@ bool wxRibbonPanel::CanAutoMinimise() const
 
 wxSize wxRibbonPanel::GetMinSize() const
 {
+    if (!IsShown())
+    {
+        return wxSize(0, 0);
+    }
     if(m_expanded_panel != nullptr)
     {
         // Minimum size depends upon children, who are currently in the
@@ -580,6 +588,10 @@ wxSize wxRibbonPanel::GetMinSize() const
 
 wxSize wxRibbonPanel::GetMinNotMinimisedSize() const
 {
+    if (!IsShown())
+    {
+        return wxSize(0, 0);
+    }
     // Ask sizer if present
     if(GetSizer())
     {


### PR DESCRIPTION
If a panel window is hidden, then don't include its size when laying out the ribbon bar. After toggling a panel's visibility, calling Realize() and Layout() will properly include the panel (if shown) or not show it and move panels to the right of it over (without a blank gap in the ribbon bar where the hidden panel would be).

Currently, hiding a panel will result in a blank gap on a ribbon bar. This PR fixes that.

For those curious, this is useful for creating a dynamic ribbon bar, where sections of it change based on context. Destroying and recreating panels can be dangerous if there are pending events, whereas hiding/showing panels is safer and more efficient.