### PR TITLE
Wrap text in wxGenericMessageDialog to prevent clipping and readability issues.

### DIFF
--- a/src/generic/msgdlgg.cpp
+++ b/src/generic/msgdlgg.cpp
@@ -185,6 +185,12 @@ void wxGenericMessageDialog::DoCreateMsgdialog()
 
     wxBoxSizer * const textsizer = new wxBoxSizer(wxVERTICAL);
 
+    // To prevent clipping
+    int maxWidth = wxSystemSettings::GetMetric( wxSYS_SCREEN_X, this ) - 25;
+
+    // To enhance readability
+    maxWidth = std::min( maxWidth, GetTextExtent( wxS( "x" ) ).x * 70 );
+
     // We want to show the main message in a different font to make it stand
     // out if the extended message is used as well. This looks better and is
     // more consistent with the native dialogs under MSW and GTK.
@@ -192,7 +198,7 @@ void wxGenericMessageDialog::DoCreateMsgdialog()
     if ( !m_extendedMessage.empty() )
     {
         wxTitleTextWrapper titleWrapper(this);
-        textsizer->Add(CreateTextSizer(GetMessage(), titleWrapper),
+        textsizer->Add(CreateTextSizer(GetMessage(), titleWrapper, maxWidth),
                        wxSizerFlags().Border(wxBOTTOM, 20));
 
         lowerMessage = GetExtendedMessage();
@@ -202,7 +208,7 @@ void wxGenericMessageDialog::DoCreateMsgdialog()
         lowerMessage = GetMessage();
     }
 
-    textsizer->Add(CreateTextSizer(lowerMessage));
+    textsizer->Add(CreateTextSizer(lowerMessage, maxWidth));
 
     icon_text->Add(textsizer, 0, wxALIGN_CENTER, 10);
     topsizer->Add( icon_text, 1, wxLEFT|wxRIGHT|wxTOP, 10 );


### PR DESCRIPTION
I'm attempting to upstream some changes from the KiCad project (which currently requires a custom fork of wxWidgets to build) in order to simplify packaging.

This one is to avoid clipping and super wide text.

See: https://gitlab.com/kicad/code/kicad/-/issues/14283

@craftyjon @jey5nd6
