### PR TITLE
github actions:  use node20 instead of deprecated node16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,11 +186,25 @@ jobs:
           esac
 
       - name: Checkout
+        if: matrix.container != 'ubuntu:18.04'
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Checkout Ubuntu 18.04
+        if: matrix.container == 'ubuntu:18.04'
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
 
       - name: Install CCache
+        if: matrix.container != 'ubuntu:18.04'
+        uses: hendrikmuhs/ccache-action@v1.2.12
+        with:
+          key: ${{ matrix.name }}
+
+      - name: Install CCache Ubuntu 18.04
+        if: matrix.container == 'ubuntu:18.04'
         uses: hendrikmuhs/ccache-action@v1.2.3
         with:
           key: ${{ matrix.name }}
@@ -312,7 +326,7 @@ jobs:
 
       - name: Setup Python
         if: matrix.container == ''
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -151,7 +151,7 @@ jobs:
             fi
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -127,7 +127,7 @@ jobs:
       # required for CMake to find Ninja
       - name: "[Windows] Set up MSVC Developer Command Prompt"
         if: runner.os == 'Windows'
-        uses: wxWidgets/gha-setup-vsdevenv@ac61ecb4b05909261f8f375601c0e15aabdd9f10
+        uses: wsu-cb/gha-setup-vsdevenv@88f270931cf5aca859332d1f0e5e3fb96c7a8261
 
       - name: Configuring
         run: |

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -115,7 +115,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -204,7 +204,7 @@ jobs:
     - name: Setup Python
       # actions/setup-python broken on self-hosted https://github.com/actions/setup-python/issues/108
       if: matrix.runner != 'self-hosted'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/ci_mac_xcode.yml
+++ b/.github/workflows/ci_mac_xcode.yml
@@ -110,7 +110,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/ci_msw.yml
+++ b/.github/workflows/ci_msw.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
@@ -91,7 +91,7 @@ jobs:
             }
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.1.3
+        uses: microsoft/setup-msbuild@v2
         with:
             vs-prerelease: true
 
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -129,12 +129,12 @@ jobs:
           echo "wxTEST_RUNNER=wine" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
       - name: Install CCache
-        uses: hendrikmuhs/ccache-action@v1.2.3
+        uses: hendrikmuhs/ccache-action@v1.2.12
         with:
           key: ${{ matrix.name }}
 

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install codespell
         run: |
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check for trailing whitespace and TABs
         run: |
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dos2unix
         run: |
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check for obsolete macros use
         run: |


### PR DESCRIPTION
This is a PR to test fixing the node16 deprecation warnings when building with Microsoft Visual Studio and CMake.

See https://groups.google.com/g/wx-dev/c/O_wpfSMEj1E/m/OJNscdB5AQAJ