### PR TITLE
Fix crash due to using wxLog during shutdown in a better way

### DIFF
--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -488,16 +488,10 @@ static void DoCommonPostCleanup()
 
 void wxEntryCleanup()
 {
-    // delete the application object
-    if ( wxTheApp )
-    {
-        wxTheApp->CleanUp();
-    }
-
-    // It's important to call this after wxApp::CleanUp() as it can log some
-    // messages that will be flushed inside DoCommonPreCleanup().
     DoCommonPreCleanup();
 
+
+    // delete the application object
     if ( wxTheApp )
     {
         // reset the global pointer to it to nullptr before destroying it as in
@@ -505,6 +499,9 @@ void wxEntryCleanup()
         // wxTheApp and using half-destroyed object is no good
         wxAppConsole * const app = wxApp::GetInstance();
         wxApp::SetInstance(nullptr);
+
+        app->CleanUp();
+
         delete app;
     }
 


### PR DESCRIPTION
This commit reverts 055c4cbed5 (Fix crash on shutdown if wxConfig couldn't be saved, 2024-01-04) and implements an alternative solution mentioned in that commit log message by setting wxTheApp to null pointer before calling CleanUp().

This ensures that wxLog creates wxLogOutputBest if necessary instead of recreating wxLogGui which can't be safely used once the cleanup starts: under MSW the dialog used by it can't be shown once the GUI objects are destroyed, so logging from CleanUp() still resulted in crashes under this platform, even after the previous fix.

This change might affect some existing code using wxTheApp during shutdown but it seems like the only really safe thing to do.