### PR TITLE
wxrc: Faster&leaner compilation of C++ source file generated by resource compiler.

### DIFF
--- a/utils/wxrc/GenerateBigXRCFile.sh
+++ b/utils/wxrc/GenerateBigXRCFile.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e -o pipefail
+
+# [2024-03-18]
+#   Usage example:
+#     './GenerateBigXRCFile.sh' 2000 >'MyResources.xrc'
+#   will generate an XRC file referencing 2000 small PNG images.
+#   Compiling this XRC file using `wxrc` and further compiling the generated C++ source code
+#   can help us tune our code and avoid slow C++ compilation process.
+
+GenerateExampleImages ()
+{
+    local folder_images='ExampleImages'
+    mkdir -p "${folder_images}/"
+
+    local i
+    local n="${1:-10000}"
+
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+    printf '<resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">\n'
+    for ((i = 0; i < n; ++i)); do
+        local pathname_image; printf -v pathname_image "%s/Example_%04Xh.png" "${folder_images}" "$((i))"
+
+        if ((1)); then
+            rm -f "${pathname_image}"
+            printf >>"${pathname_image}" "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A\x00\x00\x00\x0D\x49\x48\x44\x52"
+            printf >>"${pathname_image}" "\x00\x00\x00\x10\x00\x00\x00\x10\x08\x02\x00\x00\x00\x90\x91\x68"
+            printf >>"${pathname_image}" "\x36\x00\x00\x00\x09\x70\x48\x59\x73\x00\x00\x0E\xC4\x00\x00\x0E"
+            printf >>"${pathname_image}" "\xC4\x01\x95\x2B\x0E\x1B\x00\x00\x00\x1A\x49\x44\x41\x54\x28\xCF"
+            printf >>"${pathname_image}" "\x63\x6C\x60\xF8\xCF\x40\x0A\x60\x62\x20\x11\x8C\x6A\x18\xD5\x30"
+            printf >>"${pathname_image}" "\x74\x34\x00\x00\xC5\xBF\x01\x9F\x22\x91\xFF\xBD\x00\x00\x00\x00"
+            printf >>"${pathname_image}" "\x49\x45\x4E\x44\xAE\x42\x60\x82"
+        fi
+
+        printf '  <object class="wxBitmap" name="Cat_%04Xh">%s</object>\n' "$((i))" "${pathname_image}"
+    done
+    printf '</resource>\n'
+}
+
+GenerateExampleImages "$@"


### PR DESCRIPTION
In the C++ source code generated by the resource compiler, for each binary file (XRC file or file referenced from an XRC file), a call to `XRC_ADD_FILE` is placed in the generated file.

Previously, `XRC_ADD_FILE` used to be a function-like macro (similar to a function, with all calls inlined), simply "forwarding" its arguments to `wxMemoryFSHandler::AddFile`.

But some parameters of `wxMemoryFSHandler::AddFile` are of type `const wxString &` while the arguments we have are of type `const wxChar *`, and using the macro used to force at every "call" site the construction and destruction of temporary `wxString` objects.

When there are thousands of such calls, the compilation of the generated C++ source code takes much time and memory:

```
  For  2,000 binary files:
    g++-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0  (`g++-11 -O2 -g`):  42.95 seconds and 1,107,296 KiB of RAM
    g++-14 (GCC) 14.0.1 20240117 (experimental)   (`g++    -O2 -g`):  93.44 seconds and 1,149,840 KiB of RAM

  For 10,000 binary files:
    Visual C++ 2019 (version 19.29.30151 for x64) (`cl /O2 /Zi`):     46.51 seconds
    g++-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0  (`g++-11 -O2 -g`): 151.13 seconds and 3,265,268 KiB of RAM
    g++-14 (GCC) 14.0.1 20240117 (experimental)   (`g++    -O2 -g`): 491.27 seconds and 3,489,140 KiB of RAM
```

We have now changed `XRC_ADD_FILE` into a function. It simply calls `wxMemoryFSHandler::AddFile`, therefore the behaviour is the same. But its parameters are not of type `const wxString &`, but of type `const wxChar *` instead, exactly matching the arguments in the generated C++ source code (and not requiring construction and destruction of temporary `wxString` objects; these constructions and destructions are now centralized in the body of `XRC_ADD_FILE`).

The benchmarks of compiling generated C++ source code are as follows:

```
  For  2,000 binary files:
    g++-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0  (`g++-11 -O2 -g`):   2.22 seconds and   358,936 KiB of RAM
    g++-14 (GCC) 14.0.1 20240117 (experimental)   (`g++    -O2 -g`):   4.52 seconds and   343,872 KiB of RAM

  For 10,000 binary files:
    Visual C++ 2019 (version 19.29.30151 for x64) (`cl /O2 /Zi`):      3.23 seconds
    g++-11 (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0  (`g++-11 -O2 -g`):  13.59 seconds and   803,592 KiB of RAM
    g++-14 (GCC) 14.0.1 20240117 (experimental)   (`g++    -O2 -g`):  31.80 seconds and   858,884 KiB of RAM
```

A Bash script which generates an XRC file referencing many binary files (small PNG images) is now included (`GenerateBigXRCFile.sh`).

Additionally, we are now restricting the size of each binary file not to the limit of `size_t` (because anyway this used to be the `size_t` of the resource compiler, not the `size_t` of the subsequent C++ compiler, and because anyway for Windows, even in 64-bit processes, each module (EXE or DLL) cannot occupy more than 4 GiB of virtual memory (relative virtual addresses are limited to 32-bit, and the file format is not called "PE64", but "PE32+" instead).

Additionally, in the generated C++ source code, the individual bytes of binary files are now represented not as decimal integer literals, but instead as hexadecimal integer literals, 16 on a line, and with 256-byte sections delimited by comments showing the current offset and the total size and the percentage (the "progress").

(The name of the temporary files are also included as comments.)