### PR TITLE
Fix icons in the generic log dialog under Mac in high DPI

### DIFF
--- a/src/generic/logg.cpp
+++ b/src/generic/logg.cpp
@@ -848,9 +848,9 @@ void wxLogDialog::CreateDetailsControls(wxWindow *parent)
 
     bool loadedIcons = true;
 
-    for ( size_t icon = 0; icon < WXSIZEOF(icons); icon++ )
+    for ( const auto& icon: icons )
     {
-        auto bmp = wxArtProvider::GetBitmapBundle(icons[icon], wxART_LIST);
+        auto bmp = wxArtProvider::GetBitmapBundle(icon, wxART_LIST);
 
         // This may very well fail if there are insufficient colours available.
         // Degrade gracefully.

--- a/src/generic/logg.cpp
+++ b/src/generic/logg.cpp
@@ -846,22 +846,9 @@ void wxLogDialog::CreateDetailsControls(wxWindow *parent)
         wxART_INFORMATION
     };
 
-    bool loadedIcons = true;
-
     for ( const auto& icon: icons )
     {
-        auto bmp = wxArtProvider::GetBitmapBundle(icon, wxART_LIST);
-
-        // This may very well fail if there are insufficient colours available.
-        // Degrade gracefully.
-        if ( !bmp.IsOk() )
-        {
-            loadedIcons = false;
-
-            break;
-        }
-
-        images.push_back(bmp);
+        images.push_back(wxArtProvider::GetBitmapBundle(icon, wxART_LIST));
     }
 
     m_listctrl->SetSmallImages(images);
@@ -871,26 +858,18 @@ void wxLogDialog::CreateDetailsControls(wxWindow *parent)
     for ( size_t n = 0; n < count; n++ )
     {
         int image;
-
-        if ( loadedIcons )
+        switch ( m_severity[n] )
         {
-            switch ( m_severity[n] )
-            {
-                case wxLOG_Error:
-                    image = 0;
-                    break;
+            case wxLOG_Error:
+                image = 0;
+                break;
 
-                case wxLOG_Warning:
-                    image = 1;
-                    break;
+            case wxLOG_Warning:
+                image = 1;
+                break;
 
-                default:
-                    image = 2;
-            }
-        }
-        else // failed to load images
-        {
-            image = -1;
+            default:
+                image = 2;
         }
 
         wxString msg = m_messages[n];

--- a/src/generic/logg.cpp
+++ b/src/generic/logg.cpp
@@ -835,11 +835,8 @@ void wxLogDialog::CreateDetailsControls(wxWindow *parent)
     if (hasTimeStamp)
         m_listctrl->InsertColumn(1, wxT("Time"));
 
-    // prepare the imagelist
-    wxSize iconSize(16, 16);
-    iconSize *= parent->GetDPIScaleFactor();
-
-    wxImageList *imageList = new wxImageList(iconSize.x, iconSize.y);
+    // prepare the images
+    wxVector<wxBitmapBundle> images;
 
     // order should be the same as in the switch below!
     static wxString const icons[] =
@@ -853,8 +850,7 @@ void wxLogDialog::CreateDetailsControls(wxWindow *parent)
 
     for ( size_t icon = 0; icon < WXSIZEOF(icons); icon++ )
     {
-        wxBitmap bmp = wxArtProvider::GetBitmap(icons[icon], wxART_MESSAGE_BOX,
-                                                iconSize);
+        auto bmp = wxArtProvider::GetBitmapBundle(icons[icon], wxART_LIST);
 
         // This may very well fail if there are insufficient colours available.
         // Degrade gracefully.
@@ -865,10 +861,10 @@ void wxLogDialog::CreateDetailsControls(wxWindow *parent)
             break;
         }
 
-        imageList->Add(bmp);
+        images.push_back(bmp);
     }
 
-    m_listctrl->SetImageList(imageList, wxIMAGE_LIST_SMALL);
+    m_listctrl->SetSmallImages(images);
 
     // fill the listctrl
     size_t count = m_messages.GetCount();


### PR DESCRIPTION
The dialog shown by the dialogs sample currently looks like this:

<img width="557" alt="mac_log_bad" src="https://github.com/wxWidgets/wxWidgets/assets/146917/90ee154b-52fe-47c1-81eb-6c5a00cc5138">

in high DPI and this PR turns it into the expected

<img width="557" alt="mac_log_good" src="https://github.com/wxWidgets/wxWidgets/assets/146917/39772f7e-e4ea-410c-9d26-36afcc9ddea6">
