### PR TITLE
fix compiling include/wx/list.h in MSVC 19.38.33133.0

### DIFF
--- a/include/wx/list.h
+++ b/include/wx/list.h
@@ -242,7 +242,7 @@ public:
     }
     /* Workaround for broken VC6 std::list::sort() see above */
     void Sort( wxSortCompareFunction compfunc )
-        { sort( wxList_SortFunction<elT>(compfunc ) ); }
+        { this->sort( wxList_SortFunction<elT>(compfunc ) ); }
     ~wxListImpl() { Clear(); }
 
     /* It needs access to our EmptyList */


### PR DESCRIPTION
Since I assume compiling succeeds in the CI system, I'm surprised to see that this is failing for me in MSVC 19.38.33133.0.

Nevertheless, to compile on my system, I need to make this change.  I am not an expert, but, based on C++ 17 standard Clause 17.6.2 small-number 3, I suspect MSVC is correct to report an error here.

(What are those small-numbers called, anyway?  Paragraphs?)
