### PR TITLE
Put in wxUSE_ guards for wxQt components

### DIFF
--- a/include/wx/qt/frame.h
+++ b/include/wx/qt/frame.h
@@ -46,7 +46,9 @@ public:
     virtual void SetStatusBar(wxStatusBar *statusBar ) override;
 #endif // wxUSE_STATUSBAR
 
+#if wxUSE_TOOLBAR
     virtual void SetToolBar(wxToolBar *toolbar) override;
+#endif // wxUSE_TOOLBAR
 
     virtual void SetWindowStyleFlag( long style ) override;
 

--- a/include/wx/qt/frame.h
+++ b/include/wx/qt/frame.h
@@ -41,7 +41,11 @@ public:
                 const wxString& name = wxASCII_STR(wxFrameNameStr));
 
     virtual void SetMenuBar(wxMenuBar *menubar) override;
+
+#if wxUSE_STATUSBAR
     virtual void SetStatusBar(wxStatusBar *statusBar ) override;
+#endif // wxUSE_STATUSBAR
+
     virtual void SetToolBar(wxToolBar *toolbar) override;
 
     virtual void SetWindowStyleFlag( long style ) override;

--- a/src/qt/accel.cpp
+++ b/src/qt/accel.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_ACCEL
+
 #include "wx/accel.h"
 #include "wx/qt/private/converter.h"
 #include <QtCore/QVariant>
@@ -94,3 +96,5 @@ bool wxAcceleratorTable::IsOk() const
 {
     return (m_refData != nullptr);
 }
+
+#endif // wxUSE_ACCEL

--- a/src/qt/bmpbuttn.cpp
+++ b/src/qt/bmpbuttn.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_BMPBUTTON
+
 #include "wx/bmpbuttn.h"
 
 wxBitmapButton::wxBitmapButton()
@@ -51,3 +53,4 @@ bool wxBitmapButton::Create(wxWindow *parent,
     return true;
 }
 
+#endif // wxUSE_BMPBUTTON

--- a/src/qt/checkbox.cpp
+++ b/src/qt/checkbox.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_CHECKBOX
+
 #include "wx/checkbox.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
@@ -144,3 +146,4 @@ void wxCheckBox::SetLabel(const wxString& label)
     m_qtCheckBox->setText( wxQtConvertString(label) );
 }
 
+#endif // wxUSE_CHECKBOX

--- a/src/qt/checklst.cpp
+++ b/src/qt/checklst.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_CHECKLISTBOX
+
 #include "wx/checklst.h"
 #include "wx/qt/private/winevent.h"
 
@@ -89,3 +91,4 @@ void wxCheckListBox::Check(unsigned int n, bool check )
     item->setCheckState(check ? Qt::Checked : Qt::Unchecked);
 }
 
+#endif // wxUSE_CHECKLISTBOX

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_CHOICE
+
 #include "wx/choice.h"
 #include "wx/qt/private/winevent.h"
 
@@ -264,3 +266,5 @@ QWidget *wxChoice::GetHandle() const
 {
     return m_qtComboBox;
 }
+
+#endif // wxUSE_CHOICE

--- a/src/qt/clipbrd.cpp
+++ b/src/qt/clipbrd.cpp
@@ -8,6 +8,7 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_CLIPBOARD
 
 #include <QtWidgets/QApplication>
 #include <QtGui/QClipboard>
@@ -144,3 +145,5 @@ int wxClipboard::Mode()
 {
     return m_usePrimary ? QClipboard::Selection : QClipboard::Clipboard;
 }
+
+#endif // wxUSE_CLIPBOARD

--- a/src/qt/clrpicker.cpp
+++ b/src/qt/clrpicker.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_COLOURPICKERCTRL
+
 #include "wx/clrpicker.h"
 
 wxColourPickerWidget::wxColourPickerWidget()
@@ -45,3 +47,4 @@ void wxColourPickerWidget::UpdateColour()
     wxGenericColourButton::UpdateColour();
 }
 
+#endif // wxUSE_COLOURPICKERCTRL

--- a/src/qt/colordlg.cpp
+++ b/src/qt/colordlg.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_COLOURDLG
+
 #include "wx/qt/private/winevent.h"
 #include "wx/colordlg.h"
 
@@ -55,3 +57,5 @@ QColorDialog *wxColourDialog::GetQColorDialog() const
 {
     return static_cast<QColorDialog *>(m_qtWindow);
 }
+
+#endif // wxUSE_COLOURDLG

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_COMBOBOX
+
 #include "wx/combobox.h"
 #include "wx/window.h"
 #include "wx/qt/private/converter.h"
@@ -336,3 +338,5 @@ void wxComboBox::GetSelection(long* from, long* to) const
     // No selection or text control, call base for default behaviour:
     wxTextEntry::GetSelection(from, to);
 }
+
+#endif // wxUSE_COMBOBOX

--- a/src/qt/dcprint.cpp
+++ b/src/qt/dcprint.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_PRINTING_ARCHITECTURE
+
 #include "wx/dcprint.h"
 #include "wx/qt/dcprint.h"
 
@@ -199,4 +201,4 @@ void wxPrinterDCImpl::DoDrawPolygon(int WXUNUSED(n), const wxPoint WXUNUSED(poin
 {
 }
 
-
+#endif // wxUSE_PRINTING_ARCHITECTURE

--- a/src/qt/filedlg.cpp
+++ b/src/qt/filedlg.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_FILEDLG
+
 #include "wx/filename.h"
 
 #include "wx/qt/private/converter.h"
@@ -257,3 +259,5 @@ QFileDialog *wxDirDialog::GetQFileDialog() const
 {
     return static_cast<QFileDialog *>(m_qtWindow);
 }
+
+#endif // wxUSE_FILEDLG

--- a/src/qt/fontdlg.cpp
+++ b/src/qt/fontdlg.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_FONTDLG
+
 #include "wx/qt/private/winevent.h"
 #include "wx/fontdlg.h"
 
@@ -37,4 +39,4 @@ bool wxFontDialog::DoCreate(wxWindow *parent)
     return wxFontDialogBase::DoCreate(parent);
 }
 
-
+#endif // wxUSE_FONTDLG

--- a/src/qt/fontenum.cpp
+++ b/src/qt/fontenum.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_FONTENUM
+
 #include "wx/fontenum.h"
 #include "wx/qt/private/converter.h"
 
@@ -44,3 +46,5 @@ bool wxFontEnumerator::EnumerateEncodingsUTF8(const wxString& facename)
     return false;
 }
 #endif
+
+#endif // wxUSE_FONTENUM

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -111,6 +111,7 @@ void wxFrame::SetStatusBar( wxStatusBar *statusBar )
 }
 #endif // wxUSE_STATUSBAR
 
+#if wxUSE_TOOLBAR
 void wxFrame::SetToolBar(wxToolBar *toolbar)
 {
     if ( toolbar != nullptr )
@@ -135,6 +136,7 @@ void wxFrame::SetToolBar(wxToolBar *toolbar)
     }
     wxFrameBase::SetToolBar( toolbar );
 }
+#endif // wxUSE_TOOLBAR
 
 void wxFrame::SetWindowStyleFlag( long style )
 {

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -93,6 +93,7 @@ void wxFrame::SetMenuBar( wxMenuBar *menuBar )
     wxFrameBase::SetMenuBar( menuBar );
 }
 
+#if wxUSE_STATUSBAR
 void wxFrame::SetStatusBar( wxStatusBar *statusBar )
 {
     // The current status bar could be deleted by Qt when dereferencing it
@@ -108,6 +109,7 @@ void wxFrame::SetStatusBar( wxStatusBar *statusBar )
     }
     wxFrameBase::SetStatusBar( statusBar );
 }
+#endif // wxUSE_STATUSBAR
 
 void wxFrame::SetToolBar(wxToolBar *toolbar)
 {

--- a/src/qt/gauge.cpp
+++ b/src/qt/gauge.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_GAUGE
+
 #include "wx/gauge.h"
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
@@ -92,3 +94,5 @@ int wxGauge::GetValue() const
 {
     return m_qtProgressBar->value();
 }
+
+#endif // wxUSE_GAUGE

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_LISTBOX
+
 #include "wx/listbox.h"
 #include "wx/qt/private/winevent.h"
 
@@ -379,3 +381,5 @@ void wxListBox::UnSelectAll()
         l->setSelected(false);
     }
 }
+
+#endif // wxUSE_LISTBOX

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -8,6 +8,7 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_LISTCTRL
 
 #include <QtWidgets/QHeaderView>
 #include <QtWidgets/QTreeView>
@@ -2177,3 +2178,5 @@ QWidget *wxListCtrl::GetHandle() const
 {
     return m_qtTreeWidget;
 }
+
+#endif // wxUSE_LISTCTRL

--- a/src/qt/menu.cpp
+++ b/src/qt/menu.cpp
@@ -137,6 +137,7 @@ static void InsertMenuItemAction( const wxMenu *menu, const wxMenuItem *previous
             if ( wxIsStockID( id ) )
             {
                 itemAction->setText( wxQtConvertString( wxGetStockLabel( id ) ) );
+#if wxUSE_ACCEL
                 wxAcceleratorEntry accel = wxGetStockAccelerator( id );
                 QString shortcut;
                 if ( id == wxID_EXIT )
@@ -151,6 +152,7 @@ static void InsertMenuItemAction( const wxMenu *menu, const wxMenuItem *previous
                 {
                     itemAction->setShortcut( QKeySequence( shortcut ) );
                 }
+#endif // wxUSE_ACCEL
             }
             break;
         }

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_NOTEBOOK
+
 #include "wx/notebook.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
@@ -244,3 +246,5 @@ QWidget *wxNotebook::GetHandle() const
 {
     return m_qtTabWidget;
 }
+
+#endif // wxUSE_NOTEBOOK

--- a/src/qt/printdlg.cpp
+++ b/src/qt/printdlg.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_PRINTING_ARCHITECTURE
+
 #include "wx/qt/printdlg.h"
 
 wxQtPrintNativeData::wxQtPrintNativeData()
@@ -81,3 +83,4 @@ wxPageSetupDialogData& wxQtPageSetupDialog::GetPageSetupDialogData()
     return s_data;
 }
 
+#endif // wxUSE_PRINTING_ARCHITECTURE

--- a/src/qt/printqt.cpp
+++ b/src/qt/printqt.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_PRINTING_ARCHITECTURE
+
 #include "wx/print.h"
 
 wxQtPrinter::wxQtPrinter( wxPrintDialogData *WXUNUSED(data))
@@ -54,3 +56,4 @@ void wxQtPrintPreview::DetermineScaling()
 {
 }
 
+#endif // wxUSE_PRINTING_ARCHITECTURE

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_RADIOBOX
+
 #include "wx/radiobox.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
@@ -376,3 +378,5 @@ wxString wxRadioBox::GetLabel() const
 {
     return wxQtConvertString( m_qtGroupBox->title() );
 }
+
+#endif // wxUSE_RADIOBOX

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_RADIOBTN
+
 #include "wx/radiobut.h"
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
@@ -176,3 +178,5 @@ void wxRadioButton::SetLabel(const wxString& label)
 
     m_qtRadioButton->setText( wxQtConvertString(label) );
 }
+
+#endif // wxUSE_RADIOBTN

--- a/src/qt/scrolbar.cpp
+++ b/src/qt/scrolbar.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_SCROLLBAR
+
 #include "wx/scrolbar.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/winevent.h"
@@ -192,3 +194,5 @@ void wxQtScrollBar::valueChanged( int position )
         EmitEvent( e );
     }
 }
+
+#endif // wxUSE_SCROLLBAR

--- a/src/qt/slider.cpp
+++ b/src/qt/slider.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_SLIDER
+
 #include "wx/slider.h"
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
@@ -292,3 +294,4 @@ QWidget *wxSlider::GetHandle() const
     return m_qtSlider;
 }
 
+#endif // wxUSE_SLIDER

--- a/src/qt/spinbutt.cpp
+++ b/src/qt/spinbutt.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_SPINBTN
+
 #include "wx/spinbutt.h"
 #include "wx/qt/private/winevent.h"
 
@@ -118,3 +120,5 @@ QWidget *wxSpinButton::GetHandle() const
 {
     return m_qtSpinBox;
 }
+
+#endif // wxUSE_SPINBTN

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_STATBMP
+
 #include "wx/statbmp.h"
 #include "wx/qt/private/winevent.h"
 
@@ -87,3 +89,5 @@ QWidget *wxStaticBitmap::GetHandle() const
 {
     return m_qtLabel;
 }
+
+#endif // wxUSE_STATBMP

--- a/src/qt/statbox.cpp
+++ b/src/qt/statbox.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_STATBOX
+
 #include "wx/statbox.h"
 #include "wx/window.h"
 #include "wx/qt/private/converter.h"
@@ -75,3 +77,5 @@ void wxStaticBox::GetBordersForSizer(int *borderTop, int *borderOther) const
     // need extra space for the label:
     *borderTop += GetCharHeight();
 }
+
+#endif // wxUSE_STATBOX

--- a/src/qt/statline.cpp
+++ b/src/qt/statline.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_STATLINE
+
 #include "wx/statline.h"
 
 #include <QtWidgets/QFrame>
@@ -47,3 +49,5 @@ QWidget *wxStaticLine::GetHandle() const
 {
     return m_qtFrame;
 }
+
+#endif // wxUSE_STATLINE

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_STATTEXT
+
 #include "wx/stattext.h"
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
@@ -97,3 +99,5 @@ QWidget *wxStaticText::GetHandle() const
 {
     return m_qtLabel;
 }
+
+#endif // wxUSE_STATTEXT

--- a/src/qt/statusbar.cpp
+++ b/src/qt/statusbar.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_STATUSBAR
+
 #include "wx/statusbr.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
@@ -211,3 +213,5 @@ QWidget *wxStatusBar::GetHandle() const
 {
     return m_qtStatusBar;
 }
+
+#endif

--- a/src/qt/taskbar.cpp
+++ b/src/qt/taskbar.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_TASKBARICON
+
 #include "wx/taskbar.h"
 
 #include <QtWidgets/QSystemTrayIcon>
@@ -49,3 +51,4 @@ bool wxTaskBarIcon::PopupMenu(wxMenu *WXUNUSED(menu))
     return false;
 }
 
+#endif // wxUSE_TASKBARICON

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_TEXTCTRL
+
 #include "wx/textctrl.h"
 #include "wx/settings.h"
 #include "wx/qt/private/converter.h"
@@ -914,3 +916,5 @@ QWidget *wxTextCtrl::GetHandle() const
 {
     return (QWidget *) m_qtEdit->GetHandle();
 }
+
+#endif // wxUSE_TEXTCTRL

--- a/src/qt/tglbtn.cpp
+++ b/src/qt/tglbtn.cpp
@@ -8,6 +8,7 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_TOGGLEBTN
 
 #ifndef WX_PRECOMP
     #include "wx/bitmap.h"
@@ -113,3 +114,5 @@ bool wxToggleButton::GetValue() const
 {
     return m_qtPushButton->isChecked();
 }
+
+#endif // wxUSE_TOGGLEBTN

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -8,6 +8,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#if wxUSE_TREECTRL
+
 #include "wx/treectrl.h"
 #include "wx/imaglist.h"
 #include "wx/settings.h"
@@ -1445,3 +1447,5 @@ void wxTreeCtrl::OnKeyDown(wxKeyEvent& event)
 
     event.Skip();
 }
+
+#endif // wxUSE_TREECTRL


### PR DESCRIPTION
A bunch of components in wxQt lacked the appropriate `wxUSE_` guards which would result in build errors if those components are disabled. 

These patches are fairly trivial and should fix many of those cases, but not all combination of features are guaranteed to build due to certain components being dependent on others.