### PR TITLE
Allow passing -1 to wxPGProperty::SetChoiceSelection() again

### DIFF
--- a/interface/wx/propgrid/property.h
+++ b/interface/wx/propgrid/property.h
@@ -1885,6 +1885,9 @@ public:
 
         Tries to retain value type, although currently if it is not string,
         then it is forced to integer.
+
+        If @a newValue is wxNOT_FOUND (`-1`), then the property's value is
+        reset to unspecified, as if SetValueToUnspecified() was called.
     */
     void SetChoiceSelection( int newValue );
 

--- a/src/propgrid/property.cpp
+++ b/src/propgrid/property.cpp
@@ -2217,6 +2217,15 @@ int wxPGProperty::GetChoiceSelection() const
 void wxPGProperty::SetChoiceSelection( int newValue )
 {
     wxCHECK_RET( m_choices.IsOk(), wxS("invalid choiceinfo") );
+
+    // Allow setting the value of -1 to reset the selection, for consistency
+    // with wxChoice::SetSelection().
+    if ( newValue == wxNOT_FOUND )
+    {
+        SetValueToUnspecified();
+        return;
+    }
+
     wxCHECK_RET( newValue >= 0 && newValue < (int)m_choices.GetCount(),
                  wxS("New index is out of range") );
 


### PR DESCRIPTION
This used to be possible in 3.0 but was disallowed back in 29bf859fae (Check if new index is in range before selecting new value in wxPGProperty::SetChoiceSelection., 2014-11-29). However there doesn't seem to be any real harm in still allowing to do this, so handle -1 as a special case here.

Closes #24279.