### PR TITLE
Fixes for wxUSE_OLE=0 and also fix --disable-graphics_d2d on configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7243,24 +7243,26 @@ if test "$wxUSE_GRAPHICS_CONTEXT" = "yes"; then
             wx_has_graphics=1
         fi
 
-        AC_CACHE_CHECK([if Direct2D is available], wx_cv_lib_direct2d,
-            [
-                dnl same as above, we need to test only for the headers
-                AC_LANG_PUSH(C++)
-                AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-                    [#include <windows.h>
-                     #include <d2d1.h>
-                     #include <dwrite.h>
-                    ],
-                    [
-                        ID2D1Factory* factory = NULL;
-                    ])],
-                    wx_cv_lib_direct2d=yes,
-                    wx_cv_lib_direct2d=no
-                )
-                AC_LANG_POP()
-            ]
-        )
+        if test "$wxUSE_GRAPHICS_DIRECT2D" = "yes"; then
+            AC_CACHE_CHECK([if Direct2D is available], wx_cv_lib_direct2d,
+                [
+                    dnl same as above, we need to test only for the headers
+                    AC_LANG_PUSH(C++)
+                    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                        [#include <windows.h>
+                        #include <d2d1.h>
+                        #include <dwrite.h>
+                        ],
+                        [
+                            ID2D1Factory* factory = NULL;
+                        ])],
+                        wx_cv_lib_direct2d=yes,
+                        wx_cv_lib_direct2d=no
+                    )
+                    AC_LANG_POP()
+                ]
+            )
+        fi
         if test "$wx_cv_lib_direct2d" = "yes"; then
             AC_DEFINE(wxUSE_GRAPHICS_DIRECT2D)
         fi

--- a/include/wx/msw/textentry.h
+++ b/include/wx/msw/textentry.h
@@ -79,8 +79,12 @@ protected:
     virtual bool DoAutoCompleteCustom(wxTextCompleter *completer) override;
 #endif // wxUSE_OLE
 
+#if wxUSE_OLE
     // Returns true if this control uses standard file names completion.
     bool MSWUsesStandardAutoComplete() const;
+#else
+    bool MSWUsesStandardAutoComplete() const { return false; }
+#endif //wxUSE_OLE
 
     // Returns false if this message shouldn't be preprocessed, but is always
     // handled by the EDIT control represented by this object itself.

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -149,6 +149,7 @@ LRESULT WXDLLEXPORT APIENTRY wxWndProc(HWND, UINT, WPARAM, LPARAM);
 // Module for OLE initialization and cleanup
 // ----------------------------------------------------------------------------
 
+#if wxUSE_OLE
 class wxOleInitModule : public wxModule
 {
 public:
@@ -171,6 +172,7 @@ private:
 };
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxOleInitModule, wxModule);
+#endif //wxUSE_OLE
 
 // ===========================================================================
 // wxGUIAppTraits implementation


### PR DESCRIPTION
These patches resolve some issues when wxWidgets is built with OLE disabled:
- linker error due to undefined `MSWUsesStandardAutoComplete()`
- runtime error where `wxOleInitModule` fails during app startup

And when using the configure script, the `--disable-graphics_d2d` seemed to have no effect, so Direct2D support was enabled solely on a compile test. The configure script will now actually check if the option is not disabled before testing Direct2D support.