### PR TITLE
wxGenericValidator:  support wxRadioButton group

### DIFF
--- a/include/wx/valgen.h
+++ b/include/wx/valgen.h
@@ -76,6 +76,10 @@ public:
     // Called to transfer data to the window
     virtual bool TransferFromWindow() override;
 
+    // Called when the validator is associated with a window, may be useful to
+    // override if it needs to somehow initialize the window.
+    virtual void SetWindow(wxWindow* win) override;
+
 protected:
     void Initialize();
 

--- a/interface/wx/valgen.h
+++ b/interface/wx/valgen.h
@@ -22,8 +22,8 @@
     wxString variable; wxListBox uses a wxArrayInt; wxCheckBox uses a boolean.
 
     @since 3.2.5
-    A wxLB_SINGLE wxListBox can also use an int.  wxColourPickerCtrl support.
-    A 3-state wxCheckBox can use wxCheckBoxState.
+    A wxLB_SINGLE wxListBox and a wxRadioButton group can also use an int.
+    wxColourPickerCtrl support.  A 3-state wxCheckBox can use wxCheckBoxState.
 
     For more information, please see @ref overview_validator.
 
@@ -79,7 +79,7 @@ public:
     wxGenericValidator(int* valPtr);
     /**
         Constructor taking a wxArrayInt pointer. This will be used for
-        wxListBox, wxCheckListBox.
+        wxListBox, wxCheckListBox, and wxRadioButton group.
 
         @param valPtr
             A pointer to a variable that contains the value. This variable

--- a/src/common/valgen.cpp
+++ b/src/common/valgen.cpp
@@ -172,6 +172,28 @@ bool wxGenericValidator::TransferToWindow()
             pControl->SetValue(*m_pBool) ;
             return true;
         }
+        else if (m_pInt)
+        {
+            wxRadioButton* selected = nullptr;
+            for (int i = 0 ;
+                pControl ;
+                ++i, pControl = pControl != pControl->GetLastInGroup() ? pControl->GetNextInGroup() : nullptr)
+            {
+                wxCHECK_MSG(!pControl->GetValidator() ||
+                            pControl == pControl->GetFirstInGroup(),
+                        false,
+                        "wxRadioButton group validator must be on first item in group");
+                if (i == *m_pInt)
+                {
+                    selected = pControl;
+                }
+            }
+            if (selected)
+            {
+                selected->SetValue(true);
+                return true;
+            }
+        }
     } else
 #endif
 
@@ -497,6 +519,25 @@ bool wxGenericValidator::TransferFromWindow()
         if (m_pBool)
         {
             *m_pBool = pControl->GetValue() ;
+            return true;
+        }
+        else if (m_pInt)
+        {
+            *m_pInt = -1;
+            for (int i = 0 ;
+                pControl ;
+                ++i, pControl = pControl != pControl->GetLastInGroup() ? pControl->GetNextInGroup() : nullptr)
+            {
+                wxCHECK_MSG(!pControl->GetValidator() ||
+                            pControl == pControl->GetFirstInGroup(),
+                        false,
+                        "wxRadioButton group validator must be on first item in group");
+                if (pControl->GetValue())
+                {
+                    *m_pInt = i;
+                }
+            }
+            wxASSERT(*m_pInt >= 0 || !"no selected radio button!");
             return true;
         }
     } else


### PR DESCRIPTION
Enable wxGenericValidator(int*) to work with wxRadioButton groups when applied to the first element of the group.  The value will be the index of the selected button within the group.