### PR TITLE
Correct Hungarian translation of "Shift" key

### DIFF
--- a/locale/hu.po
+++ b/locale/hu.po
@@ -724,7 +724,7 @@ msgstr "alt"
 #: ../src/common/accelcmn.cpp:190
 msgctxt "keyboard key"
 msgid "shift"
-msgstr "eltol"
+msgstr "shift"
 
 #: ../src/common/accelcmn.cpp:192
 #, fuzzy
@@ -769,10 +769,9 @@ msgid "Ctrl+"
 msgstr "ctrl"
 
 #: ../src/common/accelcmn.cpp:347
-#, fuzzy
 msgctxt "keyboard key"
 msgid "Shift+"
-msgstr "eltol"
+msgstr "Shift+"
 
 #: ../src/common/accelcmn.cpp:350
 #, fuzzy


### PR DESCRIPTION
I am not Hungarian, but:

* The original translator had no information that the keyboard key was meant.
  See 42a6fe0e2fcea1aca012e96b46b0d57dcf678a45 (added Hungarian translations, 2002-03-04).
* A Hungarian translator who translated texts for our software called the key "Shift".
* On Windows 10 with Hungarian selected as the display language, "Shift" is used for accelerators in the text editor.
* On the [Hungarian Wikipedia](https://hu.wikipedia.org/wiki/Shift) the key is also called "Shift".

So I am pretty sure that the current translation is wrong and the key should be called "Shift".
