### PR TITLE
bug fix: xrc xml handler for wxSpinCtrl and wxSpinCtrlDouble doesn't allow style wxTE_PROCESS_ENTER

### DIFF
--- a/src/xrc/xh_spin.cpp
+++ b/src/xrc/xh_spin.cpp
@@ -78,6 +78,7 @@ static void AddSpinCtrlStyles(wxXmlResourceHandler& handler)
     handler.XRC_ADD_STYLE(wxALIGN_LEFT);
     handler.XRC_ADD_STYLE(wxALIGN_CENTER);
     handler.XRC_ADD_STYLE(wxALIGN_RIGHT);
+    handler.XRC_ADD_STYLE(wxTE_PROCESS_ENTER);
 }
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxSpinCtrlXmlHandler, wxXmlResourceHandler);


### PR DESCRIPTION
11:17:58: XRC error: 1546: unknown style flag "wxTE_PROCESS_ENTER"
11:17:58: XRC error: 1559: unknown style flag "wxTE_PROCESS_ENTER"