### PR TITLE
wxrc: XRCWndClassData: minor improvements and `GenerateHeaderCode` bugfix.

### DIFF
--- a/utils/wxrc/wxrc.cpp
+++ b/utils/wxrc/wxrc.cpp
@@ -102,12 +102,12 @@ public:
         BrowseXmlNode(node->GetChildren());
     }
 
-    const ArrayOfXRCWidgetData& GetWidgetData()
+    const ArrayOfXRCWidgetData& GetWidgetData() const
     {
         return m_wdata;
     }
 
-    bool CanBeUsedWithXRCCTRL(const wxString& name)
+    static bool CanBeUsedWithXRCCTRL(const wxString& name)
     {
         if (name == wxT("tool") ||
             name == wxT("data") ||
@@ -170,27 +170,26 @@ public:
                     m_className +
                     wxT("(") +
                         *m_ancestorClassNames.begin() +
-                        wxT(" *parent=nullptr){\n") +
-                    wxT("  InitWidgetsFromXRC((wxWindow *)parent);\n")
+                        wxT(" *parent=nullptr){\n")
+                    wxT("  InitWidgetsFromXRC(static_cast<wxWindow *>(parent));\n")
                     wxT(" }\n")
-                    wxT("};\n")
                  );
         }
         else
         {
-            file.Write(m_className + wxT("(){\n") +
+            file.Write(m_className + wxT("(){\n")
                        wxT("  InitWidgetsFromXRC(nullptr);\n")
-                       wxT(" }\n")
-                       wxT("};\n"));
+                       wxT(" }\n"));
 
             for ( const auto& name : m_ancestorClassNames )
             {
-                file.Write(m_className + wxT("(") + name + wxT(" *parent){\n") +
-                            wxT("  InitWidgetsFromXRC((wxWindow *)parent);\n")
-                            wxT(" }\n")
-                            wxT("};\n"));
+                file.Write(m_className + wxT("(") + name + wxT(" *parent=nullptr){\n")
+                            wxT("  InitWidgetsFromXRC(static_cast<wxWindow *>(parent));\n")
+                            wxT(" }\n"));
             }
         }
+
+        file.Write(wxT("};\n"));
     }
 };
 WX_DECLARE_OBJARRAY(XRCWndClassData,ArrayOfXRCWndClassData);


### PR DESCRIPTION
For classes with more than one ancestor, the generated C++ code used to end the class definition more than once. This has now been fixed.

Also, for these classes, all constructors now have a default value (`nullptr`) for the `parent` parameter.

Other improvements (minor) have been made:

- the `GetWidgetData` member function is now `const`;
- the `CanBeUsedWithXRCCTRL` member function is now `static`;
- the generated C++ code now uses `static_cast` instead of C-style cast when preparing the `parent` argument for the call to `InitWidgetsFromXRC`;
- some string literals are now merged at preprocessing time (as opposed to being added at runtime).