### PR TITLE
Avoid implicit string conversions when using wxLog functions

### DIFF
--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -921,12 +921,15 @@ public:
     // indicates that we may have an extra first argument preceding the format
     // string and that if we do have it, we should store it in m_info using the
     // given key (while by default 0 value will be used)
-    wxLogger& MaybeStore(const wxString& key, wxUIntPtr value = 0)
+    wxLogger& MaybeStore(const char* key, wxUIntPtr value = 0)
     {
         wxASSERT_MSG( m_optKey.empty(), "can only have one optional value" );
-        m_optKey = key;
 
-        m_info.StoreValue(key, value);
+        // We only use keys defined in this file and we can be sure they
+        // contain ASCII characters only.
+        m_optKey = wxString::FromAscii(key);
+
+        m_info.StoreValue(m_optKey, value);
         return *this;
     }
 
@@ -1208,7 +1211,7 @@ WXDLLIMPEXP_BASE wxString wxSysErrorMsgStr(unsigned long nErrCode = 0);
 // and it will have changed already by then (in fact it even changes when
 // wxString::Format() is called because of vsnprintf() inside it so it can
 // change even much sooner)
-#define wxLOG_KEY_SYS_ERROR_CODE wxASCII_STR("wx.sys_error")
+#define wxLOG_KEY_SYS_ERROR_CODE "wx.sys_error"
 
 #define wxLogSysError \
     wxDO_LOG_IF_ENABLED_WITH_FUNC(Error, MaybeStore(wxLOG_KEY_SYS_ERROR_CODE, \
@@ -1224,7 +1227,7 @@ WXDLLIMPEXP_BASE wxString wxSysErrorMsgStr(unsigned long nErrCode = 0);
 #if wxUSE_GUI
     // wxLogStatus() is similar to wxLogSysError() as it allows to optionally
     // specify the frame to which the message should go
-    #define wxLOG_KEY_FRAME wxASCII_STR("wx.frame")
+    #define wxLOG_KEY_FRAME "wx.frame"
 
     #define wxLogStatus \
         wxDO_LOG_IF_ENABLED_WITH_FUNC(Status, MaybeStore(wxLOG_KEY_FRAME).Log)

--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -1208,7 +1208,7 @@ WXDLLIMPEXP_BASE wxString wxSysErrorMsgStr(unsigned long nErrCode = 0);
 // and it will have changed already by then (in fact it even changes when
 // wxString::Format() is called because of vsnprintf() inside it so it can
 // change even much sooner)
-#define wxLOG_KEY_SYS_ERROR_CODE "wx.sys_error"
+#define wxLOG_KEY_SYS_ERROR_CODE wxASCII_STR("wx.sys_error")
 
 #define wxLogSysError \
     wxDO_LOG_IF_ENABLED_WITH_FUNC(Error, MaybeStore(wxLOG_KEY_SYS_ERROR_CODE, \
@@ -1224,7 +1224,7 @@ WXDLLIMPEXP_BASE wxString wxSysErrorMsgStr(unsigned long nErrCode = 0);
 #if wxUSE_GUI
     // wxLogStatus() is similar to wxLogSysError() as it allows to optionally
     // specify the frame to which the message should go
-    #define wxLOG_KEY_FRAME "wx.frame"
+    #define wxLOG_KEY_FRAME wxASCII_STR("wx.frame")
 
     #define wxLogStatus \
         wxDO_LOG_IF_ENABLED_WITH_FUNC(Status, MaybeStore(wxLOG_KEY_FRAME).Log)

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -411,4 +411,6 @@ TEST_CASE("wxNO_IMPLICIT_WXSTRING_ENCODING", "[string]")
     // wxNO_IMPLICIT_WXSTRING_ENCODING must be set
     s = "Hello, implicit encoding";
 #endif
+
+    wxLogSysError(wxASCII_STR("Bogus error for testing"));
 }


### PR DESCRIPTION
See #24267.

The first commit can/should be backported to 3.2.