### PR TITLE
Image crash

### DIFF
--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -2185,8 +2185,7 @@ unsigned char *wxImage::GetAlpha() const
 
 void wxImage::InitAlpha()
 {
-    if (!IsOk())
-        return;
+    wxCHECK_RET( IsOk(), wxT("invalid image") );
 
     wxCHECK_RET( !HasAlpha(), wxT("image already has an alpha channel") );
 

--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -2185,6 +2185,9 @@ unsigned char *wxImage::GetAlpha() const
 
 void wxImage::InitAlpha()
 {
+    if (!IsOk())
+        return;
+
     wxCHECK_RET( !HasAlpha(), wxT("image already has an alpha channel") );
 
     // initialize memory for alpha channel

--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -167,6 +167,12 @@ void
 wxImageList::GetImageListBitmaps(wxMSWBitmaps& bitmaps,
                                  const wxBitmap& bitmap, const wxBitmap& mask)
 {
+    if (!bitmap.IsOk())
+    {
+        // We can't do anything with an invalid bitmap.
+        return;
+    }
+
     // This can be overwritten below if we need to modify the bitmap, but it
     // doesn't cost anything to initialize the bitmap with this HBITMAP.
     bitmaps.hbmp = GetHbitmapOf(bitmap);


### PR DESCRIPTION
This PR will avoid a crash if `wxImage::InitAlpha()` is called on an empty image (previously it would de-reference a null pointer). 

I also changed MSW `wxImageList::GetImageListBitmaps()` to return immediately if the bitmap is invalid rather than calling `wxImage::InitAlpha()` on it. Otherwise, the function calls `InitAlpha()`, assumes an alpha channel exists and attempts to de-reference a pointer to that channel.