### PR TITLE
Improve wxSpinCtrlDouble docs

### DIFF
--- a/interface/wx/spinctrl.h
+++ b/interface/wx/spinctrl.h
@@ -258,6 +258,18 @@ public:
            The user can use arrow keys to change the value.
     @style{wxSP_WRAP}
            The value wraps at the minimum and maximum.
+    @style{wxTE_PROCESS_ENTER}
+        Indicates that the control should generate @c wxEVT_TEXT_ENTER
+        events. Using this style will prevent the user from using the Enter key
+        for dialog navigation (e.g. activating the default button in the
+        dialog) under MSW.
+    @style{wxALIGN_LEFT}
+        Same as wxTE_LEFT for wxTextCtrl: the text is left aligned (this is the
+        default).
+    @style{wxALIGN_CENTRE_HORIZONTAL}
+        Same as wxTE_CENTRE for wxTextCtrl: the text is centered.
+    @style{wxALIGN_RIGHT}
+        Same as wxTE_RIGHT for wxTextCtrl: the text is right aligned.
     @endStyleTable
 
     @beginEventEmissionTable{wxSpinDoubleEvent}


### PR DESCRIPTION
Document all available styles, i.e., just like with wxSpinCtrl, list also wxTE_PROCESS_ENTER and the three text alignment options.

This should be backported to 3.2.