### PR TITLE
Make auto-grow of in-place editor in generic `wxListCtrl` work again

### DIFF
--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1468,7 +1468,7 @@ bool wxListTextCtrlWrapper::CheckForEndEditKey(const wxKeyEvent& event)
 
 void wxListTextCtrlWrapper::OnKeyUp( wxKeyEvent &event )
 {
-    if (m_aboutToFinish)
+    if ( !m_aboutToFinish )
     {
         // auto-grow the textctrl:
         wxSize parentSize = m_owner->GetSize();


### PR DESCRIPTION
Auto-growing of the editor has not worked since the changes of a8a89154531d94c2ff30990a0463a366242703b2 (`Made code more similar to wxTreeCtrl' code, 2008-01-10`).