### PR TITLE
Avoid showing bogus tooltips in macOS wxDataViewCtrl

### DIFF
--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1111,6 +1111,20 @@ outlineView:(NSOutlineView*)outlineView
     return cellFrame;
 }
 
+-(NSRect)expansionFrameWithFrame:(NSRect)cellFrame
+    inView:(NSView*)view
+{
+    // We override the default behaviour to avoid showing nonsensical tooltips
+    // for the custom cells: if we don't do this, NSTextFieldCell would show a
+    // tooltip with the debug representation of wxCustomRendererObject which is
+    // not very useful.
+    //
+    // Note: override outlineView:toolTipForCell:rect:tableColumn:item:mouseLocation:
+    // in NSOutlineViewDelegate if we ever want to support per-cell tooltips
+    // instead of just suppressing them.
+    return NSZeroRect;
+}
+
 @end
 
 // ============================================================================


### PR DESCRIPTION
Cells using custom renderers showed useless tooltips with the debug representation of wxCustomRendererObject, which were worse than useless, so avoid showing them.

Contrary to what might be expected, this can't be done by overriding the specific tooltip-related delegate method, because these tooltips come from NSTextFieldCell itself, so we need to prevent it from showing them.

Closes #24370.