### PR TITLE
Fix problem with disappearing `wxStaticText` text

### DIFF
--- a/interface/wx/splitter.h
+++ b/interface/wx/splitter.h
@@ -491,7 +491,7 @@ public:
 
         @since 3.3.0
     */
-    const wxPoint& GetLastSplitPosition() const;
+    wxPoint GetLastSplitPosition() const;
 
     /**
         Sets the last sash position.

--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -108,6 +108,16 @@ wxSize wxStaticText::DoGetBestClientSize() const
     // still not aligned to the same position.
     heightTextTotal += 1;
 
+    // And this extra pixel is an even worse hack which is somehow needed to
+    // avoid the problem with the native control now showing any text at all
+    // for some particular width values: e.g. without this, using " AJ" as a
+    // label doesn't show anything at all on the screen, even though the
+    // control text is properly set and it has rougly the correct (definitely
+    // not empty) size. This looks like a bug in the native control because it
+    // really should show at least the first characters, but it's not clear
+    // what else can we do about it than just add this extra pixel.
+    widthTextMax++;
+
     return wxSize(widthTextMax, heightTextTotal);
 }
 

--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -89,11 +89,6 @@ WXDWORD wxStaticText::MSWGetStyle(long style, WXDWORD *exstyle) const
 wxSize wxStaticText::DoGetBestClientSize() const
 {
     wxClientDC dc(const_cast<wxStaticText *>(this));
-    wxFont font(GetFont());
-    if (!font.IsOk())
-        font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
-
-    dc.SetFont(font);
 
     wxCoord widthTextMax, heightTextTotal;
     dc.GetMultiLineTextExtent(GetLabelText(), &widthTextMax, &heightTextTotal);


### PR DESCRIPTION
I really don't feel good doing this, but I couldn't find any other way to fix the problem described in the commit message of the second commit: without this, we may simply not show _anything_ if the width is too small and there is a space before the last not-quite-fitting word.

BTW, I didn't mention this in the commit message, but this can be reproduced in raw Win32 code, e.g.

```cpp
  HWND hwnd = CreateWindow(L"STATIC", L" AJ",
               WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS,
               5, 5, 30, 30,
               g_hwndMain, (HMENU)-1, g_hInstance, NULL);

  HFONT hFont = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
  SendMessage(hwnd, WM_SETFONT, (WPARAM)hFont, MAKELPARAM(TRUE, 0));
```

doesn't show anything, but replace the width with `31` shows the text correctly.

Again, I realize that this is ugly, but the problem it fixes is really bad: the user of our application just doesn't see anything at all in it right now for some string values.