### PR TITLE
Really fix logging during app cleanup

### DIFF
--- a/include/wx/x11/app.h
+++ b/include/wx/x11/app.h
@@ -41,8 +41,6 @@ public:
     // override base class (pure) virtuals
     // -----------------------------------
 
-    virtual void Exit();
-
     virtual void WakeUpIdle();
 
     virtual bool OnInitGui();

--- a/src/common/appcmn.cpp
+++ b/src/common/appcmn.cpp
@@ -149,6 +149,22 @@ void wxAppBase::CleanUp()
     // and any remaining TLWs
     DeleteAllTLWs();
 
+#if wxUSE_LOG
+    // flush the logged messages if any and don't use the current probably
+    // unsafe log target any more: the default one (wxLogGui) can't be used
+    // after the resources are freed below and the user supplied one might be
+    // even worse (using any wxWidgets GUI function is unsafe starting from
+    // now)
+    //
+    // notice that wxLog will still recreate a default log target if any
+    // messages are logged but that one will be safe to use until the very end
+    delete wxLog::SetActiveTarget(nullptr);
+#endif // wxUSE_LOG
+
+    // Starting from now, the application object is no longer valid and
+    // shouldn't be used any longer, so reset the global pointer to it.
+    wxApp::SetInstance(nullptr);
+
     // undo everything we did in Initialize() above
     wxBitmap::CleanUpHandlers();
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5605,7 +5605,10 @@ wxDataViewCtrl::~wxDataViewCtrl()
 
 #if wxUSE_ACCESSIBILITY
     SetAccessible(nullptr);
-    wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_DESTROY, this, wxOBJID_CLIENT, wxACC_SELF);
+    // There is no need to notify anybody if we're destroyed as part of
+    // application shutdown and doing it would just crash in this case.
+    if ( wxTheApp )
+        wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_DESTROY, this, wxOBJID_CLIENT, wxACC_SELF);
 #endif // wxUSE_ACCESSIBILITY
 }
 

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -568,6 +568,8 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
 
 void wxApp::CleanUp()
 {
+    wxAppBase::CleanUp();
+
     if (m_idleSourceId != 0)
         g_source_remove(m_idleSourceId);
 
@@ -577,8 +579,6 @@ void wxApp::CleanUp()
         g_type_class_unref(gt);
 
     gdk_threads_leave();
-
-    wxAppBase::CleanUp();
 }
 
 void wxApp::WakeUpIdle()

--- a/src/osx/carbon/app.cpp
+++ b/src/osx/carbon/app.cpp
@@ -358,13 +358,14 @@ int wxApp::OnRun()
 void wxApp::CleanUp()
 {
     wxMacAutoreleasePool autoreleasepool;
+
+    wxAppBase::CleanUp();
+
 #if wxUSE_TOOLTIPS
     wxToolTip::RemoveToolTips() ;
 #endif
 
     DoCleanUp();
-
-    wxAppBase::CleanUp();
 }
 
 //----------------------------------------------------------------------

--- a/src/x11/app.cpp
+++ b/src/x11/app.cpp
@@ -789,11 +789,3 @@ Window wxGetWindowParent(Window window)
         return (Window) 0;
 #endif
 }
-
-void wxApp::Exit()
-{
-    wxApp::CleanUp();
-
-    wxAppConsole::Exit();
-}
-

--- a/src/x11/app.cpp
+++ b/src/x11/app.cpp
@@ -198,10 +198,10 @@ bool wxApp::Initialize(int& argC, wxChar **argV)
 
 void wxApp::CleanUp()
 {
+    wxAppBase::CleanUp();
+
     wxDELETE(wxWidgetHashTable);
     wxDELETE(wxClientWidgetHashTable);
-
-    wxAppBase::CleanUp();
 }
 
 wxApp::wxApp()


### PR DESCRIPTION
This is yet another commit trying to improve things with logging on app shutdown -- without introducing bad regressions such as the one fixed by the first commit in this PR.

I'll merge this soon because this commit really needs to be merged a.s.a.p. to avoid crashes on exit.