### PR TITLE
Fix duplicate accelerator for the font dialog in dialogs sample

### DIFF
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -433,7 +433,7 @@ bool MyApp::OnInit()
     #endif // wxUSE_COLOURDLG
 
     #if wxUSE_FONTDLG
-        choices_menu->Append(DIALOGS_CHOOSE_FONT, "Choose &font\tShift-Ctrl-N");
+        choices_menu->Append(DIALOGS_CHOOSE_FONT, "Choose &font\tShift-Ctrl-J");
     #endif // wxUSE_FONTDLG
 
     #if wxUSE_CHOICEDLG


### PR DESCRIPTION
Shift-Ctrl-N was already taken when it was added for the font dialog in 9b25ed0 (Add an accelerator for the font dialog in the dialogs sample, 2022-04-16). Use Shift-Ctrl-J instead.