### PR TITLE
Various `wxPropertyGrid` tweaks

### DIFF
--- a/samples/propgrid/propgrid.xrc
+++ b/samples/propgrid/propgrid.xrc
@@ -11,7 +11,6 @@
             <object class="wxPropertyGridManager">
                 <style>wxPG_AUTO_SORT|wxPG_TOOLTIPS|wxPG_TOOLBAR</style>
                 <exstyle>wxPG_EX_MODE_BUTTONS|wxPG_EX_HELP_AS_TOOLTIPS</exstyle>
-                <virtualwidth>0</virtualwidth>
                 <page>
                     <label>Sample Page 1</label>
                     <property class="wxPropertyCategory">

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -278,7 +278,6 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
         case wxSYS_COLOUR_INFOBK:
         case wxSYS_COLOUR_LISTBOX:
         case wxSYS_COLOUR_WINDOW:
-        case wxSYS_COLOUR_BTNFACE:
             return wxColour(0x202020);
 
         case wxSYS_COLOUR_BTNTEXT:
@@ -300,6 +299,9 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
         case wxSYS_COLOUR_INACTIVECAPTION:
         case wxSYS_COLOUR_MENU:
             return wxColour(0x2b2b2b);
+
+        case wxSYS_COLOUR_BTNFACE:
+            return wxColour(0x333333);
 
         case wxSYS_COLOUR_MENUBAR:
             return wxColour(0x626262);

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -96,9 +96,10 @@
 // adjusted.
 #define IN_CELL_EXPANDER_BUTTON_X_ADJUST    2
 
-#if WXWIN_COMPATIBILITY_3_0
 namespace
 {
+
+#if WXWIN_COMPATIBILITY_3_0
 // Hash containing for every active wxPG the list of editors and their event handlers
 // to be deleted in the idle event handler.
 // It emulates member variable 'm_deletedEditorObjects' in 3.0 compatibility mode.
@@ -107,9 +108,24 @@ WX_DECLARE_HASH_MAP(wxPropertyGrid*, wxArrayPGObject*,
                     DeletedObjects);
 
 DeletedObjects gs_deletedEditorObjects;
+#endif
+
+// Bit values for wxPropertyGrid::m_coloursCustomized.
+enum CustomColour
+{
+    CustomColour_None           = 0x0000,
+    CustomColour_Margin         = 0x0001,
+    CustomColour_CaptionBg      = 0x0002,
+    CustomColour_CaptionText    = 0x0004,
+    CustomColour_CellBg         = 0x0008,
+    CustomColour_CellText       = 0x0010,
+    CustomColour_SelectionBg    = 0x0020,
+    CustomColour_SelectionText  = 0x0040,
+    CustomColour_Line           = 0x0080,
+    CustomColour_DisabledText   = 0x0100
+};
 
 } // anonymous namespace
-#endif
 
 // -----------------------------------------------------------------------
 
@@ -389,7 +405,7 @@ void wxPropertyGrid::Init1()
     AddActionTrigger(wxPGKeyboardAction::PressButton, WXK_DOWN, wxMOD_ALT);
     AddActionTrigger(wxPGKeyboardAction::PressButton, WXK_F4);
 
-    m_coloursCustomized = 0;
+    m_coloursCustomized = CustomColour_None;
 
     m_doubleBuffer = nullptr;
 
@@ -1422,7 +1438,7 @@ static int wxPGGetColAvg( const wxColour& col )
 
 void wxPropertyGrid::RegainColours()
 {
-    if ( !(m_coloursCustomized & 0x0002) )
+    if ( !(m_coloursCustomized & CustomColour_CaptionBg) )
     {
         wxColour col = wxSystemSettings::GetColour( wxSYS_COLOUR_BTNFACE );
 
@@ -1439,10 +1455,10 @@ void wxPropertyGrid::RegainColours()
         m_categoryDefaultCell.GetData()->SetBgCol(m_colCapBack);
     }
 
-    if ( !(m_coloursCustomized & 0x0001) )
+    if ( !(m_coloursCustomized & CustomColour_Margin) )
         m_colMargin = m_colCapBack;
 
-    if ( !(m_coloursCustomized & 0x0004) )
+    if ( !(m_coloursCustomized & CustomColour_CaptionText) )
     {
     #ifdef __WXGTK__
         int colDec = -90;
@@ -1457,7 +1473,7 @@ void wxPropertyGrid::RegainColours()
         m_categoryDefaultCell.GetData()->SetFgCol(capForeCol);
     }
 
-    if ( !(m_coloursCustomized & 0x0008) )
+    if ( !(m_coloursCustomized & CustomColour_CellBg) )
     {
         wxColour bgCol = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOW );
         m_colPropBack = bgCol;
@@ -1466,7 +1482,7 @@ void wxPropertyGrid::RegainColours()
             m_unspecifiedAppearance.SetBgCol(bgCol);
     }
 
-    if ( !(m_coloursCustomized & 0x0010) )
+    if ( !(m_coloursCustomized & CustomColour_CellText) )
     {
         wxColour fgCol = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT );
         m_colPropFore = fgCol;
@@ -1475,16 +1491,16 @@ void wxPropertyGrid::RegainColours()
             m_unspecifiedAppearance.SetFgCol(fgCol);
     }
 
-    if ( !(m_coloursCustomized & 0x0020) )
+    if ( !(m_coloursCustomized & CustomColour_SelectionBg) )
         m_colSelBack = wxSystemSettings::GetColour( wxSYS_COLOUR_HIGHLIGHT );
 
-    if ( !(m_coloursCustomized & 0x0040) )
+    if ( !(m_coloursCustomized & CustomColour_SelectionText) )
         m_colSelFore = wxSystemSettings::GetColour( wxSYS_COLOUR_HIGHLIGHTTEXT );
 
-    if ( !(m_coloursCustomized & 0x0080) )
+    if ( !(m_coloursCustomized & CustomColour_Line) )
         m_colLine = m_colCapBack;
 
-    if ( !(m_coloursCustomized & 0x0100) )
+    if ( !(m_coloursCustomized & CustomColour_DisabledText) )
         m_colDisPropFore = m_colCapFore;
 
     m_colEmptySpace = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOW );
@@ -1494,7 +1510,7 @@ void wxPropertyGrid::RegainColours()
 
 void wxPropertyGrid::ResetColours()
 {
-    m_coloursCustomized = 0;
+    m_coloursCustomized = CustomColour_None;
 
     RegainColours();
 
@@ -1523,7 +1539,7 @@ bool wxPropertyGrid::SetFont( const wxFont& font )
 void wxPropertyGrid::SetLineColour( const wxColour& col )
 {
     m_colLine = col;
-    m_coloursCustomized |= 0x80;
+    m_coloursCustomized |= CustomColour_Line;
     Refresh();
 }
 
@@ -1532,7 +1548,7 @@ void wxPropertyGrid::SetLineColour( const wxColour& col )
 void wxPropertyGrid::SetMarginColour( const wxColour& col )
 {
     m_colMargin = col;
-    m_coloursCustomized |= 0x01;
+    m_coloursCustomized |= CustomColour_Margin;
     Refresh();
 }
 
@@ -1541,7 +1557,7 @@ void wxPropertyGrid::SetMarginColour( const wxColour& col )
 void wxPropertyGrid::SetCellBackgroundColour( const wxColour& col )
 {
     m_colPropBack = col;
-    m_coloursCustomized |= 0x08;
+    m_coloursCustomized |= CustomColour_CellBg;
 
     m_propertyDefaultCell.GetData()->SetBgCol(col);
     m_unspecifiedAppearance.SetBgCol(col);
@@ -1554,7 +1570,7 @@ void wxPropertyGrid::SetCellBackgroundColour( const wxColour& col )
 void wxPropertyGrid::SetCellTextColour( const wxColour& col )
 {
     m_colPropFore = col;
-    m_coloursCustomized |= 0x10;
+    m_coloursCustomized |= CustomColour_CellText;
 
     m_propertyDefaultCell.GetData()->SetFgCol(col);
     m_unspecifiedAppearance.SetFgCol(col);
@@ -1576,7 +1592,7 @@ void wxPropertyGrid::SetEmptySpaceColour( const wxColour& col )
 void wxPropertyGrid::SetCellDisabledTextColour( const wxColour& col )
 {
     m_colDisPropFore = col;
-    m_coloursCustomized |= 0x100;
+    m_coloursCustomized |= CustomColour_DisabledText;
     Refresh();
 }
 
@@ -1585,7 +1601,7 @@ void wxPropertyGrid::SetCellDisabledTextColour( const wxColour& col )
 void wxPropertyGrid::SetSelectionBackgroundColour( const wxColour& col )
 {
     m_colSelBack = col;
-    m_coloursCustomized |= 0x20;
+    m_coloursCustomized |= CustomColour_SelectionBg;
     Refresh();
 }
 
@@ -1594,7 +1610,7 @@ void wxPropertyGrid::SetSelectionBackgroundColour( const wxColour& col )
 void wxPropertyGrid::SetSelectionTextColour( const wxColour& col )
 {
     m_colSelFore = col;
-    m_coloursCustomized |= 0x40;
+    m_coloursCustomized |= CustomColour_SelectionText;
     Refresh();
 }
 
@@ -1603,7 +1619,7 @@ void wxPropertyGrid::SetSelectionTextColour( const wxColour& col )
 void wxPropertyGrid::SetCaptionBackgroundColour( const wxColour& col )
 {
     m_colCapBack = col;
-    m_coloursCustomized |= 0x02;
+    m_coloursCustomized |= CustomColour_CaptionBg;
 
     m_categoryDefaultCell.GetData()->SetBgCol(col);
 
@@ -1615,7 +1631,7 @@ void wxPropertyGrid::SetCaptionBackgroundColour( const wxColour& col )
 void wxPropertyGrid::SetCaptionTextColour( const wxColour& col )
 {
     m_colCapFore = col;
-    m_coloursCustomized |= 0x04;
+    m_coloursCustomized |= CustomColour_CaptionText;
 
     m_categoryDefaultCell.GetData()->SetFgCol(col);
 

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -96,10 +96,9 @@
 // adjusted.
 #define IN_CELL_EXPANDER_BUTTON_X_ADJUST    2
 
+#if WXWIN_COMPATIBILITY_3_0
 namespace
 {
-
-#if WXWIN_COMPATIBILITY_3_0
 // Hash containing for every active wxPG the list of editors and their event handlers
 // to be deleted in the idle event handler.
 // It emulates member variable 'm_deletedEditorObjects' in 3.0 compatibility mode.
@@ -108,24 +107,9 @@ WX_DECLARE_HASH_MAP(wxPropertyGrid*, wxArrayPGObject*,
                     DeletedObjects);
 
 DeletedObjects gs_deletedEditorObjects;
-#endif
-
-// Bit values for wxPropertyGrid::m_coloursCustomized.
-enum CustomColour
-{
-    CustomColour_None           = 0x0000,
-    CustomColour_Margin         = 0x0001,
-    CustomColour_CaptionBg      = 0x0002,
-    CustomColour_CaptionText    = 0x0004,
-    CustomColour_CellBg         = 0x0008,
-    CustomColour_CellText       = 0x0010,
-    CustomColour_SelectionBg    = 0x0020,
-    CustomColour_SelectionText  = 0x0040,
-    CustomColour_Line           = 0x0080,
-    CustomColour_DisabledText   = 0x0100
-};
 
 } // anonymous namespace
+#endif
 
 // -----------------------------------------------------------------------
 
@@ -405,7 +389,7 @@ void wxPropertyGrid::Init1()
     AddActionTrigger(wxPGKeyboardAction::PressButton, WXK_DOWN, wxMOD_ALT);
     AddActionTrigger(wxPGKeyboardAction::PressButton, WXK_F4);
 
-    m_coloursCustomized = CustomColour_None;
+    m_coloursCustomized = 0;
 
     m_doubleBuffer = nullptr;
 
@@ -1438,7 +1422,7 @@ static int wxPGGetColAvg( const wxColour& col )
 
 void wxPropertyGrid::RegainColours()
 {
-    if ( !(m_coloursCustomized & CustomColour_CaptionBg) )
+    if ( !(m_coloursCustomized & 0x0002) )
     {
         wxColour col = wxSystemSettings::GetColour( wxSYS_COLOUR_BTNFACE );
 
@@ -1455,10 +1439,10 @@ void wxPropertyGrid::RegainColours()
         m_categoryDefaultCell.GetData()->SetBgCol(m_colCapBack);
     }
 
-    if ( !(m_coloursCustomized & CustomColour_Margin) )
+    if ( !(m_coloursCustomized & 0x0001) )
         m_colMargin = m_colCapBack;
 
-    if ( !(m_coloursCustomized & CustomColour_CaptionText) )
+    if ( !(m_coloursCustomized & 0x0004) )
     {
     #ifdef __WXGTK__
         int colDec = -90;
@@ -1473,7 +1457,7 @@ void wxPropertyGrid::RegainColours()
         m_categoryDefaultCell.GetData()->SetFgCol(capForeCol);
     }
 
-    if ( !(m_coloursCustomized & CustomColour_CellBg) )
+    if ( !(m_coloursCustomized & 0x0008) )
     {
         wxColour bgCol = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOW );
         m_colPropBack = bgCol;
@@ -1482,7 +1466,7 @@ void wxPropertyGrid::RegainColours()
             m_unspecifiedAppearance.SetBgCol(bgCol);
     }
 
-    if ( !(m_coloursCustomized & CustomColour_CellText) )
+    if ( !(m_coloursCustomized & 0x0010) )
     {
         wxColour fgCol = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT );
         m_colPropFore = fgCol;
@@ -1491,16 +1475,16 @@ void wxPropertyGrid::RegainColours()
             m_unspecifiedAppearance.SetFgCol(fgCol);
     }
 
-    if ( !(m_coloursCustomized & CustomColour_SelectionBg) )
+    if ( !(m_coloursCustomized & 0x0020) )
         m_colSelBack = wxSystemSettings::GetColour( wxSYS_COLOUR_HIGHLIGHT );
 
-    if ( !(m_coloursCustomized & CustomColour_SelectionText) )
+    if ( !(m_coloursCustomized & 0x0040) )
         m_colSelFore = wxSystemSettings::GetColour( wxSYS_COLOUR_HIGHLIGHTTEXT );
 
-    if ( !(m_coloursCustomized & CustomColour_Line) )
+    if ( !(m_coloursCustomized & 0x0080) )
         m_colLine = m_colCapBack;
 
-    if ( !(m_coloursCustomized & CustomColour_DisabledText) )
+    if ( !(m_coloursCustomized & 0x0100) )
         m_colDisPropFore = m_colCapFore;
 
     m_colEmptySpace = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOW );
@@ -1510,7 +1494,7 @@ void wxPropertyGrid::RegainColours()
 
 void wxPropertyGrid::ResetColours()
 {
-    m_coloursCustomized = CustomColour_None;
+    m_coloursCustomized = 0;
 
     RegainColours();
 
@@ -1539,7 +1523,7 @@ bool wxPropertyGrid::SetFont( const wxFont& font )
 void wxPropertyGrid::SetLineColour( const wxColour& col )
 {
     m_colLine = col;
-    m_coloursCustomized |= CustomColour_Line;
+    m_coloursCustomized |= 0x80;
     Refresh();
 }
 
@@ -1548,7 +1532,7 @@ void wxPropertyGrid::SetLineColour( const wxColour& col )
 void wxPropertyGrid::SetMarginColour( const wxColour& col )
 {
     m_colMargin = col;
-    m_coloursCustomized |= CustomColour_Margin;
+    m_coloursCustomized |= 0x01;
     Refresh();
 }
 
@@ -1557,7 +1541,7 @@ void wxPropertyGrid::SetMarginColour( const wxColour& col )
 void wxPropertyGrid::SetCellBackgroundColour( const wxColour& col )
 {
     m_colPropBack = col;
-    m_coloursCustomized |= CustomColour_CellBg;
+    m_coloursCustomized |= 0x08;
 
     m_propertyDefaultCell.GetData()->SetBgCol(col);
     m_unspecifiedAppearance.SetBgCol(col);
@@ -1570,7 +1554,7 @@ void wxPropertyGrid::SetCellBackgroundColour( const wxColour& col )
 void wxPropertyGrid::SetCellTextColour( const wxColour& col )
 {
     m_colPropFore = col;
-    m_coloursCustomized |= CustomColour_CellText;
+    m_coloursCustomized |= 0x10;
 
     m_propertyDefaultCell.GetData()->SetFgCol(col);
     m_unspecifiedAppearance.SetFgCol(col);
@@ -1592,7 +1576,7 @@ void wxPropertyGrid::SetEmptySpaceColour( const wxColour& col )
 void wxPropertyGrid::SetCellDisabledTextColour( const wxColour& col )
 {
     m_colDisPropFore = col;
-    m_coloursCustomized |= CustomColour_DisabledText;
+    m_coloursCustomized |= 0x100;
     Refresh();
 }
 
@@ -1601,7 +1585,7 @@ void wxPropertyGrid::SetCellDisabledTextColour( const wxColour& col )
 void wxPropertyGrid::SetSelectionBackgroundColour( const wxColour& col )
 {
     m_colSelBack = col;
-    m_coloursCustomized |= CustomColour_SelectionBg;
+    m_coloursCustomized |= 0x20;
     Refresh();
 }
 
@@ -1610,7 +1594,7 @@ void wxPropertyGrid::SetSelectionBackgroundColour( const wxColour& col )
 void wxPropertyGrid::SetSelectionTextColour( const wxColour& col )
 {
     m_colSelFore = col;
-    m_coloursCustomized |= CustomColour_SelectionText;
+    m_coloursCustomized |= 0x40;
     Refresh();
 }
 
@@ -1619,7 +1603,7 @@ void wxPropertyGrid::SetSelectionTextColour( const wxColour& col )
 void wxPropertyGrid::SetCaptionBackgroundColour( const wxColour& col )
 {
     m_colCapBack = col;
-    m_coloursCustomized |= CustomColour_CaptionBg;
+    m_coloursCustomized |= 0x02;
 
     m_categoryDefaultCell.GetData()->SetBgCol(col);
 
@@ -1631,7 +1615,7 @@ void wxPropertyGrid::SetCaptionBackgroundColour( const wxColour& col )
 void wxPropertyGrid::SetCaptionTextColour( const wxColour& col )
 {
     m_colCapFore = col;
-    m_coloursCustomized |= CustomColour_CaptionText;
+    m_coloursCustomized |= 0x04;
 
     m_categoryDefaultCell.GetData()->SetFgCol(col);
 
@@ -5024,8 +5008,10 @@ bool wxPropertyGrid::HandleMouseMove( int x, unsigned int y,
 
     if ( m_dragStatus > 0 )
     {
-        if ( x > (m_marginWidth + wxPG_DRAG_MARGIN) &&
-             x < (m_pState->GetVirtualWidth() - wxPG_DRAG_MARGIN) )
+        const int dragMargin = FromDIP(wxPG_DRAG_MARGIN);
+
+        if ( x > (m_marginWidth + dragMargin) &&
+             x < (m_pState->GetVirtualWidth() - dragMargin) )
         {
 
             int splitterX = x - splitterHitOffset;

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -492,8 +492,6 @@ void wxPropertyGrid::Init2()
     wxSize clientSize = GetClientSize();
     SetVirtualSize(clientSize);
 
-    m_timeCreated = ::wxGetLocalTimeMillis();
-
     m_iFlags |= wxPG_FL_INITIALIZED;
 
     wxSize wndsize = GetSize();

--- a/src/propgrid/propgridpagestate.cpp
+++ b/src/propgrid/propgridpagestate.cpp
@@ -885,8 +885,7 @@ void wxPropertyGridPageState::DoSetSplitter(int newXPos, int splitterColumn,
     if ( splitterColumn == 0 )
         m_fSplitterX = (double) newXPos;
 
-    if ( !(flags & wxPGSplitterPositionFlags::FromAutoCenter) &&
-         !(flags & wxPGSplitterPositionFlags::FromEvent) )
+    if ( !(flags & wxPGSplitterPositionFlags::FromAutoCenter) )
     {
         // Don't allow initial splitter auto-positioning after this.
         m_isSplitterPreSet = true;

--- a/src/propgrid/propgridpagestate.cpp
+++ b/src/propgrid/propgridpagestate.cpp
@@ -826,7 +826,7 @@ int wxPropertyGridPageState::DoGetSplitterPosition( int splitterColumn ) const
 
 int wxPropertyGridPageState::GetColumnMinWidth( int WXUNUSED(column) ) const
 {
-    return wxPG_DRAG_MARGIN;
+    return m_pPropGrid->FromDIP(wxPG_DRAG_MARGIN);
 }
 
 void wxPropertyGridPageState::PropagateColSizeDec( int column,
@@ -1118,7 +1118,7 @@ void wxPropertyGridPageState::ResetColumnSizes(wxPGSplitterPositionFlags setSpli
 void wxPropertyGridPageState::SetColumnCount( int colCount )
 {
     wxASSERT( colCount >= 2 );
-    m_colWidths.resize(colCount, wxPG_DRAG_MARGIN);
+    m_colWidths.resize(colCount, m_pPropGrid->FromDIP(wxPG_DRAG_MARGIN));
     m_columnProportions.resize(colCount, 1);
 
     CheckColumnWidths();

--- a/src/propgrid/propgridpagestate.cpp
+++ b/src/propgrid/propgridpagestate.cpp
@@ -374,8 +374,7 @@ void wxPropertyGridPageState::OnClientWidthChange( int newWidth, int widthChange
             }
             else
             {
-                DoSetSplitter( newWidth / 2 );
-                m_isSplitterPreSet = false;
+                DoSetSplitter( newWidth / 2, 0, wxPGSplitterPositionFlags::FromAutoCenter );
             }
         }
     }

--- a/src/propgrid/propgridpagestate.cpp
+++ b/src/propgrid/propgridpagestate.cpp
@@ -368,20 +368,14 @@ void wxPropertyGridPageState::OnClientWidthChange( int newWidth, int widthChange
 
         if ( !m_isSplitterPreSet && m_dontCenterSplitter )
         {
-             wxMilliClock_t timeSinceCreation = ::wxGetLocalTimeMillis() - GetGrid()->m_timeCreated;
-
-            // If too long, don't set splitter
-            if ( timeSinceCreation < 250 )
+            if ( m_properties->HasAnyChild() )
             {
-                if ( m_properties->HasAnyChild() )
-                {
-                    SetSplitterLeft( false );
-                }
-                else
-                {
-                    DoSetSplitter( newWidth / 2 );
-                    m_isSplitterPreSet = false;
-                }
+                SetSplitterLeft( false );
+            }
+            else
+            {
+                DoSetSplitter( newWidth / 2 );
+                m_isSplitterPreSet = false;
             }
         }
     }

--- a/src/propgrid/propgridpagestate.cpp
+++ b/src/propgrid/propgridpagestate.cpp
@@ -366,11 +366,12 @@ void wxPropertyGridPageState::OnClientWidthChange( int newWidth, int widthChange
             widthChange = 0;
         CheckColumnWidths(widthChange);
 
-        if ( !m_isSplitterPreSet && m_dontCenterSplitter )
+        if ( !m_isSplitterPreSet )
         {
-            if ( m_properties->HasAnyChild() )
+            if ( m_dontCenterSplitter )
             {
                 SetSplitterLeft( false );
+                m_isSplitterPreSet = false;
             }
             else
             {

--- a/src/xrc/xh_propgrid.cpp
+++ b/src/xrc/xh_propgrid.cpp
@@ -78,6 +78,7 @@ void wxPropertyGridXmlHandler::InitPopulator()
     wxPropertyGridXrcPopulator* populator
         = new wxPropertyGridXrcPopulator(this);
     m_populator = populator;
+    m_populator->SetGrid( m_pg );
 }
 
 void wxPropertyGridXmlHandler::PopulatePage( wxPropertyGridPageState* state )


### PR DESCRIPTION
Notably improve the confusingly illogical behaviour of splitter auto-centering.