### PR TITLE
Fix dialogs sample never exiting with a persistent taskbar icon

### DIFF
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -2552,6 +2552,15 @@ public:
         Bind(wxEVT_BUTTON, &TestNotificationMessageWindow::OnCloseClicked, this, wxID_CLOSE);
     }
 
+    ~TestNotificationMessageWindow()
+    {
+#if defined(__WXMSW__) && wxUSE_TASKBARICON
+        // If the persistent taskbar icon has been created and is
+        // not deleted at the end, the application will never exit.
+        delete m_taskbarIcon;
+#endif
+    }
+
 private:
     enum
     {


### PR DESCRIPTION
If the latest user notification shown was shown with "Use persistent taskbar icon" toggled on, the application process would never really exit after closing. So delete m_taskbarIcon in destructor.

Observed on Windows 10.