### PR TITLE
wxGrid: implement wxGridMoveEvent

### DIFF
--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -6335,31 +6335,6 @@ public:
         coordinates during the event handler execution, while the new ones are
         available via the event object GetRow() and GetCol() functions.
         Processes a @c wxEVT_GRID_SELECT_CELL event type.
-    @event{EVT_GRID_ROW_MOVE(func)}
-        The user tries to change the order of the rows in the grid by
-        dragging the row specified by GetRow(). This event can be vetoed to
-        either prevent the user from reordering the row change completely
-        (but notice that if you don't want to allow it at all, you simply
-        shouldn't call wxGrid::EnableDragRowMove() in the first place), vetoed
-        but handled in some way in the handler, e.g. by really moving the
-        row to the new position at the associated table level, or allowed to
-        proceed in which case wxGrid::SetRowPos() is used to reorder the
-        rows display order without affecting the use of the row indices
-        otherwise.
-        This event macro corresponds to @c wxEVT_GRID_ROW_MOVE event type.
-        It is only available since wxWidgets 3.1.7.
-    @event{EVT_GRID_COL_MOVE(func)}
-        The user tries to change the order of the columns in the grid by
-        dragging the column specified by GetCol(). This event can be vetoed to
-        either prevent the user from reordering the column change completely
-        (but notice that if you don't want to allow it at all, you simply
-        shouldn't call wxGrid::EnableDragColMove() in the first place), vetoed
-        but handled in some way in the handler, e.g. by really moving the
-        column to the new position at the associated table level, or allowed to
-        proceed in which case wxGrid::SetColPos() is used to reorder the
-        columns display order without affecting the use of the column indices
-        otherwise.
-        This event macro corresponds to @c wxEVT_GRID_COL_MOVE event type.
     @event{EVT_GRID_COL_SORT(func)}
         This event is generated when a column is clicked by the user and its
         name is explained by the fact that the custom reaction to a click on a
@@ -6527,6 +6502,87 @@ public:
     bool ShiftDown() const;
 };
 
+
+/**
+    @class wxGridMoveEvent
+
+    This event class contains information about a row/column resize event.
+
+    @beginEventTable{wxGridMoveEvent}
+    @event{EVT_GRID_ROW_MOVE(func)}
+        The user tries to change the order of the rows in the grid by
+        dragging the row specified by GetRow(). This event can be vetoed to
+        either prevent the user from reordering the row change completely
+        (but notice that if you don't want to allow it at all, you simply
+        shouldn't call wxGrid::EnableDragRowMove() in the first place), vetoed
+        but handled in some way in the handler, e.g. by really moving the
+        row to the new position at the associated table level, or allowed to
+        proceed in which case wxGrid::SetRowPos() is used to reorder the
+        rows display order without affecting the use of the row indices
+        otherwise.
+        This event macro corresponds to @c wxEVT_GRID_ROW_MOVE event type.
+        It is only available since wxWidgets 3.1.7.
+    @event{EVT_GRID_COL_MOVE(func)}
+        The user tries to change the order of the columns in the grid by
+        dragging the column specified by GetCol(). This event can be vetoed to
+        either prevent the user from reordering the column change completely
+        (but notice that if you don't want to allow it at all, you simply
+        shouldn't call wxGrid::EnableDragColMove() in the first place), vetoed
+        but handled in some way in the handler, e.g. by really moving the
+        column to the new position at the associated table level, or allowed to
+        proceed in which case wxGrid::SetColPos() is used to reorder the
+        columns display order without affecting the use of the column indices
+        otherwise.
+        This event macro corresponds to @c wxEVT_GRID_COL_MOVE event type.
+    @endEventTable
+
+    @library{wxcore}
+    @category{grid,events}
+*/
+class wxGridMoveEvent : public wxNotifyEvent
+{
+public:
+    /**
+        Default constructor.
+    */
+    wxGridMoveEvent();
+    /**
+        Constructor for initializing all event attributes.
+    */
+    wxGridMoveEvent(int id, wxEventType type, wxObject* obj,
+        int rowOrCol = -1, int newRowOrCol = -1,
+        const wxKeyboardState& kbd = wxKeyboardState());
+
+    /**
+        Returns @true if the Alt key was down at the time of the event.
+    */
+    bool AltDown() const;
+
+    /**
+        Returns @true if the Control key was down at the time of the event.
+    */
+    bool ControlDown() const;
+
+    /**
+        Row or column at that was moved.
+    */
+    int GetRowOrCol() const;
+
+    /**
+        Target Row or column.
+    */
+    int GetNewRowOrCol() const;
+
+    /**
+        Returns @true if the Meta key was down at the time of the event.
+    */
+    bool MetaDown() const;
+
+    /**
+        Returns @true if the Shift key was down at the time of the event.
+    */
+    bool ShiftDown() const;
+};
 
 
 /**

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -368,6 +368,8 @@ wxBEGIN_EVENT_TABLE( GridFrame, wxFrame )
     EVT_GRID_CELL_LEFT_CLICK( GridFrame::OnCellLeftClick )
     EVT_GRID_ROW_SIZE( GridFrame::OnRowSize )
     EVT_GRID_COL_SIZE( GridFrame::OnColSize )
+    EVT_GRID_ROW_MOVE(GridFrame::OnRowMove)
+    EVT_GRID_COL_MOVE(GridFrame::OnColMove)
     EVT_GRID_COL_AUTO_SIZE( GridFrame::OnColAutoSize )
     EVT_GRID_SELECT_CELL( GridFrame::OnSelectCell )
     EVT_GRID_RANGE_SELECTING( GridFrame::OnRangeSelecting )
@@ -1712,6 +1714,25 @@ void GridFrame::OnColAutoSize( wxGridSizeEvent &event )
     }
 }
 
+void GridFrame::OnRowMove(wxGridMoveEvent& ev)
+{
+    const int row = ev.GetRowOrCol();
+
+    wxLogMessage("Moving row %d to %d", row, ev.GetNewRowOrCol());
+
+    ev.Skip();
+}
+
+
+void GridFrame::OnColMove(wxGridMoveEvent& ev)
+{
+    const int col = ev.GetRowOrCol();
+
+    wxLogMessage("Moving col %d to %d", col, ev.GetNewRowOrCol());
+
+    ev.Skip();
+}
+
 void GridFrame::OnSelectCell( wxGridEvent& ev )
 {
     wxString logBuf;
@@ -2524,7 +2545,7 @@ private:
                              m_grid->IsSortOrderAscending()));
     }
 
-    void OnGridRowMove(wxGridEvent& event)
+    void OnGridRowMove(wxGridMoveEvent& event)
     {
         // can't update it yet as the order hasn't been changed, so do it a bit
         // later
@@ -2533,7 +2554,7 @@ private:
         event.Skip();
     }
 
-    void OnGridColMove(wxGridEvent& event)
+    void OnGridColMove(wxGridMoveEvent& event)
     {
         // can't update it yet as the order hasn't been changed, so do it a bit
         // later

--- a/samples/grid/griddemo.h
+++ b/samples/grid/griddemo.h
@@ -111,6 +111,8 @@ class GridFrame : public wxFrame
     void OnRowSize( wxGridSizeEvent& );
     void OnColSize( wxGridSizeEvent& );
     void OnColAutoSize( wxGridSizeEvent& );
+    void OnRowMove(wxGridMoveEvent&);
+    void OnColMove(wxGridMoveEvent&);
     void OnSelectCell( wxGridEvent& );
     void OnRangeSelected( wxGridRangeSelectEvent& );
     void OnRangeSelecting( wxGridRangeSelectEvent& );


### PR DESCRIPTION
When working with `EVT_GRID_ROW_MOVE` I noticed two problems:

When I did PR #22260, in `wxGrid::DoEndMoveRow(int pos)` I made a mistake with the arguments to `SendEvent(wxEVT_GRID_ROW_MOVE, -1, m_dragMoveRow)`.
Therefore, in an event handler `event.GetRow()` would always return -1 and `event.GetCol()` needs to be used instead.

The bigger issue is that there is no easy way to retrieve the target row number.


This PR adds a new event class `wxGridMoveEvent` which allows retrieveal of old and new positions using `GetRowOrCol()` and `GetNewRowOrCol()`.


The huge disadvantage of this approach is that existing C++ code needs to change the argument type of event handlers.
E.g. in the grid sample:
`void OnGridColMove(wxGridEvent& event)` -> `void OnGridRowMove(wxGridMoveEvent& event)`

I'm not a C++ guy. When creating the new class, I just copied the code from `wxGridSizeEvent`. I was surprised that there is no inheritance between the different grid event classes. Both `wxGridEvent` and `wxGridSizeEvent` are derived from `wxNotifyEvent`.
Could `wxGridMoveEvent` be changed to derive from `wxGridEvent` to be backward compatible or would that inheritance break something else? The API could be changed to `GetNewRow()` and `GetNewCol()`.

(If the change can't be done, I would remove the `GetCol()` method from the PR as at the moment it's a bit pointless.)