### PR TITLE
Semi-support Qt6 for wxQt port.

### DIFF
--- a/build/cmake/toolkit.cmake
+++ b/build/cmake/toolkit.cmake
@@ -126,14 +126,32 @@ if(UNIX AND NOT APPLE AND NOT WIN32 AND (WXX11 OR WXGTK2 OR (WXGTK AND wxHAVE_GD
 endif()
 
 if(WXQT)
-    set(QT_COMPONENTS Core Widgets Gui OpenGL Test)
+    set(QT_COMPONENTS Core Widgets Gui OpenGL OpenGLWidgets Test)
+
+    find_package(Qt6 COMPONENTS ${QT_COMPONENTS})
+    if (Qt6_FOUND)
+        set(QT_MAJOR_VERSION 6)
+
+        find_package(PkgConfig REQUIRED)
+
+        pkg_check_modules (GLIB2 REQUIRED glib-2.0)
+        include_directories(${GLIB2_INCLUDE_DIRS})
+
+        list(APPEND wxTOOLKIT_INCLUDE_DIRS ${GLIB2_INCLUDE_DIRS})
+        list(APPEND wxTOOLKIT_LIBRARIES ${GLIB_LIBRARIES})
+    else()
+        set(QT_COMPONENTS Core Widgets Gui OpenGL Test)
+
+        find_package(Qt5 5.15 REQUIRED COMPONENTS ${QT_COMPONENTS})
+        set(QT_MAJOR_VERSION 5)
+    endif()
+
     foreach(QT_COMPONENT ${QT_COMPONENTS})
-        find_package(Qt5 COMPONENTS ${QT_COMPONENT} REQUIRED)
-        list(APPEND wxTOOLKIT_INCLUDE_DIRS ${Qt5${QT_COMPONENT}_INCLUDE_DIRS})
-        list(APPEND wxTOOLKIT_LIBRARIES ${Qt5${QT_COMPONENT}_LIBRARIES})
-        list(APPEND wxTOOLKIT_DEFINITIONS ${Qt5${QT_COMPONENT}_COMPILE_DEFINITIONS})
+        list(APPEND wxTOOLKIT_INCLUDE_DIRS ${Qt${wxQT_MAJOR_VERSION}${QT_COMPONENT}_INCLUDE_DIRS})
+        list(APPEND wxTOOLKIT_LIBRARIES ${Qt${QT_MAJOR_VERSION}${QT_COMPONENT}_LIBRARIES})
+        list(APPEND wxTOOLKIT_DEFINITIONS ${Qt${QT_MAJOR_VERSION}${QT_COMPONENT}_COMPILE_DEFINITIONS})
     endforeach()
-    set(wxTOOLKIT_VERSION ${Qt5Core_VERSION})
+    set(wxTOOLKIT_VERSION ${Qt${QT_MAJOR_VERSION}Core_VERSION})
 endif()
 
 if(APPLE)

--- a/build/cmake/toolkit.cmake
+++ b/build/cmake/toolkit.cmake
@@ -135,7 +135,6 @@ if(WXQT)
         find_package(PkgConfig REQUIRED)
 
         pkg_check_modules (GLIB2 REQUIRED glib-2.0)
-        include_directories(${GLIB2_INCLUDE_DIRS})
 
         list(APPEND wxTOOLKIT_INCLUDE_DIRS ${GLIB2_INCLUDE_DIRS})
         list(APPEND wxTOOLKIT_LIBRARIES ${GLIB_LIBRARIES})

--- a/build/cmake/toolkit.cmake
+++ b/build/cmake/toolkit.cmake
@@ -141,7 +141,7 @@ if(WXQT)
     else()
         set(QT_COMPONENTS Core Widgets Gui OpenGL Test)
 
-        find_package(Qt5 5.15 REQUIRED COMPONENTS ${QT_COMPONENTS})
+        find_package(Qt5 REQUIRED COMPONENTS ${QT_COMPONENTS})
         set(QT_MAJOR_VERSION 5)
     endif()
 

--- a/include/wx/qt/glcanvas.h
+++ b/include/wx/qt/glcanvas.h
@@ -10,9 +10,9 @@
 
 #include <GL/gl.h>
 
-class QGLWidget;
-class QGLContext;
-class QGLFormat;
+class QOpenGLWidget;
+class QOpenGLContext;
+class QSurfaceFormat;
 
 class WXDLLIMPEXP_GL wxGLContext : public wxGLContextBase
 {
@@ -25,7 +25,7 @@ public:
     virtual bool SetCurrent(const wxGLCanvas& win) const override;
 
 private:
-    QGLContext* m_glContext = nullptr;
+    QOpenGLContext* m_glContext = nullptr;
 
     wxDECLARE_CLASS(wxGLContext);
 };
@@ -83,7 +83,7 @@ public:
 
     virtual bool QtCanPaintWithoutActivePainter() const override;
 
-    static bool ConvertWXAttrsToQtGL(const wxGLAttributes &glattrs, const wxGLContextAttrs ctxAttrs, QGLFormat &format);
+    static bool ConvertWXAttrsToQtGL(const wxGLAttributes &glattrs, const wxGLContextAttrs ctxAttrs, QSurfaceFormat &format);
 
 private:
     wxDECLARE_CLASS(wxGLCanvas);

--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -160,7 +160,11 @@ protected:
     //virtual void dropEvent ( QDropEvent * event ) { }
 
     //wxMouseEvent
+#if QT_VERSION_MAJOR >= 6
     virtual void enterEvent ( QEnterEvent * event ) override
+#else
+    virtual void enterEvent ( QEvent * event ) override
+#endif
     {
         if ( !this->GetHandler() )
             return;

--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -84,15 +84,15 @@ public:
         wxWindow::QtStoreWindowPointer( this, handler );
 
         // Handle QWidget destruction signal AFTER it gets deleted
-        QObject::connect( this, &QObject::destroyed, this,
-                          &wxQtEventSignalHandler::HandleDestroyedSignal );
+        // QObject::connect( this, &QObject::destroyed, this,
+        //                   &wxQtEventSignalHandler::HandleDestroyedSignal );
 
         Widget::setMouseTracking(true);
     }
 
-    void HandleDestroyedSignal()
-    {
-    }
+    // void HandleDestroyedSignal()
+    // {
+    // }
 
     virtual Handler *GetHandler() const override
     {
@@ -160,7 +160,7 @@ protected:
     //virtual void dropEvent ( QDropEvent * event ) { }
 
     //wxMouseEvent
-    virtual void enterEvent ( QEvent * event ) override
+    virtual void enterEvent ( QEnterEvent * event ) override
     {
         if ( !this->GetHandler() )
             return;
@@ -237,7 +237,7 @@ protected:
         if ( !this->GetHandler() )
             return;
 
-        if ( !this->GetHandler()->QtHandleEnterEvent(this, event) )
+        if ( !this->GetHandler()->QtHandleLeaveEvent(this, event) )
             Widget::leaveEvent(event);
         else
             event->accept();

--- a/include/wx/qt/region.h
+++ b/include/wx/qt/region.h
@@ -9,9 +9,17 @@
 #ifndef _WX_QT_REGION_H_
 #define _WX_QT_REGION_H_
 
+#include <QtCore/QtConfig>
+
 class QRegion;
 class QRect;
+
+#if QT_VERSION_MAJOR >= 6
+template <typename T> class QList;
+template<typename T> using QVector = QList<T>;
+#else
 template<class T> class QVector;
+#endif
 
 class WXDLLIMPEXP_CORE wxRegion : public wxRegionBase
 {

--- a/include/wx/qt/region.h
+++ b/include/wx/qt/region.h
@@ -9,17 +9,8 @@
 #ifndef _WX_QT_REGION_H_
 #define _WX_QT_REGION_H_
 
-#include <QtCore/QtConfig>
-
 class QRegion;
 class QRect;
-
-#if QT_VERSION_MAJOR >= 6
-template <typename T> class QList;
-template<typename T> using QVector = QList<T>;
-#else
-template<class T> class QVector;
-#endif
 
 class WXDLLIMPEXP_CORE wxRegion : public wxRegionBase
 {
@@ -92,7 +83,7 @@ public:
     wxRect GetRect() const;
 
 private:
-    QVector < QRect > *m_qtRects;
+    void *m_qtRects;
     int m_pos;
 
     wxDECLARE_DYNAMIC_CLASS(wxRegionIterator);

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -10,6 +10,7 @@
 #define _WX_QT_WINDOW_H_
 
 #include <memory>
+#include <QtConfig>
 
 class QShortcut;
 template < class T > class QList;

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -22,6 +22,7 @@ class QWidget;
 
 class QCloseEvent;
 class QContextMenuEvent;
+class QEnterEvent;
 class QEvent;
 class QFocusEvent;
 class QKeyEvent;
@@ -158,7 +159,8 @@ public:
     virtual bool QtHandleWheelEvent  ( QWidget *handler, QWheelEvent *event );
     virtual bool QtHandleKeyEvent    ( QWidget *handler, QKeyEvent *event );
     virtual bool QtHandleMouseEvent  ( QWidget *handler, QMouseEvent *event );
-    virtual bool QtHandleEnterEvent  ( QWidget *handler, QEvent *event );
+    virtual bool QtHandleEnterEvent  ( QWidget *handler, QEnterEvent *event );
+    virtual bool QtHandleLeaveEvent  ( QWidget *handler, QEvent *event );
     virtual bool QtHandleMoveEvent   ( QWidget *handler, QMoveEvent *event );
     virtual bool QtHandleShowEvent   ( QWidget *handler, QEvent *event );
     virtual bool QtHandleChangeEvent ( QWidget *handler, QEvent *event );

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -159,7 +159,13 @@ public:
     virtual bool QtHandleWheelEvent  ( QWidget *handler, QWheelEvent *event );
     virtual bool QtHandleKeyEvent    ( QWidget *handler, QKeyEvent *event );
     virtual bool QtHandleMouseEvent  ( QWidget *handler, QMouseEvent *event );
+
+#if QT_VERSION_MAJOR >= 6
     virtual bool QtHandleEnterEvent  ( QWidget *handler, QEnterEvent *event );
+#else
+    virtual bool QtHandleEnterEvent  ( QWidget *handler, QEvent *event );
+#endif
+
     virtual bool QtHandleLeaveEvent  ( QWidget *handler, QEvent *event );
     virtual bool QtHandleMoveEvent   ( QWidget *handler, QMoveEvent *event );
     virtual bool QtHandleShowEvent   ( QWidget *handler, QEvent *event );

--- a/src/qt/accel.cpp
+++ b/src/qt/accel.cpp
@@ -11,7 +11,8 @@
 #include "wx/accel.h"
 #include "wx/qt/private/converter.h"
 #include <QtCore/QVariant>
-#include <QtWidgets/QShortcut>
+#include <QShortcut>
+#include <QWidget>
 
 // ----------------------------------------------------------------------------
 // wxAccelRefData: the data used by wxAcceleratorTable

--- a/src/qt/cursor.cpp
+++ b/src/qt/cursor.cpp
@@ -10,7 +10,8 @@
 
 
 #include <QtWidgets/QApplication>
-#include <QtGui/QBitmap>
+#include <QBitmap>
+#include <QCursor>
 
 #ifndef WX_PRECOMP
     #include "wx/bitmap.h"
@@ -110,7 +111,7 @@ void wxCursor::InitFromStock( wxStockCursor cursorId )
     {
     case wxCURSOR_BLANK:
     {
-        GetHandle() = QBitmap();
+        GetHandle() = QCursor(QBitmap());
         return;
     }
 //    case wxCURSOR_ARROW:

--- a/src/qt/dcscreen.cpp
+++ b/src/qt/dcscreen.cpp
@@ -12,7 +12,6 @@
 #include "wx/qt/dcscreen.h"
 
 #include <QtWidgets/QApplication>
-#include <QtWidgets/QDesktopWidget>
 #include <QtGui/QPainter>
 #include <QtGui/QPicture>
 #include <QtGui/QPixmap>
@@ -42,7 +41,15 @@ void wxScreenDCImpl::DoGetSize(int *width, int *height) const
 // defered allocation for blit
 QPixmap *wxScreenDCImpl::GetQPixmap()
 {
-    if ( !m_qtPixmap )
-        m_qtPixmap = new QPixmap(QApplication::primaryScreen()->grabWindow(QApplication::desktop()->winId()));
+    if (!m_qtPixmap)
+    {
+        WId winId = 0;
+
+#if QT_VERSION_MAJOR < 6
+        winId = QApplication::desktop()->winId();
+#endif
+
+        m_qtPixmap = new QPixmap(QApplication::primaryScreen()->grabWindow(winId));
+    }
     return m_qtPixmap;
 }

--- a/src/qt/dcscreen.cpp
+++ b/src/qt/dcscreen.cpp
@@ -17,6 +17,10 @@
 #include <QtGui/QPixmap>
 #include <QtGui/QScreen>
 
+#if QT_VERSION_MAJOR < 6
+#include <QDesktopWidget>
+#endif
+
 wxIMPLEMENT_ABSTRACT_CLASS(wxScreenDCImpl, wxQtDCImpl);
 
 wxScreenDCImpl::wxScreenDCImpl( wxScreenDC *owner )

--- a/src/qt/display.cpp
+++ b/src/qt/display.cpp
@@ -14,6 +14,10 @@
 #include <QScreen>
 #include "wx/qt/private/converter.h"
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
+#include <QDesktopWidget>
+#endif
+
 class wxDisplayImplQt : public wxDisplayImpl
 {
 public:
@@ -98,8 +102,12 @@ unsigned wxDisplayFactoryQt::GetCount()
 
 int wxDisplayFactoryQt::GetFromPoint(const wxPoint& pt)
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
     QScreen *screen = QApplication::screenAt(wxQtConvertPoint(pt));
     return QApplication::screens().indexOf(screen);
+#else
+    return QApplication::desktop()->screenNumber( wxQtConvertPoint( pt ));
+#endif
 }
 
 //##############################################################################

--- a/src/qt/display.cpp
+++ b/src/qt/display.cpp
@@ -11,7 +11,7 @@
 #include "wx/display.h"
 #include "wx/private/display.h"
 #include <QtWidgets/QApplication>
-#include <QtWidgets/QDesktopWidget>
+#include <QScreen>
 #include "wx/qt/private/converter.h"
 
 class wxDisplayImplQt : public wxDisplayImpl
@@ -37,17 +37,17 @@ wxDisplayImplQt::wxDisplayImplQt( unsigned n )
 
 wxRect wxDisplayImplQt::GetGeometry() const
 {
-    return wxQtConvertRect( QApplication::desktop()->screenGeometry( GetIndex() ));
+    return wxQtConvertRect(QApplication::screens().value(GetIndex())->geometry());
 }
 
 wxRect wxDisplayImplQt::GetClientArea() const
 {
-    return wxQtConvertRect( QApplication::desktop()->availableGeometry( GetIndex() ));
+    return wxQtConvertRect(QApplication::screens().value(GetIndex())->availableGeometry());
 }
 
 int wxDisplayImplQt::GetDepth() const
 {
-    return IsPrimary() ? QApplication::desktop()->depth() : 0;
+    return IsPrimary() ? QApplication::screens().value(GetIndex())->depth() : 0;
 }
 
 #if wxUSE_DISPLAY
@@ -58,9 +58,11 @@ wxArrayVideoModes wxDisplayImplQt::GetModes(const wxVideoMode& WXUNUSED(mode)) c
 
 wxVideoMode wxDisplayImplQt::GetCurrentMode() const
 {
-    int width = QApplication::desktop()->width();
-    int height = QApplication::desktop()->height();
-    int depth = QApplication::desktop()->depth();
+    QScreen *screen = QApplication::screens().value(GetIndex());
+
+    int width = screen->size().width();
+    int height = screen->size().height();
+    int depth = screen->depth();
 
     return wxVideoMode( width, height, depth );
 }
@@ -91,12 +93,13 @@ wxDisplayImpl *wxDisplayFactoryQt::CreateDisplay(unsigned n)
 
 unsigned wxDisplayFactoryQt::GetCount()
 {
-    return QApplication::desktop()->screenCount();
+    return QApplication::screens().size();
 }
 
 int wxDisplayFactoryQt::GetFromPoint(const wxPoint& pt)
 {
-    return QApplication::desktop()->screenNumber( wxQtConvertPoint( pt ));
+    QScreen *screen = QApplication::screenAt(wxQtConvertPoint(pt));
+    return QApplication::screens().indexOf(screen);
 }
 
 //##############################################################################

--- a/src/qt/evtloop.cpp
+++ b/src/qt/evtloop.cpp
@@ -147,7 +147,7 @@ bool wxQtEventLoopBase::Pending() const
         return qGlobalPostedEventsCount();
     }
 #else
-    return instance->hasPendingEvents();
+    return QAbstractEventDispatcher::instance()->hasPendingEvents();
 #endif
 }
 

--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -548,7 +548,11 @@ void wxNativeFontInfo::SetStyle(wxFontStyle style)
 
 void wxNativeFontInfo::SetNumericWeight(int weight)
 {
+#if QT_VERSION_MAJOR >= 6
+    m_qtFont.setWeight(static_cast<QFont::Weight>(ConvertFontWeight(weight)));
+#else
     m_qtFont.setWeight(ConvertFontWeight(weight));
+#endif
 }
 
 void wxNativeFontInfo::SetUnderlined(bool underlined)

--- a/src/qt/glcanvas.cpp
+++ b/src/qt/glcanvas.cpp
@@ -12,20 +12,20 @@
 #include "wx/qt/private/winevent.h"
 #include "wx/glcanvas.h"
 
-#include <QtOpenGL/QGLWidget>
+#include <QOpenGLWidget>
+#include <QSurfaceFormat>
 #include <QtWidgets/QGestureRecognizer>
 #include <QtWidgets/QGestureEvent>
 
 wxGCC_WARNING_SUPPRESS(unused-parameter)
 
-class wxQtGLWidget : public wxQtEventSignalHandler< QGLWidget, wxGLCanvas >
+class wxQtGLWidget : public wxQtEventSignalHandler< QOpenGLWidget, wxGLCanvas >
 {
 public:
-    wxQtGLWidget(wxWindow *parent, wxGLCanvas *handler, QGLFormat format)
-        : wxQtEventSignalHandler<QGLWidget, wxGLCanvas>(parent, handler)
+    wxQtGLWidget(wxWindow *parent, wxGLCanvas *handler, QSurfaceFormat format)
+        : wxQtEventSignalHandler<QOpenGLWidget, wxGLCanvas>(parent, handler)
     {
         setFormat(format);
-        setAutoBufferSwap(false);
         setFocusPolicy(Qt::StrongFocus);
     }
 
@@ -39,12 +39,12 @@ protected:
 
 void wxQtGLWidget::resizeEvent ( QResizeEvent * event )
 {
-    QGLWidget::resizeEvent(event);
+    QOpenGLWidget::resizeEvent(event);
 }
 
 void wxQtGLWidget::paintEvent ( QPaintEvent * event )
 {
-    QGLWidget::paintEvent(event);
+    QOpenGLWidget::paintEvent(event);
 }
 
 void wxQtGLWidget::resizeGL(int w, int h)
@@ -343,23 +343,20 @@ wxGLContext::wxGLContext(wxGLCanvas *win,
                          const wxGLContext *other,
                          const wxGLContextAttrs *ctxAttrs)
 {
-    QGLWidget *qglWidget = static_cast<QGLWidget *>(win->GetHandle());
-    m_glContext = qglWidget->context();
-
-    if (m_glContext != nullptr)
-    {
-        m_isOk = true;
-    }
+    m_isOk = true;
 }
 
 bool wxGLContext::SetCurrent(const wxGLCanvas& win) const
 {
-    QGLWidget *qglWidget = static_cast<QGLWidget *>(win.GetHandle());
-    QGLContext *context = qglWidget->context();
+    QOpenGLWidget *qglWidget = static_cast<QOpenGLWidget *>(win.GetHandle());
+    QOpenGLContext *context = qglWidget->context();
+
+    if (!m_glContext)
+        const_cast<wxGLContext *>(this)->m_glContext = context;
 
     if (context != m_glContext)
     {
-        // I think I must destroy and recreate the QGLWidget to change the context?
+        // I think I must destroy and recreate the QOpenGLWidget to change the context?
         wxLogDebug("Calling wxGLContext::SetCurrent with a different canvas is not supported in wxQt");
         return false;
     }
@@ -463,7 +460,7 @@ bool wxGLCanvas::Create(wxWindow *parent,
     if (!ParseAttribList(attribList, dispAttrs, &ctxAttrs))
         return false;
 
-    QGLFormat format;
+    QSurfaceFormat format;
     if (!wxGLCanvas::ConvertWXAttrsToQtGL(dispAttrs, ctxAttrs, format))
         return false;
 
@@ -490,7 +487,7 @@ bool wxGLCanvas::Create(wxWindow *parent,
 
 bool wxGLCanvas::SwapBuffers()
 {
-    static_cast<QGLWidget *>(m_qtWindow)->swapBuffers();
+    static_cast<QOpenGLWidget *>(m_qtWindow)->update();
     return true;
 }
 
@@ -500,16 +497,16 @@ bool wxGLCanvas::QtCanPaintWithoutActivePainter() const
 }
 
 /* static */
-bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxGLContextAttrs wxCtxAttrs, QGLFormat &format)
+bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxGLContextAttrs wxCtxAttrs, QSurfaceFormat &format)
 {
     const int *glattrs = wxGLAttrs.GetGLAttrs();
     const int *ctxattrs = wxCtxAttrs.GetGLAttrs();
 
     // set default parameters to false
-    format.setDoubleBuffer(false);
-    format.setDepth(false);
-    format.setAlpha(false);
-    format.setStencil(false);
+    format.setSwapBehavior(QSurfaceFormat::SwapBehavior::SingleBuffer);
+    format.setDepthBufferSize(0);
+    format.setAlphaBufferSize(0);
+    format.setStencilBufferSize(0);
 
     for (int arg = 0; glattrs && glattrs[arg] != 0; arg++)
     {
@@ -522,21 +519,20 @@ bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxG
             // Pixel format attributes
 
             case WX_GL_BUFFER_SIZE:
-                format.setRgba(false);
-                // I do not know how to set the buffer size, so fail
+                // Not supported
                 return false;
 
             case WX_GL_LEVEL:
-                format.setPlane(v);
-                break;
+                // Not supported
+                return false;
 
             case WX_GL_RGBA:
-                format.setRgba(true);
+                // Non-RGBA is not supported
                 isBoolAttr = true;
                 break;
 
             case WX_GL_DOUBLEBUFFER:
-                format.setDoubleBuffer(true);
+                format.setSwapBehavior(QSurfaceFormat::SwapBehavior::DoubleBuffer);
                 isBoolAttr = true;
                 break;
 
@@ -562,17 +558,14 @@ bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxG
                 break;
 
             case WX_GL_MIN_ALPHA:
-                format.setAlpha(true);
                 format.setAlphaBufferSize(v);
                 break;
 
             case WX_GL_DEPTH_SIZE:
-                format.setDepth(true);
                 format.setDepthBufferSize(v);
                 break;
 
             case WX_GL_STENCIL_SIZE:
-                format.setStencil(true);
                 format.setStencilBufferSize(v);
                 break;
 
@@ -580,11 +573,11 @@ bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxG
             case WX_GL_MIN_ACCUM_GREEN:
             case WX_GL_MIN_ACCUM_BLUE:
             case WX_GL_MIN_ACCUM_ALPHA:
-                format.setAccumBufferSize(v);
-                break;
+                // Not supported
+                return false;
 
             case WX_GL_SAMPLE_BUFFERS:
-                format.setSampleBuffers(v);
+                format.setSamples(v > 0 ? std::max(4, format.samples()) : -1);
                 // can we somehow indicate if it's not supported?
                 break;
 
@@ -626,11 +619,11 @@ bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxG
                 break;
 
             case WX_GL_CORE_PROFILE:
-                format.setProfile(QGLFormat::CoreProfile);
+                format.setProfile(QSurfaceFormat::CoreProfile);
                 break;
 
             case wx_GL_COMPAT_PROFILE:
-                format.setProfile(QGLFormat::CompatibilityProfile);
+                format.setProfile(QSurfaceFormat::CompatibilityProfile);
                 break;
 
             default:
@@ -669,11 +662,16 @@ bool wxGLCanvasBase::IsDisplaySupported(const int *attribList)
     if (!ParseAttribList(attribList, dispAttrs, &ctxAttrs))
         return false;
 
-    QGLFormat format;
+    QSurfaceFormat format;
     if (!wxGLCanvas::ConvertWXAttrsToQtGL(dispAttrs, ctxAttrs, format))
         return false;
 
-    return QGLWidget(format).isValid();
+    // QOpenGLWidget widget;
+    // widget.setFormat(format);
+
+    // return widget.isValid();
+
+    return true;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1307,15 +1307,15 @@ void wxQtListTreeWidget::OnKeyDown(wxKeyEvent& event)
     event.Skip();
 }
 
-// Specialization: to safely remove and delete the model associated with QTreeView
-template<>
-void wxQtEventSignalHandler< QTreeView, wxListCtrl >::HandleDestroyedSignal()
-{
-    // This handler is emitted immediately before the QTreeView obj is destroyed
-    // at which point the parent object (wxListCtrl) pointer is guaranteed to still
-    // be valid for the model to be safely removed.
-    this->setModel(nullptr);
-}
+// // Specialization: to safely remove and delete the model associated with QTreeView
+// template<>
+// void wxQtEventSignalHandler< QTreeView, wxListCtrl >::HandleDestroyedSignal()
+// {
+//     // This handler is emitted immediately before the QTreeView obj is destroyed
+//     // at which point the parent object (wxListCtrl) pointer is guaranteed to still
+//     // be valid for the model to be safely removed.
+//     this->setModel(nullptr);
+// }
 
 wxListCtrl::wxListCtrl()
 {

--- a/src/qt/menu.cpp
+++ b/src/qt/menu.cpp
@@ -14,6 +14,7 @@
 #include "wx/qt/private/winevent.h"
 #include "wx/stockitem.h"
 
+#include <QActionGroup>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QMenuBar>
 

--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -15,8 +15,9 @@
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
 
-#include <QtWidgets/QAction>
-#include <QtWidgets/QMenuBar>
+#include <QAction>
+#include <QRegularExpression>
+#include <QMenuBar>
 
 class wxQtAction : public QAction
 {
@@ -37,7 +38,7 @@ public:
     static wxString Normalize(const wxString& text)
     {
         QString normalized = wxQtConvertString( text );
-        normalized.replace(QRegExp("([^+-])[-](.)"), "\\1+\\2");
+        normalized.replace(QRegularExpression("([^+-])[-](.)"), "\\1+\\2");
         return wxQtConvertString( normalized );
     }
 

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -34,7 +34,7 @@ public:
           wxQtSignalHandler(handler)
     {
         connect(this,
-                &QButtonGroup::buttonClicked,
+                static_cast<void (QButtonGroup::*)(QAbstractButton *)>(&QButtonGroup::buttonClicked),
                 this, &wxQtButtonGroup::buttonClicked);
     }
 

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -34,7 +34,7 @@ public:
           wxQtSignalHandler(handler)
     {
         connect(this,
-                static_cast<void (QButtonGroup::*)(int index)>(&QButtonGroup::buttonClicked),
+                &QButtonGroup::buttonClicked,
                 this, &wxQtButtonGroup::buttonClicked);
     }
 
@@ -44,17 +44,17 @@ public:
     }
 
 private:
-    void buttonClicked(int index);
+    void buttonClicked(QAbstractButton *qbutton);
 };
 
-void wxQtButtonGroup::buttonClicked(int index)
+void wxQtButtonGroup::buttonClicked(QAbstractButton *qbutton)
 {
     wxRadioBox *handler = GetRadioBox();
     if ( handler )
     {
         wxCommandEvent event( wxEVT_RADIOBOX, handler->GetId() );
-        event.SetInt(index);
-        event.SetString(wxQtConvertString(button(index)->text()));
+        event.SetInt(buttons().indexOf(qbutton));
+        event.SetString(wxQtConvertString(qbutton->text()));
         EmitEvent( event );
     }
 }

--- a/src/qt/region.cpp
+++ b/src/qt/region.cpp
@@ -346,6 +346,8 @@ const QRegion &wxRegion::GetHandle() const
 
 //##############################################################################
 
+#define M_QTRECTS reinterpret_cast<QVector<QRect> *>(m_qtRects)
+
 wxIMPLEMENT_DYNAMIC_CLASS(wxRegionIterator,wxObject);
 
 wxRegionIterator::wxRegionIterator()
@@ -363,21 +365,21 @@ wxRegionIterator::wxRegionIterator(const wxRegion& region)
 wxRegionIterator::wxRegionIterator(const wxRegionIterator& ri)
     : wxObject()
 {
-    m_qtRects = new QVector< QRect >( *ri.m_qtRects );
+    m_qtRects = new QVector<QRect>(*static_cast<QVector<QRect> *>(ri.m_qtRects));
     m_pos = ri.m_pos;
 }
 
 wxRegionIterator::~wxRegionIterator()
 {
-    delete m_qtRects;
+    delete M_QTRECTS;
 }
 
 wxRegionIterator& wxRegionIterator::operator=(const wxRegionIterator& ri)
 {
     if (this != &ri)
     {
-        delete m_qtRects;
-        m_qtRects = new QVector< QRect >( *ri.m_qtRects );
+        delete M_QTRECTS;
+        m_qtRects = new QVector<QRect>(*static_cast<QVector<QRect> *>(ri.m_qtRects));
         m_pos = ri.m_pos;
     }
     return *this;
@@ -390,13 +392,13 @@ void wxRegionIterator::Reset()
 
 void wxRegionIterator::Reset(const wxRegion& region)
 {
-    delete m_qtRects;
+    delete M_QTRECTS;
 
     auto qtRegion = region.GetHandle();
     m_qtRects = new QVector< QRect >();
-    m_qtRects->reserve(qtRegion.rectCount());
+    M_QTRECTS->reserve(qtRegion.rectCount());
     for (const auto& r : qtRegion)
-        m_qtRects->push_back(r);
+        M_QTRECTS->push_back(r);
 
     m_pos = 0;
 }
@@ -405,7 +407,7 @@ bool wxRegionIterator::HaveRects() const
 {
     wxCHECK_MSG( m_qtRects != nullptr, false, "Invalid iterator" );
 
-    return m_pos < m_qtRects->size();
+    return m_pos < M_QTRECTS->size();
 }
 
 wxRegionIterator::operator bool () const
@@ -429,17 +431,17 @@ wxRegionIterator wxRegionIterator::operator ++ (int)
 wxCoord wxRegionIterator::GetX() const
 {
     wxCHECK_MSG( m_qtRects != nullptr, 0, "Invalid iterator" );
-    wxCHECK_MSG( m_pos < m_qtRects->size(), 0, "Invalid position" );
+    wxCHECK_MSG( m_pos < M_QTRECTS->size(), 0, "Invalid position" );
 
-    return m_qtRects->at( m_pos ).x();
+    return M_QTRECTS->at( m_pos ).x();
 }
 
 wxCoord wxRegionIterator::GetY() const
 {
     wxCHECK_MSG( m_qtRects != nullptr, 0, "Invalid iterator" );
-    wxCHECK_MSG( m_pos < m_qtRects->size(), 0, "Invalid position" );
+    wxCHECK_MSG( m_pos < M_QTRECTS->size(), 0, "Invalid position" );
 
-    return m_qtRects->at( m_pos ).y();
+    return M_QTRECTS->at( m_pos ).y();
 }
 
 wxCoord wxRegionIterator::GetW() const
@@ -450,9 +452,9 @@ wxCoord wxRegionIterator::GetW() const
 wxCoord wxRegionIterator::GetWidth() const
 {
     wxCHECK_MSG( m_qtRects != nullptr, 0, "Invalid iterator" );
-    wxCHECK_MSG( m_pos < m_qtRects->size(), 0, "Invalid position" );
+    wxCHECK_MSG( m_pos < M_QTRECTS->size(), 0, "Invalid position" );
 
-    return m_qtRects->at( m_pos ).width();
+    return M_QTRECTS->at( m_pos ).width();
 }
 
 wxCoord wxRegionIterator::GetH() const
@@ -463,16 +465,16 @@ wxCoord wxRegionIterator::GetH() const
 wxCoord wxRegionIterator::GetHeight() const
 {
     wxCHECK_MSG( m_qtRects != nullptr, 0, "Invalid iterator" );
-    wxCHECK_MSG( m_pos < m_qtRects->size(), 0, "Invalid position" );
+    wxCHECK_MSG( m_pos < M_QTRECTS->size(), 0, "Invalid position" );
 
-    return m_qtRects->at( m_pos ).height();
+    return M_QTRECTS->at( m_pos ).height();
 }
 
 wxRect wxRegionIterator::GetRect() const
 {
     wxCHECK_MSG( m_qtRects != nullptr, wxRect(), "Invalid iterator" );
-    wxCHECK_MSG( m_pos < m_qtRects->size(), wxRect(), "Invalid position" );
+    wxCHECK_MSG( m_pos < M_QTRECTS->size(), wxRect(), "Invalid position" );
 
-    return wxQtConvertRect( m_qtRects->at( m_pos ) );
+    return wxQtConvertRect( M_QTRECTS->at( m_pos ) );
 }
 

--- a/src/qt/renderer.cpp
+++ b/src/qt/renderer.cpp
@@ -623,8 +623,10 @@ wxRendererQt::DrawGauge(wxWindow* win, wxDC& dc, const wxRect& rect,
 
     if ( flags & wxCONTROL_SPECIAL )
     {
+#if QT_VERSION_MAJOR < 6
         if ( isKDE )
             option.orientation = Qt::Vertical;
+#endif
     }
     else
     {

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -12,8 +12,8 @@
 #include "wx/qt/private/converter.h"
 #include <QtGui/QPalette>
 #include <QtWidgets/QApplication>
-#include <QtWidgets/QDesktopWidget>
 #include <QtWidgets/QStyle>
+#include <QScreen>
 
 wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
 {
@@ -196,10 +196,10 @@ int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUN
             return QApplication::style()->pixelMetric(QStyle::PM_IconViewIconSize);
 
         case wxSYS_SCREEN_X:
-            return QApplication::desktop()->screenGeometry().width();
+            return QApplication::primaryScreen()->size().width();
 
         case wxSYS_SCREEN_Y:
-            return QApplication::desktop()->screenGeometry().height();
+            return QApplication::primaryScreen()->size().height();
 
         case wxSYS_HSCROLL_Y:
         case wxSYS_VSCROLL_X:

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -75,9 +75,15 @@ wxBitmap wxStaticBitmap::GetBitmap() const
     wxBitmap bitmap = m_bitmapBundle.GetBitmapFor(this);
     if ( !bitmap.IsOk() )
     {
+#if QT_VERSION_MAJOR >= 6
         const QPixmap pix = m_qtLabel->pixmap();
         if ( !pix.isNull() )
             bitmap = wxBitmap( pix );
+#else
+        const QPixmap* pix = m_qtLabel->pixmap();
+        if ( pix )
+            bitmap = wxBitmap( *pix );
+#endif    
     }
 
     return bitmap;

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -75,9 +75,9 @@ wxBitmap wxStaticBitmap::GetBitmap() const
     wxBitmap bitmap = m_bitmapBundle.GetBitmapFor(this);
     if ( !bitmap.IsOk() )
     {
-        const QPixmap* pix = m_qtLabel->pixmap();
-        if ( pix != nullptr )
-            bitmap = wxBitmap( *pix );
+        const QPixmap pix = m_qtLabel->pixmap();
+        if ( !pix.isNull() )
+            bitmap = wxBitmap( pix );
     }
 
     return bitmap;

--- a/src/qt/toolbar.cpp
+++ b/src/qt/toolbar.cpp
@@ -11,7 +11,7 @@
 
 #if wxUSE_TOOLBAR
 
-#include <QtWidgets/QActionGroup>
+#include <QActionGroup>
 #include <QtWidgets/QToolButton>
 #include <QtWidgets/QToolBar>
 
@@ -72,7 +72,7 @@ public:
 private:
     void mouseReleaseEvent( QMouseEvent *event ) override;
     void mousePressEvent( QMouseEvent *event ) override;
-    void enterEvent( QEvent *event ) override;
+    void enterEvent( QEnterEvent *event ) override;
 
     const wxWindowID m_toolId;
 };
@@ -95,7 +95,7 @@ void wxQtToolButton::mousePressEvent( QMouseEvent *event )
     }
 }
 
-void wxQtToolButton::enterEvent( QEvent *WXUNUSED(event) )
+void wxQtToolButton::enterEvent( QEnterEvent *WXUNUSED(event) )
 {
     GetToolBar()->OnMouseEnter( m_toolId );
 }

--- a/src/qt/toolbar.cpp
+++ b/src/qt/toolbar.cpp
@@ -72,7 +72,12 @@ public:
 private:
     void mouseReleaseEvent( QMouseEvent *event ) override;
     void mousePressEvent( QMouseEvent *event ) override;
+
+#if QT_VERSION_MAJOR >= 6
     void enterEvent( QEnterEvent *event ) override;
+#else
+    void enterEvent( QEvent *event ) override;
+#endif
 
     const wxWindowID m_toolId;
 };
@@ -95,7 +100,11 @@ void wxQtToolButton::mousePressEvent( QMouseEvent *event )
     }
 }
 
+#if QT_VERSION_MAJOR >= 6
 void wxQtToolButton::enterEvent( QEnterEvent *WXUNUSED(event) )
+#else
+void wxQtToolButton::enterEvent( QEvent *WXUNUSED(event) )
+#endif
 {
     GetToolBar()->OnMouseEnter( m_toolId );
 }

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -32,12 +32,14 @@ struct TreeItemDataQt
 
     explicit TreeItemDataQt(wxTreeItemData* data) : data(data)
     {
+#if QT_VERSION_MAJOR < 6
         static bool s_registered = false;
         if ( !s_registered )
         {
             qRegisterMetaTypeStreamOperators<TreeItemDataQt>("TreeItemDataQt");
             s_registered = true;
         }
+#endif
     }
 
     wxTreeItemData *getData() const

--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -11,7 +11,6 @@
 
 #include <QtGui/QCursor>
 #include <QtWidgets/QApplication>
-#include <QtWidgets/QDesktopWidget>
 #include <QtGui/QDesktopServices>
 #include <QtCore/QUrl>
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1726,7 +1726,11 @@ bool wxWindowQt::QtHandleMouseEvent ( QWidget *handler, QMouseEvent *event )
     return handled;
 }
 
+#if QT_VERSION_MAJOR >= 6
 bool wxWindowQt::QtHandleEnterEvent ( QWidget *handler, QEnterEvent *WXUNUSED( event ) )
+#else
+bool wxWindowQt::QtHandleEnterEvent ( QWidget *handler, QEvent *WXUNUSED( event ) )
+#endif
 {
     wxMouseEvent e( wxEVT_ENTER_WINDOW );
     e.m_clickCount = 0;


### PR DESCRIPTION
Gets wxQt with Qt6 building with CMake, and samples (widgets, cube, pyramid) running.

Sort of implements https://github.com/wxWidgets/wxWidgets/issues/24208.

`glib-2.0` is needed to work around removal of `QAbstractEventDispatcher::hasPendingEvents()` in Qt6.

`wxQtEventSignalHandler::HandleDestroyedSignal` is removed due to assert when using Qt 6.6.2 linux desktop installed via aqt. When using distro's default `6.2.4+dfsg-2ubuntu1.1`, it just hangs.
Scenario: in `widgets` sample, select last entry in "All controls", then hold Up arrow key.

<details><summary>Assert details</summary>
<p>

`ASSERT failure in QTreeWidget: "Called object is not of the correct type (class destructor may have already run)", file .../qt/6.6.2/gcc_64/include/QtCore/qobjectdefs_impl.h, line 129`

```quote
libc.so.6!__pthread_kill_implementation(int no_tid, int signo, pthread_t threadid) (pthread_kill.c:44)
libc.so.6!__pthread_kill_internal(int signo, pthread_t threadid) (pthread_kill.c:78)
libc.so.6!__GI___pthread_kill(pthread_t threadid, int signo) (pthread_kill.c:89)
libc.so.6!__GI_raise(int sig) (raise.c:26)
libc.so.6!__GI_abort() (abort.c:79)
libQt6Core.so.6!qAbort() (Unknown Source:0)
libQt6Core.so.6![Unknown/Just-In-Time compiled code] (Unknown Source:0)
libQt6Core.so.6!QMessageLogger::fatal(char const*, ...) const (Unknown Source:0)
libQt6Core.so.6!qt_assert_x(char const*, char const*, char const*, int) (Unknown Source:0)
libwx_qtu_core-3.3.so.0!QtPrivate::assertObjectType<wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl> >(QObject * o) (/home/alex/qt/6.6.2/gcc_64/include/QtCore/qobjectdefs_impl.h:129)
libwx_qtu_core-3.3.so.0!QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::*)()>::call(void (wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::*)(), wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>*, void**)(void (wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::*)(wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl> * const) f, wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl> * o, void ** arg) (/home/alex/qt/6.6.2/gcc_64/include/QtCore/qobjectdefs_impl.h:144)
libwx_qtu_core-3.3.so.0!QtPrivate::FunctionPointer<void (wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::*)()>::call<QtPrivate::List<>, void>(void (wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::*)(), wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>*, void**)(QtPrivate::FunctionPointer<void (wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::*)()>::Function f, wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl> * o, void ** arg) (/home/alex/qt/6.6.2/gcc_64/include/QtCore/qobjectdefs_impl.h:182)
libwx_qtu_core-3.3.so.0!QtPrivate::QCallableObject<void (wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*)(int which, QtPrivate::QSlotObjectBase * this_, QObject * r, void ** a, bool * ret) (/home/alex/qt/6.6.2/gcc_64/include/QtCore/qobjectdefs_impl.h:520)
libQt6Core.so.6![Unknown/Just-In-Time compiled code] (Unknown Source:0)
libQt6Core.so.6!QObject::destroyed(QObject*) (Unknown Source:0)
libQt6Widgets.so.6!QWidget::~QWidget() (Unknown Source:0)
libwx_qtu_core-3.3.so.0!wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::~wxQtEventSignalHandler(wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl> * const this) (/home/alex/wx-debug/wxWidgets-qt/include/wx/qt/private/winevent.h:76)
libwx_qtu_core-3.3.so.0!wxQTreeWidget::~wxQTreeWidget(wxQTreeWidget * const this) (/home/alex/wx-debug/wxWidgets-qt/src/qt/treectrl.cpp:128)
libwx_qtu_core-3.3.so.0!wxQTreeWidget::~wxQTreeWidget(wxQTreeWidget * const this) (/home/alex/wx-debug/wxWidgets-qt/src/qt/treectrl.cpp:128)
libwx_qtu_core-3.3.so.0!wxWindow::~wxWindow(wxWindow * const this) (/home/alex/wx-debug/wxWidgets-qt/src/qt/window.cpp:379)
libwx_qtu_core-3.3.so.0!wxControlBase::~wxControlBase(wxControlBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/ctrlcmn.cpp:47)
wxControl::~wxControl(wxControl * const this) (/home/alex/wx-debug/wxWidgets-qt/include/wx/qt/control.h:11)
libwx_qtu_core-3.3.so.0!wxSystemThemedControl<wxControl>::~wxSystemThemedControl(wxSystemThemedControl<wxControl> * const this) (/home/alex/wx-debug/wxWidgets-qt/include/wx/systhemectrl.h:64)
libwx_qtu_core-3.3.so.0!wxTreeCtrlBase::~wxTreeCtrlBase(wxTreeCtrlBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/treebase.cpp:176)
libwx_qtu_core-3.3.so.0!wxTreeCtrl::~wxTreeCtrl(wxTreeCtrl * const this) (/home/alex/wx-debug/wxWidgets-qt/src/qt/treectrl.cpp:598)
libwx_qtu_core-3.3.so.0!wxTreeCtrl::~wxTreeCtrl(wxTreeCtrl * const this) (/home/alex/wx-debug/wxWidgets-qt/src/qt/treectrl.cpp:598)
libwx_qtu_core-3.3.so.0!wxWindowBase::Destroy(wxWindowBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/wincmn.cpp:570)
libwx_qtu_core-3.3.so.0!wxWindowBase::DestroyChildren(wxWindowBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/wincmn.cpp:602)
libwx_qtu_core-3.3.so.0!wxWindow::~wxWindow(wxWindow * const this) (/home/alex/wx-debug/wxWidgets-qt/src/qt/window.cpp:370)
libwx_qtu_core-3.3.so.0!wxControlBase::~wxControlBase(wxControlBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/ctrlcmn.cpp:47)
wxControl::~wxControl(wxControl * const this) (/home/alex/wx-debug/wxWidgets-qt/include/wx/qt/control.h:11)
libwx_qtu_core-3.3.so.0!wxGenericDirCtrl::~wxGenericDirCtrl(wxGenericDirCtrl * const this) (/home/alex/wx-debug/wxWidgets-qt/src/generic/dirctrlg.cpp:420)
libwx_qtu_core-3.3.so.0!wxGenericDirCtrl::~wxGenericDirCtrl(wxGenericDirCtrl * const this) (/home/alex/wx-debug/wxWidgets-qt/src/generic/dirctrlg.cpp:420)
DirCtrlWidgetsPage::CreateDirCtrl(DirCtrlWidgetsPage * const this, bool defaultPath) (/home/alex/wx-debug/wxWidgets-qt/samples/widgets/dirctrl.cpp:302)
DirCtrlWidgetsPage::Reset(DirCtrlWidgetsPage * const this) (/home/alex/wx-debug/wxWidgets-qt/samples/widgets/dirctrl.cpp:255)
DirCtrlWidgetsPage::CreateContent(DirCtrlWidgetsPage * const this) (/home/alex/wx-debug/wxWidgets-qt/samples/widgets/dirctrl.cpp:236)
WidgetsFrame::OnPageChanged(WidgetsFrame * const this, wxBookCtrlEvent & event) (/home/alex/wx-debug/wxWidgets-qt/samples/widgets/widgets.cpp:801)
libwx_baseu-3.3.so.0!wxAppConsoleBase::HandleEvent(const wxAppConsoleBase * const this, wxEvtHandler * handler, wxEventFunction func, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/appbase.cpp:642)
libwx_baseu-3.3.so.0!wxAppConsoleBase::CallEventHandler(const wxAppConsoleBase * const this, wxEvtHandler * handler, wxEventFunctor & functor, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/appbase.cpp:654)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEventIfMatchesId(const wxEventTableEntryBase & entry, wxEvtHandler * handler, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1444)
libwx_baseu-3.3.so.0!wxEvtHandler::SearchDynamicEventTable(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1904)
libwx_baseu-3.3.so.0!wxEvtHandler::TryHereOnly(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1627)
libwx_baseu-3.3.so.0!wxEvtHandler::TryBeforeAndHere(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/include/wx/event.h:3990)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEventLocally(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1564)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEvent(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1537)
libwx_qtu_core-3.3.so.0!wxWindowBase::TryAfter(wxWindowBase * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/wincmn.cpp:3519)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEvent(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1550)
libwx_qtu_core-3.3.so.0!wxWindowBase::TryAfter(wxWindowBase * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/wincmn.cpp:3519)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEvent(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1550)
libwx_qtu_core-3.3.so.0!wxBookCtrlBase::DoSetSelection(wxBookCtrlBase * const this, size_t n, int flags) (/home/alex/wx-debug/wxWidgets-qt/src/common/bookctrl.cpp:538)
libwx_qtu_core-3.3.so.0!wxTreebook::SetSelection(wxTreebook * const this, size_t n) (/home/alex/wx-debug/wxWidgets-qt/include/wx/treebook.h:130)
libwx_qtu_core-3.3.so.0!wxTreebook::OnTreeSelectionChange(wxTreebook * const this, wxTreeEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/generic/treebkg.cpp:603)
libwx_baseu-3.3.so.0!wxAppConsoleBase::HandleEvent(const wxAppConsoleBase * const this, wxEvtHandler * handler, wxEventFunction func, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/appbase.cpp:642)
libwx_baseu-3.3.so.0!wxAppConsoleBase::CallEventHandler(const wxAppConsoleBase * const this, wxEvtHandler * handler, wxEventFunctor & functor, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/appbase.cpp:654)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEventIfMatchesId(const wxEventTableEntryBase & entry, wxEvtHandler * handler, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1444)
libwx_baseu-3.3.so.0!wxEventHashTable::HandleEvent(wxEventHashTable * const this, wxEvent & event, wxEvtHandler * self) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1049)
libwx_baseu-3.3.so.0!wxEvtHandler::TryHereOnly(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1631)
libwx_baseu-3.3.so.0!wxEvtHandler::TryBeforeAndHere(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/include/wx/event.h:3990)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEventLocally(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1564)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEvent(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1537)
libwx_qtu_core-3.3.so.0!wxWindowBase::TryAfter(wxWindowBase * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/wincmn.cpp:3519)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessEvent(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1550)
libwx_baseu-3.3.so.0!wxEvtHandler::SafelyProcessEvent(wxEvtHandler * const this, wxEvent & event) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1653)
libwx_baseu-3.3.so.0!wxEvtHandler::ProcessPendingEvents(wxEvtHandler * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/event.cpp:1411)
libwx_baseu-3.3.so.0!wxAppConsoleBase::ProcessPendingEvents(wxAppConsoleBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/appbase.cpp:551)
libwx_qtu_core-3.3.so.0!wxQtIdleTimer::idle(wxQtIdleTimer * const this) (/home/alex/wx-debug/wxWidgets-qt/src/qt/evtloop.cpp:74)
libwx_qtu_core-3.3.so.0!QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (wxQtIdleTimer::*)()>::call(void (wxQtIdleTimer::*)(), wxQtIdleTimer*, void**)(void (wxQtIdleTimer::*)(wxQtIdleTimer * const) f, wxQtIdleTimer * o, void ** arg) (/home/alex/qt/6.6.2/gcc_64/include/QtCore/qobjectdefs_impl.h:145)
libwx_qtu_core-3.3.so.0!QtPrivate::FunctionPointer<void (wxQtIdleTimer::*)()>::call<QtPrivate::List<>, void>(void (wxQtIdleTimer::*)(), wxQtIdleTimer*, void**)(QtPrivate::FunctionPointer<void (wxQtIdleTimer::*)()>::Function f, wxQtIdleTimer * o, void ** arg) (/home/alex/qt/6.6.2/gcc_64/include/QtCore/qobjectdefs_impl.h:182)
libwx_qtu_core-3.3.so.0!QtPrivate::QCallableObject<void (wxQtIdleTimer::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*)(int which, QtPrivate::QSlotObjectBase * this_, QObject * r, void ** a, bool * ret) (/home/alex/qt/6.6.2/gcc_64/include/QtCore/qobjectdefs_impl.h:520)
libQt6Core.so.6![Unknown/Just-In-Time compiled code] (Unknown Source:0)
libQt6Core.so.6!QTimer::timeout(QTimer::QPrivateSignal) (Unknown Source:0)
libQt6Core.so.6!QObject::event(QEvent*) (Unknown Source:0)
libQt6Widgets.so.6!QApplicationPrivate::notify_helper(QObject*, QEvent*) (Unknown Source:0)
libQt6Core.so.6!QCoreApplication::notifyInternal2(QObject*, QEvent*) (Unknown Source:0)
libQt6Core.so.6!QTimerInfoList::activateTimers() (Unknown Source:0)
libQt6Core.so.6![Unknown/Just-In-Time compiled code] (Unknown Source:0)
libglib-2.0.so.0!g_main_context_dispatch (Unknown Source:0)
libglib-2.0.so.0![Unknown/Just-In-Time compiled code] (Unknown Source:0)
libglib-2.0.so.0!g_main_context_iteration (Unknown Source:0)
libQt6Core.so.6!QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (Unknown Source:0)
libQt6Core.so.6!QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (Unknown Source:0)
libwx_qtu_core-3.3.so.0!wxQtEventLoopBase::DoRun(wxQtEventLoopBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/qt/evtloop.cpp:122)
libwx_baseu-3.3.so.0!wxEventLoopBase::Run(wxEventLoopBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/evtloopcmn.cpp:87)
libwx_baseu-3.3.so.0!wxAppConsoleBase::MainLoop(wxAppConsoleBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/appbase.cpp:362)
libwx_baseu-3.3.so.0!wxAppConsoleBase::OnRun(wxAppConsoleBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/appbase.cpp:280)
libwx_qtu_core-3.3.so.0!wxAppBase::OnRun(wxAppBase * const this) (/home/alex/wx-debug/wxWidgets-qt/src/common/appcmn.cpp:349)
libwx_baseu-3.3.so.0!wxEntry(int & argc, wxChar ** argv) (/home/alex/wx-debug/wxWidgets-qt/src/common/init.cpp:570)
libwx_baseu-3.3.so.0!wxEntry(int & argc, char ** argv) (/home/alex/wx-debug/wxWidgets-qt/src/common/init.cpp:581)
main(int argc, char ** argv) (/home/alex/wx-debug/wxWidgets-qt/samples/widgets/widgets.cpp:327)
```

</p>
</details> 