### PR TITLE
Fix drawing of wxListCtrl last item in Windows 11 dark mode

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3415,7 +3415,7 @@ void wxListCtrl::OnPaint(wxPaintEvent& event)
 
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(GetBackgroundColour());
-        dc.DrawRectangle(0, lastRect.y, clientSize.x, clientSize.y - lastRect.y);
+        dc.DrawRectangle(0, lastRect.GetBottom(), clientSize.x, clientSize.y - lastRect.GetBottom());
         return;
     }
 


### PR DESCRIPTION
Fix coordinates of the rectangle we use to erase the unwanted separator line in wxListCtrl report view in Windows 11 dark mode.

The rectangle was painted over the last item, instead below it as intended.

Closes #24024.