### PR TITLE
Replace 16-bit code in MSW wxGetUserName

### DIFF
--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -857,7 +857,7 @@ wxString wxGetUserHome(const wxString& user = wxEmptyString);
     This function returns the "user id" also known as "login name" under Unix
     (i.e. something like "jsmith"). It uniquely identifies the current user (on
     this system).  Under Windows, this function looks in the
-    environment variables USER and LOGNAME.
+    environment variable USERNAME.
 
     @return The login name if successful or an empty string otherwise.
 
@@ -880,12 +880,11 @@ wxString wxGetUserId();
 bool wxGetUserId(char* buf, int sz);
 
 /**
-    This function returns the full user name (something like "Mr. John Smith").
+    This function returns the full user name (something like "John Smith").
 
-    Under Windows, this function looks for the entry UserName in the
-    wxWidgets section of the WIN.INI file. Then it will attempt to get the
-    user's full name from the domain controller; if that fails, it will
-    stay with the login name.
+    Under Windows, this function will attempt to get the user's full name
+    from the domain controller (or local computer); if that fails, it will
+    return the login name (or empty string if that cannot be resolved).
 
     @return The full user name if successful or an empty string otherwise.
 

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -856,9 +856,8 @@ wxString wxGetUserHome(const wxString& user = wxEmptyString);
 /**
     This function returns the "user id" also known as "login name" under Unix
     (i.e. something like "jsmith"). It uniquely identifies the current user (on
-    this system).  Under Windows or NT, this function first looks in the
-    environment variables USER and LOGNAME; if neither of these is found, the
-    entry @b UserId in the @b wxWidgets section of the WIN.INI file is tried.
+    this system).  Under Windows, this function looks in the
+    environment variables USER and LOGNAME.
 
     @return The login name if successful or an empty string otherwise.
 
@@ -883,9 +882,10 @@ bool wxGetUserId(char* buf, int sz);
 /**
     This function returns the full user name (something like "Mr. John Smith").
 
-    Under Windows or NT, this function looks for the entry UserName in the
-    wxWidgets section of the WIN.INI file. If PenWindows is running, the entry
-    Current in the section User of the PENWIN.INI file is used.
+    Under Windows, this function looks for the entry UserName in the
+    wxWidgets section of the WIN.INI file. Then it will attempt to get the
+    user's full name from the domain controller; if that fails, it will
+    stay with the login name.
 
     @return The full user name if successful or an empty string otherwise.
 

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -302,11 +302,11 @@ bool wxGetUserName(wxChar* buf, int maxSize)
     }
 
     const NetGetAnyDCName_t netGetAnyDCName =
-        static_cast<NetGetAnyDCName_t>(netapi32.GetSymbol("NetGetAnyDCName"));
+        reinterpret_cast<NetGetAnyDCName_t>(netapi32.GetSymbol("NetGetAnyDCName"));
     const NetUserGetInfo_t netUserGetInfo =
-        static_cast<NetUserGetInfo_t>(netapi32.GetSymbol("NetUserGetInfo"));
+        reinterpret_cast<NetUserGetInfo_t>(netapi32.GetSymbol("NetUserGetInfo"));
     const NetApiBufferFree_t netApiBufferFree =
-        static_cast<NetApiBufferFree_t>(netapi32.GetSymbol("NetApiBufferFree"));
+        reinterpret_cast<NetApiBufferFree_t>(netapi32.GetSymbol("NetApiBufferFree"));
 
     if (netGetAnyDCName == nullptr ||
         netUserGetInfo == nullptr ||

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -275,7 +275,7 @@ bool wxGetUserName(wxChar* buf, int maxSize)
     const static wxDynamicLibrary netapi32("netapi32", wxDL_VERBATIM | wxDL_QUIET);
     if ( !netapi32.IsLoaded() )
     {
-        wxLogTrace("utils", _("Failed to load netapi32.dll"));
+        wxLogTrace("utils", "Failed to load netapi32.dll");
         return false;
     }
 


### PR DESCRIPTION
Uses `NetAPIXXX` functions now instead of `GetProfileString`.
Also reformats user names like "Smart, Julian" into "Julian Smart".