### PR TITLE
BusyCursor doc: add hint about BusyInfo

### DIFF
--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -134,7 +134,7 @@ public:
     @library{wxcore}
     @category{misc}
 
-    @see wxBeginBusyCursor(), wxEndBusyCursor(), wxWindowDisabler
+    @see wxBeginBusyCursor(), wxEndBusyCursor(), wxWindowDisabler, wxBusyInfo
 */
 class wxBusyCursor
 {


### PR DESCRIPTION
Small documentation updated, triggered by wxPython https://github.com/wxWidgets/Phoenix/issues/2535
I did not even know about wxBusyInfo before.