### PR TITLE
Try to fix wxAUI broken layout under wxQt

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -627,6 +627,11 @@ public:
 protected:
     void Init();
 
+    // Override to return the calculated client size because under wxMSW
+    // wxControl::DoGetBestSize() returns DEFAULT_ITEM_HEIGHT which is too
+    // wide as a default toolbar height.
+    virtual wxSize DoGetBestSize() const override;
+
     virtual void OnCustomRender(wxDC& WXUNUSED(dc),
                                 const wxAuiToolBarItem& WXUNUSED(item),
                                 const wxRect& WXUNUSED(rect)) { }

--- a/include/wx/qt/dcclient.h
+++ b/include/wx/qt/dcclient.h
@@ -22,6 +22,8 @@ public:
 
     ~wxWindowDCImpl();
 
+    virtual void DoGetSize(int *width, int *height) const override;
+
 protected:
     std::unique_ptr<QPicture> m_pict;
 
@@ -39,6 +41,8 @@ class WXDLLIMPEXP_CORE wxClientDCImpl : public wxWindowDCImpl
 public:
     wxClientDCImpl( wxDC *owner );
     wxClientDCImpl( wxDC *owner, wxWindow *win );
+
+    virtual void DoGetSize(int *width, int *height) const override;
 
     static bool
     CanBeUsedForDrawing(const wxWindow* WXUNUSED(window)) { return false; }

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2248,6 +2248,10 @@ void wxAuiToolBar::DoIdleUpdate()
     }
 }
 
+wxSize wxAuiToolBar::DoGetBestSize() const
+{
+    return GetClientSize();
+}
 
 void wxAuiToolBar::OnSize(wxSizeEvent& WXUNUSED(evt))
 {

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -644,6 +644,18 @@ void wxAuiManager::SetManagedWindow(wxWindow* wnd)
     }
 
 #endif
+
+#ifdef __WXQT__
+    Bind(wxEVT_SHOW, [this](wxShowEvent& event)
+    {
+        if ( event.IsShown() )
+        {
+            this->Update();
+        }
+
+        event.Skip();
+    });
+#endif
 }
 
 
@@ -2201,6 +2213,11 @@ void wxAuiManager::GetDockSizeConstraint(double* width_pct, double* height_pct) 
 
 void wxAuiManager::Update()
 {
+#ifdef __WXQT__
+    if ( !GetManagedWindow()->IsShownOnScreen() )
+        return;
+#endif
+
     m_hoverButton = nullptr;
     m_actionPart = nullptr;
 

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -797,17 +797,7 @@ bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
     if (pinfo.best_size == wxDefaultSize &&
         pinfo.window)
     {
-        pinfo.best_size = pinfo.window->GetClientSize();
-
-#if wxUSE_TOOLBAR
-        if (wxDynamicCast(pinfo.window, wxToolBar))
-        {
-            // GetClientSize() doesn't get the best size for
-            // a toolbar under some newer versions of wxWidgets,
-            // so use GetBestSize()
-            pinfo.best_size = pinfo.window->GetBestSize();
-        }
-#endif // wxUSE_TOOLBAR
+        pinfo.best_size = pinfo.window->GetBestSize();
 
         if (pinfo.min_size != wxDefaultSize)
         {

--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -94,6 +94,13 @@ wxWindowDCImpl::~wxWindowDCImpl()
     // Painter will be deleted by base class if we own it
 }
 
+void wxWindowDCImpl::DoGetSize(int *width, int *height) const
+{
+    wxCHECK_RET( m_window, "wxWindowDCImpl without a window?" );
+
+    m_window->GetSize(width, height);
+}
+
 //##############################################################################
 
 wxIMPLEMENT_CLASS(wxClientDCImpl,wxWindowDCImpl);
@@ -113,6 +120,12 @@ wxClientDCImpl::wxClientDCImpl( wxDC *owner, wxWindow *win )
     }
 }
 
+void wxClientDCImpl::DoGetSize(int *width, int *height) const
+{
+    wxCHECK_RET( m_window, "wxClientDCImpl without a window?" );
+
+    m_window->GetClientSize(width, height);
+}
 
 //##############################################################################
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1128,7 +1128,7 @@ wxSize wxWindowQt::DoGetBestSize() const
 {
     const wxSize size = wxWindowBase::DoGetBestSize();
 
-    if ( dynamic_cast<wxQtWidget*>(GetHandle()) )
+    if ( !GetHandle() || dynamic_cast<wxQtWidget*>(GetHandle()) )
     {
         return size;
     }


### PR DESCRIPTION
The `wxAUI` layout is screwed up at start up as can be seen in the **auidemo** sample:

![Screenshot_2024-02-15_14-33-01](https://github.com/wxWidgets/wxWidgets/assets/7704771/1500177e-dc18-451d-90e1-e833c5d0f241)

With this PR applied, the layout is fixed if you select **Perspectives -> Default Startup**:

![Screenshot_2024-02-15_14-33-41](https://github.com/wxWidgets/wxWidgets/assets/7704771/8110b4e8-c1db-4105-ae5f-c2f93e03c418)

There are three possible solutions to this problem, but unfortunately none of them is perfect/ideal:

1. Commenting out line **1581** https://github.com/wxWidgets/wxWidgets/blob/47b011c665b7e07eef90489c22ff426a60b38ddb/src/aui/framemanager.cpp#L1578-L1581 but as you can see, the comment there says that we can't do this! see commit 5c62cb6 and commit dec588b.
2. Apply this patch:
```
  diff --git a/src/qt/window.cpp b/src/qt/window.cpp
index ba3db6c8bb..a31eef27d8 100644
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -434,6 +434,9 @@ bool wxWindowQt::Create( wxWindowQt * parent, wxWindowID id, const wxPoint & pos
     if ( parent )
         parent->AddChild( this );
 
+    if ( IsTopLevel() )
+        GetHandle()->setVisible(true);
+
     wxPoint p;
     if ( pos != wxDefaultPosition )
         p = pos;
``` 

   i.e. _**Temporarily**_ show the top-level window at creation time before calling `DoMoveWindow()` to get an immediate window resize at the **Qt** level. Note that the top-level window will still be created hidden as documented when `PostCreation()` is called.

3. Postpone calling `wxAuiManager::Update()` in the auidemo like this:

```
diff --git a/samples/aui/auidemo.cpp b/samples/aui/auidemo.cpp
index 56f5384bb6..19ef383cfd 100644
--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1015,7 +1015,11 @@ MyFrame::MyFrame(wxWindow* parent,
     m_perspectives.Add(perspective_all);
 
     // "commit" all changes made to wxAuiManager
+#ifndef __WXQT__
     m_mgr.Update();
+#else // __WXQT__
+    m_mgr.CallAfter(&wxAuiManager::Update);
+#endif // !__WXQT__
 }
 
 wxAuiDockArt* MyFrame::GetDockArt()
```
4. Any better idea ?