### PR TITLE
Add translucent stipple brush support under wxQt

### DIFF
--- a/src/qt/brush.cpp
+++ b/src/qt/brush.cpp
@@ -74,6 +74,15 @@ public:
         m_style = data.m_style;
     }
 
+    void DoSetStipple(const wxBitmap& stipple)
+    {
+        m_qtBrush.setTexture(*stipple.GetHandle());
+        if (stipple.GetMask() != nullptr)
+            m_style = wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE;
+        else
+            m_style = wxBRUSHSTYLE_STIPPLE;
+    }
+
     bool operator == (const wxBrushRefData& data) const
     {
         return m_qtBrush == data.m_qtBrush;
@@ -113,11 +122,8 @@ wxBrush::wxBrush(const wxColour& col, int style)
 wxBrush::wxBrush(const wxBitmap& stipple)
 {
     m_refData = new wxBrushRefData();
-    M_BRUSHDATA.setTexture(*stipple.GetHandle());
-    if (stipple.GetMask() != nullptr)
-        M_STYLEDATA = wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE;
-    else
-        M_STYLEDATA = wxBRUSHSTYLE_STIPPLE;
+
+    static_cast<wxBrushRefData*>(m_refData)->DoSetStipple(stipple);
 }
 
 
@@ -143,12 +149,8 @@ void wxBrush::SetStyle(wxBrushStyle style)
 void wxBrush::SetStipple(const wxBitmap& stipple)
 {
     AllocExclusive();
-    M_BRUSHDATA.setTexture(*stipple.GetHandle());
 
-    if (stipple.GetMask() != nullptr)
-        M_STYLEDATA = wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE;
-    else
-        M_STYLEDATA = wxBRUSHSTYLE_STIPPLE;
+    static_cast<wxBrushRefData*>(m_refData)->DoSetStipple(stipple);
 }
 
 

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -194,26 +194,10 @@ void wxQtDCImpl::SetBrush(const wxBrush& brush)
     if (brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE)
     {
         // Use a monochrome mask: use foreground color for the mask
-        QBrush b(brush.GetHandle());
-        b.setColor(m_textForegroundColour.GetQColor());
-        b.setTexture(b.texture().mask());
-        m_qtPainter->setBrush(b);
+        m_brush.SetColour(m_textForegroundColour);
     }
-    else if (brush.GetStyle() == wxBRUSHSTYLE_STIPPLE)
-    {
-        //Don't use the mask
-        QBrush b(brush.GetHandle());
 
-        QPixmap p = b.texture();
-        p.setMask(QBitmap());
-        b.setTexture(p);
-
-        m_qtPainter->setBrush(b);
-    }
-    else
-    {
-        m_qtPainter->setBrush(brush.GetHandle());
-    }
+    m_qtPainter->setBrush(m_brush.GetHandle());
 
     ApplyRasterColourOp();
 }


### PR DESCRIPTION
This is to support **venetian blinds bitmap** creation in `wxAUI`

![Screenshot from 2024-02-18 18-24-17](https://github.com/wxWidgets/wxWidgets/assets/7704771/58a5340d-cc11-4768-9e36-a4ea0259d4fd)
