### PR TITLE
Add missing GetDropTarget() method override to wxGrid

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2376,6 +2376,7 @@ public:
     // ------- drag and drop
 #if wxUSE_DRAG_AND_DROP
     virtual void SetDropTarget(wxDropTarget *dropTarget) override;
+    virtual wxDropTarget* GetDropTarget() const override;
 #endif // wxUSE_DRAG_AND_DROP
 
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11075,6 +11075,11 @@ void wxGrid::SetDropTarget(wxDropTarget *dropTarget)
     GetGridWindow()->SetDropTarget(dropTarget);
 }
 
+wxDropTarget* wxGrid::GetDropTarget() const
+{
+    return GetGridWindow()->GetDropTarget();
+}
+
 #endif // wxUSE_DRAG_AND_DROP
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Added `GetDropTarget()` override method to the `wxGrid` class to match that of the `SetDropTarget(wxDropTarget*)` method.

Fixes #24447

Fingers crossed I have done everything correctly. Let me know if anything requires changing.