### PR TITLE
Switch to using FreeBSD 14 on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,9 +10,9 @@ env:
 task:
   skip: "changesIncludeOnly('appveyor.yml','CMakeLists.txt','.circleci/**','.github/**','docs/**','interface/**','include/wx/{msw,osx,qt}/**','src/{msw,osx,qt}/**','build/{cmake,msw,osx}/**','locale/**')"
   matrix:
-    - name: Cirrus CI / FreeBSD 13 wxGTK 3
+    - name: Cirrus CI / FreeBSD wxGTK 3
       freebsd_instance:
-        image_family: freebsd-13-2
+        image_family: freebsd-14-0
       env:
         osname: FreeBSD
     - name: Cirrus CI / Debian ARM wxGTK 3


### PR DESCRIPTION
FreeBSD 13.2 doesn't seem to be available any longer.