### PR TITLE
Further improve wxListCtrl appearance in Windows dark mode

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3435,7 +3435,10 @@ void wxListCtrl::OnPaint(wxPaintEvent& event)
         return;
     }
 
-    wxPen pen(wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT));
+    const wxColour penColour(wxSystemSettings::GetColour(wxMSWDarkMode::IsActive()
+                                                         ? wxSYS_COLOUR_GRAYTEXT
+                                                         : wxSYS_COLOUR_3DLIGHT));
+    wxPen pen(penColour);
     dc.SetPen(pen);
     dc.SetBrush(* wxTRANSPARENT_BRUSH);
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3226,23 +3226,8 @@ void HandleItemPaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT hfont)
 
     if ( nmcd.uItemState & CDIS_SELECTED )
     {
-        wxSystemColour syscolFg, syscolBg;
-        if ( ::GetFocus() == hwndList )
-        {
-            syscolFg = wxSYS_COLOUR_HIGHLIGHTTEXT;
-            syscolBg = wxSYS_COLOUR_HIGHLIGHT;
-        }
-        else // selected but unfocused
-        {
-            syscolFg = wxSYS_COLOUR_WINDOWTEXT;
-            syscolBg = wxSYS_COLOUR_BTNFACE;
-
-            // don't grey out the icon in this case either
-            nmcd.uItemState &= ~CDIS_SELECTED;
-        }
-
-        pLVCD->clrText = wxColourToRGB(wxSystemSettings::GetColour(syscolFg));
-        pLVCD->clrTextBk = wxColourToRGB(wxSystemSettings::GetColour(syscolBg));
+        pLVCD->clrText = wxColourToRGB(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
+        pLVCD->clrTextBk = wxColourToRGB(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
     }
     //else: not selected, use normal colours from pLVCD
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3265,6 +3265,14 @@ WXLPARAM HandleItemPrepaint(wxListCtrl *listctrl,
         // We need to always paint selected items ourselves as they come
         // out completely wrong in DarkMode_Explorer theme, see the comment
         // before MSWGetDarkModeSupport().
+        wxFont font;
+
+        if ( attr && attr->HasFont() )
+        {
+            font = attr->GetFont();
+            font.WXAdjustToPPI(listctrl->GetDPI());
+        }
+
         pLVCD->clrText = attr && attr->HasTextColour()
                             ? wxColourToRGB(attr->GetTextColour())
                             : wxColourToRGB(listctrl->GetTextColour());
@@ -3272,7 +3280,7 @@ WXLPARAM HandleItemPrepaint(wxListCtrl *listctrl,
                             ? wxColourToRGB(attr->GetBackgroundColour())
                             : wxColourToRGB(listctrl->GetBackgroundColour());
 
-        HandleItemPaint(listctrl, pLVCD, nullptr);
+        HandleItemPaint(listctrl, pLVCD, font.IsOk() ? GetHfontOf(font) : nullptr);
         return CDRF_SKIPDEFAULT;
     }
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3067,7 +3067,7 @@ bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT h
         rc.right = rc2.left;
     }
 
-    if ( listctrl->HasCheckBoxes() )
+    if ( !col && listctrl->HasCheckBoxes() )
     {
         const HIMAGELIST himl = ListView_GetImageList(hwndList, LVSIL_STATE);
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3111,9 +3111,13 @@ bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT h
     HIMAGELIST himl = ListView_GetImageList(hwndList, LVSIL_SMALL);
     if ( himl && ImageList_GetImageCount(himl) )
     {
+        int wImage, hImage;
+        ImageList_GetIconSize(himl, &wImage, &hImage);
+
         if ( it.iImage != -1 )
         {
-            ImageList_Draw(himl, it.iImage, hdc, rc.left, rc.top,
+            int imgY = rc.top + ((rc.bottom - rc.top) / 2 - hImage / 2);
+            ImageList_Draw(himl, it.iImage, hdc, rc.left, imgY,
                            nmcd.uItemState & CDIS_SELECTED ? ILD_SELECTED
                                                            : ILD_TRANSPARENT);
         }
@@ -3124,9 +3128,6 @@ bool HandleSubItemPrepaint(wxListCtrl* listctrl, LPNMLVCUSTOMDRAW pLVCD, HFONT h
         // images align?)
         if ( it.iImage != -1 || it.iSubItem == 0 )
         {
-            int wImage, hImage;
-            ImageList_GetIconSize(himl, &wImage, &hImage);
-
             rc.left += wImage + 2;
         }
     }


### PR DESCRIPTION
## Fix missing checkboxes in wxListCtrl in Windows dark mode

Under Windows dark mode, we paint wxListCtrl in report view by ourselves and so we need to paint also the checkboxes when needed.

There is a small glitch on Windows 11, where a selected checkbox has black instead of transparent pixels inside the rounded corners.

Closes #24410.

----

I tried also @MaartenBent code from #24410 using `wxRendererNative::Get().DrawCheckBox()`: The glitch is smaller (only in the upper corners) but the checkmark is a bit jagged, so I kept my code. I have no idea what to do about this, perhaps I am missing something here. @MaartenBent could you please tell me what you think?
 

## Always paint item selection in wxListCtrl in Windows dark mode

When painting items in wxListCtrl in report view under Windows dark mode,
the selection was painted only when the control had focus.

However, this did not match the light mode, where the selection is always drawn
regardless of the focus (the listview is created with LVS_SHOWSELALWAYS style).

---
@vadz, this goes directly against what you coded, I think this commit makes sense but please review.


## Fix item selection painting in wxListCtrl in Windows dark mode

The item selection/focus rectangle should include not only the item text but also the checkbox and image.