### PR TITLE
Allow separators in wxChoice popup menus

### DIFF
--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -816,6 +816,8 @@ public :
 
     virtual void InsertItem(size_t pos, int itemid, const wxString& text) = 0;
 
+    virtual void InsertSeparator(size_t WXUNUSED(pos)) {}
+
     virtual void RemoveItem(size_t pos) = 0;
 
     virtual void Clear()

--- a/src/osx/choice_osx.cpp
+++ b/src/osx/choice_osx.cpp
@@ -129,7 +129,10 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
         wxString text = items[i];
         if (text.empty())
             text = " ";  // menu items can't have empty labels
-        dynamic_cast<wxChoiceWidgetImpl*>(GetPeer())->InsertItem( idx, i+1, text );
+        if (text == wxT("---"))
+            dynamic_cast<wxChoiceWidgetImpl*>(GetPeer())->InsertSeparator( idx );
+        else
+            dynamic_cast<wxChoiceWidgetImpl*>(GetPeer())->InsertItem( idx, i+1, text );
         m_datas.Insert( NULL, idx );
         AssignNewItemClientData(idx, clientData, i, type);
     }

--- a/src/osx/cocoa/choice.mm
+++ b/src/osx/cocoa/choice.mm
@@ -78,6 +78,11 @@ public:
         m_popUpMenu->Insert( pos, itemid, text );
     }
 
+    void InsertSeparator(size_t pos) wxOVERRIDE
+    {
+        m_popUpMenu->InsertSeparator(pos);
+    }
+
     size_t GetNumberOfItems() const wxOVERRIDE
     {
         return m_popUpMenu->GetMenuItemCount();


### PR DESCRIPTION
I'm attempting to upstream some changes from the KiCad project (which currently requires a custom fork of wxWidgets to build) in order to simplify packaging.

(It would be great if patches could end up in the 3.2 branch as 3.4 isn't likely to be released any time soon, but for this particular one I'm not sure whether it breaks ABI compatibility or breaks the rules for backporting to 3.2. If it is not allowed to stay, just say so and I'll rebase it and retarget it to the master branch.)

@craftyjon @jey5nd6