### PR TITLE
Stop inheriting `wxFileButton` from `wxButton` in wxGTK

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -156,6 +156,9 @@ Changes in behaviour which may result in build errors
   be completely removed in the future. If you overrode this function, don't
   do it any longer. If you call it, replace it with wxBORDER_THEME constant.
 
+- wxGTK wxDirButton::Create() doesn't have unused "wildcard" parameter any
+  longer, please just remove it from your code if you used it.
+
 
 3.3.0: (released 2022-??-??)
 ----------------------------

--- a/include/wx/filepicker.h
+++ b/include/wx/filepicker.h
@@ -90,7 +90,7 @@ public:
     virtual void SetPath(const wxString &str) { m_path=str; }
 
     // Set the directory to open the file browse dialog at initially.
-    virtual void SetInitialDirectory(const wxString& dir) = 0;
+    virtual void SetInitialDirectory(const wxString& dir) { m_initialDir = dir; }
 
     // returns the picker widget cast to wxControl
     virtual wxControl *AsControl() = 0;
@@ -100,6 +100,9 @@ protected:
     virtual void UpdatePathFromDialog(wxDialog *) = 0;
 
     wxString m_path;
+
+    // Initial directory set by SetInitialDirectory() call or empty.
+    wxString m_initialDir;
 };
 
 // Styles which must be supported by all controls implementing wxFileDirPickerWidgetBase

--- a/include/wx/filepicker.h
+++ b/include/wx/filepicker.h
@@ -113,12 +113,17 @@ protected:
 #define wxFLP_CHANGE_DIR              0x4000
 #define wxFLP_SMALL                   wxPB_SMALL
 
+#define wxFILEBTN_DEFAULT_STYLE       (wxFLP_OPEN)
+
 // NOTE: wxMULTIPLE is not supported !
 
 
 #define wxDIRP_DIR_MUST_EXIST         0x0008
 #define wxDIRP_CHANGE_DIR             0x0010
 #define wxDIRP_SMALL                  wxPB_SMALL
+
+#define wxDIRBTN_DEFAULT_STYLE        0
+
 
 
 // map platform-dependent controls which implement the wxFileDirPickerWidgetBase

--- a/include/wx/filepicker.h
+++ b/include/wx/filepicker.h
@@ -86,7 +86,7 @@ public:
     virtual ~wxFileDirPickerWidgetBase() = default;
 
     // Path here is the name of the selected file or directory.
-    wxString GetPath() const { return m_path; }
+    virtual wxString GetPath() const { return m_path; }
     virtual void SetPath(const wxString &str) { m_path=str; }
 
     // Set the directory to open the file browse dialog at initially.
@@ -96,9 +96,6 @@ public:
     virtual wxControl *AsControl() = 0;
 
 protected:
-    virtual void UpdateDialogPath(wxDialog *) = 0;
-    virtual void UpdatePathFromDialog(wxDialog *) = 0;
-
     wxString m_path;
 
     // Initial directory set by SetInitialDirectory() call or empty.

--- a/include/wx/generic/filepickerg.h
+++ b/include/wx/generic/filepickerg.h
@@ -90,8 +90,6 @@ protected:
 // wxGenericFileButton: a button which brings up a wxFileDialog
 //-----------------------------------------------------------------------------
 
-#define wxFILEBTN_DEFAULT_STYLE                     (wxFLP_OPEN)
-
 class WXDLLIMPEXP_CORE wxGenericFileButton : public wxGenericFileDirButton
 {
 public:
@@ -157,8 +155,6 @@ private:
 //-----------------------------------------------------------------------------
 // wxGenericDirButton: a button which brings up a wxDirDialog
 //-----------------------------------------------------------------------------
-
-#define wxDIRBTN_DEFAULT_STYLE                     0
 
 class WXDLLIMPEXP_CORE wxGenericDirButton : public wxGenericFileDirButton
 {

--- a/include/wx/generic/filepickerg.h
+++ b/include/wx/generic/filepickerg.h
@@ -55,8 +55,6 @@ public:     // overridable
 
     virtual wxEventType GetEventType() const = 0;
 
-    virtual void SetInitialDirectory(const wxString& dir) override;
-
 public:
 
     bool Create(wxWindow *parent, wxWindowID id,
@@ -80,9 +78,6 @@ protected:
     // wxButton as some of our bits can conflict with wxButton styles and it
     // just doesn't make sense to use picker styles for wxButton anyhow
     long m_pickerStyle = -1;
-
-    // Initial directory set by SetInitialDirectory() call or empty.
-    wxString m_initialDir;
 };
 
 

--- a/include/wx/generic/filepickerg.h
+++ b/include/wx/generic/filepickerg.h
@@ -27,7 +27,7 @@ class WXDLLIMPEXP_CORE wxGenericFileDirButton : public wxButton,
                                                 public wxFileDirPickerWidgetBase
 {
 public:
-    wxGenericFileDirButton() { Init(); }
+    wxGenericFileDirButton() = default;
     wxGenericFileDirButton(wxWindow *parent,
                            wxWindowID id,
                            const wxString& label = wxASCII_STR(wxFilePickerWidgetLabel),
@@ -40,7 +40,6 @@ public:
                            const wxValidator& validator = wxDefaultValidator,
                            const wxString& name = wxASCII_STR(wxFilePickerWidgetNameStr))
     {
-        Init();
         Create(parent, id, label, path, message, wildcard,
                pos, size, style, validator, name);
     }
@@ -80,14 +79,10 @@ protected:
     // we just store the style passed to the ctor here instead of passing it to
     // wxButton as some of our bits can conflict with wxButton styles and it
     // just doesn't make sense to use picker styles for wxButton anyhow
-    long m_pickerStyle;
+    long m_pickerStyle = -1;
 
     // Initial directory set by SetInitialDirectory() call or empty.
     wxString m_initialDir;
-
-private:
-    // common part of all ctors
-    void Init() { m_pickerStyle = -1; }
 };
 
 

--- a/include/wx/generic/filepickerg.h
+++ b/include/wx/generic/filepickerg.h
@@ -107,28 +107,32 @@ public:
 
 public:     // overridable
 
-    virtual long GetDialogStyle() const
+    static long GetDialogStyle(long pickerStyle)
+    {
+        long filedlgstyle = 0;
+
+        if ( pickerStyle & wxFLP_OPEN )
+            filedlgstyle |= wxFD_OPEN;
+        if ( pickerStyle & wxFLP_SAVE )
+            filedlgstyle |= wxFD_SAVE;
+        if ( pickerStyle & wxFLP_OVERWRITE_PROMPT )
+            filedlgstyle |= wxFD_OVERWRITE_PROMPT;
+        if ( pickerStyle & wxFLP_FILE_MUST_EXIST )
+            filedlgstyle |= wxFD_FILE_MUST_EXIST;
+        if ( pickerStyle & wxFLP_CHANGE_DIR )
+            filedlgstyle |= wxFD_CHANGE_DIR;
+
+        return filedlgstyle;
+    }
+
+    long GetDialogStyle() const
     {
         // the derived class must initialize it if it doesn't use the
         // non-default wxGenericFileDirButton ctor
         wxASSERT_MSG( m_pickerStyle != -1,
                       "forgot to initialize m_pickerStyle?" );
 
-
-        long filedlgstyle = 0;
-
-        if ( m_pickerStyle & wxFLP_OPEN )
-            filedlgstyle |= wxFD_OPEN;
-        if ( m_pickerStyle & wxFLP_SAVE )
-            filedlgstyle |= wxFD_SAVE;
-        if ( m_pickerStyle & wxFLP_OVERWRITE_PROMPT )
-            filedlgstyle |= wxFD_OVERWRITE_PROMPT;
-        if ( m_pickerStyle & wxFLP_FILE_MUST_EXIST )
-            filedlgstyle |= wxFD_FILE_MUST_EXIST;
-        if ( m_pickerStyle & wxFLP_CHANGE_DIR )
-            filedlgstyle |= wxFD_CHANGE_DIR;
-
-        return filedlgstyle;
+        return GetDialogStyle(m_pickerStyle);
     }
 
     virtual wxDialog *CreateDialog() override;
@@ -172,16 +176,21 @@ public:
 
 public:     // overridable
 
-    virtual long GetDialogStyle() const
+    static long GetDialogStyle(long pickerStyle)
     {
         long dirdlgstyle = wxDD_DEFAULT_STYLE;
 
-        if ( m_pickerStyle & wxDIRP_DIR_MUST_EXIST )
+        if ( pickerStyle & wxDIRP_DIR_MUST_EXIST )
             dirdlgstyle |= wxDD_DIR_MUST_EXIST;
-        if ( m_pickerStyle & wxDIRP_CHANGE_DIR )
+        if ( pickerStyle & wxDIRP_CHANGE_DIR )
             dirdlgstyle |= wxDD_CHANGE_DIR;
 
         return dirdlgstyle;
+    }
+
+    long GetDialogStyle() const
+    {
+        return GetDialogStyle(m_pickerStyle);
     }
 
     virtual wxDialog *CreateDialog() override;

--- a/include/wx/generic/filepickerg.h
+++ b/include/wx/generic/filepickerg.h
@@ -72,6 +72,11 @@ public:
     void OnButtonClick(wxCommandEvent &);
 
 protected:
+    // Return the path from the button-specific dialog (this is the same dialog
+    // that is returned by CreateDialog()).
+    virtual wxString GetPathFromDialog(wxDialog *p) const = 0;
+
+
     wxString m_message, m_wildcard;
 
     // we just store the style passed to the ctor here instead of passing it to
@@ -141,10 +146,8 @@ public:     // overridable
         { return wxEVT_FILEPICKER_CHANGED; }
 
 protected:
-    void UpdateDialogPath(wxDialog *p) override
-        { wxStaticCast(p, wxFileDialog)->SetPath(m_path); }
-    void UpdatePathFromDialog(wxDialog *p) override
-        { m_path = wxStaticCast(p, wxFileDialog)->GetPath(); }
+    wxString GetPathFromDialog(wxDialog *p) const override
+        { return wxStaticCast(p, wxFileDialog)->GetPath(); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxGenericFileButton);
@@ -199,10 +202,8 @@ public:     // overridable
         { return wxEVT_DIRPICKER_CHANGED; }
 
 protected:
-    void UpdateDialogPath(wxDialog *p) override
-        { wxStaticCast(p, wxDirDialog)->SetPath(m_path); }
-    void UpdatePathFromDialog(wxDialog *p) override
-        { m_path = wxStaticCast(p, wxDirDialog)->GetPath(); }
+    wxString GetPathFromDialog(wxDialog *p) const override
+        { return wxStaticCast(p, wxDirDialog)->GetPath(); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxGenericDirButton);

--- a/include/wx/gtk/filepicker.h
+++ b/include/wx/gtk/filepicker.h
@@ -127,7 +127,7 @@ public:
     {
         m_pickerStyle = style;
 
-        Create(parent, id, label, path, message, wxEmptyString,
+        Create(parent, id, label, path, message,
                 pos, size, style, validator, name);
     }
 
@@ -141,7 +141,6 @@ public:     // overrides
                 const wxString& label = wxASCII_STR(wxFilePickerWidgetLabel),
                 const wxString &path = wxEmptyString,
                 const wxString &message = wxASCII_STR(wxFileSelectorPromptStr),
-                const wxString &wildcard = wxASCII_STR(wxFileSelectorDefaultWildcardStr),
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
                 long style = 0,

--- a/include/wx/gtk/filepicker.h
+++ b/include/wx/gtk/filepicker.h
@@ -52,7 +52,7 @@ protected:                                                                    \
 class WXDLLIMPEXP_CORE wxFileButton : public wxGenericFileButton
 {
 public:
-    wxFileButton() { Init(); }
+    wxFileButton() = default;
     wxFileButton(wxWindow *parent,
                  wxWindowID id,
                  const wxString& label = wxASCII_STR(wxFilePickerWidgetLabel),
@@ -65,7 +65,6 @@ public:
                  const wxValidator& validator = wxDefaultValidator,
                  const wxString& name = wxASCII_STR(wxFilePickerWidgetNameStr))
     {
-        Init();
         m_pickerStyle = style;
         Create(parent, id, label, path, message, wildcard,
                pos, size, style, validator, name);
@@ -98,14 +97,11 @@ public:     // overrides
     FILEDIRBTN_OVERRIDES
 
 protected:
-    wxDialog *m_dialog;
+    wxDialog* m_dialog = nullptr;
 
     virtual void DoApplyWidgetStyle(GtkRcStyle*) override;
 
 private:
-    // common part of all ctors
-    void Init() { m_dialog = nullptr; }
-
     wxDECLARE_DYNAMIC_CLASS(wxFileButton);
 };
 
@@ -117,7 +113,7 @@ private:
 class WXDLLIMPEXP_CORE wxDirButton : public wxGenericDirButton
 {
 public:
-    wxDirButton() { Init(); }
+    wxDirButton() = default;
     wxDirButton(wxWindow *parent,
                 wxWindowID id,
                 const wxString& label = wxASCII_STR(wxFilePickerWidgetLabel),
@@ -129,8 +125,6 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxASCII_STR(wxFilePickerWidgetNameStr))
     {
-        Init();
-
         m_pickerStyle = style;
 
         Create(parent, id, label, path, message, wxEmptyString,
@@ -169,23 +163,17 @@ public:     // overrides
     FILEDIRBTN_OVERRIDES
 
 protected:
-    wxDialog *m_dialog;
+    wxDialog* m_dialog = nullptr;
 
     virtual void DoApplyWidgetStyle(GtkRcStyle*) override;
 
 public:    // used by the GTK callback only
 
-    bool m_bIgnoreNextChange;
+    bool m_bIgnoreNextChange = false;
 
     void GTKUpdatePath(const char *gtkpath);
 
 private:
-    void Init()
-    {
-        m_dialog = nullptr;
-        m_bIgnoreNextChange = false;
-    }
-
     wxDECLARE_DYNAMIC_CLASS(wxDirButton);
 };
 

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -25,6 +25,7 @@
 // for all others, include the necessary headers
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/button.h"
     #include "wx/log.h"
     #include "wx/radiobox.h"
     #include "wx/statbox.h"

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -25,6 +25,7 @@
 // for all others, include the necessary headers
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/button.h"
     #include "wx/log.h"
     #include "wx/radiobox.h"
     #include "wx/statbox.h"

--- a/src/generic/filepickerg.cpp
+++ b/src/generic/filepickerg.cpp
@@ -94,7 +94,7 @@ void wxGenericFileDirButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
     if (p->ShowModal() == wxID_OK)
     {
         // save updated path in m_path
-        UpdatePathFromDialog(p.get());
+        SetPath(GetPathFromDialog(p.get()));
 
         // fire an event
         wxFileDirPickerEvent event(GetEventType(), this, GetId(), m_path);

--- a/src/generic/filepickerg.cpp
+++ b/src/generic/filepickerg.cpp
@@ -24,6 +24,8 @@
 #include "wx/filename.h"
 #include "wx/filepicker.h"
 
+#include "wx/generic/filepickerg.h"
+
 #include <memory>
 
 
@@ -98,11 +100,6 @@ void wxGenericFileDirButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
         wxFileDirPickerEvent event(GetEventType(), this, GetId(), m_path);
         GetEventHandler()->ProcessEvent(event);
     }
-}
-
-void wxGenericFileDirButton::SetInitialDirectory(const wxString& dir)
-{
-    m_initialDir = dir;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/gtk/filepicker.cpp
+++ b/src/gtk/filepicker.cpp
@@ -226,7 +226,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxDirButton, wxButton);
 
 bool wxDirButton::Create( wxWindow *parent, wxWindowID id,
                         const wxString &label, const wxString &path,
-                        const wxString &message, const wxString &wildcard,
+                        const wxString &message,
                         const wxPoint &pos, const wxSize &size,
                         long style, const wxValidator& validator,
                         const wxString &name )
@@ -247,7 +247,6 @@ bool wxDirButton::Create( wxWindow *parent, wxWindowID id,
         // create the dialog associated with this button
         SetWindowStyle(style);
         m_message = message;
-        m_wildcard = wildcard;
         if ((m_dialog = CreateDialog()) == nullptr)
             return false;
 

--- a/src/gtk/filepicker.cpp
+++ b/src/gtk/filepicker.cpp
@@ -25,11 +25,29 @@
 #include "wx/filepicker.h"
 #include "wx/tooltip.h"
 
+#include "wx/generic/filepickerg.h"
+
 #include "wx/gtk/private.h"
 
 // ============================================================================
 // implementation
 // ============================================================================
+
+/*
+    The complication here is that we have to fall back on the generic
+    implementation for the flags not supported by the native control, but we
+    can't inherit from the generic classes as they inherit from wxButton but
+    the native widgets used here are not buttons in the GTK sense (i.e.
+    GtkFileChooserButton doesn't inherit from GtkButton).
+
+    So we use composition instead of inheritance, with the GTK control either
+    being a native widget or a generic window containing the generic control,
+    resulting in two exclusive modes:
+
+    1. m_dialog is non-null and m_genericButton is null: we use the native GTK
+       control.
+    2. m_dialog is null and m_genericButton is non-null: we use the generic one.
+ */
 
 //-----------------------------------------------------------------------------
 // wxFileButton
@@ -63,11 +81,26 @@ bool wxFileButton::Create( wxWindow *parent, wxWindowID id,
         // NB: unlike generic implementation, native GTK implementation needs to create
         //     the filedialog here as it needs to use gtk_file_chooser_button_new_with_dialog()
         SetWindowStyle(style);
+
         m_path = path;
-        m_message = message;
-        m_wildcard = wildcard;
-        if ((m_dialog = CreateDialog()) == nullptr)
-            return false;
+
+        // Determine the initial directory for the dialog: it comes either from the
+        // default path, if it has it, or from the separately specified initial
+        // directory that can be set even if the path is e.g. empty.
+        wxFileName fn(m_path);
+        wxString initialDir = fn.GetPath();
+        if ( initialDir.empty() )
+            initialDir = m_initialDir;
+
+        m_dialog = new wxFileDialog
+                   (
+                        nullptr,
+                        message,
+                        initialDir,
+                        fn.GetFullName(),
+                        wildcard,
+                        wxGenericFileButton::GetDialogStyle(style)
+                   );
 
         // little trick used to avoid problems when there are other GTK windows 'grabbed':
         // GtkFileChooserDialog won't be responsive to user events if there is another
@@ -95,9 +128,24 @@ bool wxFileButton::Create( wxWindow *parent, wxWindowID id,
         PostCreation(size);
         SetInitialSize(size);
     }
-    else
-        return wxGenericFileButton::Create(parent, id, label, path, message, wildcard,
-                                           pos, size, style, validator, name);
+    else // Use generic implementation.
+    {
+        if ( !wxControl::Create(parent, id, pos, size, wxBORDER_NONE, validator, name) )
+            return false;
+
+        m_genericButton = new wxGenericFileButton
+                              (
+                                this, wxID_ANY, label, path, message, wildcard,
+                                {}, size, style
+                              );
+
+        Bind(wxEVT_SIZE, [this](wxSizeEvent& event)
+        {
+            m_genericButton->SetSize(wxRect{event.GetSize()});
+            event.Skip();
+        });
+    }
+
     return true;
 }
 
@@ -123,7 +171,7 @@ void wxFileButton::OnDialogOK(wxCommandEvent& ev)
     if (ev.GetId() == wxID_OK)
     {
         // ...update our path
-        UpdatePathFromDialog(m_dialog);
+        m_path = m_dialog->GetPath();
 
         // ...and fire an event
         wxFileDirPickerEvent event(wxEVT_FILEPICKER_CHANGED, this, GetId(), m_path);
@@ -131,18 +179,36 @@ void wxFileButton::OnDialogOK(wxCommandEvent& ev)
     }
 }
 
+wxString wxFileButton::GetPath() const
+{
+    if ( m_genericButton )
+        return m_genericButton->GetPath();
+
+    return m_path;
+}
+
 void wxFileButton::SetPath(const wxString &str)
 {
+    if ( m_genericButton )
+    {
+        m_genericButton->SetPath(str);
+        return;
+    }
+
     m_path = str;
 
     if (GTK_IS_FILE_CHOOSER(m_widget))
         gtk_file_chooser_set_filename((GtkFileChooser*)m_widget, str.utf8_str());
-    else if (m_dialog)
-        UpdateDialogPath(m_dialog);
 }
 
 void wxFileButton::SetInitialDirectory(const wxString& dir)
 {
+    if ( m_genericButton )
+    {
+        m_genericButton->SetInitialDirectory(dir);
+        return;
+    }
+
     if (m_dialog)
     {
         // Only change the directory if the default file name doesn't have any
@@ -150,16 +216,11 @@ void wxFileButton::SetInitialDirectory(const wxString& dir)
         if ( m_path.find_first_of(wxFileName::GetPathSeparators()) ==
                 wxString::npos )
         {
-            static_cast<wxFileDialog*>(m_dialog)->SetDirectory(dir);
+            m_dialog->SetDirectory(dir);
         }
     }
-    else
-        wxGenericFileButton::SetInitialDirectory(dir);
 }
 
-void wxFileButton::DoApplyWidgetStyle(GtkRcStyle*)
-{
-}
 #endif // wxUSE_FILEPICKERCTRL
 
 #if wxUSE_DIRPICKERCTRL
@@ -178,7 +239,9 @@ static void file_set(GtkFileChooser* widget, wxDirButton* p)
     // NB: it's important to use gtk_file_chooser_get_filename instead of
     //     gtk_file_chooser_get_current_folder (see GTK docs) !
     wxGtkString filename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget)));
-    p->GTKUpdatePath(filename);
+
+    // Just update m_path here.
+    p->wxFileDirPickerWidgetBase::SetPath(wxString::FromUTF8(filename));
 
     // since GtkFileChooserButton when used to pick directories also uses a combobox,
     // maybe that the current folder has been changed but not through the GtkFileChooserDialog
@@ -246,9 +309,18 @@ bool wxDirButton::Create( wxWindow *parent, wxWindowID id,
 
         // create the dialog associated with this button
         SetWindowStyle(style);
-        m_message = message;
-        if ((m_dialog = CreateDialog()) == nullptr)
-            return false;
+
+        m_path = path;
+
+        // GtkFileChooserButton does not support GTK_FILE_CHOOSER_CREATE_FOLDER
+        // thus we must ensure that the wxDD_DIR_MUST_EXIST style was given
+        m_dialog = new wxDirDialog
+                       (
+                            nullptr,
+                            message,
+                            m_path.empty() ? m_initialDir : m_path,
+                            wxGenericDirButton::GetDialogStyle(style | wxDIRP_DIR_MUST_EXIST)
+                       );
 
         // little trick used to avoid problems when there are other GTK windows 'grabbed':
         // GtkFileChooserDialog won't be responsive to user events if there is another
@@ -286,9 +358,24 @@ bool wxDirButton::Create( wxWindow *parent, wxWindowID id,
         PostCreation(size);
         SetInitialSize(size);
     }
-    else
-        return wxGenericDirButton::Create(parent, id, label, path, message, wildcard,
-                                          pos, size, style, validator, name);
+    else // Use generic implementation.
+    {
+        if ( !wxControl::Create(parent, id, pos, size, wxBORDER_NONE, validator, name) )
+            return false;
+
+        m_genericButton = new wxGenericDirButton
+                              (
+                                this, wxID_ANY, label, path, message,
+                                {}, size, style
+                              );
+
+        Bind(wxEVT_SIZE, [this](wxSizeEvent& event)
+        {
+            m_genericButton->SetSize(wxRect{event.GetSize()});
+            event.Skip();
+        });
+    }
+
     return true;
 }
 
@@ -302,12 +389,22 @@ wxDirButton::~wxDirButton()
     }
 }
 
-void wxDirButton::GTKUpdatePath(const char *gtkpath)
+wxString wxDirButton::GetPath() const
 {
-    m_path = wxString::FromUTF8(gtkpath);
+    if ( m_genericButton )
+        return m_genericButton->GetPath();
+
+    return m_path;
 }
+
 void wxDirButton::SetPath(const wxString& str)
 {
+    if ( m_genericButton )
+    {
+        m_genericButton->SetPath(str);
+        return;
+    }
+
     if ( m_path == str )
         return;
 
@@ -317,22 +414,21 @@ void wxDirButton::SetPath(const wxString& str)
 
     if (GTK_IS_FILE_CHOOSER(m_widget))
         gtk_file_chooser_set_filename((GtkFileChooser*)m_widget, str.utf8_str());
-    else if (m_dialog)
-        UpdateDialogPath(m_dialog);
 }
 
 void wxDirButton::SetInitialDirectory(const wxString& dir)
 {
+    if ( m_genericButton )
+    {
+        m_genericButton->SetInitialDirectory(dir);
+        return;
+    }
+
     if (m_dialog)
     {
         if (m_path.empty())
-            static_cast<wxDirDialog*>(m_dialog)->SetPath(dir);
+            m_dialog->SetPath(dir);
     }
-    else
-        wxGenericDirButton::SetInitialDirectory(dir);
 }
 
-void wxDirButton::DoApplyWidgetStyle(GtkRcStyle*)
-{
-}
 #endif // wxUSE_DIRPICKERCTRL


### PR DESCRIPTION
The important commit here is the last one, the rest are just preparation for it.

And this fixes messages like this:

```
GLib-GObject-WARNING **: 19:27:35.092: invalid cast from 'GtkFileChooserButton' to 'GtkBin'
Gtk-CRITICAL **: 19:27:35.093: gtk_bin_get_child: assertion 'GTK_IS_BIN (bin)' failed
Gtk-CRITICAL **: 19:27:35.093: gtk_widget_set_sensitive: assertion 'GTK_IS_WIDGET (widget)' failed
```

when trying to disable `wxFileButton` in wxGTK.