### PR TITLE
Fix crash on spin page of widgets sample

### DIFF
--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -415,9 +415,6 @@ void SpinBtnWidgetsPage::CreateSpin()
     m_spinbtn = new wxSpinButton(this, SpinBtnPage_SpinBtn,
                                  wxDefaultPosition, wxDefaultSize,
                                  flags);
-
-    NotifyWidgetRecreation(m_spinbtn);
-
     m_spinbtn->SetValue(val);
     m_spinbtn->SetRange(m_min, m_max);
 
@@ -427,14 +424,14 @@ void SpinBtnWidgetsPage::CreateSpin()
                                 flags | textFlags,
                                 m_min, m_max, val);
 
-    NotifyWidgetRecreation(m_spinctrl);
-
     m_spinctrldbl = new wxSpinCtrlDouble(this, SpinBtnPage_SpinCtrlDouble,
                                          wxString::Format("%d", val),
                                          wxDefaultPosition, wxDefaultSize,
                                          flags | textFlags,
                                          m_min, m_max, val, 0.1);
 
+    NotifyWidgetRecreation(m_spinbtn);
+    NotifyWidgetRecreation(m_spinctrl);
     NotifyWidgetRecreation(m_spinctrldbl);
 
     // Add spacers, labels and spin controls to the sizer.


### PR DESCRIPTION
Attempting to change the style or alignment of the spin controls in the widgets sample made the sample crash. This was caused by a8b4753 (Reconnect events to the widget after recreating it in the sample, 2024-02-19) which resulted in using windows that were previously destroyed.

Fix this by calling NotifyWidgetRecreation() for each spin control only after they were all recreated.