### PR TITLE
Fix button size of generic wxColourPickerCtrl in high DPI

### DIFF
--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -57,7 +57,9 @@ bool wxGenericColourButton::Create( wxWindow *parent, wxWindowID id,
     // and handle user clicks on it
     Bind(wxEVT_BUTTON, &wxGenericColourButton::OnButtonClick, this, GetId());
 
-    m_bitmap = wxBitmap(FromDIP(defaultBitmapSize));
+    wxBitmap bmp;
+    bmp.CreateWithDIPSize( defaultBitmapSize, GetDPIScaleFactor() );
+    m_bitmap = bmp;
     m_colour = col;
     UpdateColour();
     InitColourData();
@@ -121,7 +123,9 @@ void wxGenericColourButton::OnColourChanged(wxColourDialogEvent& ev)
 
 void wxGenericColourButton::OnDPIChanged(wxDPIChangedEvent& event)
 {
-    m_bitmap = wxBitmap(FromDIP(defaultBitmapSize));
+    wxBitmap bmp;
+    bmp.CreateWithDIPSize( defaultBitmapSize, GetDPIScaleFactor() );
+    m_bitmap = bmp;
     UpdateColour();
 
     event.Skip();


### PR DESCRIPTION
With wxWidgets-3.2.4, the picker button of the generic `wxColourPickerCtrl` is too large on high DPI screens.

This issue, which can also be seen in the widgets sample, will be fixed by this PR.

The sample under Windows 10 at different DPI scalings:
![widgets-sample-colour-picker-win10-hidpi](https://github.com/wxWidgets/wxWidgets/assets/99262969/09a1def6-cd6c-4fe8-9b1e-572600491c3a)
