### PR TITLE
Locale script fixes

### DIFF
--- a/docs/doxygen/overviews/envvars.h
+++ b/docs/doxygen/overviews/envvars.h
@@ -54,9 +54,10 @@ wxWidgets programs.
 @itemdef{WXLANGUAGE,
          This variable can be set to override OS setting of preferred languages
          and make wxUILocale::GetPreferredUILanguages() return the set list
-         instead. The format is same as GNU's <a
+         instead. The format is a superset of GNU's <a
          href="https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html">LANGUAGE</a>
-         variable: a colon-separated list of language codes.}
+         variable: a colon-separated list of language tags (which are, in their
+         simplest form, just the language names).}
 */
 
 @see wxSystemOptions

--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -387,6 +387,18 @@ MyFrame::MyFrame()
                       ),
                   wxSizerFlags().Center().Border());
 
+    topSizer->Add(new wxStaticText
+                      (
+                        panel,
+                        wxID_ANY,
+                        wxString::Format
+                        (
+                          _("Preferred UI languages: [%s]"),
+                          wxJoin(wxUILocale::GetPreferredUILanguages(), ',')
+                        )
+                      ),
+                  wxSizerFlags().Center().Border());
+
     // create some controls affected by the locale
 
     // this demonstrates RTL layout mirroring for Arabic locales and using

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -404,7 +404,11 @@ wxString wxLocaleIdent::GetTag(wxLocaleTagType tagType) const
             if (!m_charset.empty())
                 tag << '.' << m_charset;
             if (!m_script.empty())
-                tag << '@' << wxUILocale::GetScriptAliasFromName(m_script);
+            {
+                const wxString& script = wxUILocale::GetScriptAliasFromName(m_script);
+                if (!script.empty())
+                    tag << '@' << script;
+            }
             else if (!m_modifier.empty())
                 tag << '@' << m_modifier;
             break;

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -763,14 +763,25 @@ wxVector<wxString> wxUILocale::GetPreferredUILanguages()
         while (tknzr.HasMoreTokens())
         {
             const wxString tok = tknzr.GetNextToken();
-            if (const wxLanguageInfo* li = wxUILocale::FindLanguageInfo(tok))
+            auto ident = wxLocaleIdent::FromTag(tok);
+            if ( ident.IsEmpty() )
             {
-                preferred.push_back(li->CanonicalName);
+                wxLogTrace(TRACE_I18N, "Invalid language code '%s' in WXLANGUAGE", tok);
+                continue;
             }
+
+            if ( !wxUILocale::FindLanguageInfo(ident.GetLanguage()) )
+            {
+                wxLogTrace(TRACE_I18N, "Unknown language in '%s' in WXLANGUAGE", tok);
+                continue;
+            }
+
+            preferred.push_back(ident.GetTag());
         }
         if (!preferred.empty())
         {
-            wxLogTrace(TRACE_I18N, " - using languages override from WXLANGUAGE: '%s'", languageFromEnv);
+            wxLogTrace(TRACE_I18N, " - using languages override from WXLANGUAGE: [%s]",
+                       wxJoin(preferred, ','));
             return preferred;
         }
     }

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -332,20 +332,7 @@ wxString wxLocaleIdent::GetName() const
 
     wxString name;
     if ( !m_language.empty() )
-    {
-        name << m_language;
-
-        if ( !m_region.empty() )
-            name << "_" << m_region;
-
-        if ( !m_charset.empty() )
-            name << "." << m_charset;
-
-        if ( !m_script.empty() )
-            name << "@" << wxUILocale::GetScriptAliasFromName(m_script);
-        else if ( !m_modifier.empty() )
-            name << "@" << m_modifier;
-    }
+        name = GetTag(wxLOCALE_TAGTYPE_POSIX);
 
     return name;
 }

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -476,6 +476,11 @@ static void CheckTag(const wxString& tag)
     CHECK( wxLocaleIdent::FromTag(tag).GetTag() == tag );
 }
 
+static wxString TagToPOSIX(const char* tag)
+{
+    return wxLocaleIdent::FromTag(tag).GetTag(wxLOCALE_TAGTYPE_POSIX);
+}
+
 TEST_CASE("wxLocaleIdent::FromTag", "[uilocale][localeident]")
 {
     CheckTag("");
@@ -485,6 +490,8 @@ TEST_CASE("wxLocaleIdent::FromTag", "[uilocale][localeident]")
     CheckTag("English");
     CheckTag("English_United States");
     CheckTag("English_United States.utf8");
+
+    CHECK( TagToPOSIX("zh-Hans-CN") == "zh_CN" );
 }
 
 // Yet another helper for the test below.

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -344,6 +344,25 @@ TEST_CASE("wxTranslations::GetBestTranslation", "[translations]")
     }
 }
 
+// This test can be used to check how GetBestTranslation() and
+// GetAvailableTranslations() work with the given preferred languages: set
+// WXLANGUAGE environment variable to the colon-separated list of preferred
+// languages to test before running it.
+TEST_CASE("wxTranslations::ShowAvailable", "[.]")
+{
+    wxFileTranslationsLoader::AddCatalogLookupPathPrefix("./intl");
+
+    const wxString domain("internat");
+
+    wxTranslations trans;
+
+    WARN
+    (
+        "Available: [" << wxJoin(trans.GetAvailableTranslations(domain), ',') << "]\n"
+        "Best:      [" << trans.GetBestTranslation(domain) << "]"
+    );
+}
+
 TEST_CASE("wxLocale::Default", "[locale]")
 {
     const int langDef = wxUILocale::GetSystemLanguage();


### PR DESCRIPTION
The net result of this PR is that `zh_CN` translations should be correctly loaded on macOS systems using simplified Chinese locale, which corresponds to `zh-Hans-CN` being returned from `wxUILocale::GetPreferredUILanguages()`. @t123yh Could you please confirm this?

The rest is just helpers for testing.

I also think that we need to change `wxTranslations::DoGetBestAvailableTranslation()` to compare `wxLocaleIdent` objects rather than using string comparisons, but I haven't done this yet.

@vslavik This is not really related to #24297 (except in the sense that it shows once again that these changes were correct), but I've slightly tweaked `WXLANGUAGE` handling for convenience.

@utelle I think the extra `@` in the tag was an obvious bug, but please let me know if I'm missing something. The thing that I don't understand is why we don't have neither `Hans` nor `Hant` in `misc/languages/scripttabl.txt`? Of course, in a way it's lucky that we don't, because if we did return `zh_CN@Hans` as the POSIX locale name, we wouldn't find `zh_CN` translations for it due to the current code using string comparisons.