### PR TITLE
fix grid selection end when deleting grid rows or cols

### DIFF
--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -488,7 +488,7 @@ void wxGridSelection::UpdateRows( size_t pos, int numRows )
                         count--;
                     }
                     else
-                        block.SetBottomRow( pos );
+                        block.SetBottomRow( pos - 1 );
                 }
             }
         }
@@ -537,7 +537,7 @@ void wxGridSelection::UpdateCols( size_t pos, int numCols )
                         count--;
                     }
                     else
-                        block.SetRightCol(pos);
+                        block.SetRightCol( pos - 1 );
                 }
             }
         }


### PR DESCRIPTION
I recently had an assertion failing when:
 - the whole grid is selected with e.g. SelectAll
 - rows are deleted from the end

E.g.
 - old shape: `27, 17`,  selection:  `(0, 0, 26, 16)`
 - `DeleteRows(5, 22)`
 - new shape: `5, 17`, selection: `(0, 0, 5, 16)`

The selection after deleting should end at row index 4, not 5.

When `ClearSelection()` is called, this triggers the assertion:
`wx._core.wxAssertionError: C++ assertion "idx >= 0 && idx < m_numRows" failed at ..\..\src\generic\grid.cpp(5221) in wxGrid::GetRowPos(): invalid row index`

This PR fixes the issue. Please also backport to 3.2. Thanks.
