### PR TITLE
Expose reason for notification dismissal through SetInt()

### DIFF
--- a/include/wx/notifmsg.h
+++ b/include/wx/notifmsg.h
@@ -81,6 +81,15 @@ public:
         Timeout_Never = 0   // notification will never time out
     };
 
+    // reasons for dismissal, posted with wxEVT_NOTIFICATION_MESSAGE_DISMISSED events
+    enum class DismissalReason
+    {
+        Unknown,
+        ByUser,
+        ByApp,
+        TimedOut
+    };
+
     // show the notification to the user and hides it after timeout seconds
     // pass (special values Timeout_Auto and Timeout_Never can be used)
     //

--- a/interface/wx/notifmsg.h
+++ b/interface/wx/notifmsg.h
@@ -44,7 +44,10 @@
            is clicked.
     @event{EVT_NOTIFICATION_MESSAGE_DISMISSED(id, func)}
            Process a @c wxEVT_NOTIFICATION_MESSAGE_DISMISSED event, when a notification
-           is dismissed by the user or times out.
+           is dismissed by the user or times out. Since wxWidgets 3.3.0, on platforms
+           supporting it, the reason for dismissal can be obtained from
+           wxCommandEvent::GetInt(), with values corresponding to those of
+           wxNotificationMessage::DismissalReason.
     @event{EVT_NOTIFICATION_MESSAGE_ACTION(id, func)}
            Process a @c wxEVT_NOTIFICATION_MESSAGE_ACTION event, when the user
            selects on of the actions added by AddAction()
@@ -62,6 +65,19 @@ public:
     {
         Timeout_Auto = -1,  ///< Notification will be hidden automatically.
         Timeout_Never = 0   ///< Notification will never time out.
+    };
+
+    /**
+      Reasons for dismissal, posted with wxEVT_NOTIFICATION_MESSAGE_DISMISSED events.
+
+      @since 3.3.0
+    */
+    enum class DismissalReason
+    {
+        Unknown,            ///< Reason unknown, possibly unsupported on this platform.
+        ByUser,             ///< The user dismissed the notification.
+        ByApp,              ///< The application itself closed the notification.
+        TimedOut            ///< The notification expired after reaching its timeout.
     };
 
     /**

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -2782,7 +2782,8 @@ private:
 
     void OnNotificationDismissed(wxCommandEvent& event)
     {
-        ShowStatus("Notification was dismissed");
+        // See wxNotificationMessage::DismissalReason for reason explanations.
+        ShowStatus(wxString::Format("Notification was dismissed (reason: %d)", event.GetInt()));
 
         Raise();
 

--- a/src/generic/notifmsgg.cpp
+++ b/src/generic/notifmsgg.cpp
@@ -265,6 +265,8 @@ void wxNotificationMessageWindow::Set(int timeout)
 void wxNotificationMessageWindow::OnClose(wxCloseEvent& WXUNUSED(event))
 {
     wxCommandEvent evt(wxEVT_NOTIFICATION_MESSAGE_DISMISSED);
+    evt.SetInt(static_cast<int>(wxNotificationMessage::DismissalReason::ByApp));
+
     m_notificationImpl->ProcessNotificationEvent(evt);
 
     if ( m_timer.IsRunning() )
@@ -307,6 +309,7 @@ void wxNotificationMessageWindow::OnNotificationMouseLeave(wxMouseEvent& WXUNUSE
 void wxNotificationMessageWindow::OnCloseClicked(wxCommandEvent& WXUNUSED(event))
 {
     wxCommandEvent evt(wxEVT_NOTIFICATION_MESSAGE_DISMISSED);
+    evt.SetInt(static_cast<int>(wxNotificationMessage::DismissalReason::ByUser));
     m_notificationImpl->ProcessNotificationEvent(evt);
 
     m_notificationImpl->Close();

--- a/src/gtk/notifmsg.cpp
+++ b/src/gtk/notifmsg.cpp
@@ -312,15 +312,33 @@ public:
         // Values according to the OpenDesktop specification at:
         // https://developer.gnome.org/notification-spec/
 
+        auto reason = wxNotificationMessage::DismissalReason::Unknown;
         switch (closeReason)
         {
-            case 1: // Expired
-            case 2: // The notification was dismissed by the user.
+            case 1: // "The notification expired."
+                reason = wxNotificationMessage::DismissalReason::TimedOut;
+                break;
+            case 2: // "The notification was dismissed by the user."
+                reason = wxNotificationMessage::DismissalReason::ByUser;
+                break;
+            case 3: // "The notification was closed by a call to CloseNotification."
+                reason = wxNotificationMessage::DismissalReason::ByApp;
+                break;
+        }
+
+        switch (reason)
+        {
+            case wxNotificationMessage::DismissalReason::TimedOut:
+            case wxNotificationMessage::DismissalReason::ByUser:
             {
                 wxCommandEvent evt(wxEVT_NOTIFICATION_MESSAGE_DISMISSED);
+                evt.SetInt(static_cast<int>(reason));
                 ProcessNotificationEvent(evt);
                 break;
             }
+            case wxNotificationMessage::DismissalReason::ByApp:
+            case wxNotificationMessage::DismissalReason::Unknown:
+                break;
         }
 
     }

--- a/src/gtk/notifmsg.cpp
+++ b/src/gtk/notifmsg.cpp
@@ -326,20 +326,9 @@ public:
                 break;
         }
 
-        switch (reason)
-        {
-            case wxNotificationMessage::DismissalReason::TimedOut:
-            case wxNotificationMessage::DismissalReason::ByUser:
-            {
-                wxCommandEvent evt(wxEVT_NOTIFICATION_MESSAGE_DISMISSED);
-                evt.SetInt(static_cast<int>(reason));
-                ProcessNotificationEvent(evt);
-                break;
-            }
-            case wxNotificationMessage::DismissalReason::ByApp:
-            case wxNotificationMessage::DismissalReason::Unknown:
-                break;
-        }
+        wxCommandEvent evt(wxEVT_NOTIFICATION_MESSAGE_DISMISSED);
+        evt.SetInt(static_cast<int>(reason));
+        ProcessNotificationEvent(evt);
 
     }
 

--- a/src/msw/notifmsg.cpp
+++ b/src/msw/notifmsg.cpp
@@ -214,6 +214,7 @@ void wxBalloonNotifMsgImpl::OnIconDismiss(wxTaskBarIconEvent& WXUNUSED(event))
 void wxBalloonNotifMsgImpl::OnTimeout(wxTaskBarIconEvent& WXUNUSED(event))
 {
     wxCommandEvent evt(wxEVT_NOTIFICATION_MESSAGE_DISMISSED);
+    evt.SetInt(static_cast<int>(wxNotificationMessage::DismissalReason::TimedOut));
     ProcessNotificationEvent(evt);
 
     OnIconHidden();
@@ -330,6 +331,7 @@ wxBalloonNotifMsgImpl::Show(int timeout)
 bool wxBalloonNotifMsgImpl::Close()
 {
     wxCommandEvent evt(wxEVT_NOTIFICATION_MESSAGE_DISMISSED);
+    evt.SetInt(static_cast<int>(wxNotificationMessage::DismissalReason::ByUser));
     ProcessNotificationEvent(evt);
 
     OnIconHidden();

--- a/src/osx/cocoa/notifmsg.mm
+++ b/src/osx/cocoa/notifmsg.mm
@@ -143,6 +143,8 @@ public:
             case NSUserNotificationActivationTypeNone:
             {
                 wxCommandEvent evt(wxEVT_NOTIFICATION_MESSAGE_DISMISSED);
+                // reason for dismissal not available on Mac
+                evt.SetInt(static_cast<int>(wxNotificationMessage::DismissalReason::Unknown));
                 ProcessNotificationEvent(evt);
                 break;
             }


### PR DESCRIPTION
On all platforms, except macOS, the reason why a notification was dismissed is known. Specifically, it can be useful to distinguish whether the notification closed because of a timeout, or a click by the user.

This is left undocumented on purpose for now. The values passed are platform-dependent, and this is not the most elegant API.