### PR TITLE
Add missing 'textctrl.h' inclusion

### DIFF
--- a/include/wx/generic/creddlgg.h
+++ b/include/wx/generic/creddlgg.h
@@ -15,6 +15,7 @@
 #if wxUSE_CREDENTIALDLG
 
 #include "wx/dialog.h"
+#include "wx/textctrl.h"
 #include "wx/webrequest.h"
 
 class WXDLLIMPEXP_CORE wxGenericCredentialEntryDialog : public wxDialog


### PR DESCRIPTION
Without this, I get a number of compile issues where ` wxTextCtrl* m_userTextCtrl;` is declared. (At least on MSW.)