### PR TITLE
Fix centering of item label in generic `wxListCtrl`

### DIFF
--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -190,10 +190,11 @@ public:
             wxASSERT_MSG( m_rectAll.width <= w,
                             wxT("width can only be increased") );
 
+            int delta = (w - m_rectAll.width) / 2;
             m_rectAll.width = w;
-            m_rectLabel.x += (w - m_rectLabel.width) / 2;
-            m_rectIcon.x += (w - m_rectIcon.width) / 2;
-            m_rectHighlight.x += (w - m_rectHighlight.width) / 2;
+            m_rectLabel.x += delta;
+            m_rectIcon.x += delta;
+            m_rectHighlight.x += delta;
         }
     };
 

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -518,7 +518,7 @@ void wxListLineData::CalculateSize( wxDC *dc, int spacing )
     }
 }
 
-void wxListLineData::SetPosition( int x, int y, int spacing )
+void wxListLineData::SetPosition( int x, int y, int WXUNUSED(spacing) )
 {
     wxCHECK_RET( !m_items.empty(), wxT("no subitems at all??") );
 
@@ -533,19 +533,19 @@ void wxListLineData::SetPosition( int x, int y, int spacing )
 
             if ( item->HasImage() )
             {
-                m_gi->m_rectIcon.x = m_gi->m_rectAll.x + 4;
+                m_gi->m_rectIcon.x = m_gi->m_rectAll.x + 4 +
+                    (m_gi->m_rectAll.width - m_gi->m_rectIcon.width) / 2;
                 m_gi->m_rectIcon.y = m_gi->m_rectAll.y + 4;
             }
 
             if ( item->HasText() )
             {
-                if (m_gi->m_rectAll.width > spacing)
-                    m_gi->m_rectLabel.x = m_gi->m_rectAll.x + (EXTRA_WIDTH/2);
-                else
-                    m_gi->m_rectLabel.x = m_gi->m_rectAll.x + (EXTRA_WIDTH/2) + (spacing / 2) - (m_gi->m_rectLabel.width / 2);
-                m_gi->m_rectLabel.y = m_gi->m_rectAll.y + m_gi->m_rectAll.height + 2 - m_gi->m_rectLabel.height;
-                m_gi->m_rectHighlight.x = m_gi->m_rectLabel.x - 2;
-                m_gi->m_rectHighlight.y = m_gi->m_rectLabel.y - 2;
+                m_gi->m_rectLabel.x = m_gi->m_rectAll.x + (EXTRA_WIDTH/2) +
+                    (m_gi->m_rectAll.width - m_gi->m_rectLabel.width) / 2;
+                m_gi->m_rectLabel.y = m_gi->m_rectAll.y + m_gi->m_rectAll.height +
+                    (EXTRA_HEIGHT/2) - m_gi->m_rectLabel.height;
+                m_gi->m_rectHighlight.x = m_gi->m_rectLabel.x - (EXTRA_WIDTH/2);
+                m_gi->m_rectHighlight.y = m_gi->m_rectLabel.y - (EXTRA_HEIGHT/2);
             }
             else // no text, highlight the icon
             {


### PR DESCRIPTION
With wxWidgets-3.2.4, in a generic `wxListCtrl` the label is not centered on the icon as intended if the icon is wider than the label.

![wxListCtrl-master](https://github.com/wxWidgets/wxWidgets/assets/99262969/3b098278-88cc-449b-998a-2fbaa0a8a281)

This PR fixes this issue.

![wxListCtrl-PR](https://github.com/wxWidgets/wxWidgets/assets/99262969/dee4ef2f-f5c7-4ef5-8c44-b50cbbe67e6e)

Please also backport this fix to 3.2. TIA!