### PR TITLE
Fix crash when wxWindowMac peer was not created

### DIFF
--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2148,7 +2148,9 @@ void wxWindowMac::MacRepositionScrollBars()
             }
         }
     }
-    m_peer->AdjustClippingView(m_hScrollBar, m_vScrollBar);
+
+    if( GetPeer() )
+        GetPeer()->AdjustClippingView(m_hScrollBar, m_vScrollBar);
 #endif
 }
 


### PR DESCRIPTION
After testing the fixes for Sonoma clipping problems (bcbc31e97f, 5dffb76d0a, 6e7bbfd17) backported to 3.2 in KiCad, I had a crash on startup because we have at least one control with `m_peer` set to `kOSXNoWidgetImpl`