### PR TITLE
CYGWIN: DLL files must be installed into bin.

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -453,7 +453,7 @@ macro(wx_add_library name)
 
         # Setup install
         set(runtime_dir "lib")
-        if(WIN32 AND NOT WIN32_MSVC_NAMING)
+        if(WIN32 AND NOT WIN32_MSVC_NAMING OR CYGWIN)
             # configure puts the .dll in the bin directory
             set(runtime_dir "bin")
         endif()


### PR DESCRIPTION
I compiled successfully wxWidgets for CYGWIN with CMake.
However, it happened that DLL files are installed into the `lib` directory instead of `bin`.
Hopefully, the fix is very easy because `runtime_dir` just needs to be set to `bin` when `CYGWIN` is detected, exactly like `WIN32`.
This PR fixes this issue.