### PR TITLE
wxAUI: fix venetian blinds hint in dark mode

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -79,10 +79,12 @@ const int auiToolBarLayer = 10;
 
 static wxBitmap wxCreateVenetianBlindsBitmap(wxByte r, wxByte g, wxByte b, wxByte a)
 {
-    unsigned char data[] = { r,g,b, 0,0,0, r,g,b };
-    unsigned char alpha[] = { a, 128, a };
+    const unsigned char c = wxSystemSettings::GetAppearance().IsDark() ? 220 : 5;
 
-    wxImage img(1,3,data,true);
+    unsigned char data[] = { r,g,b, r,g,b, c,c,c, c,c,c };
+    unsigned char alpha[] = { a, a, 200, 200 };
+
+    wxImage img(1,4,data,true);
     img.SetAlpha(alpha,true);
     return wxBitmap(img);
 }


### PR DESCRIPTION
Also a small aesthetic change is made to make it easier to discern.

wxMSW:
![aui_msw](https://github.com/wxWidgets/wxWidgets/assets/7704771/a21e816b-d496-4df5-9dee-5ddf05c70402)

wxMSW (dark):
![aui_dark_msw](https://github.com/wxWidgets/wxWidgets/assets/7704771/2ba08d0b-7c91-40e1-ba6e-071a67d355bd)

wxGTK3:
![aui_gtk3](https://github.com/wxWidgets/wxWidgets/assets/7704771/32fd4388-99ab-4b96-a34d-69e8889588b3)

wxGTK3 (dark):
![aui_dark_gtk3](https://github.com/wxWidgets/wxWidgets/assets/7704771/33e7cefb-694d-4083-8791-716b4b8c9495)

wxQt:
![aui_qt](https://github.com/wxWidgets/wxWidgets/assets/7704771/c9ba49cc-f960-4293-a74c-1c4e8f72c795)

wxQt (KDE):
![aui_kde_qt](https://github.com/wxWidgets/wxWidgets/assets/7704771/be0ae42d-7079-4a4f-8e0f-62c73556f346)

**Edit:** wxQt depends on this #24337
