### PR TITLE
Update generic `wxListCtrl` after user has edited an item label

### DIFF
--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -2395,8 +2395,12 @@ bool wxListMainWindow::OnRenameAccept(size_t itemEdit, const wxString& value)
 
     data->GetItem( 0, le.m_item );
     le.m_item.m_text = value;
-    return !GetParent()->GetEventHandler()->ProcessEvent( le ) ||
-                le.IsAllowed();
+    bool accept = !GetParent()->GetEventHandler()->ProcessEvent( le ) ||
+                      le.IsAllowed();
+    if ( accept )
+        m_dirty = true;
+
+    return accept;
 }
 
 void wxListMainWindow::OnRenameCancelled(size_t itemEdit)


### PR DESCRIPTION
With wxWidgets-3.2.4, a generic `wxListCtrl` is not automatically updated when an item label was edited by the user.

For example, if the user edits the label of the first item, adds a few characters and completes the editing by pressing the Enter key, the result currently looks like this:
![wxListCtrl-master](https://github.com/wxWidgets/wxWidgets/assets/99262969/c6824e62-cbc2-49b4-884a-32a3da7a9f26)


This PR fixes this issue by triggering a list control update, including a recalculation of sizes and positions, on the next idle.

![wxListCtrl-PR](https://github.com/wxWidgets/wxWidgets/assets/99262969/1c0e2f42-0157-4179-837b-252d607653b5)

In case you are wondering if this is a regression or has always been broken.
What I can say is that it doesn't work with either wxWidgets 3.2.4 or 3.0.5.

It may have been broken a long time ago, in the year 2002 by commit 62d89eb4c981d1abf2f7aac5ead7d2f862407f2d.
See the changes there in `wxListMainWindow::OnRenameAccept(...)`.
But that's just speculation, i.e. I have not tested that.