### PR TITLE
Document needing to Unbind wxEVT_LIST_DELETE_ALL_ITEMS in derived (generic) listctrl DTORs

### DIFF
--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -420,9 +420,17 @@ public:
 
         This function does @e not send the @c wxEVT_LIST_DELETE_ITEM
         event because deleting many items from the control would be too slow
-        then (unlike wxListCtrl::DeleteItem) but it does send the special @c
+        then (unlike wxListCtrl::DeleteItem), but it does send the special @c
         wxEVT_LIST_DELETE_ALL_ITEMS event if the control was not empty.
         If it was already empty, nothing is done and no event is sent.
+
+        @note If using the generic version of this control
+        (e.g., GTK+) and you bind a function to
+        wxEVT_LIST_DELETE_ALL_ITEMS from a derived class,
+        then it is recommended to unbind this in your derived class's destructor.
+        The base version of wxListCtrl will send a wxEVT_LIST_DELETE_ALL_ITEMS
+        event from its destructor, so you must unbind your class from
+        this event before that occurs.
 
         @return @true if the items were successfully deleted or if the control
             was already empty, @false if an error occurred while deleting the

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1603,8 +1603,6 @@ wxListMainWindow::~wxListMainWindow()
     if ( m_textctrlWrapper )
         m_textctrlWrapper->EndEdit(wxListTextCtrlWrapper::End_Destroy);
 
-    DoDeleteAllItems();
-
     delete m_highlightBrush;
     delete m_highlightUnfocusedBrush;
     delete m_renameTimer;

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1603,6 +1603,8 @@ wxListMainWindow::~wxListMainWindow()
     if ( m_textctrlWrapper )
         m_textctrlWrapper->EndEdit(wxListTextCtrlWrapper::End_Destroy);
 
+    DoDeleteAllItems();
+
     delete m_highlightBrush;
     delete m_highlightUnfocusedBrush;
     delete m_renameTimer;


### PR DESCRIPTION
`DoDeleteAllItems()` fires an event and can cause a bound function in derived classes to be called after the destruction process starts, causing possibly unexpected behavior. See #24440.