### PR TITLE
wxGrid: implement basic accessibility / screen reader support

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -3510,8 +3510,8 @@ public:
 private:
     wxGridCellAccessible *m_gridCellAccessible;
 
-    int wxGridAccessible::GetChildId(wxGrid* grid, int row, int col,
-                                     bool isRowHeader, bool isColHeader);
+    int GetChildId(wxGrid* grid, int row, int col,
+                   bool isRowHeader, bool isColHeader);
 };
 
 class WXDLLIMPEXP_CORE wxGridCellAccessible: public wxAccessible

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -3499,19 +3499,12 @@ public:
                                 wxAccessible** childObject) override;
 
     virtual wxAccStatus GetLocation(wxRect& rect, int elementId) override;
-
     virtual wxAccStatus GetName(int childId, wxString* name) override;
-
     virtual wxAccStatus GetChildCount(int* childCount) override;
-
     virtual wxAccStatus GetChild(int childId, wxAccessible** child) override;
-
     virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
-
     virtual wxAccStatus GetState(int childId, long* state) override;
-
     virtual wxAccStatus GetValue(int childId, wxString* strValue) override;
-
     virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
 
 private:
@@ -3530,21 +3523,13 @@ public:
                                 wxAccessible** childObject) override;
 
     virtual wxAccStatus GetLocation(wxRect& rect, int elementId) override;
-
     virtual wxAccStatus GetName(int childId, wxString* name) override;
-
     virtual wxAccStatus GetChildCount(int* childCount) override;
-
     virtual wxAccStatus GetChild(int childId, wxAccessible** child) override;
-
     virtual wxAccStatus GetParent(wxAccessible** parent) override;
-
     virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
-
     virtual wxAccStatus GetState(int childId, long* state) override;
-
     virtual wxAccStatus GetValue(int childId, wxString* strValue) override;
-
     virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
 
 private:

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -120,6 +120,11 @@ class wxGridRowOperations;
 class wxGridColumnOperations;
 class wxGridDirectionOperations;
 
+#if wxUSE_ACCESSIBILITY
+class WXDLLIMPEXP_FWD_CORE wxGridAccessible;
+class WXDLLIMPEXP_FWD_CORE wxGridCellAccessible;
+#endif // wxUSE_ACCESSIBILITY
+
 
 // ----------------------------------------------------------------------------
 // macros
@@ -2411,6 +2416,13 @@ public:
     // implementation only
     void CancelMouseCapture();
 
+#if wxUSE_ACCESSIBILITY
+    virtual wxAccessible* CreateAccessible() override;
+    virtual bool Show(bool show) override;
+    virtual void SetName(const wxString &name) override;
+    virtual bool Reparent(wxWindowBase *newParent) override;
+#endif // wxUSE_ACCESSIBILITY
+
 protected:
     virtual wxSize DoGetBestSize() const override;
     virtual void DoEnable(bool enable) override;
@@ -2768,6 +2780,11 @@ protected:
 
     friend class wxGridHeaderColumn;
     friend class wxGridHeaderCtrl;
+
+#if wxUSE_ACCESSIBILITY
+    friend class wxGridAccessible;
+    friend class wxGridCellAccessible;
+#endif // wxUSE_ACCESSIBILITY
 
 private:
     // This is called from both Create() and OnDPIChanged() to (re)initialize
@@ -3466,6 +3483,80 @@ extern const int wxEVT_GRID_CHANGE_SEL_LABEL;
 #define EVT_GRID_CHANGE_SEL_LABEL(fn) wxDECLARE_EVENT_TABLE_ENTRY( wxEVT_GRID_CHANGE_SEL_LABEL, wxID_ANY, wxID_ANY, (wxObjectEventFunction) (wxEventFunction)  wxStaticCastEvent( wxGridEventFunction, &fn ), nullptr ),
 
 #endif
+
+#if wxUSE_ACCESSIBILITY
+//-----------------------------------------------------------------------------
+// accessibility support for whole grid and per cell
+//-----------------------------------------------------------------------------
+
+class WXDLLIMPEXP_CORE wxGridAccessible: public wxWindowAccessible
+{
+public:
+    wxGridAccessible(wxGrid* win);
+    virtual ~wxGridAccessible();
+
+    virtual wxAccStatus HitTest(const wxPoint& pt, int* childId,
+                                wxAccessible** childObject) override;
+
+    virtual wxAccStatus GetLocation(wxRect& rect, int elementId) override;
+
+    virtual wxAccStatus GetName(int childId, wxString* name) override;
+
+    virtual wxAccStatus GetChildCount(int* childCount) override;
+
+    virtual wxAccStatus GetChild(int childId, wxAccessible** child) override;
+
+    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
+
+    virtual wxAccStatus GetState(int childId, long* state) override;
+
+    virtual wxAccStatus GetValue(int childId, wxString* strValue) override;
+
+    virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
+
+private:
+    wxGridCellAccessible *m_gridCellAccessible;
+
+    int wxGridAccessible::GetChildId(wxGrid* grid, int row, int col,
+                                     bool isRowHeader, bool isColHeader);
+};
+
+class WXDLLIMPEXP_CORE wxGridCellAccessible: public wxAccessible
+{
+public:
+    wxGridCellAccessible(wxGrid* win, int childId);
+
+    virtual wxAccStatus HitTest(const wxPoint& pt, int* childId,
+                                wxAccessible** childObject) override;
+
+    virtual wxAccStatus GetLocation(wxRect& rect, int elementId) override;
+
+    virtual wxAccStatus GetName(int childId, wxString* name) override;
+
+    virtual wxAccStatus GetChildCount(int* childCount) override;
+
+    virtual wxAccStatus GetChild(int childId, wxAccessible** child) override;
+
+    virtual wxAccStatus GetParent(wxAccessible** parent) override;
+
+    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
+
+    virtual wxAccStatus GetState(int childId, long* state) override;
+
+    virtual wxAccStatus GetValue(int childId, wxString* strValue) override;
+
+    virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
+
+private:
+    int m_childId;
+    int m_row;
+    int m_col;
+    bool m_isRowHeader;
+    bool m_isColHeader;
+    friend class wxGridAccessible;
+    void DoGetLocation(wxGrid* grid, wxRect& rect);
+};
+#endif // wxUSE_ACCESSIBILITY
 
 #endif // wxUSE_GRID
 #endif // _WX_GENERIC_GRID_H_

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -3509,9 +3509,6 @@ public:
 
 private:
     wxGridCellAccessible *m_gridCellAccessible;
-
-    int GetChildId(wxGrid* grid, int row, int col,
-                   bool isRowHeader, bool isColHeader);
 };
 
 class WXDLLIMPEXP_CORE wxGridCellAccessible: public wxAccessible

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -3484,63 +3484,6 @@ extern const int wxEVT_GRID_CHANGE_SEL_LABEL;
 
 #endif
 
-#if wxUSE_ACCESSIBILITY
-//-----------------------------------------------------------------------------
-// accessibility support for whole grid and per cell
-//-----------------------------------------------------------------------------
-
-class WXDLLIMPEXP_CORE wxGridAccessible: public wxWindowAccessible
-{
-public:
-    wxGridAccessible(wxGrid* win);
-    virtual ~wxGridAccessible();
-
-    virtual wxAccStatus HitTest(const wxPoint& pt, int* childId,
-                                wxAccessible** childObject) override;
-
-    virtual wxAccStatus GetLocation(wxRect& rect, int elementId) override;
-    virtual wxAccStatus GetName(int childId, wxString* name) override;
-    virtual wxAccStatus GetChildCount(int* childCount) override;
-    virtual wxAccStatus GetChild(int childId, wxAccessible** child) override;
-    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
-    virtual wxAccStatus GetState(int childId, long* state) override;
-    virtual wxAccStatus GetValue(int childId, wxString* strValue) override;
-    virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
-
-private:
-    wxGridCellAccessible *m_gridCellAccessible;
-};
-
-class WXDLLIMPEXP_CORE wxGridCellAccessible: public wxAccessible
-{
-public:
-    wxGridCellAccessible(wxGrid* win, int childId);
-
-    virtual wxAccStatus HitTest(const wxPoint& pt, int* childId,
-                                wxAccessible** childObject) override;
-
-    virtual wxAccStatus GetLocation(wxRect& rect, int elementId) override;
-    virtual wxAccStatus GetName(int childId, wxString* name) override;
-    virtual wxAccStatus GetChildCount(int* childCount) override;
-    virtual wxAccStatus GetChild(int childId, wxAccessible** child) override;
-    virtual wxAccStatus GetParent(wxAccessible** parent) override;
-    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
-    virtual wxAccStatus GetState(int childId, long* state) override;
-    virtual wxAccStatus GetValue(int childId, wxString* strValue) override;
-    virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
-
-private:
-    int m_childId;
-    int m_row;
-    int m_col;
-    bool m_isRowHeader;
-    bool m_isColHeader;
-    bool m_isSameRow;
-    bool m_isSameCol;
-    friend class wxGridAccessible;
-    void DoGetLocation(wxGrid* grid, wxRect& rect);
-};
-#endif // wxUSE_ACCESSIBILITY
 
 #endif // wxUSE_GRID
 #endif // _WX_GENERIC_GRID_H_

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -3535,6 +3535,8 @@ private:
     int m_col;
     bool m_isRowHeader;
     bool m_isColHeader;
+    bool m_isSameRow;
+    bool m_isSameCol;
     friend class wxGridAccessible;
     void DoGetLocation(wxGrid* grid, wxRect& rect);
 };

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1292,7 +1292,6 @@ class WXDLLIMPEXP_CORE wxGridAccessible : public wxWindowAccessible
 {
 public:
     explicit wxGridAccessible(wxGrid* win);
-    virtual ~wxGridAccessible();
 
     virtual wxAccStatus HitTest(const wxPoint& pt, int* childId,
         wxAccessible** childObject) override;

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1282,5 +1282,64 @@ TryGetValueAsDate(wxDateTime& result,
 
 } // namespace wxGridPrivate
 
+
+#if wxUSE_ACCESSIBILITY
+//-----------------------------------------------------------------------------
+// accessibility support for whole grid and per cell
+//-----------------------------------------------------------------------------
+
+class WXDLLIMPEXP_CORE wxGridAccessible : public wxWindowAccessible
+{
+public:
+    explicit wxGridAccessible(wxGrid* win);
+    virtual ~wxGridAccessible();
+
+    virtual wxAccStatus HitTest(const wxPoint& pt, int* childId,
+        wxAccessible** childObject) override;
+
+    virtual wxAccStatus GetLocation(wxRect& rect, int elementId) override;
+    virtual wxAccStatus GetName(int childId, wxString* name) override;
+    virtual wxAccStatus GetChildCount(int* childCount) override;
+    virtual wxAccStatus GetChild(int childId, wxAccessible** child) override;
+    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
+    virtual wxAccStatus GetState(int childId, long* state) override;
+    virtual wxAccStatus GetValue(int childId, wxString* strValue) override;
+    virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
+
+private:
+    wxGridCellAccessible* m_gridCellAccessible;
+};
+
+class WXDLLIMPEXP_CORE wxGridCellAccessible : public wxAccessible
+{
+public:
+    wxGridCellAccessible(wxGrid* win, int childId);
+
+    virtual wxAccStatus HitTest(const wxPoint& pt, int* childId,
+        wxAccessible** childObject) override;
+
+    virtual wxAccStatus GetLocation(wxRect& rect, int elementId) override;
+    virtual wxAccStatus GetName(int childId, wxString* name) override;
+    virtual wxAccStatus GetChildCount(int* childCount) override;
+    virtual wxAccStatus GetChild(int childId, wxAccessible** child) override;
+    virtual wxAccStatus GetParent(wxAccessible** parent) override;
+    virtual wxAccStatus GetRole(int childId, wxAccRole* role) override;
+    virtual wxAccStatus GetState(int childId, long* state) override;
+    virtual wxAccStatus GetValue(int childId, wxString* strValue) override;
+    virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
+
+private:
+    int m_childId;
+    int m_row;
+    int m_col;
+    bool m_isRowHeader;
+    bool m_isColHeader;
+    bool m_isSameRow;
+    bool m_isSameCol;
+    friend class wxGridAccessible;
+    void DoGetLocation(wxGrid* grid, wxRect& rect);
+};
+#endif // wxUSE_ACCESSIBILITY
+
 #endif // wxUSE_GRID
 #endif // _WX_GENERIC_GRID_PRIVATE_H_

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1307,7 +1307,7 @@ public:
     virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
 
 private:
-    wxGridCellAccessible* m_gridCellAccessible;
+    std::unique_ptr<wxGridCellAccessible> m_gridCellAccessible;
 };
 
 class WXDLLIMPEXP_CORE wxGridCellAccessible : public wxAccessible

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1330,12 +1330,10 @@ public:
 
 private:
     int m_childId;
-    int m_row;
-    int m_col;
-    bool m_isRowHeader;
-    bool m_isColHeader;
-    bool m_isSameRow;
-    bool m_isSameCol;
+    // row and / or col can be -1 for column or row header
+    wxGridCellCoords m_coords;
+    bool m_isSameRow = false;
+    bool m_isSameCol = false;
     friend class wxGridAccessible;
     void DoGetLocation(wxGrid* grid, wxRect& rect);
 };

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1329,14 +1329,17 @@ public:
     virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) override;
 
 private:
-    int m_childId;
+    const int m_childId;
     // row and / or col can be -1 for column or row header
-    wxGridCellCoords m_coords;
+    const wxGridCellCoords m_coords;
+
     bool m_isSameRow = false;
     bool m_isSameCol = false;
+
     friend class wxGridAccessible;
     void DoGetLocation(wxGrid* grid, wxRect& rect);
 };
+
 #endif // wxUSE_ACCESSIBILITY
 
 #endif // wxUSE_GRID

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11459,24 +11459,27 @@ wxGridCellCoords ConvertChildIdToCoords(wxGrid* grid, int childId)
         int numCols = grid->GetNumberCols();
         if ( grid->GetRowLabelSize() )
             numCols++;
-        int row = (childId - 1) / numCols;
-        int col = (childId - 1) % numCols;
-        if ( grid->GetRowLabelSize() )
-        {
-            if ( col == 0 )
-                col = -1;
-            else
-                col--;
+        if ( numCols ) {
+            // actually, numCols == 0 should not happen
+            int row = (childId - 1) / numCols;
+            int col = (childId - 1) % numCols;
+            if ( grid->GetRowLabelSize() )
+            {
+                if ( col == 0 )
+                    col = -1;
+                else
+                    col--;
+            }
+            if ( grid->GetColLabelSize() )
+            {
+                if ( row == 0 )
+                    row = -1;
+                else
+                    row--;
+            }
+            coords.SetCol(col);
+            coords.SetRow(row);
         }
-        if ( grid->GetColLabelSize() )
-        {
-            if ( row == 0 )
-                row = -1;
-            else
-                row--;
-        }
-        coords.SetCol(col);
-        coords.SetRow(row);
     }
 
     return coords;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11481,15 +11481,6 @@ wxGridCellCoords GetRowCol(wxGrid* grid, int childId)
 wxGridAccessible::wxGridAccessible(wxGrid* win)
     : wxWindowAccessible(win)
 {
-    m_gridCellAccessible = nullptr;
-}
-
-wxGridAccessible::~wxGridAccessible()
-{
-    if ( m_gridCellAccessible )
-    {
-        m_gridCellAccessible.reset();
-    }
 }
 
 // Can return either a child object, or an integer
@@ -11654,14 +11645,14 @@ wxAccStatus wxGridAccessible::GetChild(int childId, wxAccessible** child)
     {
         if ( !m_gridCellAccessible )
         {
-            m_gridCellAccessible.reset( new wxGridCellAccessible(grid, childId) );
+            m_gridCellAccessible.reset(new wxGridCellAccessible(grid, childId));
         }
         else if ( m_gridCellAccessible->m_childId != childId )
         {
             // pass on the information whether the cell is on the same row or
             // column than the previous one to avoid redundant coordinate info
             wxGridCellCoords previous_coords = m_gridCellAccessible->m_coords;
-            m_gridCellAccessible.reset( new wxGridCellAccessible(grid, childId) );
+            m_gridCellAccessible.reset(new wxGridCellAccessible(grid, childId));
             if ( m_gridCellAccessible->m_coords.GetRow() == previous_coords.GetRow() )
             {
                 m_gridCellAccessible->m_isSameRow = true;
@@ -11779,11 +11770,10 @@ wxAccStatus wxGridAccessible::GetFocus(int* childId, wxAccessible** child)
 //-----------------------------------------------------------------------------
 
 wxGridCellAccessible::wxGridCellAccessible(wxGrid* grid, int childId)
-    : wxAccessible(grid)
+    : wxAccessible(grid),
+      m_childId{childId},
+      m_coords{GetRowCol(grid, childId)}
 {
-    m_childId = childId;
-    m_coords = GetRowCol(grid, childId);
-    m_isSameRow = m_isSameCol = false;
 }
 
 // Gets the parent

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11903,8 +11903,6 @@ wxAccStatus wxGridCellAccessible::GetChildCount(int* childCount)
 }
 
 // Gets the specified child (starting from 1).
-// If *child is nullptr and return value is wxACC_OK, this means that the child
-// is a simple element and not an accessible object.
 wxAccStatus wxGridCellAccessible::GetChild(int childId, wxAccessible** child)
 {
     if (childId != wxACC_SELF)
@@ -11988,7 +11986,7 @@ wxAccStatus wxGridCellAccessible::GetState(int childId, long* state)
 }
 
 // Returns a localized string representing the value for the object or child.
-wxAccStatus wxGridCellAccessible::GetValue(int childId, wxString* strValue)
+wxAccStatus wxGridCellAccessible::GetValue(int childId, wxString* WXUNUSED(strValue))
 {
     wxGrid* grid = wxDynamicCast(GetWindow(), wxGrid);
     wxCHECK( grid, wxACC_FAIL );

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11723,7 +11723,7 @@ wxAccStatus wxGridAccessible::GetState(int childId, long* state)
     // this needs to be returned such that a child below is recognized as focused
     // (check for cursorRow and cursorCol being != -1?)
     if ( grid->HasFocus() )
-        st |=  wxACC_STATE_SYSTEM_FOCUSED;
+        st |= wxACC_STATE_SYSTEM_FOCUSED;
 
     *state = st;
     return wxACC_OK;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11459,27 +11459,25 @@ wxGridCellCoords ConvertChildIdToCoords(wxGrid* grid, int childId)
         int numCols = grid->GetNumberCols();
         if ( grid->GetRowLabelSize() )
             numCols++;
-        if ( numCols ) {
-            // actually, numCols == 0 should not happen
-            int row = (childId - 1) / numCols;
-            int col = (childId - 1) % numCols;
-            if ( grid->GetRowLabelSize() )
-            {
-                if ( col == 0 )
-                    col = -1;
-                else
-                    col--;
-            }
-            if ( grid->GetColLabelSize() )
-            {
-                if ( row == 0 )
-                    row = -1;
-                else
-                    row--;
-            }
-            coords.SetCol(col);
-            coords.SetRow(row);
+        wxCHECK_MSG(numCols, coords, "childId invalid for empty grid");
+        int row = (childId - 1) / numCols;
+        int col = (childId - 1) % numCols;
+        if ( grid->GetRowLabelSize() )
+        {
+            if ( col == 0 )
+                col = -1;
+            else
+                col--;
         }
+        if ( grid->GetColLabelSize() )
+        {
+            if ( row == 0 )
+                row = -1;
+            else
+                row--;
+        }
+        coords.SetCol(col);
+        coords.SetRow(row);
     }
 
     return coords;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11878,7 +11878,7 @@ wxAccStatus wxGridCellAccessible::GetName(int childId, wxString* name)
     else if ( m_coords.GetRow() == -1 )
         *name = wxString::Format(_("Column %s Header"), grid->GetColLabelValue(m_coords.GetCol()));
     else if ( m_coords.GetCol()  == -1 )
-        *name = wxString::Format(_("Row %s Header"), grid->GetRowLabelValue(m_coords.GetCol()));
+        *name = wxString::Format(_("Row %s Header"), grid->GetRowLabelValue(m_coords.GetRow()));
     else if ( m_isSameRow )
         *name = wxString::Format(_("Column %s: %s"),
             grid->GetColLabelValue(m_coords.GetCol()),

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11663,7 +11663,7 @@ wxAccStatus wxGridAccessible::GetState(int childId, long* state)
 }
 
 // Returns a localized string representing the value for the object.
-wxAccStatus wxGridAccessible::GetValue(int childId, wxString* strValue)
+wxAccStatus wxGridAccessible::GetValue(int childId, wxString* WXUNUSED(strValue))
 {
 
     wxGrid* grid = wxDynamicCast(GetWindow(), wxGrid);

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11858,7 +11858,7 @@ wxAccStatus wxGridCellAccessible::GetChildCount(int* childCount)
 }
 
 // Gets the specified child (starting from 1).
-// If *child is NULL and return value is wxACC_OK, this means that the child
+// If *child is nullptr and return value is wxACC_OK, this means that the child
 // is a simple element and not an accessible object.
 wxAccStatus wxGridCellAccessible::GetChild(int childId, wxAccessible** child)
 {
@@ -11965,7 +11965,7 @@ wxAccStatus wxGridCellAccessible::GetValue(int childId, wxString* strValue)
 }
 
 // Gets the window with the keyboard focus.
-// If childId is 0 and child is NULL, no object in this subhierarchy has the focus.
+// If childId is 0 and child is nullptr, no object in this subhierarchy has the focus.
 // If this object has the focus, child should be 'this'.
 wxAccStatus wxGridCellAccessible::GetFocus(int* childId, wxAccessible** child)
 {

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6262,7 +6262,6 @@ bool wxGrid::SetCurrentCell( const wxGridCellCoords& coords )
         objectId++;
     wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_SELECTIONWITHIN, this, wxOBJID_CLIENT, wxACC_SELF);
     wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_FOCUS, this, wxOBJID_CLIENT, objectId);
-    printf("\nwxGrid::SetCurrentCell -> sending wxACC_EVENT_OBJECT_FOCUS %d and wxACC_EVENT_OBJECT_SELECTIONWITHIN %x\n", objectId, (int)this);
 #endif // wxUSE_ACCESSIBILITY
 
     return true;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11488,8 +11488,7 @@ wxGridAccessible::~wxGridAccessible()
 {
     if ( m_gridCellAccessible )
     {
-        delete m_gridCellAccessible;
-        m_gridCellAccessible = nullptr;
+        m_gridCellAccessible.reset();
     }
 }
 
@@ -11655,15 +11654,14 @@ wxAccStatus wxGridAccessible::GetChild(int childId, wxAccessible** child)
     {
         if ( !m_gridCellAccessible )
         {
-            m_gridCellAccessible = new wxGridCellAccessible(grid, childId);
+            m_gridCellAccessible.reset( new wxGridCellAccessible(grid, childId) );
         }
         else if ( m_gridCellAccessible->m_childId != childId )
         {
             // pass on the information whether the cell is on the same row or
             // column than the previous one to avoid redundant coordinate info
             wxGridCellCoords previous_coords = m_gridCellAccessible->m_coords;
-            delete m_gridCellAccessible;
-            m_gridCellAccessible = new wxGridCellAccessible(grid, childId);
+            m_gridCellAccessible.reset( new wxGridCellAccessible(grid, childId) );
             if ( m_gridCellAccessible->m_coords.GetRow() == previous_coords.GetRow() )
             {
                 m_gridCellAccessible->m_isSameRow = true;
@@ -11673,7 +11671,7 @@ wxAccStatus wxGridAccessible::GetChild(int childId, wxAccessible** child)
                 m_gridCellAccessible->m_isSameCol = true;
             }
         }
-        *child = m_gridCellAccessible;
+        *child = m_gridCellAccessible.get();
     }
     return wxACC_OK;
 }

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -867,6 +867,10 @@ wxGridSelection::Select(const wxGridBlockCoords& block,
         m_grid->RefreshBlock(block.GetTopLeft(), block.GetBottomRight());
     }
 
+#if wxUSE_ACCESSIBILITY
+    wxAccessible::NotifyEvent(wxACC_EVENT_OBJECT_SELECTIONWITHIN, m_grid, wxOBJID_CLIENT, wxACC_SELF);
+#endif // wxUSE_ACCESSIBILITY
+
     // Send Event, if not disabled.
     if ( eventType != wxEVT_NULL )
     {


### PR DESCRIPTION
This does add basic support only.

`GetName` is returning row/col information and `GetValue` is returning the string value of a cell.
Maybe the other way round would be better. The documenation is not clear about this and I don't have feedback from actual screen reader users yet.
`GetDescription` is not implemented.

For non-string values like checkboxes, a more sophisticated implementation would be nice, but I think this PR is already a huge step forward from the current situation.

I'm wondering whether there is some method already to convert a position to cell and label coordinate information.
This could replace many lines inside `wxGridAccessible::HitTest`.