### PR TITLE
Update tab control height in wxAuiNotebook on DPI change

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -434,6 +434,7 @@ protected:
     void OnTabBgDClick(wxAuiNotebookEvent& evt);
     void OnNavigationKeyNotebook(wxNavigationKeyEvent& event);
     void OnSysColourChanged(wxSysColourChangedEvent& event);
+    void OnDpiChanged(wxDPIChangedEvent& event);
 
     // set selection to the given window (which must be non-null and be one of
     // our pages, otherwise an assert is raised)

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1700,6 +1700,7 @@ wxBEGIN_EVENT_TABLE(wxAuiNotebook, wxBookCtrlBase)
                       wxAuiNotebook::OnTabBgDClick)
     EVT_NAVIGATION_KEY(wxAuiNotebook::OnNavigationKeyNotebook)
     EVT_SYS_COLOUR_CHANGED(wxAuiNotebook::OnSysColourChanged)
+    EVT_DPI_CHANGED(wxAuiNotebook::OnDpiChanged)
 wxEND_EVENT_TABLE()
 
 void wxAuiNotebook::OnSysColourChanged(wxSysColourChangedEvent &event)
@@ -1721,6 +1722,12 @@ void wxAuiNotebook::OnSysColourChanged(wxSysColourChangedEvent &event)
         tabctrl->Refresh();
     }
     Refresh();
+}
+
+void wxAuiNotebook::OnDpiChanged(wxDPIChangedEvent& event)
+{
+    UpdateTabCtrlHeight();
+    event.Skip();
 }
 
 void wxAuiNotebook::Init()


### PR DESCRIPTION
Otherwise layout is computed incorrectly, resulting in visual artefacts.

Closes #24348.