### PR TITLE
Limit radius of rounded rectangles in graphics rendering.

### DIFF
--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -436,6 +436,9 @@ void wxGraphicsPathData::AddRoundedRectangle( wxDouble x, wxDouble y, wxDouble w
         AddRectangle(x,y,w,h);
     else
     {
+        wxDouble maxR = std::min(w, h) / 2.0;
+        if ( radius > maxR ) radius = maxR;
+
         MoveToPoint(x+w, y+h/2);
         AddArc(x+w-radius, y+h-radius, radius, 0.0, M_PI/2.0, true);
         AddArc(x+radius, y+h-radius, radius, M_PI/2.0, M_PI, true);

--- a/src/gtk/dcclient.cpp
+++ b/src/gtk/dcclient.cpp
@@ -864,6 +864,9 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
 
     if (radius < 0.0) radius = - radius * ((width < height) ? width : height);
 
+    wxDouble maxR = std::min(width, height) / 2.0;
+    if ( radius > maxR ) radius = maxR;
+
     wxCoord xx = XLOG2DEV(x);
     wxCoord yy = YLOG2DEV(y);
     wxCoord ww = m_signX * XLOG2DEVREL(width);


### PR DESCRIPTION

Test case (replaces "bombs" demo): [dctest.zip](https://github.com/wxWidgets/wxWidgets/files/14302935/dctest.zip)

Before (GTK3):
![gtk_before](https://github.com/wxWidgets/wxWidgets/assets/37658952/64254b39-7b87-446a-b6d8-ac7b555f1272)

After:
![gtk_after](https://github.com/wxWidgets/wxWidgets/assets/37658952/5b87cc1e-2044-4e21-938e-165ea9b0fdf3)
