### PR TITLE
Prefer EGL configurations without alpha if it wasn't requested

### DIFF
--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -703,18 +703,67 @@ EGLConfig *wxGLCanvasEGL::InitConfig(const wxGLAttributes& dispAttrs)
         return nullptr;
     }
 
-    EGLConfig *config = new EGLConfig;
-    int returned;
-    // Use the first good match
-    if ( eglChooseConfig(dpy, attrsList, config, 1, &returned) && returned == 1 )
+    EGLint numConfigs = 0;
+
+    // Check if we need to filter out the configs using alpha, as getting one
+    // is unexpected if it hasn't been explicitly requested by using MinRGBA().
+    for ( int i = 0; attrsList[i] != EGL_NONE; i += 2 )
     {
-        return config;
+        if ( attrsList[i] == EGL_ALPHA_SIZE )
+        {
+            if ( attrsList[i + 1] > 0 )
+            {
+                // We can just get the first config proposed by the driver in
+                // this case.
+                std::unique_ptr<EGLConfig> config(new EGLConfig);
+
+                if ( !eglChooseConfig(dpy, attrsList, config.get(), 1, &numConfigs)
+                        || numConfigs != 1 )
+                {
+                    // This is not necessarily an error, there may just be no
+                    // matches.
+                    return nullptr;
+                }
+
+                return config.release();
+            }
+        }
     }
-    else
+
+    // We get here only if alpha was not requested or is zero and we want to
+    // ensure that we really return a config not using alpha in this case, so
+    // get all of them and try to find the first one without alpha.
+    if ( !eglChooseConfig(dpy, attrsList, nullptr, 0, &numConfigs) || !numConfigs )
+        return nullptr;
+
+    wxLogTrace(TRACE_EGL, "Enumerated %d matching EGL configs", numConfigs);
+
+    std::vector<EGLConfig> configs(numConfigs);
+    if ( !eglChooseConfig(dpy, attrsList, &configs[0], configs.size(), &numConfigs) )
     {
-        delete config;
+        wxLogTrace(TRACE_EGL, "Failed to get all EGL configs");
         return nullptr;
     }
+
+    for ( auto& config : configs )
+    {
+        EGLint alpha = 0;
+        if ( !eglGetConfigAttrib(dpy, config, EGL_ALPHA_SIZE, &alpha) )
+        {
+            wxLogTrace(TRACE_EGL, "Failed to get EGL_ALPHA_SIZE for config");
+            continue;
+        }
+
+        if ( alpha == 0 )
+        {
+            // We can use this one.
+            return new EGLConfig(config);
+        }
+    }
+
+    // Choose the first config, it's better to return something using alpha
+    // than nothing at all.
+    return new EGLConfig(configs.front());
 }
 
 /* static */


### PR DESCRIPTION
At least Mesa Iris on Wayland is known to put RGBA5551 and RGBA4444 formats at the start of the config list, even if we didn't request alpha, which is unexpected, so filter them out manually in this case to ensure we get the expected RGB444, as with the other drivers.

See #24395.