### PR TITLE
Add wxGridCellCoords::IsFullySpecified()

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -968,19 +968,24 @@ public:
     void SetCol( int n ) { m_col = n; }
     void Set( int row, int col ) { m_row = row; m_col = col; }
 
+    bool IsFullySpecified() const
+    {
+        return (m_row != -1 && m_col != -1);
+    }
+
     bool operator==( const wxGridCellCoords& other ) const
     {
-        return (m_row == other.m_row  &&  m_col == other.m_col);
+        return (m_row == other.m_row && m_col == other.m_col);
     }
 
     bool operator!=( const wxGridCellCoords& other ) const
     {
-        return (m_row != other.m_row  ||  m_col != other.m_col);
+        return (m_row != other.m_row || m_col != other.m_col);
     }
 
     bool operator!() const
     {
-        return (m_row == -1 && m_col == -1 );
+        return (m_row == -1 && m_col == -1);
     }
 
 private:

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -1955,7 +1955,7 @@ public:
         Default constructor initializes the object to invalid state.
 
         Initially the row and column are both invalid (-1) and so operator!()
-        for an uninitialized wxGridCellCoords returns false.
+        for an uninitialized wxGridCellCoords returns @c false.
      */
     wxGridCellCoords();
 
@@ -1990,6 +1990,13 @@ public:
     void Set(int row, int col);
 
     /**
+        Returns @c true if neither the row nor column are invalid (-1).
+
+        @since 3.3.0
+     */
+    bool IsFullySpecified() const
+
+    /**
         Assignment operator for coordinate types.
      */
     wxGridCellCoords& operator=(const wxGridCellCoords& other);
@@ -2007,8 +2014,8 @@ public:
     /**
         Checks whether the coordinates are invalid.
 
-        Returns false only if both row and column are -1. Notice that if either
-        row or column (but not both) are -1, this method returns true even if
+        Returns @c false only if both row and column are -1. Notice that if either
+        row or column (but not both) are -1, this method returns @c true even if
         the object is invalid. This is done because objects in such state
         should actually never exist, i.e. either both coordinates should be -1
         or none of them should be -1.

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -865,6 +865,7 @@ TEST_CASE_METHOD(GridTestCase, "Grid::KeyboardSelection", "[grid][selection]")
     m_grid->SetCellValue(7, 0, "R8C1");
 
     CHECK(m_grid->GetGridCursorCoords() == wxGridCellCoords(0, 0));
+    CHECK(m_grid->GetGridCursorCoords().IsFullySpecified());
 
     m_grid->MoveCursorRight(true);
     CheckSelection(wxGridBlockCoords(0, 0, 0, 1));


### PR DESCRIPTION
Provides parity with `wxPoint` and an alternative to comparing against `wxGridNoCellCoords`.
Also, cleaned up some stray spaces.

Related question: in a separate PR, should I replace `-1` with `wxDefaultCoord` in this class's API?