### PR TITLE
Switch to using TTM_RELAY for tooltips in wxMSW to simplify the code and avoid problems with MFC

### DIFF
--- a/include/wx/msw/statusbar.h
+++ b/include/wx/msw/statusbar.h
@@ -66,7 +66,6 @@ protected:
     virtual wxSize DoGetBestSize() const override;
     virtual void DoMoveWindow(int x, int y, int width, int height) override;
 #if wxUSE_TOOLTIPS
-    virtual bool MSWProcessMessage(WXMSG* pMsg) override;
     virtual bool MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM* result) override;
 #endif
 

--- a/include/wx/msw/tooltip.h
+++ b/include/wx/msw/tooltip.h
@@ -54,9 +54,6 @@ public:
     // implementation only from now on
     // -------------------------------
 
-    // should be called in response to WM_MOUSEMOVE
-    static void RelayEvent(WXMSG *msg);
-
     // add a window to the tooltip control
     void AddOtherWindow(WXHWND hwnd);
 

--- a/src/msw/evtloop.cpp
+++ b/src/msw/evtloop.cpp
@@ -78,18 +78,6 @@ bool wxGUIEventLoop::PreProcessMessage(WXMSG *msg)
         return true;
     }
 
-#if wxUSE_TOOLTIPS
-    // we must relay WM_MOUSEMOVE events to the tooltip ctrl if we want it to
-    // popup the tooltip bubbles
-    if ( msg->message == WM_MOUSEMOVE )
-    {
-        // we should do it if one of window children has an associated tooltip
-        // (and not just if the window has a tooltip itself)
-        if ( wndThis->HasToolTips() )
-            wxToolTip::RelayEvent((WXMSG *)msg);
-    }
-#endif // wxUSE_TOOLTIPS
-
     // allow the window to prevent certain messages from being
     // translated/processed (this is currently used by wxTextCtrl to always
     // grab Ctrl-C/V/X, even if they are also accelerators in some parent)

--- a/src/msw/statusbar.cpp
+++ b/src/msw/statusbar.cpp
@@ -647,30 +647,13 @@ wxStatusBar::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 }
 
 #if wxUSE_TOOLTIPS
-bool wxStatusBar::MSWProcessMessage(WXMSG* pMsg)
-{
-    if ( HasFlag(wxSTB_SHOW_TIPS) )
-    {
-        // for a tooltip to be shown, we need to relay mouse events to it;
-        // this is typically done by wxWindowMSW::MSWProcessMessage but only
-        // if wxWindow::m_tooltip pointer is non-null.
-        // Since wxStatusBar has multiple tooltips for a single HWND, it keeps
-        // wxWindow::m_tooltip == nullptr and then relays mouse events here:
-        MSG *msg = (MSG *)pMsg;
-        if ( msg->message == WM_MOUSEMOVE )
-            wxToolTip::RelayEvent(pMsg);
-    }
-
-    return wxWindow::MSWProcessMessage(pMsg);
-}
-
 bool wxStatusBar::MSWOnNotify(int WXUNUSED(idCtrl), WXLPARAM lParam, WXLPARAM* WXUNUSED(result))
 {
     if ( HasFlag(wxSTB_SHOW_TIPS) )
     {
-        // see comment in wxStatusBar::MSWProcessMessage for more info;
-        // basically we need to override wxWindow::MSWOnNotify because
-        // we have wxWindow::m_tooltip always null but we still use tooltips...
+        // Since wxStatusBar has multiple tooltips for a single HWND, it keeps
+        // wxWindow::m_tooltip == nullptr, so we need to override
+        // wxWindow::MSWOnNotify because we still use tooltips...
 
         NMHDR* hdr = (NMHDR *)lParam;
 

--- a/src/msw/tooltip.cpp
+++ b/src/msw/tooltip.cpp
@@ -129,6 +129,10 @@ public:
         // tooltip which then reappears because mouse remains hovering over the
         // control, see SF patch 1821229
         uFlags |= TTF_TRANSPARENT;
+        // we use TTF_SUBCLASS to avoid the need for the rest of the code
+        // to handle all mouse move messages and relay them to wxToolTip
+        // (see https://github.com/wxWidgets/wxWidgets/pull/24482)
+        uFlags |= TTF_SUBCLASS;
     }
 };
 
@@ -360,12 +364,6 @@ void wxToolTip::UpdateVisibility()
 
     if ( hideTT )
         ::ShowWindow(ms_hwndTT, SW_HIDE);
-}
-
-/* static */
-void wxToolTip::RelayEvent(WXMSG *msg)
-{
-    (void)SendTooltipMessage(GetToolTipCtrl(), TTM_RELAYEVENT, msg);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2784,16 +2784,6 @@ bool wxWindowMSW::MSWProcessMessage(WXMSG* pMsg)
     wxUnusedVar(pMsg);
 #endif // !__WXUNIVERSAL__/__WXUNIVERSAL__
 
-#if wxUSE_TOOLTIPS
-    if ( m_tooltip )
-    {
-        // relay mouse move events to the tooltip control
-        MSG *msg = (MSG *)pMsg;
-        if ( msg->message == WM_MOUSEMOVE )
-            wxToolTip::RelayEvent(pMsg);
-    }
-#endif // wxUSE_TOOLTIPS
-
     return false;
 }
 


### PR DESCRIPTION
I have discovered that my previous workaround for #23574 causes some wx tooltips not to be displayed in my full application.  Unfortunately, I can't find a small sample that shows the problem.

This PR adds an ugly hack to get the wx tooltips to work in my application, and doesn't obviously make things worse for anything else.  However, since this is ugly, and I can't find a simple way to demonstrate the problem, I will understand if this PR is rejected.