### PR TITLE
Minor wxPropertyGrid fixes

### DIFF
--- a/samples/propgrid/propgrid.xrc
+++ b/samples/propgrid/propgrid.xrc
@@ -6,8 +6,7 @@
     <object class="wxBoxSizer">
         <object class="sizeritem">
             <option>1</option>
-            <flag>wxALL|wxEXPAND</flag>
-            <border>5</border>
+            <flag>wxEXPAND</flag>
             <object class="wxPropertyGridManager">
                 <style>wxPG_AUTO_SORT|wxPG_TOOLTIPS|wxPG_TOOLBAR</style>
                 <exstyle>wxPG_EX_MODE_BUTTONS|wxPG_EX_HELP_AS_TOOLTIPS</exstyle>

--- a/samples/propgrid/propgrid.xrc
+++ b/samples/propgrid/propgrid.xrc
@@ -7,6 +7,7 @@
         <object class="sizeritem">
             <option>1</option>
             <flag>wxEXPAND</flag>
+            <minsize>400,500</minsize>
             <object class="wxPropertyGridManager">
                 <style>wxPG_AUTO_SORT|wxPG_TOOLTIPS|wxPG_TOOLBAR</style>
                 <exstyle>wxPG_EX_MODE_BUTTONS|wxPG_EX_HELP_AS_TOOLTIPS</exstyle>

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1308,6 +1308,11 @@ void wxPropertyGrid::CalculateFontAndBitmapStuff( int vspacing )
 
 #endif
 
+#ifdef wxPG_ICON_WIDTH
+    // Icons are always square in this case.
+    m_iconHeight = m_iconWidth;
+#endif
+
     m_gutterWidth = m_iconWidth / wxPG_GUTTER_DIV;
     if ( m_gutterWidth < wxPG_GUTTER_MIN )
         m_gutterWidth = wxPG_GUTTER_MIN;


### PR DESCRIPTION
@a-wi I don't even know if we should have separate `m_iconHeight` different from `m_iconWidth`, IMO these icons should always be square anyhow, but as long as we have it, we need to adjust it in high DPI too. And I made this conditional on `wxPG_ICON_WIDTH` but I'd actually like to remove all tests for it and just assume that it's always 1 (which is the case) and also remove `wxPG_USE_RENDERER_NATIVE` and make it always 1 too (which is not the case under non-MSW/GTK/Mac now).