### PR TITLE
`utils/ifacecheck/xmlparser.h` now correctly includes `wx/wxHashMap.h`.

### DIFF
--- a/utils/ifacecheck/src/xmlparser.h
+++ b/utils/ifacecheck/src/xmlparser.h
@@ -16,6 +16,7 @@
 #include <wx/xml/xml.h>
 #include <wx/platinfo.h>
 #include <wx/log.h>
+#include <wx/hashmap.h>
 
 
 /*


### PR DESCRIPTION
Otherwise, I am getting (with g++ >= 11):

```
In file included from /home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/ifacecheck.cpp:24:
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:445:22: error: `wxIntegerHash` has not been declared
  445 |                      wxIntegerHash, wxIntegerEqual,
      |                      ^~~~~~~~~~~~~
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:445:37: error: `wxIntegerEqual` has not been declared
  445 |                      wxIntegerHash, wxIntegerEqual,
      |                                     ^~~~~~~~~~~~~~
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:446:22: error: `wxTypeIdHashMap` has not been declared
  446 |                      wxTypeIdHashMap );
      |                      ^~~~~~~~~~~~~~~
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:446:39: error: expected constructor, destructor, or type conversion before `;` token
  446 |                      wxTypeIdHashMap );
      |                                       ^
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:448:39: error: `wxStringHashMap` has not been declared
  448 | WX_DECLARE_STRING_HASH_MAP( wxString, wxStringHashMap );
      |                                       ^~~~~~~~~~~~~~~
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:448:56: error: expected constructor, destructor, or type conversion before `;` token
  448 | WX_DECLARE_STRING_HASH_MAP( wxString, wxStringHashMap );
      |                                                        ^
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:472:28: error: `wxTypeIdHashMap` does not name a type
  472 |                      const wxTypeIdHashMap& types,
      |                            ^~~~~~~~~~~~~~~
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:514:5: error: `wxStringHashMap` does not name a type
  514 |     wxStringHashMap m_preproc;
      |     ^~~~~~~~~~~~~~~
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h: In member function `void wxXmlDoxygenInterface::AddPreprocessorValue(const wxString&, const wxString&)`:
/home/ubuntu/Projects/com_github/wxWidgets/wxWidgets/utils/ifacecheck/src/xmlparser.h:511:11: error: `m_preproc` was not declared in this scope
  511 |         { m_preproc[name]=val; }
      |           ^~~~~~~~~
Command exited with non-zero status 1
```