### PR TITLE
Improve wxValidators (3rd attempt)

### DIFF
--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -97,6 +97,8 @@ private:
     // some valid value.
     virtual wxString NormalizeString(const wxString& s) const = 0;
 
+    // Override base class
+    virtual bool CanPaste(const wxString& text) override;
 
     // Event handlers.
     void OnChar(wxKeyEvent& event);

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -16,7 +16,7 @@
 #if wxUSE_VALIDATORS
 
 #include "wx/textentry.h"
-#include "wx/validate.h"
+#include "wx/valtext.h"
 
 // This header uses std::numeric_limits<>::min/max, but these symbols are,
 // unfortunately, often defined as macros and the code here wouldn't compile in
@@ -39,7 +39,7 @@ enum wxNumValidatorStyle
 // Base class for all numeric validators.
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxNumValidatorBase : public wxValidator
+class WXDLLIMPEXP_CORE wxNumValidatorBase : public wxTextEntryValidator
 {
 public:
     // Change the validator style. Usually it's specified during construction.
@@ -50,17 +50,13 @@ public:
     // we don't need this as we do our validation on the fly here.
     virtual bool Validate(wxWindow * WXUNUSED(parent)) override { return true; }
 
-    // Override base class method to check that the window is a text control or
-    // combobox.
-    virtual void SetWindow(wxWindow *win) override;
-
 protected:
     wxNumValidatorBase(int style)
     {
         m_style = style;
     }
 
-    wxNumValidatorBase(const wxNumValidatorBase& other) : wxValidator(other)
+    wxNumValidatorBase(const wxNumValidatorBase& other) : wxTextEntryValidator(other)
     {
         m_style = other.m_style;
     }
@@ -69,11 +65,6 @@ protected:
     {
         return (m_style & style) != 0;
     }
-
-    // Get the text entry of the associated control. Normally shouldn't ever
-    // return nullptr (and will assert if it does return it) but the caller should
-    // still test the return value for safety.
-    wxTextEntry *GetTextEntry() const;
 
     // Convert wxNUM_VAL_THOUSANDS_SEPARATOR and wxNUM_VAL_NO_TRAILING_ZEROES
     // bits of our style to the corresponding wxNumberFormatter::Style values.

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -15,9 +15,11 @@
 
 #if wxUSE_VALIDATORS && (wxUSE_TEXTCTRL || wxUSE_COMBOBOX)
 
+class WXDLLIMPEXP_FWD_BASE wxRegEx;
 class WXDLLIMPEXP_FWD_CORE wxTextEntry;
 
 #include "wx/validate.h"
+#include "wx/sharedptr.h"
 
 enum wxTextValidatorStyle
 {
@@ -200,6 +202,40 @@ private:
     wxDECLARE_DYNAMIC_CLASS(wxTextValidator);
     wxDECLARE_EVENT_TABLE();
 };
+
+#if wxUSE_REGEX
+// ----------------------------------------------------------------------------
+// wxRegexValidator declaration
+// ----------------------------------------------------------------------------
+
+class WXDLLIMPEXP_CORE wxRegexValidator : public wxTextValidator
+{
+public:
+    wxRegexValidator(long style = wxFILTER_NONE, wxString* str = nullptr);
+    wxRegexValidator(const wxString& pattern, const wxString& purpose,
+                     long style = wxFILTER_NONE, wxString* str = nullptr);
+
+    // Use one of these functions to initialize the validator if the first
+    // constructor was used to create it.
+    void SetRegEx(const wxString& pattern, const wxString& purpose);
+    void SetRegEx(wxSharedPtr<wxRegEx> regex, const wxString& purpose);
+
+    virtual wxObject* Clone() const override;
+
+    // Override base class function
+    virtual wxString IsValid(const wxString& str) const override;
+
+private:
+    void SetPurpose(const wxString& purpose);
+
+    wxSharedPtr<wxRegEx>   m_regex;
+    wxString               m_purpose; // The purpose of the regular expression,
+                                      // i.e.: phone number.
+
+    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxRegexValidator);
+};
+
+#endif // wxUSE_REGEX
 
 #endif
   // wxUSE_VALIDATORS && (wxUSE_TEXTCTRL || wxUSE_COMBOBOX)

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -59,6 +59,26 @@ protected:
     // return nullptr (and will assert if it does) but the caller should still
     // test the return value for safety.
     wxTextEntry* GetTextEntry() const;
+
+    // Return true if @text can be pasted in the control. return false otherwise.
+    //
+    // This function (called by OnPaste() handler) filters out invalid characters
+    // from the clipboard contents as it shouldn't be possible to sneak them into
+    // the control in such a way.
+    //
+    // This seems better than not allowing to paste anything at all if there is
+    // anything invalid on the clipboard, e.g. it is more user-friendly to omit
+    // any trailing spaces in a control not allowing them than to refuse to
+    // paste a string with some spaces into it completely.
+    //
+    // Out of abundance of caution also prefer to let the control do its own
+    // thing if there are no invalid characters at all, as we can be sure it
+    // does the right thing in all cases, while our code might not deal with
+    // some edge cases correctly.
+    virtual bool CanPaste(const wxString& text) = 0;
+
+    // Event handlers
+    void OnPaste(wxClipboardTextEvent& event);
 };
 
 
@@ -174,7 +194,7 @@ protected:
     wxArrayString        m_excludes;
 
 private:
-    void OnPaste(wxClipboardTextEvent& event);
+    virtual bool CanPaste(const wxString& text) override;
 
     wxDECLARE_NO_ASSIGN_CLASS(wxTextValidator);
     wxDECLARE_DYNAMIC_CLASS(wxTextValidator);

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -42,10 +42,31 @@ enum wxTextValidatorStyle
 };
 
 // ----------------------------------------------------------------------------
+// wxTextEntryValidator: common base class for wxTextValidator & wxNumValidator
+// ----------------------------------------------------------------------------
+class WXDLLIMPEXP_CORE wxTextEntryValidator : public wxValidator
+{
+public:
+    wxTextEntryValidator() = default;
+    wxTextEntryValidator(const wxTextEntryValidator& other) = default;
+
+    // Override base class method to check whether the window does support
+    // this type of validators or not.
+    virtual void SetWindow(wxWindow* win) override;
+
+protected:
+    // Get the text entry of the associated control. Normally shouldn't ever
+    // return nullptr (and will assert if it does) but the caller should still
+    // test the return value for safety.
+    wxTextEntry* GetTextEntry() const;
+};
+
+
+// ----------------------------------------------------------------------------
 // wxTextValidator
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxTextValidator: public wxValidator
+class WXDLLIMPEXP_CORE wxTextValidator: public wxTextEntryValidator
 {
 public:
     wxTextValidator(long style = wxFILTER_NONE, wxString *val = nullptr);
@@ -76,8 +97,6 @@ public:
     // ACCESSORS
     inline long GetStyle() const { return m_validatorStyle; }
     void SetStyle(long style);
-
-    wxTextEntry *GetTextEntry();
 
     // strings & chars inclusions:
     // ---------------------------

--- a/interface/wx/valtext.h
+++ b/interface/wx/valtext.h
@@ -314,3 +314,79 @@ protected:
     bool IsValidChar(const wxUniChar& c) const;
 };
 
+
+/**
+    @class wxRegexValidator
+
+    wxRegexValidator validates text controls, providing a variety of filtering
+    behaviours. It differs from wxTextValidator in that validation is also done
+    using a regular expression.
+
+    For more information, please see @ref overview_validator.
+
+    @library{wxcore}
+    @category{validator}
+
+    @see @ref overview_validator, wxValidator, wxGenericValidator, wxTextValidator
+        wxIntegerValidator, wxFloatingPointValidator, wxRegEx
+*/
+class wxRegexValidator : public wxTextValidator
+{
+public:
+    /**
+        Constructor taking a style and optional pointer to a wxString variable.
+
+        @param style
+            One or more of the ::wxTextValidatorStyle styles. See SetStyle().
+        @param valPtr
+            A pointer to a wxString variable that contains the value. This
+            variable should have a lifetime equal to or longer than the
+            validator lifetime (which is usually determined by the lifetime of
+            the window).
+
+        @note Use SetRegEx() to initialize the validator.
+    */
+    wxRegexValidator(long style = wxFILTER_NONE, wxString* valPtr = nullptr);
+
+    /**
+        Constructor taking a pattern, purpose, style and optional pointer to a
+        wxString variable.
+
+        @param pattern
+            A string to compile into a regular expression.
+        @param purpose
+            The purpose of the regular expression. Used to compose the error
+            message when validation fails.
+        @param style
+            One or more of the ::wxTextValidatorStyle styles. See SetStyle().
+        @param valPtr
+            A pointer to a wxString variable that contains the value. This
+            variable should have a lifetime equal to or longer than the
+            validator lifetime (which is usually determined by the lifetime of
+            the window).
+    */
+    wxRegexValidator(const wxString& pattern, const wxString& purpose,
+                     long style = wxFILTER_NONE, wxString* valPtr = nullptr);
+
+    /**
+        Use this function to initialize the validator if the first constructor
+        was used to create it.
+    */
+    void SetRegEx(const wxString& pattern, const wxString& purpose);
+
+    /**
+        Use this function to initialize the validator if the first constructor
+        was used to create it.
+    */
+    void SetRegEx(wxSharedPtr<wxRegEx> regex, const wxString& purpose);
+
+    /**
+        Returns the error message if the contents of @a val are invalid or the
+        empty string if @a val is valid. First, it calls the base class version
+        wxTextValidator::IsValid() if style is not wxFILTER_NONE. If it passes,
+        it validates against the regular expression.
+
+        @note Use wxFILTER_NONE to validate against the regular expression only.
+    */
+    virtual wxString IsValid(const wxString& val) const override;
+};

--- a/samples/validate/validate.h
+++ b/samples/validate/validate.h
@@ -128,6 +128,9 @@ private:
     wxString        m_charExcludes;
     wxArrayString   m_includes;
     wxArrayString   m_excludes;
+
+    wxString        m_regexStr;
+    wxString        m_regexPurpose;
 };
 
 class MyData

--- a/src/common/valnum.cpp
+++ b/src/common/valnum.cpp
@@ -196,6 +196,48 @@ void wxNumValidatorBase::OnKillFocus(wxFocusEvent& event)
         text->MarkDirty();
 }
 
+bool wxNumValidatorBase::CanPaste(const wxString& text)
+{
+    wxString valid;
+    valid.reserve(text.length());
+
+    bool hasInvalid = false;
+    int pos = 0;
+
+    // Examine all characters one by one.
+    for ( wxString::const_iterator i = text.begin(), end = text.end();
+          i != end; ++i )
+    {
+        const wxUniChar ch = *i;
+
+        if ( IsCharOk(valid, pos, ch) )
+        {
+            valid += ch;
+            ++pos;
+        }
+        else // Invalid character.
+        {
+            // Only beep once per paste, not for every invalid character.
+            if ( !hasInvalid && !wxValidator::IsSilent() )
+                wxBell();
+
+            hasInvalid = true;
+        }
+    }
+
+    // If we can't let the control paste everything, do it ourselves.
+    if ( hasInvalid )
+    {
+        wxTextEntry * const entry = GetTextEntry();
+        if ( entry )
+        {
+            entry->WriteText(valid);
+        }
+    }
+
+    return !hasInvalid;
+}
+
 // ============================================================================
 // wxIntegerValidatorBase implementation
 // ============================================================================

--- a/src/common/valnum.cpp
+++ b/src/common/valnum.cpp
@@ -23,7 +23,6 @@
 
 #ifndef WX_PRECOMP
     #include "wx/textctrl.h"
-    #include "wx/combobox.h"
 #endif
 
 #include "wx/valnum.h"
@@ -49,38 +48,6 @@ int wxNumValidatorBase::GetFormatFlags() const
         flags |= wxNumberFormatter::Style_NoTrailingZeroes;
 
     return flags;
-}
-
-void wxNumValidatorBase::SetWindow(wxWindow *win)
-{
-    wxValidator::SetWindow(win);
-
-#if wxUSE_TEXTCTRL
-    if ( wxDynamicCast(m_validatorWindow, wxTextCtrl) )
-        return;
-#endif // wxUSE_TEXTCTRL
-
-#if wxUSE_COMBOBOX
-    if ( wxDynamicCast(m_validatorWindow, wxComboBox) )
-        return;
-#endif // wxUSE_COMBOBOX
-
-    wxFAIL_MSG("Can only be used with wxTextCtrl or wxComboBox");
-}
-
-wxTextEntry *wxNumValidatorBase::GetTextEntry() const
-{
-#if wxUSE_TEXTCTRL
-    if ( wxTextCtrl *text = wxDynamicCast(m_validatorWindow, wxTextCtrl) )
-        return text;
-#endif // wxUSE_TEXTCTRL
-
-#if wxUSE_COMBOBOX
-    if ( wxComboBox *combo = wxDynamicCast(m_validatorWindow, wxComboBox) )
-        return combo;
-#endif // wxUSE_COMBOBOX
-
-    return nullptr;
 }
 
 void

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -52,6 +52,53 @@ static bool wxIsNumeric(const wxString& val)
 }
 
 // ----------------------------------------------------------------------------
+// wxTextEntryValidator implementation
+// ----------------------------------------------------------------------------
+
+void wxTextEntryValidator::SetWindow(wxWindow* win)
+{
+    wxValidator::SetWindow(win);
+
+    if ( GetTextEntry() )
+    {
+        // Bind event handlers
+    }
+    else
+    {
+        wxFAIL_MSG(
+            "wxTextEntryValidator can only be used with wxTextCtrl, wxComboBox "
+            "or wxComboCtrl"
+        );
+    }
+}
+
+wxTextEntry* wxTextEntryValidator::GetTextEntry() const
+{
+#if wxUSE_TEXTCTRL
+    if (wxDynamicCast(m_validatorWindow, wxTextCtrl))
+    {
+        return static_cast<wxTextCtrl*>(m_validatorWindow);
+    }
+#endif
+
+#if wxUSE_COMBOBOX
+    if (wxDynamicCast(m_validatorWindow, wxComboBox))
+    {
+        return static_cast<wxComboBox*>(m_validatorWindow);
+    }
+#endif
+
+#if wxUSE_COMBOCTRL
+    if (wxDynamicCast(m_validatorWindow, wxComboCtrl))
+    {
+        return static_cast<wxComboCtrl*>(m_validatorWindow);
+    }
+#endif
+
+    return nullptr;
+}
+
+// ----------------------------------------------------------------------------
 // wxTextValidator
 // ----------------------------------------------------------------------------
 
@@ -68,7 +115,7 @@ wxTextValidator::wxTextValidator(long style, wxString *val)
 }
 
 wxTextValidator::wxTextValidator(const wxTextValidator& val)
-    : wxValidator()
+    : wxTextEntryValidator()
 {
     Copy(val);
 }
@@ -91,37 +138,6 @@ bool wxTextValidator::Copy(const wxTextValidator& val)
     m_excludes     = val.m_excludes;
 
     return true;
-}
-
-wxTextEntry *wxTextValidator::GetTextEntry()
-{
-#if wxUSE_TEXTCTRL
-    if (wxDynamicCast(m_validatorWindow, wxTextCtrl))
-    {
-        return (wxTextCtrl*)m_validatorWindow;
-    }
-#endif
-
-#if wxUSE_COMBOBOX
-    if (wxDynamicCast(m_validatorWindow, wxComboBox))
-    {
-        return (wxComboBox*)m_validatorWindow;
-    }
-#endif
-
-#if wxUSE_COMBOCTRL
-    if (wxDynamicCast(m_validatorWindow, wxComboCtrl))
-    {
-        return (wxComboCtrl*)m_validatorWindow;
-    }
-#endif
-
-    wxFAIL_MSG(
-        "wxTextValidator can only be used with wxTextCtrl, wxComboBox, "
-        "or wxComboCtrl"
-    );
-
-    return nullptr;
 }
 
 // Called when the value in the window must be validated.


### PR DESCRIPTION
It's also nice to see these features implemented in `wxWidgets`:

- [x] Add `wxRegexValidator` for regular expression validations.
- [ ] Make `wxValidator`s generate events to report validation failure/success. **Or**...
- [ ] Add `wxValidatorProxy` and let users customize validation behaviours:
  - Use `wxRichToolTip` to show error messages instead of the default message box.
  - Choose to revert to the previous valid value instead of clamping the value. 
- [ ] Do not generate `wxEVT_TEXT` event while the `wxDialog`/`wxPanel` is initialized due to calling `SetValue()` in the process of transferring data to window (`TransferToWindow()`)

`wxValidatorProxy` might look like this:

```
class wxValidatorProxy
{
public:
    wxValidatorProxy() = default;
    virtual ~wxValidatorProxy() = default;

    // Return false to prevent default processing to take place

    virtual bool OnSuccess() const { return true; }
    virtual bool OnFailure(/*...*/) const { return true; }
    virtual bool OnIncompleteEntry(/*...*/) const { return true; }
};
```

Thanks for any other ideas!
