### PR TITLE
Save last sash position in wxSplitterWindow and wxPersistentSplitter

### DIFF
--- a/include/wx/generic/splitter.h
+++ b/include/wx/generic/splitter.h
@@ -227,10 +227,10 @@ public:
     wxDEPRECATED_INLINE( void SetSashSize(int WXUNUSED(width)), return; )
 
     // Get the sash position that was last used before Unsplit
-    void GetDefaultSashPosition(int& horizontal, int& vertical) const;
+    const wxPoint& GetLastSplitPosition() const;
 
     // Set the default initial sash position to use when the splitter is split
-    void SetDefaultSashPosition(int horizontal, int vertical);
+    void SetLastSplitPosition(int horizontal, int vertical);
 
 protected:
     // event handlers
@@ -295,8 +295,7 @@ protected:
     wxPoint     m_ptStart;      // mouse position when dragging started
     int         m_sashStart;    // sash position when dragging started
     int         m_minimumPaneSize;
-    int         m_latestHorizontalSashPosition;
-    int         m_latestVerticalSashPosition;
+    wxPoint     m_lastSplitPosition;
     wxCursor    m_sashCursorWE;
     wxCursor    m_sashCursorNS;
     wxOverlay   m_overlay;

--- a/include/wx/generic/splitter.h
+++ b/include/wx/generic/splitter.h
@@ -226,6 +226,12 @@ public:
     // all any more.
     wxDEPRECATED_INLINE( void SetSashSize(int WXUNUSED(width)), return; )
 
+    // Get the sash position that was last used before Unsplit
+    void GetDefaultSashPosition(int& horizontal, int& vertical) const;
+
+    // Set the default initial sash position to use when the splitter is split
+    void SetDefaultSashPosition(int horizontal, int vertical);
+
 protected:
     // event handlers
 #if defined(__WXMSW__) || defined(__WXMAC__)
@@ -289,6 +295,8 @@ protected:
     wxPoint     m_ptStart;      // mouse position when dragging started
     int         m_sashStart;    // sash position when dragging started
     int         m_minimumPaneSize;
+    int         m_latestHorizontalSashPosition;
+    int         m_latestVerticalSashPosition;
     wxCursor    m_sashCursorWE;
     wxCursor    m_sashCursorNS;
     wxOverlay   m_overlay;

--- a/include/wx/persist/splitter.h
+++ b/include/wx/persist/splitter.h
@@ -23,8 +23,8 @@
 // Special position value of -1 means the splitter is not split at all.
 #define wxPERSIST_SPLITTER_POSITION wxASCII_STR("Position")
 
-#define wxPERSIST_SPLITTER_DEFAULT_HORIZONTAL wxASCII_STR("Horizontal")
-#define wxPERSIST_SPLITTER_DEFAULT_VERTICAL wxASCII_STR("Vertical")
+#define wxPERSIST_SPLITTER_DEFAULT_HORIZONTAL wxASCII_STR("LastHorz")
+#define wxPERSIST_SPLITTER_DEFAULT_VERTICAL wxASCII_STR("LastVert")
 
 // ----------------------------------------------------------------------------
 // wxPersistentSplitter: supports saving/restoring splitter position
@@ -42,12 +42,11 @@ public:
     {
         wxSplitterWindow* const splitter = Get();
 
-        int horizontal, vertical;
-        splitter->GetDefaultSashPosition(horizontal, vertical);
+        wxPoint lastSplitPos = splitter->GetLastSplitPosition();
         int pos = splitter->IsSplit() ? splitter->GetSashPosition() : -1;
         SaveValue(wxPERSIST_SPLITTER_POSITION, pos);
-        SaveValue(wxPERSIST_SPLITTER_DEFAULT_HORIZONTAL, horizontal);
-        SaveValue(wxPERSIST_SPLITTER_DEFAULT_VERTICAL, vertical);
+        SaveValue(wxPERSIST_SPLITTER_DEFAULT_HORIZONTAL, lastSplitPos.y);
+        SaveValue(wxPERSIST_SPLITTER_DEFAULT_VERTICAL, lastSplitPos.x);
     }
 
     virtual bool Restore() override
@@ -55,17 +54,17 @@ public:
         int pos;
         if ( !RestoreValue(wxPERSIST_SPLITTER_POSITION, &pos) )
             return false;
-        
+
         int horizontal, vertical;
         if (!RestoreValue(wxPERSIST_SPLITTER_DEFAULT_HORIZONTAL, &horizontal))
             return false;
         if (!RestoreValue(wxPERSIST_SPLITTER_DEFAULT_VERTICAL, &vertical))
             return false;
-        
+
         if ( pos == -1 )
         {
             Get()->Unsplit();
-            Get()->SetDefaultSashPosition(horizontal, vertical);
+            Get()->SetLastSplitPosition(vertical, horizontal);
         }
         else
             Get()->SetSashPosition(pos);

--- a/include/wx/persist/splitter.h
+++ b/include/wx/persist/splitter.h
@@ -23,6 +23,9 @@
 // Special position value of -1 means the splitter is not split at all.
 #define wxPERSIST_SPLITTER_POSITION wxASCII_STR("Position")
 
+#define wxPERSIST_SPLITTER_DEFAULT_HORIZONTAL wxASCII_STR("Horizontal")
+#define wxPERSIST_SPLITTER_DEFAULT_VERTICAL wxASCII_STR("Vertical")
+
 // ----------------------------------------------------------------------------
 // wxPersistentSplitter: supports saving/restoring splitter position
 // ----------------------------------------------------------------------------
@@ -39,8 +42,12 @@ public:
     {
         wxSplitterWindow* const splitter = Get();
 
+        int horizontal, vertical;
+        splitter->GetDefaultSashPosition(horizontal, vertical);
         int pos = splitter->IsSplit() ? splitter->GetSashPosition() : -1;
         SaveValue(wxPERSIST_SPLITTER_POSITION, pos);
+        SaveValue(wxPERSIST_SPLITTER_DEFAULT_HORIZONTAL, horizontal);
+        SaveValue(wxPERSIST_SPLITTER_DEFAULT_VERTICAL, vertical);
     }
 
     virtual bool Restore() override
@@ -48,9 +55,18 @@ public:
         int pos;
         if ( !RestoreValue(wxPERSIST_SPLITTER_POSITION, &pos) )
             return false;
-
+        
+        int horizontal, vertical;
+        if (!RestoreValue(wxPERSIST_SPLITTER_DEFAULT_HORIZONTAL, &horizontal))
+            return false;
+        if (!RestoreValue(wxPERSIST_SPLITTER_DEFAULT_VERTICAL, &vertical))
+            return false;
+        
         if ( pos == -1 )
+        {
             Get()->Unsplit();
+            Get()->SetDefaultSashPosition(horizontal, vertical);
+        }
         else
             Get()->SetSashPosition(pos);
 

--- a/interface/wx/splitter.h
+++ b/interface/wx/splitter.h
@@ -477,6 +477,32 @@ public:
         before showing the top-level window.
     */
     void UpdateSize();
+
+    /**
+        Get the last sash position.
+
+        The last sash position gets updated each time the window is unsplit. It
+        is kept internally to restore the sash in its previous position on the
+        next split operation.
+
+        @return Point where a vertical/horizontal sash was before the last unsplit.
+    */
+    const wxPoint& GetLastSplitPosition() const;
+
+    /**
+        Sets the last sash position.
+
+        This does not affect the actual sash position while the window is split.
+        It controls the initial position of the sash each time the window
+        gets split.
+
+        @param x
+            Sash position for wxSPLIT_VERTICAL mode
+
+        @param y
+            Sash position for wxSPLIT_HORIZONTAL mode
+    */
+    void SetLastSplitPosition(int x, int y);
 };
 
 

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -130,7 +130,8 @@ void wxSplitterWindow::Init()
     m_minimumPaneSize = 0;
     m_sashCursorWE = wxCursor(wxCURSOR_SIZEWE);
     m_sashCursorNS = wxCursor(wxCURSOR_SIZENS);
-
+    m_latestHorizontalSashPosition = 0;
+    m_latestVerticalSashPosition = 0;
     m_needUpdating = false;
     m_isHot = false;
 }
@@ -471,6 +472,7 @@ void wxSplitterWindow::OnSize(wxSizeEvent& event)
                 newPosition = m_sashPosition + delta;
                 if( newPosition < m_minimumPaneSize )
                     newPosition = m_minimumPaneSize;
+
             }
 
             // Send an event with the newly calculated position. The handler
@@ -824,6 +826,7 @@ bool wxSplitterWindow::DoSplit(wxSplitMode mode,
 
 
     SetSashPosition(sashPosition, true);
+    
     return true;
 }
 
@@ -840,6 +843,12 @@ int wxSplitterWindow::ConvertSashPosition(int sashPosition) const
     }
     else // sashPosition == 0
     {
+        int defaultPos = GetWindowSize() / 2;
+        if (m_splitMode == wxSPLIT_VERTICAL) {
+            return m_latestVerticalSashPosition != 0 ? m_latestVerticalSashPosition : defaultPos;
+        } else if (m_splitMode == wxSPLIT_HORIZONTAL) {
+            return m_latestHorizontalSashPosition != 0 ? m_latestHorizontalSashPosition : defaultPos;
+        }
         // default, put it in the centre
         return GetWindowSize() / 2;
     }
@@ -869,6 +878,12 @@ bool wxSplitterWindow::Unsplit(wxWindow *toRemove)
         wxFAIL_MSG(wxT("splitter: attempt to remove a non-existent window"));
 
         return false;
+    }
+
+    if (m_splitMode == wxSPLIT_VERTICAL) {
+        m_latestVerticalSashPosition = m_sashPosition;
+    } else if (m_splitMode == wxSPLIT_HORIZONTAL) {
+        m_latestHorizontalSashPosition = m_sashPosition;
     }
 
     OnUnsplit(win);
@@ -1085,6 +1100,19 @@ void wxSplitterWindow::OnUnsplit(wxWindow *winRemoved)
     // call this before calling the event handler which may delete the window
     winRemoved->Show(false);
 }
+
+void wxSplitterWindow::GetDefaultSashPosition(int& horizontal, int& vertical) const
+{
+    horizontal = m_latestHorizontalSashPosition;
+    vertical = m_latestVerticalSashPosition;
+}
+
+void wxSplitterWindow::SetDefaultSashPosition(int horizontal, int vertical)
+{
+    m_latestHorizontalSashPosition = horizontal;
+    m_latestVerticalSashPosition = vertical;
+}
+
 
 #if defined( __WXMSW__ ) || defined( __WXMAC__)
 

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -130,8 +130,7 @@ void wxSplitterWindow::Init()
     m_minimumPaneSize = 0;
     m_sashCursorWE = wxCursor(wxCURSOR_SIZEWE);
     m_sashCursorNS = wxCursor(wxCURSOR_SIZENS);
-    m_latestHorizontalSashPosition = 0;
-    m_latestVerticalSashPosition = 0;
+    m_lastSplitPosition = wxPoint(0, 0);
     m_needUpdating = false;
     m_isHot = false;
 }
@@ -472,7 +471,6 @@ void wxSplitterWindow::OnSize(wxSizeEvent& event)
                 newPosition = m_sashPosition + delta;
                 if( newPosition < m_minimumPaneSize )
                     newPosition = m_minimumPaneSize;
-
             }
 
             // Send an event with the newly calculated position. The handler
@@ -826,7 +824,6 @@ bool wxSplitterWindow::DoSplit(wxSplitMode mode,
 
 
     SetSashPosition(sashPosition, true);
-    
     return true;
 }
 
@@ -844,13 +841,16 @@ int wxSplitterWindow::ConvertSashPosition(int sashPosition) const
     else // sashPosition == 0
     {
         int defaultPos = GetWindowSize() / 2;
-        if (m_splitMode == wxSPLIT_VERTICAL) {
-            return m_latestVerticalSashPosition != 0 ? m_latestVerticalSashPosition : defaultPos;
-        } else if (m_splitMode == wxSPLIT_HORIZONTAL) {
-            return m_latestHorizontalSashPosition != 0 ? m_latestHorizontalSashPosition : defaultPos;
+        if (m_splitMode == wxSPLIT_VERTICAL)
+        {
+            return m_lastSplitPosition.x != 0 ? m_lastSplitPosition.x : defaultPos;
+        }
+        else if (m_splitMode == wxSPLIT_HORIZONTAL)
+        {
+            return m_lastSplitPosition.y != 0 ? m_lastSplitPosition.y : defaultPos;
         }
         // default, put it in the centre
-        return GetWindowSize() / 2;
+        return defaultPos;
     }
 }
 
@@ -880,10 +880,13 @@ bool wxSplitterWindow::Unsplit(wxWindow *toRemove)
         return false;
     }
 
-    if (m_splitMode == wxSPLIT_VERTICAL) {
-        m_latestVerticalSashPosition = m_sashPosition;
-    } else if (m_splitMode == wxSPLIT_HORIZONTAL) {
-        m_latestHorizontalSashPosition = m_sashPosition;
+    if (m_splitMode == wxSPLIT_VERTICAL)
+    {
+        m_lastSplitPosition.x = m_sashPosition;
+    }
+    else if (m_splitMode == wxSPLIT_HORIZONTAL)
+    {
+        m_lastSplitPosition.y = m_sashPosition;
     }
 
     OnUnsplit(win);
@@ -1101,16 +1104,14 @@ void wxSplitterWindow::OnUnsplit(wxWindow *winRemoved)
     winRemoved->Show(false);
 }
 
-void wxSplitterWindow::GetDefaultSashPosition(int& horizontal, int& vertical) const
+const wxPoint& wxSplitterWindow::GetLastSplitPosition() const
 {
-    horizontal = m_latestHorizontalSashPosition;
-    vertical = m_latestVerticalSashPosition;
+    return m_lastSplitPosition;
 }
 
-void wxSplitterWindow::SetDefaultSashPosition(int horizontal, int vertical)
+void wxSplitterWindow::SetLastSplitPosition(int horizontal, int vertical)
 {
-    m_latestHorizontalSashPosition = horizontal;
-    m_latestVerticalSashPosition = vertical;
+    m_lastSplitPosition = wxPoint(horizontal, vertical);
 }
 
 


### PR DESCRIPTION
Work on issue: #22712

Adds members to wxSplitterWindow for storing the last sash position of a horizontal/vertical split when Unsplit is called. This allows the previous sash position to be restored instead of resetting back to the default position when the window is split again.

Adds setter / getter for the new members which are used by wxPersistentSplitter to save and restore state.
