### PR TITLE
Add size parameter to wxTextEntryDialog

### DIFF
--- a/include/wx/generic/textdlgg.h
+++ b/include/wx/generic/textdlgg.h
@@ -46,9 +46,10 @@ public:
                       const wxString& caption = wxASCII_STR(wxGetTextFromUserPromptStr),
                       const wxString& value = wxEmptyString,
                       long style = wxTextEntryDialogStyle,
-                      const wxPoint& pos = wxDefaultPosition)
+                      const wxPoint& pos = wxDefaultPosition,
+                      const wxSize sz = wxDefaultSize)
     {
-        Create(parent, message, caption, value, style, pos);
+        Create(parent, message, caption, value, style, pos, sz);
     }
 
     bool Create(wxWindow *parent,
@@ -56,7 +57,8 @@ public:
                 const wxString& caption = wxASCII_STR(wxGetTextFromUserPromptStr),
                 const wxString& value = wxEmptyString,
                 long style = wxTextEntryDialogStyle,
-                const wxPoint& pos = wxDefaultPosition);
+                const wxPoint& pos = wxDefaultPosition,
+                const wxSize sz = wxDefaultSize);
 
     void SetValue(const wxString& val);
     wxString GetValue() const { return m_value; }

--- a/interface/wx/textdlg.h
+++ b/interface/wx/textdlg.h
@@ -117,7 +117,7 @@ public:
         @param pos
             Dialog position.
         @param sz
-            The size of the dialog.
+            The size of the dialog (this parameter is only available since wxWidgets 3.3.0).
 
         @since 2.9.5
     */

--- a/interface/wx/textdlg.h
+++ b/interface/wx/textdlg.h
@@ -96,7 +96,8 @@ public:
                       const wxString& caption = wxGetTextFromUserPromptStr,
                       const wxString& value = wxEmptyString,
                       long style = wxTextEntryDialogStyle,
-                      const wxPoint& pos = wxDefaultPosition);
+                      const wxPoint& pos = wxDefaultPosition,
+                      const wxSize sz = wxDefaultSize);
 
     /**
         @param parent
@@ -115,6 +116,8 @@ public:
             make sense for this dialog, used for text input.
         @param pos
             Dialog position.
+        @param sz
+            The size of the dialog.
 
         @since 2.9.5
     */
@@ -122,7 +125,8 @@ public:
                       const wxString& caption = wxGetTextFromUserPromptStr,
                       const wxString& value = wxEmptyString,
                       long style = wxTextEntryDialogStyle,
-                      const wxPoint& pos = wxDefaultPosition);
+                      const wxPoint& pos = wxDefaultPosition,
+                      const wxSize sz = wxDefaultSize);
 
     /**
         Destructor.

--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -64,7 +64,8 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
                                      const wxString& caption,
                                      const wxString& value,
                                      long style,
-                                     const wxPoint& pos)
+                                     const wxPoint& pos,
+                                     const wxSize sz)
 {
     // Do not pass style to GetParentForModalDialog() as wxDIALOG_NO_PARENT
     // has the same numeric value as wxTE_MULTILINE and so attempting to create
@@ -74,11 +75,13 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
     // important problem.
     if ( !wxDialog::Create(GetParentForModalDialog(parent, 0),
                            wxID_ANY, caption,
-                           pos, wxDefaultSize,
+                           pos, sz,
                            wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) )
     {
         return false;
     }
+
+    SetMinSize( sz );
 
     m_dialogStyle = style;
     m_value = value;
@@ -112,7 +115,7 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
 
     SetSizer( topsizer );
 
-    topsizer->SetSizeHints( this );
+    topsizer->Fit( this );
 
     if ( style & wxCENTRE )
         Centre( wxBOTH );


### PR DESCRIPTION
I fit the sizer to the dialog (instead of the other way around) after setting the dialog's min size.

Leaving the default results in the same appearance as before, and providing a custom sizes works.

This implements #24465.