### PR TITLE
Support Y2K38 in wxDateTime

### DIFF
--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -1728,9 +1728,11 @@ protected:
 
 inline bool wxDateTime::IsInStdRange() const
 {
-    // currently we don't know what is the real type of time_t so prefer to err
-    // on the safe side and limit it to 32 bit values which is safe everywhere
-    return m_time >= 0l && (m_time / TIME_T_FACTOR) < wxINT32_MAX;
+    // if sizeof(time_t) is greater than 32 bits, we assume it
+    // is safe to return values exceeding wxINT32_MAX
+
+    return m_time >= 0l &&
+        ( (sizeof(time_t) > 4 ) || ( (m_time / TIME_T_FACTOR) < wxINT32_MAX) );
 }
 
 /* static */
@@ -1837,7 +1839,7 @@ inline time_t wxDateTime::GetTicks() const
         return (time_t)-1;
     }
 
-    return (time_t)((m_time / (long)TIME_T_FACTOR).ToLong()) + WX_TIME_BASE_OFFSET;
+    return (time_t)((m_time / TIME_T_FACTOR).GetValue()) + WX_TIME_BASE_OFFSET;
 }
 
 inline bool wxDateTime::SetToLastWeekDay(WeekDay weekday,

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -1273,14 +1273,13 @@ wxDateTime& wxDateTime::Set(wxDateTime_t day,
     // While the range for 64-bit time_t is billions of years per se,
     // we cannot expect the C runtime to support dates thousands of years
     // in the future. MSVC claims to support dates up to 3000-12-31;
-    // what macOS and *nix support is unknown, but let us pick year 2200
-    // as the maximum for now.
+    // however, we do not set an upper limit for the year.
     static const int yearMinInRange = 1970;
-    static const int yearMaxInRange = sizeof(time_t) > 4 ? 2200 : 2037;
+    static const int yearMaxInRange = sizeof(time_t) > 4 ? -1 : 2037;
 
     // test only the year instead of testing for the exact end of the Unix
     // time_t range - it doesn't bring anything to do more precise checks
-    if ( year >= yearMinInRange && year <= yearMaxInRange )
+    if ( year >= yearMinInRange && (yearMaxInRange == -1 || year <= yearMaxInRange) )
     {
         // use the standard library version if the date is in range - this is
         // probably more efficient than our code

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -26,7 +26,8 @@
  *    algorithms limitations, only dates from Nov 24, 4714BC are handled
  *
  * 3. standard ANSI C functions are used to do time calculations whenever
- *    possible, i.e. when the date is in the range Jan 1, 1970 to 2038
+ *    possible, i.e. when the date is in the range Jan 1, 1970 to 2038 (32-bit
+ *    time_t) or 2200 (64-bit time_t).
  *
  * 4. otherwise, the calculations are done by converting the date to/from JDN
  *    first (the range limitation mentioned above comes from here: the
@@ -1269,8 +1270,13 @@ wxDateTime& wxDateTime::Set(wxDateTime_t day,
                       wxT("Invalid date in wxDateTime::Set()") );
 
     // the range of time_t type (inclusive)
+    // While the range for 64-bit time_t is billions of years per se,
+    // we cannot expect the C runtime to support dates thousands of years
+    // in the future. MSVC claims to support dates up to 3000-12-31;
+    // what macOS and *nix support is unknown, but let us pick year 2200
+    // as the maximum for now.
     static const int yearMinInRange = 1970;
-    static const int yearMaxInRange = 2037;
+    static const int yearMaxInRange = sizeof(time_t) > 4 ? 2200 : 2037;
 
     // test only the year instead of testing for the exact end of the Unix
     // time_t range - it doesn't bring anything to do more precise checks

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -184,6 +184,7 @@ static const Date testDates[] =
     {  8, wxDateTime::Feb,  2036, 00, 00, 00, 2464731.5, wxDateTime::Fri,        -1 },
     {  1, wxDateTime::Jan,  2037, 00, 00, 00, 2465059.5, wxDateTime::Thu,        -1 },
     {  1, wxDateTime::Jan,  2038, 00, 00, 00, 2465424.5, wxDateTime::Fri,        -1 },
+    {  1, wxDateTime::Jan,  2044, 00, 00, 00, 2467615.5, wxDateTime::Fri,        -1 },
     { 21, wxDateTime::Jan,  2222, 00, 00, 00, 2532648.5, wxDateTime::Mon,        -1 },
     { 29, wxDateTime::May,  1976, 12, 00, 00, 2442928.0, wxDateTime::Sat, 202219200 },
     { 29, wxDateTime::Feb,  1976, 00, 00, 00, 2442837.5, wxDateTime::Sun, 194400000 },

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1111,6 +1111,12 @@ void DateTimeTestCase::TestParseRFC822()
         },
 
         {
+            "Tue, 12 Apr 2044 10:48:30 -0500",
+            { 12, wxDateTime::Apr, 2044, 15, 48, 30 },
+            true
+        },
+
+        {
             "Sat, 18 Dec 1999 10:48:30 G", // military time zone
             { 18, wxDateTime::Dec, 1999, 17, 48, 30 },
             true
@@ -1282,6 +1288,7 @@ void DateTimeTestCase::TestDateParse()
         { "31/03/06",    { 31, wxDateTime::Mar,    6 }, true, "" },
         { "31/03/2006",  { 31, wxDateTime::Mar, 2006 }, true, "" },
         { "Thu 20 Jun 2019", { 20, wxDateTime::Jun, 2019 }, true, "" },
+        { "Sun 20 Jun 2049", { 20, wxDateTime::Jun, 2049 }, true, "" },
         { "20 Jun 2019 Thu", { 20, wxDateTime::Jun, 2019 }, true, "" },
         { "Dec sixth 2017",  {  6, wxDateTime::Dec, 2017 }, true, "" },
 
@@ -1429,6 +1436,14 @@ void DateTimeTestCase::TestDateTimeParse()
         {
             "Thu 22 Nov 2007 07:40:00 PM",
             { 22, wxDateTime::Nov, 2007, 19, 40,  0 },
+            true,
+            "",
+            false
+        },
+
+        {
+            "Sun 20 Jun 2049 07:40:00 PM",
+            { 20, wxDateTime::Jun, 2049, 19, 40,  0 },
             true,
             "",
             false

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -127,7 +127,7 @@ struct Date
     wxDateTime::wxDateTime_t hour, min, sec;
     double jdn;
     wxDateTime::WeekDay wday;
-    time_t gmticks;
+    wxInt64 gmticks;
 
     void Init(const wxDateTime::Tm& tm)
     {
@@ -184,8 +184,8 @@ static const Date testDates[] =
     {  8, wxDateTime::Feb,  2036, 00, 00, 00, 2464731.5, wxDateTime::Fri,        -1 },
     {  1, wxDateTime::Jan,  2037, 00, 00, 00, 2465059.5, wxDateTime::Thu,        -1 },
     {  1, wxDateTime::Jan,  2038, 00, 00, 00, 2465424.5, wxDateTime::Fri,        -1 },
-    {  1, wxDateTime::Jan,  2044, 00, 00, 00, 2467615.5, wxDateTime::Fri,        -1 },
-    { 21, wxDateTime::Jan,  2222, 00, 00, 00, 2532648.5, wxDateTime::Mon,        -1 },
+    {  1, wxDateTime::Jan,  2044, 00, 00, 00, 2467615.5, wxDateTime::Fri, 2335219200LL },
+    { 21, wxDateTime::Jan,  2222, 00, 00, 00, 2532648.5, wxDateTime::Mon, 7954070400LL },
     { 29, wxDateTime::May,  1976, 12, 00, 00, 2442928.0, wxDateTime::Sat, 202219200 },
     { 29, wxDateTime::Feb,  1976, 00, 00, 00, 2442837.5, wxDateTime::Sun, 194400000 },
     {  1, wxDateTime::Jan,  1900, 12, 00, 00, 2415021.0, wxDateTime::Mon,        -1 },
@@ -1071,7 +1071,7 @@ void DateTimeTestCase::TestTimeTicks()
 
         INFO("n=" << n);
 
-        time_t ticks = (dt.GetValue() / 1000).ToLong();
+        wxInt64 ticks = (dt.GetValue() / 1000).GetValue();
         CHECK( d.gmticks == ticks );
     }
 }


### PR DESCRIPTION
* Return 64-bit values from `GetTicks()` if `time_t` is 64-bit
* Use CRT for dates up to (the arbitrarily chosen) year 2200
* Add some 64-bit timestamps to test

There are actually fewer changes than I expected to be needed; I hope this is all that it takes.

This is could and probably should be backported to 3.2.

May fix #24414.
Should fix #22561.
