### PR TITLE
Revert clipping changes under Mac as they break `wxGrid`

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -220,14 +220,9 @@ public :
     // from the same pimpl class.
     virtual void                controlTextDidChange();
 
-    virtual void                AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical) override;
-    virtual void                UseClippingView(bool clip) override;
-    virtual WXWidget            GetContainer() const override { return m_osxClipView ? m_osxClipView : m_osxView; }
-
 protected:
     WXWidget m_osxView;
-    WXWidget m_osxClipView;
-
+    
     // begins processing of native key down event, storing the native event for later wx event generation
     void BeginNativeKeyDownEvent( NSEvent* event );
     // done with the current native key down event

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -221,7 +221,7 @@ public :
     virtual void                controlTextDidChange();
 
     virtual void                AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical) override;
-    virtual void                UseClippingView() override;
+    virtual void                UseClippingView(bool clip) override;
     virtual WXWidget            GetContainer() const override { return m_osxClipView ? m_osxClipView : m_osxView; }
 
 protected:

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -365,14 +365,6 @@ public :
 
     virtual bool        EnableTouchEvents(int eventsMask) = 0;
 
-    // scrolling views need a clip subview that acts as parent for native children
-    // (except for the scollbars) which are children of the view itself
-    virtual void        AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical);
-    virtual void        UseClippingView(bool clip);
-
-    // returns native view which acts as a parent for native children
-    virtual WXWidget    GetContainer() const;
-
     // Mechanism used to keep track of whether a change should send an event
     // Do SendEvents(false) when starting actions that would trigger programmatic events
     // and SendEvents(true) at the end of the block.

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -368,7 +368,7 @@ public :
     // scrolling views need a clip subview that acts as parent for native children
     // (except for the scollbars) which are children of the view itself
     virtual void        AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical);
-    virtual void        UseClippingView();
+    virtual void        UseClippingView(bool clip);
 
     // returns native view which acts as a parent for native children
     virtual WXWidget    GetContainer() const;

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -224,7 +224,7 @@ public:
     // returns true if children have to clipped to the content area
     // (e.g., scrolled windows)
     bool                MacClipChildren() const { return m_clipChildren ; }
-    void                MacSetClipChildren( bool clip );
+    void                MacSetClipChildren( bool clip ) { m_clipChildren = clip ; }
 
     // returns true if the grandchildren need to be clipped to the children's content area
     // (e.g., splitter windows)

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -224,7 +224,7 @@ public:
     // returns true if children have to clipped to the content area
     // (e.g., scrolled windows)
     bool                MacClipChildren() const { return m_clipChildren ; }
-    void                MacSetClipChildren();
+    void                MacSetClipChildren( bool clip );
 
     // returns true if the grandchildren need to be clipped to the children's content area
     // (e.g., splitter windows)

--- a/include/wx/scrolwin.h
+++ b/include/wx/scrolwin.h
@@ -439,7 +439,7 @@ public:
         m_targetWindow = this;
 
 #ifdef __WXMAC__
-        this->MacSetClipChildren();
+        this->MacSetClipChildren(true);
 #endif
 
         // by default, we're scrollable in both directions (but if one of the

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5644,7 +5644,7 @@ bool wxDataViewCtrl::Create(wxWindow *parent,
     SetInitialSize(size);
 
 #ifdef __WXMAC__
-    MacSetClipChildren();
+    MacSetClipChildren( true );
 #endif
 
     m_clientArea = new wxDataViewMainWindow( this, wxID_ANY );

--- a/src/generic/laywin.cpp
+++ b/src/generic/laywin.cpp
@@ -50,7 +50,7 @@ void wxSashLayoutWindow::Init()
     m_orientation = wxLAYOUT_HORIZONTAL;
     m_alignment = wxLAYOUT_TOP;
 #ifdef __WXMAC__
-    MacSetClipChildren() ;
+    MacSetClipChildren( true ) ;
 #endif
 }
 

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -444,7 +444,7 @@ void wxScrollHelperBase::DoSetTargetWindow(wxWindow *target)
 {
     m_targetWindow = target;
 #ifdef __WXMAC__
-    target->MacSetClipChildren() ;
+    target->MacSetClipChildren( true ) ;
 #endif
 
     // install the event handler which will intercept the events we're

--- a/src/generic/vscroll.cpp
+++ b/src/generic/vscroll.cpp
@@ -435,7 +435,7 @@ void wxVarScrollHelperBase::DoSetTargetWindow(wxWindow *target)
 {
     m_targetWindow = target;
 #ifdef __WXMAC__
-    target->MacSetClipChildren() ;
+    target->MacSetClipChildren( true ) ;
 #endif
 
     // install the event handler which will intercept the events we're

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -4077,7 +4077,7 @@ void wxWidgetCocoaImpl::AdjustClippingView(wxScrollBar* horizontal, wxScrollBar*
     }
 }
 
-void wxWidgetCocoaImpl::UseClippingView()
+void wxWidgetCocoaImpl::UseClippingView(bool clip)
 {
    wxWindow* peer = m_wxPeer;
 

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -16,7 +16,6 @@
     #include "wx/textctrl.h"
     #include "wx/combobox.h"
     #include "wx/radiobut.h"
-    #include "wx/scrolbar.h"
 #endif
 
 #ifdef __WXMAC__
@@ -2563,8 +2562,7 @@ wxWidgetImpl( peer, flags )
 {
     Init();
     m_osxView = w;
-    m_osxClipView = nil;
-
+    
     // check if the user wants to create the control initially hidden
     if ( !peer->IsShown() )
         SetVisibility(false);
@@ -3217,21 +3215,6 @@ bool wxWidgetCocoaImpl::CanFocus() const
     return canFocus;
 }
 
-@interface wxNSClipView : NSClipView
-
-@end
-
-@implementation wxNSClipView
-
-#if wxOSX_USE_NATIVE_FLIPPED
-- (BOOL)isFlipped
-{
-    return YES;
-}
-#endif
-
-@end
-
 bool wxWidgetCocoaImpl::HasFocus() const
 {
     NSView* targetView = m_osxView;
@@ -3322,13 +3305,7 @@ void wxWidgetCocoaImpl::RemoveFromParent()
 
 void wxWidgetCocoaImpl::Embed( wxWidgetImpl *parent )
 {
-    NSView* container = nil;
-
-    if ( m_wxPeer->MacIsWindowScrollbar( parent->GetWXPeer()))
-        container = parent->GetWXWidget();
-    else
-        container = parent->GetContainer();
-
+    NSView* container = parent->GetWXWidget() ;
     wxASSERT_MSG( container != nullptr , wxT("No valid mac container control") ) ;
     [container addSubview:m_osxView];
     
@@ -4057,41 +4034,6 @@ void wxWidgetCocoaImpl::SetDrawingEnabled(bool enabled)
         [[m_osxView window] disableFlushWindow];
     }
 }
-
-void wxWidgetCocoaImpl::AdjustClippingView(wxScrollBar* horizontal, wxScrollBar* vertical)
-{
-    if( m_osxClipView )
-    {
-        NSRect bounds = m_osxView.bounds;
-        if( horizontal && horizontal->IsShown() )
-        {
-            int sz = horizontal->GetSize().y;
-            bounds.size.height -= sz;
-        }
-        if( vertical && vertical->IsShown() )
-        {
-            int sz = vertical->GetSize().x;
-            bounds.size.width -= sz;
-        }
-        m_osxClipView.frame = bounds;
-    }
-}
-
-void wxWidgetCocoaImpl::UseClippingView(bool clip)
-{
-   wxWindow* peer = m_wxPeer;
-
-    if ( peer && m_osxClipView == nil)
-    {
-        m_osxClipView = [[wxNSClipView alloc] initWithFrame: m_osxView.bounds];
-        [(NSClipView*)m_osxClipView setDrawsBackground: NO];
-        [m_osxView addSubview:m_osxClipView];
-
-        // TODO check for additional subwindows which might have to be moved to the clip view ?
-    }
-}
-
-
 //
 // Factory methods
 //

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -261,13 +261,6 @@ wxWindowMac::~wxWindowMac()
     delete GetPeer() ;
 }
 
-void wxWindowMac::MacSetClipChildren( bool clip )
-{
-    m_clipChildren = clip ;
-    if ( m_peer )
-        m_peer->UseClippingView(clip);
-}
-
 WXWidget wxWindowMac::GetHandle() const
 {
     if ( GetPeer() )
@@ -393,8 +386,6 @@ bool wxWindowMac::Create(wxWindowMac *parent,
     {
         SetPeer(wxWidgetImpl::CreateUserPane( this, parent, id, pos, size , style, GetExtraStyle() ));
         MacPostControlCreate(pos, size) ;
-        if ( m_clipChildren )
-            m_peer->UseClippingView(m_clipChildren);
     }
 
     wxWindowCreateEvent event((wxWindow*)this);
@@ -2148,7 +2139,6 @@ void wxWindowMac::MacRepositionScrollBars()
                 m_growBox->Hide();
         }
     }
-    m_peer->AdjustClippingView(m_hScrollBar, m_vScrollBar);
 #endif
 }
 
@@ -2709,17 +2699,4 @@ bool wxWidgetImpl::NeedsFrame() const
 
 void wxWidgetImpl::SetDrawingEnabled(bool WXUNUSED(enabled))
 {
-}
-
-void wxWidgetImpl::AdjustClippingView(wxScrollBar* WXUNUSED(horizontal), wxScrollBar* WXUNUSED(vertical))
-{
-}
-
-void wxWidgetImpl::UseClippingView(bool WXUNUSED(clip))
-{
-}
-
-WXWidget wxWidgetImpl::GetContainer() const
-{
-    return GetWXWidget();
 }

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -261,11 +261,11 @@ wxWindowMac::~wxWindowMac()
     delete GetPeer() ;
 }
 
-void wxWindowMac::MacSetClipChildren()
+void wxWindowMac::MacSetClipChildren( bool clip )
 {
-    m_clipChildren = true ;
+    m_clipChildren = clip ;
     if ( m_peer )
-        m_peer->UseClippingView();
+        m_peer->UseClippingView(clip);
 }
 
 WXWidget wxWindowMac::GetHandle() const
@@ -394,7 +394,7 @@ bool wxWindowMac::Create(wxWindowMac *parent,
         SetPeer(wxWidgetImpl::CreateUserPane( this, parent, id, pos, size , style, GetExtraStyle() ));
         MacPostControlCreate(pos, size) ;
         if ( m_clipChildren )
-            m_peer->UseClippingView();
+            m_peer->UseClippingView(m_clipChildren);
     }
 
     wxWindowCreateEvent event((wxWindow*)this);
@@ -2715,7 +2715,7 @@ void wxWidgetImpl::AdjustClippingView(wxScrollBar* WXUNUSED(horizontal), wxScrol
 {
 }
 
-void wxWidgetImpl::UseClippingView()
+void wxWidgetImpl::UseClippingView(bool WXUNUSED(clip))
 {
 }
 


### PR DESCRIPTION
Stefan, as I don't know how to fix #24201, it looks like we need to revert your fix for the scrollbars under macOS 14.

Please let me know if I should hold off merging this to give you time to see if you can fix the other bug in a better way. TIA!