### PR TITLE
Bugfixes in evtloop.mm on mac

### DIFF
--- a/src/osx/cocoa/evtloop.mm
+++ b/src/osx/cocoa/evtloop.mm
@@ -521,6 +521,7 @@ void wxGUIEventLoop::EndModalSession()
         m_modalSession = nil;
         if ( m_dummyWindow )
         {
+            [m_dummyWindow close];
             [m_dummyWindow release];
             m_dummyWindow = nil;
         }
@@ -545,8 +546,10 @@ void wxGUIEventLoop::EndModalSession()
         
         if ( m_dummyWindow != element.dummyWindow )
         {
-            if ( element.dummyWindow )
-                [element.dummyWindow release];
+            if ( m_dummyWindow ) {
+                [m_dummyWindow close];
+                [m_dummyWindow release];
+            }
 
             m_dummyWindow = element.dummyWindow;
         }


### PR DESCRIPTION
1. Not closing of modal dialogs led to (zero size) ghost windows in expose through e.g. wxWindowDisabler and wxSafeyield.
2. Logic fix for higher stacking in dummyWindow close/release.