### PR TITLE
Fix case sensitive item selection in wxOwnerDrawnComboBox

### DIFF
--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -645,7 +645,7 @@ int wxVListBoxComboPopup::FindString(const wxString& s, bool bCase) const
 
 bool wxVListBoxComboPopup::FindItem(const wxString& item, wxString* trueItem)
 {
-    int idx = m_strings.Index(item, false);
+    int idx = m_strings.Index(item, true);
     if ( idx == wxNOT_FOUND )
         return false;
     if ( trueItem != nullptr )


### PR DESCRIPTION
Currently the selection of items in wxOwnerDrawnComboBox is case insensitive, see #24289. Fix this by making FindItem() in wxVListBoxComboPopup case sensitive.