### PR TITLE
Restore wxAuiToolBar::RealizeHelper(bool) for compatibility

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -693,6 +693,13 @@ protected:
     bool m_gripperVisible;
     bool m_overflowVisible;
 
+    // This function is only kept for compatibility, don't use in the new code.
+    bool RealizeHelper(wxClientDC& dc, bool horizontal)
+    {
+        RealizeHelper(dc, horizontal ? wxHORIZONTAL : wxVERTICAL);
+        return true;
+    }
+
     static bool IsPaneValid(long style, const wxAuiPaneInfo& pane);
     bool IsPaneValid(long style) const;
     void SetArtFlags() const;


### PR DESCRIPTION
This function was replaced with a more useful function taking wxOrientation and returning wxSize in bbba3b7cb9 (Make wxAuiToolBar::RealizeHelper() return value actually useful, 2023-12-25) but there is some existing code using the old RealizeHelper() from its overridden Realize(), so restore it for compatibility, even if it's quite useless now.

See #24023, #24164.

---

cc @dsa-t @marekr 