### PR TITLE
wxGrid: allow drag-resizing row and col labels

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2680,12 +2680,15 @@ protected:
     const wxColour *m_dragLastColour;
 
     // Row or column (depending on m_cursorMode value) currently being resized
-    // or -2 if row or col label is being resized
     // or -1 if there is no resize operation in progress.
     int     m_dragRowOrCol;
 
-    // Original row or column size when resizing; used when the user cancels
+    // Original row, column or label size when resizing; used when the user cancels
     int     m_dragRowOrColOldSize;
+
+    // Row or column labels (depending on m_cursorMode value) currently being
+    // resized
+    bool    m_dragLabel;
 
     // true if a drag operation is in progress; when this is true,
     // m_startDragPos is valid, i.e. not wxDefaultPosition
@@ -2936,13 +2939,16 @@ private:
 
     void DoStartResizeRowOrCol(int col, int size);
     void DoStartMoveRowOrCol(int col);
+    void DoStartResizeLabel(int size);
 
     // These functions should only be called when actually resizing/moving,
-    // i.e. m_dragRowOrCol and m_dragMoveCol, respectively, are valid.
+    // i.e. m_dragRowOrCol, m_dragMoveCol, m_dragLabel, respectively, are valid.
     void DoEndDragResizeRow(const wxMouseEvent& event, wxGridWindow *gridWindow);
     void DoEndDragResizeCol(const wxMouseEvent& event, wxGridWindow *gridWindow);
     void DoEndMoveRow(int pos);
     void DoEndMoveCol(int pos);
+    void DoEndDragResizeRowLabel(const wxMouseEvent& event, wxGridWindow* gridWindow);
+    void DoEndDragResizeColLabel(const wxMouseEvent& event, wxGridWindow* gridWindow);
 
     // Helper function returning the position (only the horizontal component
     // really counts) corresponding to the given column drag-resize event.

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1946,7 +1946,7 @@ public:
         { return m_canDragColSize && DoCanResizeLine(col, m_setFixedCols); }
 
     // functions globally enabling row/column label interactive resizing
-    // (enabled by default)
+    // (disabled by default)
     void     EnableDragRowLabelSize(bool enable = true);
     void     DisableDragRowLabelSize() { EnableDragRowLabelSize(false); }
 

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1956,7 +1956,7 @@ public:
     bool CanDragRowLabelSize() const
         { return m_canDragRowLabelSize; }
     bool CanDragColLabelSize() const
-        { return m_canDragRowLabelSize; }
+        { return m_canDragColLabelSize; }
 
     // interactive row reordering (disabled by default)
     bool     EnableDragRowMove( bool enable = true );

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2905,7 +2905,8 @@ private:
     // process different clicks on grid cells
     void DoGridCellLeftDown(wxMouseEvent& event,
                             const wxGridCellCoords& coords,
-                            const wxPoint& pos);
+                            const wxPoint& pos,
+                            wxGridWindow* gridWindow);
     void DoGridCellLeftDClick(wxMouseEvent& event,
                              const wxGridCellCoords& coords,
                              const wxPoint& pos);

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2948,7 +2948,7 @@ private:
     void DoEndMoveRow(int pos);
     void DoEndMoveCol(int pos);
     void DoEndDragResizeLabel(const wxMouseEvent& event, wxGridWindow* gridWindow,
-                              const wxGridOperations* oper);
+                              const wxGridOperations& oper);
 
     // Helper function returning the position (only the horizontal component
     // really counts) corresponding to the given column drag-resize event.

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2943,8 +2943,8 @@ private:
 
     // These functions should only be called when actually resizing/moving,
     // i.e. m_dragRowOrCol, m_dragMoveCol, m_dragLabel, respectively, are valid.
-    void DoEndDragResizeRow(const wxMouseEvent& event, wxGridWindow *gridWindow);
-    void DoEndDragResizeCol(const wxMouseEvent& event, wxGridWindow *gridWindow);
+    void DoEndDragResizeRowOrCol(const wxMouseEvent& event, wxGridWindow* gridWindow,
+                                 const wxGridOperations& oper);
     void DoEndMoveRow(int pos);
     void DoEndMoveCol(int pos);
     void DoEndDragResizeLabel(const wxMouseEvent& event, wxGridWindow* gridWindow,

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2947,8 +2947,8 @@ private:
     void DoEndDragResizeCol(const wxMouseEvent& event, wxGridWindow *gridWindow);
     void DoEndMoveRow(int pos);
     void DoEndMoveCol(int pos);
-    void DoEndDragResizeRowLabel(const wxMouseEvent& event, wxGridWindow* gridWindow);
-    void DoEndDragResizeColLabel(const wxMouseEvent& event, wxGridWindow* gridWindow);
+    void DoEndDragResizeLabel(const wxMouseEvent& event, wxGridWindow* gridWindow,
+                              const wxGridOperations* oper);
 
     // Helper function returning the position (only the horizontal component
     // really counts) corresponding to the given column drag-resize event.

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2905,6 +2905,9 @@ private:
                           const wxGridOperations& oper,
                           wxGridWindow* gridWindow);
 
+    // helper to get the wxGridOperations that match the cursor mode
+    std::unique_ptr<wxGridOperations> DoGetOperationsFromCursorMode(void);
+
     // process different clicks on grid cells
     void DoGridCellLeftDown(wxMouseEvent& event,
                             const wxGridCellCoords& coords,

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -634,6 +634,8 @@ public:
     virtual bool CanDragLabelSize(wxGrid* grid) const = 0;
     // call DoEndDragResizeRowLabel or DoEndDragResizeColLabel
     virtual void DoEndLabelResize(wxGrid* grid, const wxMouseEvent& event, wxGridWindow* gridWindow) const = 0;
+    // the event type for the previous method
+    virtual wxEventType GetEventTypeLabelSize() const = 0;
     // set the column/row label size
     virtual void SetLabelSize(wxGrid* grid, int size) const = 0;
     // return the column/row label size
@@ -784,7 +786,10 @@ public:
         { return grid->CanDragColLabelSize(); }
     virtual void DoEndLabelResize(wxGrid *grid, const wxMouseEvent& event,
         wxGridWindow* gridWindow) const override
-        { grid->DoEndDragResizeColLabel(event, gridWindow); }
+        { grid->DoEndDragResizeLabel(event, gridWindow, this); }
+    virtual wxEventType GetEventTypeLabelSize() const override
+        { return wxEVT_GRID_COL_LABEL_SIZE; }
+
     virtual void SetLabelSize(wxGrid* grid, int size) const override
         { grid->SetColLabelSize(size); }
     virtual int GetLabelSize(wxGrid* grid) const override
@@ -938,7 +943,9 @@ public:
         { return grid->CanDragRowLabelSize();}
     virtual void DoEndLabelResize(wxGrid *grid, const wxMouseEvent& event,
         wxGridWindow* gridWindow) const override
-        { grid->DoEndDragResizeRowLabel(event, gridWindow); }
+        { grid->DoEndDragResizeLabel(event, gridWindow, this); }
+    virtual wxEventType GetEventTypeLabelSize() const override
+        { return wxEVT_GRID_ROW_LABEL_SIZE; }
     virtual int GetLabelSize(wxGrid* grid) const override
         { return grid->m_rowLabelWidth; }
     virtual void SetLabelSize(wxGrid* grid, int size) const override

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -786,7 +786,7 @@ public:
         { return grid->CanDragColLabelSize(); }
     virtual void DoEndLabelResize(wxGrid *grid, const wxMouseEvent& event,
         wxGridWindow* gridWindow) const override
-        { grid->DoEndDragResizeLabel(event, gridWindow, this); }
+        { grid->DoEndDragResizeLabel(event, gridWindow, *this); }
     virtual wxEventType GetEventTypeLabelSize() const override
         { return wxEVT_GRID_COL_LABEL_SIZE; }
 
@@ -943,7 +943,7 @@ public:
         { return grid->CanDragRowLabelSize();}
     virtual void DoEndLabelResize(wxGrid *grid, const wxMouseEvent& event,
         wxGridWindow* gridWindow) const override
-        { grid->DoEndDragResizeLabel(event, gridWindow, this); }
+        { grid->DoEndDragResizeLabel(event, gridWindow, *this); }
     virtual wxEventType GetEventTypeLabelSize() const override
         { return wxEVT_GRID_ROW_LABEL_SIZE; }
     virtual int GetLabelSize(wxGrid* grid) const override

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -627,8 +627,8 @@ public:
     // return whether the given row/column can be interactively resized
     virtual bool CanDragLineSize(wxGrid *grid, int line) const = 0;
 
-    // call DoEndDragResizeRow or DoEndDragResizeCol
-    virtual void DoEndLineResize(wxGrid *grid, const wxMouseEvent& event, wxGridWindow* gridWindow) const = 0;
+    // the event type after a row row or col resize
+    virtual wxEventType GetEventTypeLineSize() const = 0;
 
     // return whether the column/row label window can be interactively resized
     virtual bool CanDragLabelSize(wxGrid* grid) const = 0;
@@ -779,9 +779,9 @@ public:
 
     virtual bool CanDragLineSize(wxGrid *grid, int line) const override
         { return grid->CanDragRowSize(line); }
-    virtual void DoEndLineResize(wxGrid *grid, const wxMouseEvent& event,
-        wxGridWindow* gridWindow) const override
-        { grid->DoEndDragResizeRow(event, gridWindow); }
+    virtual wxEventType GetEventTypeLineSize() const override
+        { return wxEVT_GRID_ROW_SIZE; }
+
     virtual bool CanDragLabelSize(wxGrid* grid) const override
         { return grid->CanDragColLabelSize(); }
     virtual void DoEndLabelResize(wxGrid *grid, const wxMouseEvent& event,
@@ -935,9 +935,8 @@ public:
 
     virtual bool CanDragLineSize(wxGrid *grid, int line) const override
         { return grid->CanDragColSize(line); }
-    virtual void DoEndLineResize(wxGrid *grid, const wxMouseEvent& event,
-        wxGridWindow* gridWindow) const override
-        { grid->DoEndDragResizeCol(event, gridWindow); }
+    virtual wxEventType GetEventTypeLineSize() const override
+        { return wxEVT_GRID_COL_SIZE; }
 
     virtual bool CanDragLabelSize(wxGrid* grid) const override
         { return grid->CanDragRowLabelSize();}

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -630,6 +630,13 @@ public:
     // call DoEndDragResizeRow or DoEndDragResizeCol
     virtual void DoEndLineResize(wxGrid *grid, const wxMouseEvent& event, wxGridWindow* gridWindow) const = 0;
 
+    // return whether the column/row label window can be interactively resized
+    virtual bool CanDragLabelSize(wxGrid* grid) const = 0;
+    // set the column/row label size
+    virtual void SetLabelSize(wxGrid* grid, int size) const = 0;
+    // return the column/row label size
+    virtual int GetLabelSize(wxGrid* grid) const = 0;
+    virtual int GetMinimalLabelSize(wxGrid* grid) const = 0;
 
     // extend current selection block up to given row or column
     virtual bool SelectionExtendCurrentBlock(wxGrid *grid, int line,
@@ -771,7 +778,14 @@ public:
     virtual void DoEndLineResize(wxGrid *grid, const wxMouseEvent& event,
         wxGridWindow* gridWindow) const override
         { grid->DoEndDragResizeRow(event, gridWindow); }
-
+    virtual bool CanDragLabelSize(wxGrid* grid) const override
+        { return grid->CanDragColLabelSize(); }
+    virtual void SetLabelSize(wxGrid* grid, int size) const override
+        { grid->SetColLabelSize(size); }
+    virtual int GetLabelSize(wxGrid* grid) const override
+        { return grid->m_colLabelHeight; }
+    virtual int GetMinimalLabelSize(wxGrid* grid) const override
+        { return grid->m_colLabelMinHeight; }
 
     virtual bool SelectionExtendCurrentBlock(wxGrid *grid, int line,
         const wxMouseEvent &event,
@@ -914,6 +928,15 @@ public:
     virtual void DoEndLineResize(wxGrid *grid, const wxMouseEvent& event,
         wxGridWindow* gridWindow) const override
         { grid->DoEndDragResizeCol(event, gridWindow); }
+
+    virtual bool CanDragLabelSize(wxGrid* grid) const override
+        { return grid->CanDragRowLabelSize();}
+    virtual int GetLabelSize(wxGrid* grid) const override
+        { return grid->m_rowLabelWidth; }
+    virtual void SetLabelSize(wxGrid* grid, int size) const override
+        { grid->SetRowLabelSize(size); }
+    virtual int GetMinimalLabelSize(wxGrid* grid) const override
+        { return grid->m_rowLabelMinWidth; }
 
     virtual bool SelectionExtendCurrentBlock(wxGrid *grid, int line,
         const wxMouseEvent &event,

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -632,6 +632,8 @@ public:
 
     // return whether the column/row label window can be interactively resized
     virtual bool CanDragLabelSize(wxGrid* grid) const = 0;
+    // call DoEndDragResizeRowLabel or DoEndDragResizeColLabel
+    virtual void DoEndLabelResize(wxGrid* grid, const wxMouseEvent& event, wxGridWindow* gridWindow) const = 0;
     // set the column/row label size
     virtual void SetLabelSize(wxGrid* grid, int size) const = 0;
     // return the column/row label size
@@ -780,6 +782,9 @@ public:
         { grid->DoEndDragResizeRow(event, gridWindow); }
     virtual bool CanDragLabelSize(wxGrid* grid) const override
         { return grid->CanDragColLabelSize(); }
+    virtual void DoEndLabelResize(wxGrid *grid, const wxMouseEvent& event,
+        wxGridWindow* gridWindow) const override
+        { grid->DoEndDragResizeColLabel(event, gridWindow); }
     virtual void SetLabelSize(wxGrid* grid, int size) const override
         { grid->SetColLabelSize(size); }
     virtual int GetLabelSize(wxGrid* grid) const override
@@ -931,6 +936,9 @@ public:
 
     virtual bool CanDragLabelSize(wxGrid* grid) const override
         { return grid->CanDragRowLabelSize();}
+    virtual void DoEndLabelResize(wxGrid *grid, const wxMouseEvent& event,
+        wxGridWindow* gridWindow) const override
+        { grid->DoEndDragResizeRowLabel(event, gridWindow); }
     virtual int GetLabelSize(wxGrid* grid) const override
         { return grid->m_rowLabelWidth; }
     virtual void SetLabelSize(wxGrid* grid, int size) const override

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -4564,6 +4564,24 @@ public:
     bool CanDragRowSize(int row) const;
 
     /**
+        Returns @true if the row labels can be resized by dragging with the
+        mouse (which is the case by default).
+
+        @since 3.3.0
+    */
+    bool CanDragRowLabelSize();
+
+    /**
+        Returns @true if the column labels can be resized by dragging with the
+        mouse (which is the case by default).
+
+        This is the same as CanDragRowLabelSize() but for column labels.
+
+        @since 3.3.0
+    */
+    bool CanDragColLabelSize();
+
+    /**
         Returns @true if columns can be hidden from the popup menu of the native header.
 
         @since 3.1.3
@@ -4638,6 +4656,24 @@ public:
     void DisableDragRowSize();
 
     /**
+        Disables row label sizing by dragging with the mouse.
+
+        Equivalent to passing @false to EnableDragRowLabelSize().
+
+        @since 3.3.0
+    */
+    void DisableDragRowLabelSize();
+
+    /**
+        Disables column label sizing by dragging with the mouse.
+
+        Equivalent to passing @false to EnableDragColLabelSize().
+
+        @since 3.3.0
+    */
+    void DisableDragColLabelSize();
+
+    /**
         Disables column hiding from the header popup menu.
 
         Equivalent to passing @false to EnableHidingColumns().
@@ -4705,6 +4741,24 @@ public:
         @see DisableRowResize()
     */
     void EnableDragRowSize(bool enable = true);
+
+    /**
+        Enables or disables row label sizing by dragging with the mouse.
+
+        @see DisableDragRowLabelSize()
+
+        @since 3.3.0
+    */
+    void EnableDragRowLabelSize(bool enable = true);
+
+    /**
+        Enables or disables col label sizing by dragging with the mouse.
+
+        @see DisableDragColLabelSize()
+
+        @since 3.3.0
+    */
+    void EnableDragColLabelSize(bool enable = true);
 
     /**
         Enables or disables column hiding from the header popup menu.
@@ -6477,6 +6531,14 @@ public:
         wxWidgets 2.9.5.
     @event{EVT_GRID_ROW_SIZE(func)}
         Same as EVT_GRID_CMD_ROW_SIZE() but uses `wxID_ANY` id.
+    @event{EVT_GRID_ROW_LABEL_SIZE(id, func)}
+        The user resized the row labels.
+        Corresponds to @c wxEVT_GRID_ROW_LABEL_SIZE event type.
+        This is new since wxWidgets 3.3.0.
+    @event{EVT_GRID_COL_LABEL_SIZE(id, func)}
+        The user resized the column labels.
+        Corresponds to @c wxEVT_GRID_COL_LABEL_SIZE event type.
+        This is new since wxWidgets 3.3.0.
     @endEventTable
 
     @library{wxcore}
@@ -6742,6 +6804,8 @@ wxEventType wxEVT_GRID_ROW_SIZE;
 wxEventType wxEVT_GRID_ROW_AUTO_SIZE;
 wxEventType wxEVT_GRID_COL_SIZE;
 wxEventType wxEVT_GRID_COL_AUTO_SIZE;
+wxEventType wxEVT_GRID_ROW_LABEL_SIZE;
+wxEventType wxEVT_GRID_COL_LABEL_SIZE;
 wxEventType wxEVT_GRID_RANGE_SELECTING;
 wxEventType wxEVT_GRID_RANGE_SELECTED;
 wxEventType wxEVT_GRID_CELL_CHANGING;

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -4565,7 +4565,7 @@ public:
 
     /**
         Returns @true if the row labels can be resized by dragging with the
-        mouse (which is the case by default).
+        mouse.
 
         @since 3.3.0
     */
@@ -4573,7 +4573,7 @@ public:
 
     /**
         Returns @true if the column labels can be resized by dragging with the
-        mouse (which is the case by default).
+        mouse.
 
         This is the same as CanDragRowLabelSize() but for column labels.
 

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -281,6 +281,8 @@ wxBEGIN_EVENT_TABLE( GridFrame, wxFrame )
     EVT_MENU( ID_TOGGLEEDIT, GridFrame::ToggleEditing )
     EVT_MENU( ID_TOGGLEROWSIZING, GridFrame::ToggleRowSizing )
     EVT_MENU( ID_TOGGLECOLSIZING, GridFrame::ToggleColSizing )
+    EVT_MENU(ID_TOGGLEROWLABELSIZING, GridFrame::ToggleRowLabelSizing)
+    EVT_MENU(ID_TOGGLECOLLABELSIZING, GridFrame::ToggleColLabelSizing)
     EVT_MENU( ID_TOGGLEROWMOVING, GridFrame::ToggleRowMoving)
     EVT_MENU( ID_TOGGLECOLMOVING, GridFrame::ToggleColMoving )
     EVT_MENU( ID_TOGGLECOLHIDING, GridFrame::ToggleColHiding )
@@ -369,6 +371,8 @@ wxBEGIN_EVENT_TABLE( GridFrame, wxFrame )
     EVT_GRID_ROW_SIZE( GridFrame::OnRowSize )
     EVT_GRID_COL_SIZE( GridFrame::OnColSize )
     EVT_GRID_COL_AUTO_SIZE( GridFrame::OnColAutoSize )
+    EVT_GRID_ROW_LABEL_SIZE( GridFrame::OnRowLabelSize )
+    EVT_GRID_COL_LABEL_SIZE( GridFrame::OnColLabelSize )
     EVT_GRID_SELECT_CELL( GridFrame::OnSelectCell )
     EVT_GRID_RANGE_SELECTING( GridFrame::OnRangeSelecting )
     EVT_GRID_RANGE_SELECTED( GridFrame::OnRangeSelected )
@@ -438,6 +442,8 @@ GridFrame::GridFrame()
     viewMenu->AppendCheckItem(ID_TOGGLEEDIT,"&Editable");
     viewMenu->AppendCheckItem(ID_TOGGLEROWSIZING, "Ro&w drag-resize");
     viewMenu->AppendCheckItem(ID_TOGGLECOLSIZING, "C&ol drag-resize");
+    viewMenu->AppendCheckItem(ID_TOGGLEROWLABELSIZING, "Row label drag-resize");
+    viewMenu->AppendCheckItem(ID_TOGGLECOLLABELSIZING, "Col label drag-resize");
     viewMenu->AppendCheckItem(ID_TOGGLEROWMOVING, "Row drag-move");
     viewMenu->AppendCheckItem(ID_TOGGLECOLMOVING, "Col drag-&move");
     viewMenu->AppendCheckItem(ID_TOGGLECOLHIDING, "Col hiding popup menu");
@@ -812,6 +818,8 @@ void GridFrame::SetDefaults()
     GetMenuBar()->Check( ID_TOGGLEEDIT, true );
     GetMenuBar()->Check( ID_TOGGLEROWSIZING, true );
     GetMenuBar()->Check( ID_TOGGLECOLSIZING, true );
+    GetMenuBar()->Check(ID_TOGGLEROWLABELSIZING, true);
+    GetMenuBar()->Check(ID_TOGGLECOLLABELSIZING, true);
     GetMenuBar()->Check( ID_TOGGLECOLMOVING, false );
     GetMenuBar()->Check( ID_TOGGLECOLHIDING, true );
     GetMenuBar()->Check( ID_TOGGLEGRIDSIZING, true );
@@ -866,6 +874,21 @@ void GridFrame::ToggleColSizing( wxCommandEvent& WXUNUSED(ev) )
     grid->EnableDragColSize(
         GetMenuBar()->IsChecked( ID_TOGGLECOLSIZING ) );
 }
+
+
+void GridFrame::ToggleRowLabelSizing(wxCommandEvent& WXUNUSED(ev))
+{
+    grid->EnableDragRowLabelSize(
+        GetMenuBar()->IsChecked(ID_TOGGLEROWLABELSIZING));
+}
+
+
+void GridFrame::ToggleColLabelSizing(wxCommandEvent& WXUNUSED(ev))
+{
+    grid->EnableDragColLabelSize(
+        GetMenuBar()->IsChecked(ID_TOGGLECOLLABELSIZING));
+}
+
 
 void GridFrame::ToggleRowMoving( wxCommandEvent& WXUNUSED(ev) )
 {
@@ -1711,6 +1734,24 @@ void GridFrame::OnColAutoSize( wxGridSizeEvent &event )
         event.Skip();
     }
 }
+
+
+void GridFrame::OnRowLabelSize(wxGridSizeEvent& ev)
+{
+    wxLogMessage("Resized row label, new width = %d",
+        grid->GetRowLabelSize());
+
+    ev.Skip();
+}
+
+void GridFrame::OnColLabelSize(wxGridSizeEvent& ev)
+{
+    wxLogMessage("Resized column label, new height = %d",
+        grid->GetColLabelSize());
+
+    ev.Skip();
+}
+
 
 void GridFrame::OnSelectCell( wxGridEvent& ev )
 {

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -818,8 +818,8 @@ void GridFrame::SetDefaults()
     GetMenuBar()->Check( ID_TOGGLEEDIT, true );
     GetMenuBar()->Check( ID_TOGGLEROWSIZING, true );
     GetMenuBar()->Check( ID_TOGGLECOLSIZING, true );
-    GetMenuBar()->Check(ID_TOGGLEROWLABELSIZING, true);
-    GetMenuBar()->Check(ID_TOGGLECOLLABELSIZING, true);
+    GetMenuBar()->Check(ID_TOGGLEROWLABELSIZING, false);
+    GetMenuBar()->Check(ID_TOGGLECOLLABELSIZING, false);
     GetMenuBar()->Check( ID_TOGGLECOLMOVING, false );
     GetMenuBar()->Check( ID_TOGGLECOLHIDING, true );
     GetMenuBar()->Check( ID_TOGGLEGRIDSIZING, true );

--- a/samples/grid/griddemo.h
+++ b/samples/grid/griddemo.h
@@ -34,6 +34,8 @@ class GridFrame : public wxFrame
     void ToggleEditing( wxCommandEvent& );
     void ToggleRowSizing( wxCommandEvent& );
     void ToggleColSizing( wxCommandEvent& );
+    void ToggleRowLabelSizing(wxCommandEvent&);
+    void ToggleColLabelSizing(wxCommandEvent&);
     void ToggleRowMoving( wxCommandEvent& );
     void ToggleColMoving( wxCommandEvent& );
     void ToggleColHiding( wxCommandEvent& );
@@ -111,6 +113,8 @@ class GridFrame : public wxFrame
     void OnRowSize( wxGridSizeEvent& );
     void OnColSize( wxGridSizeEvent& );
     void OnColAutoSize( wxGridSizeEvent& );
+    void OnRowLabelSize( wxGridSizeEvent& );
+    void OnColLabelSize( wxGridSizeEvent& );
     void OnSelectCell( wxGridEvent& );
     void OnRangeSelected( wxGridRangeSelectEvent& );
     void OnRangeSelecting( wxGridRangeSelectEvent& );
@@ -148,6 +152,8 @@ public:
         ID_TOGGLEEDIT,
         ID_TOGGLEROWSIZING,
         ID_TOGGLECOLSIZING,
+        ID_TOGGLEROWLABELSIZING,
+        ID_TOGGLECOLLABELSIZING,
         ID_TOGGLEROWMOVING,
         ID_TOGGLECOLMOVING,
         ID_TOGGLECOLHIDING,

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3981,7 +3981,7 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
         // near the edge to the corner label window
         labelEdgeOper = &oper;
     }
-    else if ( dual.CanDragLabelSize(this) && oper.Select(unscrolledPos) > dual.GetLabelSize(this) - edge )
+    else if ( dual.CanDragLabelSize(this) && oper.Select(posEvent) > dual.GetLabelSize(this) - edge )
     {
         // near the right/bottom edge to the grid window
         labelEdgeOper = &dual;
@@ -4018,7 +4018,7 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
             else if ( labelEdgeOper && m_cursorMode == labelEdgeOper->GetCursorModeResize() )
             {
                 // resizing labels at the edge to the grid window
-                DoGridDragResize(event.GetPosition(), *labelEdgeOper, nullptr);
+                DoGridDragResize(posEvent, *labelEdgeOper, nullptr);
             }
             else if ( m_cursorMode == oper.GetCursorModeSelect() && line >=0 )
             {
@@ -4207,6 +4207,7 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
         }
         else if ( labelEdgeOper && m_cursorMode == labelEdgeOper->GetCursorModeResize() )
         {
+            event.SetPosition(posEvent);
             labelEdgeOper->DoEndLineResize(this, event, nullptr);
         }
         else if ( m_cursorMode == oper.GetCursorModeMove() )

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4935,7 +4935,7 @@ wxGrid::DoGridCellLeftUp(wxMouseEvent& event,
         if ( m_dragRowOrCol != -1 )
             DoEndDragResizeRow(event, gridWindow);
         else if ( m_dragLabel )
-            DoEndDragResizeColLabel(event, gridWindow);
+            DoEndDragResizeLabel(event, gridWindow, &wxGridRowOperations());
     }
     else if ( m_cursorMode == WXGRID_CURSOR_RESIZE_COL )
     {
@@ -4943,7 +4943,7 @@ wxGrid::DoGridCellLeftUp(wxMouseEvent& event,
         if ( m_dragRowOrCol != -1 )
             DoEndDragResizeCol(event, gridWindow);
         else if ( m_dragLabel )
-            DoEndDragResizeRowLabel(event, gridWindow);
+            DoEndDragResizeLabel(event, gridWindow, &wxGridColumnOperations());
     }
 
     m_dragLastPos = -1;
@@ -5194,19 +5194,12 @@ void wxGrid::DoEndDragResizeCol(const wxMouseEvent& event, wxGridWindow* gridWin
     m_dragRowOrCol = -1;
 }
 
-void wxGrid::DoEndDragResizeColLabel(const wxMouseEvent& event, wxGridWindow* gridWindow)
+void wxGrid::DoEndDragResizeLabel(const wxMouseEvent& event, wxGridWindow* gridWindow,
+    const wxGridOperations* oper)
 {
     printf("DoEndDragResizeColLabel\n");
-    DoGridDragResize(event.GetPosition(), wxGridRowOperations(), gridWindow);
-    SendGridSizeEvent(wxEVT_GRID_COL_LABEL_SIZE, -1, event);
-    m_dragLabel = false;
-}
-
-void wxGrid::DoEndDragResizeRowLabel(const wxMouseEvent& event, wxGridWindow* gridWindow)
-{
-    printf("DoEndDragResizeRowLabel\n");
-    DoGridDragResize(event.GetPosition(), wxGridColumnOperations(), gridWindow);
-    SendGridSizeEvent(wxEVT_GRID_ROW_LABEL_SIZE, -1, event);
+    DoGridDragResize(event.GetPosition(), *oper, gridWindow);
+    SendGridSizeEvent(oper->GetEventTypeLabelSize(), -1, event);
     m_dragLabel = false;
 }
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4935,7 +4935,7 @@ wxGrid::DoGridCellLeftUp(wxMouseEvent& event,
         if ( m_dragRowOrCol != -1 )
             DoEndDragResizeRow(event, gridWindow);
         else if ( m_dragLabel )
-            DoEndDragResizeLabel(event, gridWindow, &wxGridRowOperations());
+            DoEndDragResizeLabel(event, gridWindow, wxGridRowOperations());
     }
     else if ( m_cursorMode == WXGRID_CURSOR_RESIZE_COL )
     {
@@ -4943,7 +4943,7 @@ wxGrid::DoGridCellLeftUp(wxMouseEvent& event,
         if ( m_dragRowOrCol != -1 )
             DoEndDragResizeCol(event, gridWindow);
         else if ( m_dragLabel )
-            DoEndDragResizeLabel(event, gridWindow, &wxGridColumnOperations());
+            DoEndDragResizeLabel(event, gridWindow, wxGridColumnOperations());
     }
 
     m_dragLastPos = -1;
@@ -5195,11 +5195,11 @@ void wxGrid::DoEndDragResizeCol(const wxMouseEvent& event, wxGridWindow* gridWin
 }
 
 void wxGrid::DoEndDragResizeLabel(const wxMouseEvent& event, wxGridWindow* gridWindow,
-    const wxGridOperations* oper)
+    const wxGridOperations& oper)
 {
     printf("DoEndDragResizeColLabel\n");
-    DoGridDragResize(event.GetPosition(), *oper, gridWindow);
-    SendGridSizeEvent(oper->GetEventTypeLabelSize(), -1, event);
+    DoGridDragResize(event.GetPosition(), oper, gridWindow);
+    SendGridSizeEvent(oper.GetEventTypeLabelSize(), -1, event);
     m_dragLabel = false;
 }
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4011,10 +4011,13 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
         {
             if ( m_cursorMode == oper.GetCursorModeResize() )
             {
+                // resizing a row/col
+                // or the labels at the edge to the corner label window
                 DoGridDragResize(event.GetPosition(), oper, gridWindow);
             }
             else if ( labelEdgeOper && m_cursorMode == labelEdgeOper->GetCursorModeResize() )
             {
+                // resizing labels at the edge to the grid window
                 DoGridDragResize(event.GetPosition(), *labelEdgeOper, nullptr);
             }
             else if ( m_cursorMode == oper.GetCursorModeSelect() && line >=0 )

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4087,7 +4087,7 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
         return;
     }
 
-    if ( m_isDragging && (event.Entering() || event.Leaving()) )
+    if ( (m_isDragging || m_winCapture == labelWin) && (event.Entering() || event.Leaving()) )
         return;
 
     // ------------ Entering or leaving the window
@@ -4457,7 +4457,7 @@ void wxGrid::ProcessCornerLabelMouseEvent( wxMouseEvent& event )
         return;
     }
 
-    if ( m_isDragging && (event.Entering() || event.Leaving()) )
+    if ( (m_isDragging || m_winCapture == m_cornerLabelWin) && (event.Entering() || event.Leaving()) )
         return;
 
     if ( event.Entering() || event.Leaving() )

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4905,36 +4905,31 @@ wxGrid::DoGridCellLeftUp(wxMouseEvent& event,
                          const wxGridCellCoords& coords,
                          wxGridWindow* gridWindow)
 {
-
-    switch ( m_cursorMode )
+    if ( m_cursorMode == WXGRID_CURSOR_SELECT_CELL )
     {
-        case WXGRID_CURSOR_SELECT_CELL:
-            if ( coords == m_currentCellCoords && m_waitForSlowClick && CanEnableCellControl() )
-            {
-                ClearSelection();
-
-                if ( DoEnableCellEditControl(wxGridActivationSource::From(event)) )
-                    GetCurrentCellEditorPtr()->StartingClick();
-
-                m_waitForSlowClick = false;
-            }
-            break;
-
-        case WXGRID_CURSOR_RESIZE_ROW:
-        case WXGRID_CURSOR_RESIZE_COL:
+        if ( coords == m_currentCellCoords && m_waitForSlowClick && CanEnableCellControl() )
         {
-            const wxGridOperations* oper = (m_cursorMode == WXGRID_CURSOR_RESIZE_ROW
-                ? (wxGridOperations*) new wxGridRowOperations()
-                : (wxGridOperations*) new wxGridColumnOperations());
-            ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL);
-            if ( m_dragRowOrCol != -1 )
-                DoEndDragResizeRowOrCol(event, gridWindow, *oper);
-            else if ( m_dragLabel )
-                DoEndDragResizeLabel(event, gridWindow, *oper);
+            ClearSelection();
 
-            delete oper;
+            if ( DoEnableCellEditControl(wxGridActivationSource::From(event)) )
+                GetCurrentCellEditorPtr()->StartingClick();
+
+            m_waitForSlowClick = false;
         }
-        break;
+    }
+    else if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW ||
+              m_cursorMode == WXGRID_CURSOR_RESIZE_COL )
+    {
+        const wxGridOperations* oper = (m_cursorMode == WXGRID_CURSOR_RESIZE_ROW
+            ? (wxGridOperations*) new wxGridRowOperations()
+            : (wxGridOperations*) new wxGridColumnOperations());
+        ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL);
+        if ( m_dragRowOrCol != -1 )
+            DoEndDragResizeRowOrCol(event, gridWindow, *oper);
+        else if ( m_dragLabel )
+            DoEndDragResizeLabel(event, gridWindow, *oper);
+
+        delete oper;
     }
 
     m_dragLastPos = -1;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4743,11 +4743,9 @@ bool wxGrid::DoGridDragEvent(wxMouseEvent& event,
         case WXGRID_CURSOR_RESIZE_ROW:
         case WXGRID_CURSOR_RESIZE_COL:
         {
-            //const wxGridOperations* oper = DoGetOperationsFromCursorMode();
-            std::unique_ptr<wxGridOperations> oper (DoGetOperationsFromCursorMode());
+            const auto oper(DoGetOperationsFromCursorMode());
             if ( m_dragLabel || m_dragRowOrCol != -1 )
                 DoGridDragResize(event.GetPosition(), *oper, gridWindow);
-            //delete oper;
         }
         break;
 
@@ -4779,8 +4777,7 @@ wxGrid::DoGridCellLeftDown(wxMouseEvent& event,
         case WXGRID_CURSOR_RESIZE_ROW:
         case WXGRID_CURSOR_RESIZE_COL:
             {
-                //const wxGridOperations* oper = DoGetOperationsFromCursorMode();
-                std::unique_ptr<wxGridOperations> oper(DoGetOperationsFromCursorMode());
+                const auto oper(DoGetOperationsFromCursorMode());
                 int dragRowOrCol = PosToEdgeOfLine(oper->Dual().Select(pos), *oper);
 
                 if ( dragRowOrCol != wxNOT_FOUND )
@@ -4792,7 +4789,6 @@ wxGrid::DoGridCellLeftDown(wxMouseEvent& event,
                     DoStartResizeLabel(oper->GetLabelSize(this));
                     captureMouse = true;
                 }
-                //delete oper;
             }
             break;
 
@@ -4901,13 +4897,13 @@ wxGrid::DoGridCellLeftDClick(wxMouseEvent& event,
 }
 
 // helper to get the wxGridOperations that match the cursor mode
-// the returned instance needs to be destroyed by the calling code
-wxGridOperations* wxGrid::DoGetOperationsFromCursorMode()
+// the returned unique_ptr does not require a delete
+std::unique_ptr<wxGridOperations> wxGrid::DoGetOperationsFromCursorMode()
 {
     if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW )
-        return new wxGridRowOperations();
+        return std::unique_ptr<wxGridOperations> (new wxGridRowOperations());
     if ( m_cursorMode == WXGRID_CURSOR_RESIZE_COL )
-        return new wxGridColumnOperations();
+        return std::unique_ptr<wxGridOperations> (new wxGridColumnOperations());
     return nullptr;
 }
 
@@ -4931,15 +4927,12 @@ wxGrid::DoGridCellLeftUp(wxMouseEvent& event,
     else if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW ||
               m_cursorMode == WXGRID_CURSOR_RESIZE_COL )
     {
-        //wxGridOperations* oper = DoGetOperationsFromCursorMode();
-        std::unique_ptr<wxGridOperations> oper(DoGetOperationsFromCursorMode());
+        const auto oper(DoGetOperationsFromCursorMode());
         ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL);
         if ( m_dragRowOrCol != -1 )
             DoEndDragResizeRowOrCol(event, gridWindow, *oper);
         else if ( m_dragLabel )
             DoEndDragResizeLabel(event, gridWindow, *oper);
-
-        //delete oper;
     }
 
     m_dragLastPos = -1;
@@ -6082,8 +6075,7 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                         case WXGRID_CURSOR_RESIZE_COL:
                         {
                             // reset to size from before dragging
-                            //const wxGridOperations* oper = DoGetOperationsFromCursorMode();
-                            std::unique_ptr<wxGridOperations> oper(DoGetOperationsFromCursorMode());
+                            const auto oper(DoGetOperationsFromCursorMode());
                             if ( m_dragLabel )
                             {
                                 oper->SetLabelSize(this, m_dragRowOrColOldSize);
@@ -6094,7 +6086,6 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                                 oper->SetLineSize(this, m_dragRowOrCol, m_dragRowOrColOldSize);
                                 m_dragRowOrCol = -1;
                             }
-                            //delete oper;
                         }
                         break;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3966,6 +3966,7 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
     // index into data rows/cols
     int lineAt = oper.GetLineAt(this, posAt);
 
+
     int edge = FromDIP(WXGRID_LABEL_EDGE_ZONE);
     // this will be set if we are dragging or could drag a label window edge
     const wxGridOperations* labelEdgeOper = nullptr;
@@ -4428,7 +4429,7 @@ void wxGrid::ProcessCornerLabelMouseEvent( wxMouseEvent& event )
     bool atBottomEdge = false, atRightEdge = false, atLabelEdge = false;
     const wxPoint posEvent = event.GetPosition();
     int edge = FromDIP(WXGRID_LABEL_EDGE_ZONE);
-    const wxGridOperations* oper = nullptr;
+    std::unique_ptr<wxGridOperations> oper;
 
     if ( m_canDragRowLabelSize && posEvent.x >= m_rowLabelWidth - edge )
         atLabelEdge = atRightEdge = true;
@@ -4437,9 +4438,9 @@ void wxGrid::ProcessCornerLabelMouseEvent( wxMouseEvent& event )
 
     if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW ||
         ( atBottomEdge && m_cursorMode == WXGRID_CURSOR_SELECT_CELL ) )
-        oper = new wxGridRowOperations();
+        oper.reset(new wxGridRowOperations());
     else if ( m_cursorMode == WXGRID_CURSOR_RESIZE_COL || atRightEdge )
-        oper = new wxGridColumnOperations();
+        oper.reset(new wxGridColumnOperations());
 
     if ( m_dragRowOrCol == -2 && event.Dragging() )
     {
@@ -6070,7 +6071,8 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                         case WXGRID_CURSOR_RESIZE_COL:
                             // reset to size from before dragging
                             if ( m_dragRowOrCol == -2 )
-                            {   if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW )
+                            {
+                                if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW )
                                     SetColLabelSize(m_dragRowOrColOldSize);
                                 else
                                     SetRowLabelSize(m_dragRowOrColOldSize);
@@ -8890,15 +8892,15 @@ void wxGrid::SetColLabelSize( int height )
 
 void wxGrid::SetRowLabelMinimalSize(int width)
 {
-    if ( width >= 0 )
-        m_rowLabelMinWidth = width;
+    wxCHECK_RET(width >= 0, "invalid min row label width");
+    m_rowLabelMinWidth = width;
 }
 
 
 void wxGrid::SetColLabelMinimalSize(int height)
 {
-    if ( height >= 0 )
-        m_colLabelMinHeight = height;
+    wxCHECK_RET(height >= 0, "invalid min col label height");
+    m_colLabelMinHeight = height;
 }
 
 void wxGrid::SetLabelBackgroundColour( const wxColour& colour )

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4526,7 +4526,6 @@ void wxGrid::ProcessCornerLabelMouseEvent( wxMouseEvent& event )
             ChangeCursorMode(oper->GetCursorModeResize(), m_cornerLabelWin, false);
         else
             ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL, m_cornerLabelWin, false);
-        event.Skip();
     }
     else
     {

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4778,33 +4778,21 @@ wxGrid::DoGridCellLeftDown(wxMouseEvent& event,
         case WXGRID_CURSOR_RESIZE_ROW:
         case WXGRID_CURSOR_RESIZE_COL:
             {
-                int dragRowOrCol = wxNOT_FOUND;
-                if ( m_cursorMode == WXGRID_CURSOR_RESIZE_COL )
+                const wxGridOperations* oper = (m_cursorMode == WXGRID_CURSOR_RESIZE_ROW
+                                               ? (wxGridOperations*) new wxGridRowOperations()
+                                               : (wxGridOperations*) new wxGridColumnOperations());
+                int dragRowOrCol = PosToEdgeOfLine(oper->Dual().Select(pos), *oper);
+
+                if ( dragRowOrCol != wxNOT_FOUND )
                 {
-                    dragRowOrCol = XToEdgeOfCol(pos.x);
-                    if ( dragRowOrCol != wxNOT_FOUND )
-                    {
-                        DoStartResizeRowOrCol(dragRowOrCol, GetColSize(dragRowOrCol));
-                    }
-                    else
-                    {
-                        DoStartResizeLabel(m_rowLabelWidth);
-                        captureMouse = true;
-                    }
+                    DoStartResizeRowOrCol(dragRowOrCol, oper->GetLineSize(this, dragRowOrCol));
                 }
                 else
                 {
-                    dragRowOrCol = YToEdgeOfRow(pos.y);
-                    if ( dragRowOrCol != wxNOT_FOUND )
-                    {
-                        DoStartResizeRowOrCol(dragRowOrCol, GetRowSize(dragRowOrCol));
-                    }
-                    else
-                    {
-                        DoStartResizeLabel(m_colLabelHeight);
-                        captureMouse = true;
-                    }
+                    DoStartResizeLabel(oper->GetLabelSize(this));
+                    captureMouse = true;
                 }
+                delete oper;
             }
             break;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2999,6 +2999,9 @@ void wxGrid::Init()
     m_canDragColMove = false;
     m_canHideColumns = true;
 
+    m_canDragRowLabelSize = false;
+    m_canDragColLabelSize = false;
+
     m_cursorMode  = WXGRID_CURSOR_SELECT_CELL;
     m_winCapture = nullptr;
     m_canDragRowSize = true;


### PR DESCRIPTION
This is a first version to add a feature that has been on my wish list for years.

This first version only allows dragging the edges of the corner label.

I'm not sure whether this is good enough or it should also be possible to drag the edges of the whole label windows.
When you look at the modifications, you can see that the modifications in `ProcessRowColLabelMouseEvent` are rather simple compared to `ProcessCornerLabelMouseEvent` where both directions have to be handled.

The new methods and events are not yet in the interface header files. I will add them as soon as the API modifications are agreed:

```C++
// for grid:
int GetRowLabelMinimalSize();
int GetColLabelMinimalSize();
SetRowLabelMinimalSize( int width );
SetColLabelMinimalSize( int height );

EnableDragRowLabelSize(bool enable = true);
DisableDragRowLabelSize();
EnableDragColLabelSize(bool enable = true);
DisableDragColLabelSize();

bool CanDragRowLabelSize();
bool CanDragColLabelSize();

EVT_GRID_ROW_LABEL_SIZE
EVT_GRID_COL_LABEL_SIZE

// for wxGridOperations:
bool CanDragLabelSize(wxGrid* grid);
void SetLabelSize(wxGrid* grid, int size);
int GetLabelSize(wxGrid* grid);
int GetMinimalLabelSize(wxGrid* grid);
```

Internally, a `m_dragRowOrCol` value `-2` is used:
```
    // or -2 if row or col label is being resized
    // or -1 if there is no resize operation in progress.
    int     m_dragRowOrCol; 
```


To be decided:
 - should it be enabled by default? I would say yes.
 - implement for more than the corner label edges? Probably yes, but the code would be more complicated.
 - I was wondering about `event.Skip()` calls. I have added it to the case of `event.Moving()` inside `ProcessCornerLabelMouseEvent`.
   Inside `ProcessRowColLabelMouseEvent` this is not done now. I'm wondering what is the correct way and whether `event.Skip()` should also be added to e.g. `event.Leaving()`.
