### PR TITLE
Fixes for wxGTK enter/leave window events

### DIFF
--- a/include/wx/gtk/private/event.h
+++ b/include/wx/gtk/private/event.h
@@ -88,6 +88,12 @@ template<typename T> void InitMouseEvent(wxWindowGTK *win,
     event.SetTimestamp( gdk_event->time );
 }
 
+// Update the window currently known to be under the mouse pointer.
+//
+// Returns true if it was updated, false if this window was already known to
+// contain the mouse pointer.
+bool SetWindowUnderMouse(wxWindowGTK* win);
+
 } // namespace wxGTKImpl
 
 #endif // _GTK_PRIVATE_EVENT_H_

--- a/include/wx/gtk/private/event.h
+++ b/include/wx/gtk/private/event.h
@@ -94,6 +94,17 @@ template<typename T> void InitMouseEvent(wxWindowGTK *win,
 // contain the mouse pointer.
 bool SetWindowUnderMouse(wxWindowGTK* win);
 
+// Implementation of enter/leave window callbacks.
+gboolean
+WindowEnterCallback(GtkWidget* widget,
+                    GdkEventCrossing* event,
+                    wxWindowGTK* win);
+
+gboolean
+WindowLeaveCallback(GtkWidget* widget,
+                    GdkEventCrossing* event,
+                    wxWindowGTK* win);
+
 } // namespace wxGTKImpl
 
 #endif // _GTK_PRIVATE_EVENT_H_

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -171,14 +171,9 @@ public:
     virtual GtkWidget* GetConnectWidget();
     void ConnectWidget( GtkWidget *widget );
 
-    // Called from several event handlers, if it returns true or false, the
-    // same value should be immediately returned by the handler without doing
-    // anything else. If it returns -1, the handler should continue as usual
-    int GTKCallbackCommonPrologue(struct _GdkEventAny *event) const;
 
-    // Simplified form of GTKCallbackCommonPrologue() which can be used from
-    // GTK callbacks without return value to check if the event should be
-    // ignored: if this returns true, the event shouldn't be handled
+    // Returns true if GTK callbacks are blocked due to a drag event being in
+    // progress.
     bool GTKShouldIgnoreEvent() const;
 
 

--- a/samples/widgets/activityindicator.cpp
+++ b/samples/widgets/activityindicator.cpp
@@ -145,6 +145,8 @@ void ActivityIndicatorWidgetsPage::RecreateWidget()
                                           wxDefaultPosition, wxDefaultSize,
                                           GetAttrs().m_defaultFlags);
 
+    NotifyWidgetRecreation(m_indicator);
+
     m_sizerIndicator->AddStretchSpacer();
     m_sizerIndicator->Add(m_indicator, wxSizerFlags().Centre());
     m_sizerIndicator->AddStretchSpacer();

--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -478,6 +478,8 @@ void BitmapComboBoxWidgetsPage::CreateCombo()
     m_combobox->SetPopupMaxHeight(600);
 #endif
 
+    NotifyWidgetRecreation(m_combobox);
+
     unsigned int count = items.GetCount();
     for ( unsigned int n = 0; n < count; n++ )
     {

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -562,6 +562,8 @@ void ButtonWidgetsPage::CreateButton()
     m_sizerNote->Show(m_chkCommandLink->GetValue());
 #endif
 
+    NotifyWidgetRecreation(m_button);
+
     if ( !showsBitmap && m_chkTextAndBitmap->GetValue() )
     {
         showsBitmap = true;

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -276,6 +276,8 @@ void CheckBoxWidgetsPage::CreateCheckbox()
                               wxDefaultPosition, wxDefaultSize,
                               flags);
 
+    NotifyWidgetRecreation(m_checkbox);
+
     m_sizerCheckbox->Add(0, 0, 1, wxCENTRE);
     m_sizerCheckbox->Add(m_checkbox, 1, wxCENTRE);
     m_sizerCheckbox->Add(0, 0, 1, wxCENTRE);

--- a/samples/widgets/choice.cpp
+++ b/samples/widgets/choice.cpp
@@ -303,6 +303,8 @@ void ChoiceWidgetsPage::CreateChoice()
                             0, nullptr,
                             flags);
 
+    NotifyWidgetRecreation(m_choice);
+
     m_choice->Set(items);
     m_sizerChoice->Add(m_choice, 0, wxGROW | wxALL, 5);
     m_sizerChoice->Layout();

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -191,6 +191,8 @@ void ColourPickerWidgetsPage::CreatePicker()
     m_clrPicker = new wxColourPickerCtrl(this, PickerPage_Colour, *wxRED,
                                          wxDefaultPosition, wxDefaultSize,
                                          style);
+
+    NotifyWidgetRecreation(m_clrPicker);
 }
 
 void ColourPickerWidgetsPage::RecreatePicker()

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -476,6 +476,8 @@ void ComboboxWidgetsPage::CreateCombo()
     delete m_combobox;
     m_combobox = newCb;
     m_combobox->SetId(ComboPage_Combo);
+
+    NotifyWidgetRecreation(m_combobox);
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -285,6 +285,8 @@ void DatePickerWidgetsPage::CreateDatePicker()
                                         wxDefaultPosition, wxDefaultSize,
                                         style);
 
+    NotifyWidgetRecreation(m_datePicker);
+
     m_sizerDatePicker->Add(0, 0, 1, wxCENTRE);
     m_sizerDatePicker->Add(m_datePicker, 1, wxCENTRE);
     m_sizerDatePicker->Add(0, 0, 1, wxCENTRE);

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -302,6 +302,8 @@ void DirCtrlWidgetsPage::CreateDirCtrl(bool defaultPath)
     delete m_dirCtrl;
     m_dirCtrl = dirCtrl;
 
+    NotifyWidgetRecreation(m_dirCtrl);
+
     // relayout the sizer
     GetSizer()->Layout();
 }

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -209,6 +209,8 @@ void DirPickerWidgetsPage::CreatePicker()
                                       wxGetHomeDir(), "Hello!",
                                       wxDefaultPosition, wxDefaultSize,
                                       style);
+
+    NotifyWidgetRecreation(m_dirPicker);
 }
 
 void DirPickerWidgetsPage::RecreatePicker()

--- a/samples/widgets/editlbox.cpp
+++ b/samples/widgets/editlbox.cpp
@@ -198,6 +198,8 @@ void EditableListboxWidgetsPage::CreateLbox()
                                    wxDefaultPosition, wxDefaultSize,
                                    flags);
 
+    NotifyWidgetRecreation(m_lbox);
+
     m_lbox->SetStrings(items);
     m_sizerLbox->Add(m_lbox, 1, wxGROW | wxALL, 5);
     m_sizerLbox->Layout();

--- a/samples/widgets/filectrl.cpp
+++ b/samples/widgets/filectrl.cpp
@@ -275,6 +275,8 @@ void FileCtrlWidgetsPage::CreateFileCtrl()
     delete m_fileCtrl;
     m_fileCtrl = fileCtrl;
 
+    NotifyWidgetRecreation(m_fileCtrl);
+
     // relayout the sizer
     GetSizer()->Layout();
 }

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -248,6 +248,8 @@ void FilePickerWidgetsPage::CreatePicker()
                                         "Hello!", "*",
                                         wxDefaultPosition, wxDefaultSize,
                                         style);
+
+    NotifyWidgetRecreation(m_filePicker);
 }
 
 void FilePickerWidgetsPage::RecreatePicker()

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -186,6 +186,8 @@ void FontPickerWidgetsPage::CreatePicker()
                                         *wxSWISS_FONT,
                                         wxDefaultPosition, wxDefaultSize,
                                         style);
+
+    NotifyWidgetRecreation(m_fontPicker);
 }
 
 void FontPickerWidgetsPage::RecreatePicker()

--- a/samples/widgets/gauge.cpp
+++ b/samples/widgets/gauge.cpp
@@ -307,6 +307,9 @@ void GaugeWidgetsPage::CreateGauge()
     m_gauge = new wxGauge(this, GaugePage_Gauge, m_range,
                           wxDefaultPosition, wxDefaultSize,
                           flags);
+
+    NotifyWidgetRecreation(m_gauge);
+
     m_gauge->SetValue(val);
 
     if ( flags & wxGA_VERTICAL )

--- a/samples/widgets/headerctrl.cpp
+++ b/samples/widgets/headerctrl.cpp
@@ -200,6 +200,8 @@ void HeaderCtrlWidgetsPage::RecreateWidget()
                                       wxDefaultPosition, wxDefaultSize,
                                       flags);
 
+    NotifyWidgetRecreation(m_header);
+
     m_header->Bind(wxEVT_HEADER_RESIZING, &HeaderCtrlWidgetsPage::OnResizing, this);
     m_header->Bind(wxEVT_HEADER_BEGIN_RESIZE, &HeaderCtrlWidgetsPage::OnBeginResize, this);
     m_header->Bind(wxEVT_HEADER_END_RESIZE, &HeaderCtrlWidgetsPage::OnEndResize, this);

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -288,6 +288,8 @@ void HyperlinkWidgetsPage::CreateHyperlink()
     delete m_hyperlink;
     m_hyperlink = hyp;
 
+    NotifyWidgetRecreation(m_hyperlink);
+
     // relayout the sizer
     GetSizer()->Layout();
 }

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -506,6 +506,8 @@ void ListboxWidgetsPage::CreateLbox()
                                flags);
     }
 
+    NotifyWidgetRecreation(m_lbox);
+
     m_sizerLbox->Add(m_lbox, 1, wxGROW | wxALL, 5);
     m_sizerLbox->Layout();
 }

--- a/samples/widgets/native.cpp
+++ b/samples/widgets/native.cpp
@@ -308,6 +308,8 @@ void NativeWidgetsPage::RecreateWidget()
     delete m_nativeWindow;
     m_nativeWindow = new NativeWindow(this);
 
+    NotifyWidgetRecreation(m_nativeWindow);
+
     m_sizerCtrl->Clear();
     if ( m_chkExpand->IsChecked() )
     {

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -365,6 +365,8 @@ void BookWidgetsPage::RecreateBook()
 
     m_book = CreateBook(flags);
 
+    NotifyWidgetRecreation(m_book);
+
     CreateImageList();
 
     if ( oldBook )

--- a/samples/widgets/odcombobox.cpp
+++ b/samples/widgets/odcombobox.cpp
@@ -527,6 +527,8 @@ void ODComboboxWidgetsPage::CreateCombo()
                        0, nullptr,
                        flags);
 
+    NotifyWidgetRecreation(m_combobox);
+
     unsigned int count = items.GetCount();
     for ( unsigned int n = 0; n < count; n++ )
     {

--- a/samples/widgets/radiobox.cpp
+++ b/samples/widgets/radiobox.cpp
@@ -358,6 +358,8 @@ void RadioWidgetsPage::CreateRadio()
                              majorDim,
                              flags);
 
+    NotifyWidgetRecreation(m_radio);
+
     if ( sel >= 0 && (size_t)sel < count )
     {
         m_radio->SetSelection(sel);

--- a/samples/widgets/searchctrl.cpp
+++ b/samples/widgets/searchctrl.cpp
@@ -178,6 +178,8 @@ void SearchCtrlWidgetsPage::CreateControl()
 
     m_srchCtrl = new wxSearchCtrl(this, -1, wxEmptyString, wxDefaultPosition,
                                   FromDIP(wxSize(150, -1)), style);
+
+    NotifyWidgetRecreation(m_srchCtrl);
 }
 
 void SearchCtrlWidgetsPage::RecreateWidget()

--- a/samples/widgets/slider.cpp
+++ b/samples/widgets/slider.cpp
@@ -517,6 +517,8 @@ void SliderWidgetsPage::CreateSlider()
                             wxDefaultPosition, wxDefaultSize,
                             flags);
 
+    NotifyWidgetRecreation(m_slider);
+
     if ( m_slider->HasFlag(wxSL_VERTICAL) )
     {
         m_sizerSlider->AddStretchSpacer(1);

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -416,6 +416,8 @@ void SpinBtnWidgetsPage::CreateSpin()
                                  wxDefaultPosition, wxDefaultSize,
                                  flags);
 
+    NotifyWidgetRecreation(m_spinbtn);
+
     m_spinbtn->SetValue(val);
     m_spinbtn->SetRange(m_min, m_max);
 
@@ -425,11 +427,15 @@ void SpinBtnWidgetsPage::CreateSpin()
                                 flags | textFlags,
                                 m_min, m_max, val);
 
+    NotifyWidgetRecreation(m_spinctrl);
+
     m_spinctrldbl = new wxSpinCtrlDouble(this, SpinBtnPage_SpinCtrlDouble,
                                          wxString::Format("%d", val),
                                          wxDefaultPosition, wxDefaultSize,
                                          flags | textFlags,
                                          m_min, m_max, val, 0.1);
+
+    NotifyWidgetRecreation(m_spinctrldbl);
 
     // Add spacers, labels and spin controls to the sizer.
     m_sizerSpin->Add(0, 0, 1);

--- a/samples/widgets/statbmp.cpp
+++ b/samples/widgets/statbmp.cpp
@@ -161,6 +161,8 @@ void StatBmpWidgetsPage::RecreateWidget()
                                               style);
     }
 
+    NotifyWidgetRecreation(m_statbmp);
+
     wxStaticBitmapBase::ScaleMode scaleMode = (wxStaticBitmapBase::ScaleMode) m_scaleRadio->GetSelection();
     m_statbmp->SetScaleMode(scaleMode);
     if ( m_statbmp->GetScaleMode() != scaleMode )

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -525,9 +525,13 @@ void StaticWidgetsPage::CreateStatic()
 #endif // wxUSE_MARKUP
     }
 
+    NotifyWidgetRecreation(m_statText);
+
     m_statText->SetToolTip("Tooltip for a label inside the box");
 
 #if wxUSE_MARKUP
+    NotifyWidgetRecreation(m_statMarkup);
+
     m_statMarkup->SetLabelMarkup(m_textLabelWithMarkup->GetValue());
 
     if ( m_chkGreen->GetValue() )
@@ -538,6 +542,8 @@ void StaticWidgetsPage::CreateStatic()
     m_statLine = new wxStaticLine(staticBox, wxID_ANY,
                                   wxDefaultPosition, wxDefaultSize,
                                   isVert ? wxLI_VERTICAL : wxLI_HORIZONTAL);
+
+    NotifyWidgetRecreation(m_statLine);
 #endif // wxUSE_STATLINE
 
     m_sizerStatBox->Add(m_statText, 0, wxGROW);

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -787,6 +787,8 @@ void TextWidgetsPage::CreateText()
 
     m_text = new WidgetsTextCtrl(m_sizerText->GetStaticBox(), TextPage_Textctrl, valueOld, flags);
 
+    NotifyWidgetRecreation(m_text);
+
 #if 0
     if ( m_chkFilename->GetValue() )
         ;

--- a/samples/widgets/timepick.cpp
+++ b/samples/widgets/timepick.cpp
@@ -198,6 +198,8 @@ void TimePickerWidgetsPage::CreateTimePicker()
                                         wxDefaultPosition, wxDefaultSize,
                                         style);
 
+    NotifyWidgetRecreation(m_timePicker);
+
     m_sizerTimePicker->Add(0, 0, 1, wxCENTRE);
     m_sizerTimePicker->Add(m_timePicker, 1, wxCENTRE);
     m_sizerTimePicker->Add(0, 0, 1, wxCENTRE);

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -461,6 +461,9 @@ void ToggleWidgetsPage::CreateToggle()
                                       wxDefaultPosition, wxDefaultSize,
                                       flags);
     }
+
+    NotifyWidgetRecreation(m_toggle);
+
     m_toggle->SetValue(value);
 
 #ifdef wxHAS_BITMAPTOGGLEBUTTON

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -741,6 +741,17 @@ void WidgetsFrame::ConnectToWidgetEvents()
         w->Bind(wxEVT_SET_FOCUS, &WidgetsFrame::OnWidgetFocus, this);
         w->Bind(wxEVT_KILL_FOCUS, &WidgetsFrame::OnWidgetFocus, this);
 
+        w->Bind(wxEVT_ENTER_WINDOW, [w](wxMouseEvent& event)
+            {
+                wxLogMessage("Mouse entered into '%s'", w->GetClassInfo()->GetClassName());
+                event.Skip();
+            });
+        w->Bind(wxEVT_LEAVE_WINDOW, [w](wxMouseEvent& event)
+            {
+                wxLogMessage("Mouse left '%s'", w->GetClassInfo()->GetClassName());
+                event.Skip();
+            });
+
         w->Bind(wxEVT_CONTEXT_MENU, &WidgetsFrame::OnWidgetContextMenu, this);
     }
 }

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -149,6 +149,13 @@ public:
     // this is currently used only to take into account the border flags
     virtual void RecreateWidget() = 0;
 
+    // notify the main window about the widget recreation if it didn't happen
+    // due to a call to RecreateWidget()
+    void NotifyWidgetRecreation(wxWindow* widget);
+
+    // enable notifications about the widget recreation disabled initially
+    void EnableRecreationNotifications() { m_notifyRecreate = true; }
+
     // apply current attributes to the widget(s)
     void SetUpWidget();
 
@@ -191,6 +198,9 @@ protected:
 public:
     // the head of the linked list containinginfo about all pages
     static WidgetsPageInfo *ms_widgetPages;
+
+private:
+    bool m_notifyRecreate = false;
 };
 
 // ----------------------------------------------------------------------------

--- a/src/gtk/srchctrl.cpp
+++ b/src/gtk/srchctrl.cpp
@@ -20,6 +20,7 @@
 
 #include "wx/utils.h"
 #include "wx/gtk/private.h"
+#include "wx/gtk/private/event.h"
 #include "wx/gtk/private/gtk3-compat.h"
 
 
@@ -91,6 +92,28 @@ wx_gtk_icon_press(GtkEntry* WXUNUSED(entry),
         event.SetEventObject(ctrl);
         ctrl->HandleWindowEvent(event);
     }
+}
+
+static gboolean
+wx_gtk_entry_event(GtkEntry* WXUNUSED(entry),
+                   GdkEvent* event,
+                   wxSearchCtrl* ctrl)
+{
+    if ( event->type == GDK_MOTION_NOTIFY )
+    {
+        // GtkEntry "event" signal handler ignores motion events happening over
+        // inactive icons, but we want to notify the window about the mouse
+        // entering it when they happen.
+        if ( wxGTKImpl::SetWindowUnderMouse(ctrl) )
+        {
+            wxMouseEvent mouseEvent(wxEVT_ENTER_WINDOW);
+            wxGTKImpl::InitMouseEvent(ctrl, mouseEvent, (GdkEventMotion*)event);
+
+            ctrl->GTKProcessEvent(mouseEvent);
+        }
+    }
+
+    return FALSE;
 }
 
 }
@@ -209,6 +232,8 @@ void wxSearchCtrl::GTKCreateSearchEntryWidget()
     }
 
     g_signal_connect(m_entry, "icon-press", G_CALLBACK(wx_gtk_icon_press), this);
+
+    g_signal_connect(m_entry, "event", G_CALLBACK(wx_gtk_entry_event), this);
 }
 
 GtkEditable *wxSearchCtrl::GetEditable() const

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2246,14 +2246,16 @@ wx_window_focus_callback(GtkWidget *widget,
     return FALSE;
 }
 
+} // extern "C"
+
 //-----------------------------------------------------------------------------
 // "enter_notify_event"
 //-----------------------------------------------------------------------------
 
-static gboolean
-gtk_window_enter_callback( GtkWidget* widget,
-                           GdkEventCrossing *gdk_event,
-                           wxWindowGTK *win )
+gboolean
+wxGTKImpl::WindowEnterCallback(GtkWidget* widget,
+                               GdkEventCrossing* gdk_event,
+                               wxWindowGTK* win)
 {
     wxLogTrace(TRACE_MOUSE, "Window enter in %s (window %p) for window %p",
                wxDumpWindow(win), gtk_widget_get_window(widget), gdk_event->window);
@@ -2297,14 +2299,26 @@ gtk_window_enter_callback( GtkWidget* widget,
     return win->GTKProcessEvent(event);
 }
 
+extern "C" {
+
+static gboolean
+gtk_window_enter_callback( GtkWidget* widget,
+                           GdkEventCrossing *gdk_event,
+                           wxWindowGTK *win )
+{
+    return wxGTKImpl::WindowEnterCallback(widget, gdk_event, win);
+}
+
+} // extern "C"
+
 //-----------------------------------------------------------------------------
 // "leave_notify_event"
 //-----------------------------------------------------------------------------
 
-static gboolean
-gtk_window_leave_callback( GtkWidget* widget,
-                           GdkEventCrossing *gdk_event,
-                           wxWindowGTK *win )
+gboolean
+wxGTKImpl::WindowLeaveCallback(GtkWidget* widget,
+                               GdkEventCrossing* gdk_event,
+                               wxWindowGTK* win)
 {
     wxLogTrace(TRACE_MOUSE, "Window leave in %s (window %p) for window %p",
                wxDumpWindow(win), gtk_widget_get_window(widget), gdk_event->window);
@@ -2329,6 +2343,16 @@ gtk_window_leave_callback( GtkWidget* widget,
     InitMouseEvent(win, event, gdk_event);
 
     return win->GTKProcessEvent(event);
+}
+
+extern "C" {
+
+static gboolean
+gtk_window_leave_callback( GtkWidget* widget,
+                           GdkEventCrossing *gdk_event,
+                           wxWindowGTK *win )
+{
+    return wxGTKImpl::WindowLeaveCallback(widget, gdk_event, win);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -72,6 +72,8 @@ typedef guint KeySym;
     #define PANGO_VERSION_CHECK(a,b,c) 0
 #endif
 
+constexpr const char* TRACE_MOUSE = "mouse";
+
 //-----------------------------------------------------------------------------
 // documentation on internals
 //-----------------------------------------------------------------------------
@@ -2248,14 +2250,21 @@ wx_window_focus_callback(GtkWidget *widget,
 //-----------------------------------------------------------------------------
 
 static gboolean
-gtk_window_enter_callback( GtkWidget*,
+gtk_window_enter_callback( GtkWidget* widget,
                            GdkEventCrossing *gdk_event,
                            wxWindowGTK *win )
 {
+    wxLogTrace(TRACE_MOUSE, "Window enter in %s (window %p) for window %p",
+               wxDumpWindow(win), gtk_widget_get_window(widget), gdk_event->window);
+
     wxCOMMON_CALLBACK_PROLOGUE(gdk_event, win);
 
     // Event was emitted after a grab
-    if (gdk_event->mode != GDK_CROSSING_NORMAL) return FALSE;
+    if (gdk_event->mode != GDK_CROSSING_NORMAL)
+    {
+        wxLogTrace(TRACE_MOUSE, "Ignore event with mode %d", gdk_event->mode);
+        return FALSE;
+    }
 
     wxMouseEvent event( wxEVT_ENTER_WINDOW );
     InitMouseEvent(win, event, gdk_event);
@@ -2271,17 +2280,24 @@ gtk_window_enter_callback( GtkWidget*,
 //-----------------------------------------------------------------------------
 
 static gboolean
-gtk_window_leave_callback( GtkWidget*,
+gtk_window_leave_callback( GtkWidget* widget,
                            GdkEventCrossing *gdk_event,
                            wxWindowGTK *win )
 {
+    wxLogTrace(TRACE_MOUSE, "Window leave in %s (window %p) for window %p",
+               wxDumpWindow(win), gtk_widget_get_window(widget), gdk_event->window);
+
     wxCOMMON_CALLBACK_PROLOGUE(gdk_event, win);
 
     if (win->m_needCursorReset)
         win->GTKUpdateCursor();
 
     // Event was emitted after an ungrab
-    if (gdk_event->mode != GDK_CROSSING_NORMAL) return FALSE;
+    if (gdk_event->mode != GDK_CROSSING_NORMAL)
+    {
+        wxLogTrace(TRACE_MOUSE, "Ignore event with mode %d", gdk_event->mode);
+        return FALSE;
+    }
 
     wxMouseEvent event( wxEVT_LEAVE_WINDOW );
     InitMouseEvent(win, event, gdk_event);

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1669,15 +1669,12 @@ bool wxWindowGTK::GTKShouldIgnoreEvent() const
     return g_blockEventsOnDrag;
 }
 
-int wxWindowGTK::GTKCallbackCommonPrologue(GdkEventAny *event) const
+int wxWindowGTK::GTKCallbackCommonPrologue(GdkEventAny* WXUNUSED(event)) const
 {
     if (g_blockEventsOnDrag)
         return TRUE;
     if (g_blockEventsOnScroll)
         return TRUE;
-
-    if (!GTKIsOwnWindow(event->window))
-        return FALSE;
 
     return -1;
 }


### PR DESCRIPTION
As discussed in #24245, this fixes the remaining problem with missing enter events for `wxSearchCtrl` when the mouse enters it over the icon by hooking into `event` signal handling before `GtkEntry` can eat it.

It also fixes #24295 by connecting to the correct `GtkWidget` for `wxChoice`.

The changes to the sample are just to allow testing these events easily in it.