### PR TITLE
wxGrid: skip EVT_KEY_UP event for pure ALT key

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6117,9 +6117,12 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
     }
 }
 
-void wxGrid::OnKeyUp( wxKeyEvent& WXUNUSED(event) )
+void wxGrid::OnKeyUp( wxKeyEvent& event )
 {
-    // try local handlers
+    // try local handlers for anything except pure ALT key
+    // MenuBar needs ALT to enable navigation via arrow keys
+    if ( event.GetKeyCode() == WXK_ALT && !event.GetModifiers() )
+        event.Skip();
 }
 
 void wxGrid::OnChar( wxKeyEvent& event )


### PR DESCRIPTION
This fixes issue #24246 by skipping EVT_KEY_UP when only the ALT key is pressed.

If you accept the modification, please also port back to 3.2 such that it finds it's way into wxPython soon.