### PR TITLE
Add EnablePersistentStorage method to wxWebSession

### DIFF
--- a/include/wx/osx/private/webrequest_urlsession.h
+++ b/include/wx/osx/private/webrequest_urlsession.h
@@ -156,9 +156,9 @@ public:
     WX_wxWebSessionDelegate GetDelegate() { return m_delegate; }
 
 private:
-    WX_NSURLSession m_session;
+    WX_NSURLSession m_session = nullptr;
     WX_wxWebSessionDelegate m_delegate;
-    bool m_persistentStorageEnabled;
+    bool m_persistentStorageEnabled = false;
 
     wxDECLARE_NO_COPY_CLASS(wxWebSessionURLSession);
 };

--- a/include/wx/osx/private/webrequest_urlsession.h
+++ b/include/wx/osx/private/webrequest_urlsession.h
@@ -149,13 +149,16 @@ public:
         return (wxWebSessionHandle)m_session;
     }
 
-    WX_NSURLSession GetSession() { return m_session; }
+    bool EnablePersistentStorage(bool enable) override;
+
+    WX_NSURLSession GetSession();
 
     WX_wxWebSessionDelegate GetDelegate() { return m_delegate; }
 
 private:
     WX_NSURLSession m_session;
     WX_wxWebSessionDelegate m_delegate;
+    bool m_persistentStorageEnabled;
 
     wxDECLARE_NO_COPY_CLASS(wxWebSessionURLSession);
 };

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -254,6 +254,8 @@ public:
 
     virtual wxWebSessionHandle GetNativeHandle() const = 0;
 
+    virtual bool EnablePersistentStorage(bool WXUNUSED(enable)) { return false; }
+
 protected:
     wxWebSessionImpl();
 

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -242,6 +242,8 @@ public:
 
     void Close();
 
+    bool EnablePersistentStorage(bool enable = true);
+
     wxWebSessionHandle GetNativeHandle() const;
 
 private:

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -800,6 +800,23 @@ public:
         allow using this object again.
      */
     void Close();
+
+    /**
+        Allows to enable persistent storage for the session.
+
+        The default is to disable persistent storage. Before the first request
+        is created, this function can be called to enable persistent storage.
+        When enabled the session will store cookies and other data between
+        sessions.
+
+        @return @true if the backend supports to modify this setting. @false if
+            the setting is not supported by the backend.
+
+        @note This is only implemented on the macOS backend.
+
+        @since 3.3.0
+     */
+    bool EnablePersistentStorage(bool enable);
 };
 
 /**

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -804,15 +804,18 @@ public:
     /**
         Allows to enable persistent storage for the session.
 
-        The default is to disable persistent storage. Before the first request
-        is created, this function can be called to enable persistent storage.
-        When enabled the session will store cookies and other data between
-        sessions.
+        Persistent storage is disabled by default, but this function can be
+        called to enable it before the first request is created. Note that it
+        can't be called any more after creating the first request in this
+        session.
+
+        When persistent storage is enabled, the session will store cookies and
+        other data between sessions.
 
         @return @true if the backend supports to modify this setting. @false if
             the setting is not supported by the backend.
 
-        @note This is only implemented on the macOS backend.
+        @note This is only implemented in the macOS backend.
 
         @since 3.3.0
      */

--- a/samples/webrequest/webrequest.cpp
+++ b/samples/webrequest/webrequest.cpp
@@ -104,6 +104,9 @@ public:
         textSizer->Add(m_textResponseTextCtrl,
             wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM));
 
+        m_peristentStorageCheckBox = new wxCheckBox(textPanel, wxID_ANY, "Enable persistent storage");
+        textSizer->Add(m_peristentStorageCheckBox, wxSizerFlags().Border());
+
         textPanel->SetSizer(textSizer);
         m_notebook->AddPage(textPanel, "Text");
 
@@ -192,6 +195,15 @@ public:
     void OnStartButton(wxCommandEvent& WXUNUSED(evt))
     {
         wxLogStatus(this, "Started request...");
+
+        if (m_notebook->GetSelection() == Page_Text && m_peristentStorageCheckBox->IsEnabled())
+        {
+            if (!wxWebSession::GetDefault().EnablePersistentStorage(m_peristentStorageCheckBox->IsChecked()) &&
+                m_peristentStorageCheckBox->IsChecked())
+                wxLogDebug("Persistent storage is not supported by the current backend");
+
+            m_peristentStorageCheckBox->Disable();
+        }
 
         // Create request for the specified URL from the default session
         m_currentRequest = wxWebSession::GetDefault().CreateRequest(this,
@@ -469,6 +481,7 @@ private:
     wxTextCtrl* m_postContentTypeTextCtrl;
     wxTextCtrl* m_postRequestTextCtrl;
     wxTextCtrl* m_textResponseTextCtrl;
+    wxCheckBox* m_peristentStorageCheckBox;
 
     wxGauge* m_downloadGauge;
     wxStaticText* m_downloadStaticText;

--- a/samples/webrequest/webrequest.cpp
+++ b/samples/webrequest/webrequest.cpp
@@ -104,8 +104,8 @@ public:
         textSizer->Add(m_textResponseTextCtrl,
             wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM));
 
-        m_peristentStorageCheckBox = new wxCheckBox(textPanel, wxID_ANY, "Enable persistent storage");
-        textSizer->Add(m_peristentStorageCheckBox, wxSizerFlags().Border());
+        m_persistentStorageCheckBox = new wxCheckBox(textPanel, wxID_ANY, "Enable persistent storage");
+        textSizer->Add(m_persistentStorageCheckBox, wxSizerFlags().Border());
 
         textPanel->SetSizer(textSizer);
         m_notebook->AddPage(textPanel, "Text");
@@ -196,13 +196,13 @@ public:
     {
         wxLogStatus(this, "Started request...");
 
-        if (m_notebook->GetSelection() == Page_Text && m_peristentStorageCheckBox->IsEnabled())
+        if (m_notebook->GetSelection() == Page_Text && m_persistentStorageCheckBox->IsEnabled())
         {
-            if (!wxWebSession::GetDefault().EnablePersistentStorage(m_peristentStorageCheckBox->IsChecked()) &&
-                m_peristentStorageCheckBox->IsChecked())
+            if (!wxWebSession::GetDefault().EnablePersistentStorage(m_persistentStorageCheckBox->IsChecked()) &&
+                m_persistentStorageCheckBox->IsChecked())
                 wxLogDebug("Persistent storage is not supported by the current backend");
 
-            m_peristentStorageCheckBox->Disable();
+            m_persistentStorageCheckBox->Disable();
         }
 
         // Create request for the specified URL from the default session
@@ -481,7 +481,7 @@ private:
     wxTextCtrl* m_postContentTypeTextCtrl;
     wxTextCtrl* m_postRequestTextCtrl;
     wxTextCtrl* m_textResponseTextCtrl;
-    wxCheckBox* m_peristentStorageCheckBox;
+    wxCheckBox* m_persistentStorageCheckBox;
 
     wxGauge* m_downloadGauge;
     wxStaticText* m_downloadStaticText;

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -1060,6 +1060,11 @@ wxWebSessionHandle wxWebSession::GetNativeHandle() const
     return m_impl ? m_impl->GetNativeHandle() : nullptr;
 }
 
+bool wxWebSession::EnablePersistentStorage(bool enable)
+{
+    return m_impl->EnablePersistentStorage(enable);
+}
+
 // ----------------------------------------------------------------------------
 // Module ensuring all global/singleton objects are destroyed on shutdown.
 // ----------------------------------------------------------------------------

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -362,9 +362,7 @@ wxString wxWebResponseURLSession::GetSuggestedFileName() const
 // wxWebSessionURLSession
 //
 
-wxWebSessionURLSession::wxWebSessionURLSession():
-    m_session(nil),
-    m_persistentStorageEnabled(false)
+wxWebSessionURLSession::wxWebSessionURLSession()
 {
     m_delegate = [[wxWebSessionDelegate alloc] initWithSession:this];
 }

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -362,13 +362,11 @@ wxString wxWebResponseURLSession::GetSuggestedFileName() const
 // wxWebSessionURLSession
 //
 
-wxWebSessionURLSession::wxWebSessionURLSession()
+wxWebSessionURLSession::wxWebSessionURLSession():
+    m_session(nil),
+    m_persistentStorageEnabled(false)
 {
     m_delegate = [[wxWebSessionDelegate alloc] initWithSession:this];
-
-    m_session = [[NSURLSession sessionWithConfiguration:
-                  [NSURLSessionConfiguration defaultSessionConfiguration]
-                                               delegate:m_delegate delegateQueue:nil] retain];
 }
 
 wxWebSessionURLSession::~wxWebSessionURLSession()
@@ -391,6 +389,31 @@ wxVersionInfo wxWebSessionURLSession::GetLibraryVersionInfo()
     int verMaj, verMin, verMicro;
     wxGetOsVersion(&verMaj, &verMin, &verMicro);
     return wxVersionInfo("URLSession", verMaj, verMin, verMicro);
+}
+
+bool wxWebSessionURLSession::EnablePersistentStorage(bool enable)
+{
+    if (m_session)
+    {
+        wxFAIL_MSG("Persistent storage can only be enabled before the first request is made.");
+        return false;
+    }
+
+    m_persistentStorageEnabled = enable;
+    return true;
+}
+
+WX_NSURLSession wxWebSessionURLSession::GetSession()
+{
+    if (!m_session)
+    {
+        NSURLSessionConfiguration* config = (m_persistentStorageEnabled) ?
+             [NSURLSessionConfiguration defaultSessionConfiguration] :
+             [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        m_session = [[NSURLSession sessionWithConfiguration:config delegate:m_delegate delegateQueue:nil] retain];
+    }
+
+    return m_session;
 }
 
 #endif // wxUSE_WEBREQUEST_URLSESSION


### PR DESCRIPTION
Currently only implemented for the macOS backend.

Default is changed to non persistent to be consistent with other backends

Fixes: #23743