### PR TITLE
added stock accelerators for Close and SaveAs

### DIFF
--- a/src/common/stockitem.cpp
+++ b/src/common/stockitem.cpp
@@ -303,11 +303,13 @@ wxAcceleratorEntry wxGetStockAccelerator(wxWindowID id)
         STOCKITEM(wxID_FIND,                wxACCEL_CTRL,'F')
         STOCKITEM(wxID_NEW,                 wxACCEL_CTRL,'N')
         STOCKITEM(wxID_OPEN,                wxACCEL_CTRL,'O')
+        STOCKITEM(wxID_CLOSE,               wxACCEL_CTRL,'W')
         STOCKITEM(wxID_PASTE,               wxACCEL_CTRL,'V')
         STOCKITEM(wxID_PRINT,               wxACCEL_CTRL,'P')
         STOCKITEM(wxID_REDO,                wxACCEL_CTRL | wxACCEL_SHIFT,'Z')
         STOCKITEM(wxID_REPLACE,             wxACCEL_CTRL,'H')
         STOCKITEM(wxID_SAVE,                wxACCEL_CTRL,'S')
+        STOCKITEM(wxID_SAVEAS,              wxACCEL_CTRL | wxACCEL_SHIFT,'S'),
         STOCKITEM(wxID_SELECTALL,           wxACCEL_CTRL,'A')
         STOCKITEM(wxID_UNDO,                wxACCEL_CTRL,'Z')
 #ifdef __WXOSX__

--- a/src/common/stockitem.cpp
+++ b/src/common/stockitem.cpp
@@ -309,7 +309,7 @@ wxAcceleratorEntry wxGetStockAccelerator(wxWindowID id)
         STOCKITEM(wxID_REDO,                wxACCEL_CTRL | wxACCEL_SHIFT,'Z')
         STOCKITEM(wxID_REPLACE,             wxACCEL_CTRL,'H')
         STOCKITEM(wxID_SAVE,                wxACCEL_CTRL,'S')
-        STOCKITEM(wxID_SAVEAS,              wxACCEL_CTRL | wxACCEL_SHIFT,'S'),
+        STOCKITEM(wxID_SAVEAS,              wxACCEL_CTRL | wxACCEL_SHIFT,'S')
         STOCKITEM(wxID_SELECTALL,           wxACCEL_CTRL,'A')
         STOCKITEM(wxID_UNDO,                wxACCEL_CTRL,'Z')
 #ifdef __WXOSX__


### PR DESCRIPTION
wxWidgets includes a number of stock buttons and menu items, with associated mnemonics, help texts and images (under GTK). Some of these also have stock accelerators. This pull requests adds stock accelerators for the Close (Ctrl+W) and Save As... (Ctrl+Shift+S) menu items.