### PR TITLE
Don't make black transparent when drawing on wxOverlay under MSW

### DIFF
--- a/include/wx/generic/private/drawresize.h
+++ b/include/wx/generic/private/drawresize.h
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/generic/private/drawresize.h
+// Purpose:     Helper function for drawing "resize hint".
+// Author:      Vadim Zeitlin
+// Created:     2024-04-20
+// Copyright:   (c) 2024 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_GENERIC_PRIVATE_DRAWRESIZE_H_
+#define _WX_GENERIC_PRIVATE_DRAWRESIZE_H_
+
+// This function is also used by wxAuiManager when not using overlay, so it has
+// to remain separate from wxDrawOverlayResizeHint().
+inline wxBitmap wxPaneCreateStippleBitmap()
+{
+    // Notice that wxOverlay, under wxMSW, uses the wxBLACK colour i.e.(0,0,0)
+    // as the key colour for transparency. and using it for the stipple bitmap
+    // will make the sash feedback totaly invisible if the window's background
+    // colour is (192,192,192) or so. (1,1,1) is used instead.
+    unsigned char data[] = { 1,1,1,192,192,192, 192,192,192,1,1,1 };
+    wxImage img(2,2,data,true);
+    return wxBitmap(img);
+}
+
+// This is used by both wxSplitterWindow and wxAuiManager to draw the resize
+// hint using the overlay associated with the given window.
+inline void
+wxDrawOverlayResizeHint(wxWindow* win, wxOverlay& overlay, const wxRect& rect)
+{
+    wxClientDC dc{win};
+    wxDCOverlay overlaydc(overlay, &dc);
+    overlaydc.Clear();
+
+    wxBitmap stipple = wxPaneCreateStippleBitmap();
+    wxBrush brush(stipple);
+    dc.SetBrush(brush);
+    dc.SetPen(*wxTRANSPARENT_PEN);
+
+    dc.DrawRectangle(rect);
+}
+
+#endif // _WX_GENERIC_PRIVATE_DRAWRESIZE_H_

--- a/include/wx/generic/private/drawresize.h
+++ b/include/wx/generic/private/drawresize.h
@@ -14,11 +14,7 @@
 // to remain separate from wxDrawOverlayResizeHint().
 inline wxBitmap wxPaneCreateStippleBitmap()
 {
-    // Notice that wxOverlay, under wxMSW, uses the wxBLACK colour i.e.(0,0,0)
-    // as the key colour for transparency. and using it for the stipple bitmap
-    // will make the sash feedback totaly invisible if the window's background
-    // colour is (192,192,192) or so. (1,1,1) is used instead.
-    unsigned char data[] = { 1,1,1,192,192,192, 192,192,192,1,1,1 };
+    unsigned char data[] = { 0,0,0,192,192,192, 192,192,192,0,0,0 };
     wxImage img(2,2,data,true);
     return wxBitmap(img);
 }

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -66,6 +66,8 @@ wxDEFINE_EVENT( wxEVT_AUI_FIND_MANAGER, wxAuiManagerEvent );
 
 #include "wx/dcgraph.h"
 
+#include "wx/generic/private/drawresize.h"
+
 #include <memory>
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxAuiManagerEvent, wxEvent);
@@ -88,29 +90,6 @@ static wxBitmap wxCreateVenetianBlindsBitmap(wxByte r, wxByte g, wxByte b, wxByt
     img.SetAlpha(alpha,true);
     return wxBitmap(img);
 }
-
-static wxBitmap wxPaneCreateStippleBitmap()
-{
-    // Notice that wxOverlay, under wxMSW, uses the wxBLACK colour i.e.(0,0,0)
-    // as the key colour for transparency. and using it for the stipple bitmap
-    // will make the sash feedback totaly invisible if the window's background
-    // colour is (192,192,192) or so. (1,1,1) is used instead.
-    unsigned char data[] = { 1,1,1,192,192,192, 192,192,192,1,1,1 };
-    wxImage img(2,2,data,true);
-    return wxBitmap(img);
-}
-
-static void DrawResizeHint(wxDC& dc, const wxRect& rect)
-{
-    wxBitmap stipple = wxPaneCreateStippleBitmap();
-    wxBrush brush(stipple);
-    dc.SetBrush(brush);
-    dc.SetPen(*wxTRANSPARENT_PEN);
-
-    dc.DrawRectangle(rect);
-}
-
-
 
 // CopyDocksAndPanes() - this utility function creates copies of
 // the dock and pane info.  wxAuiDockInfo's usually contain pointers
@@ -4285,14 +4264,10 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
                     m_actionHintRect = wxRect();
                 }
 
-                wxClientDC dc{m_frame};
-                wxDCOverlay overlaydc(m_overlay, &dc);
-                overlaydc.Clear();
-
                 // draw resize hint
                 m_actionHintRect = rect;
                 rect.SetPosition(rect.GetPosition() + m_frame->GetClientAreaOrigin());
-                DrawResizeHint(dc, rect);
+                wxDrawOverlayResizeHint(m_frame, m_overlay, rect);
             }
         }
     }

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -36,6 +36,8 @@
 
 #include "wx/renderer.h"
 
+#include "wx/generic/private/drawresize.h"
+
 #include <stdlib.h>
 
 wxDEFINE_EVENT( wxEVT_SPLITTER_SASH_POS_CHANGED, wxSplitterEvent );
@@ -68,17 +70,6 @@ wxBEGIN_EVENT_TABLE(wxSplitterWindow, wxWindow)
     EVT_SET_CURSOR(wxSplitterWindow::OnSetCursor)
 #endif // wxMSW
 wxEND_EVENT_TABLE()
-
-static wxBitmap wxPaneCreateStippleBitmap()
-{
-    // Notice that wxOverlay, under wxMSW, uses the wxBLACK colour i.e.(0,0,0)
-    // as the key colour for transparency. and using it for the stipple bitmap
-    // will make the sash feedback totaly invisible if the window's background
-    // colour is (192,192,192) or so. (1,1,1) is used instead.
-    unsigned char data[] = { 1,1,1,192,192,192, 192,192,192,1,1,1 };
-    wxImage img(2,2,data,true);
-    return wxBitmap(img);
-}
 
 bool wxSplitterWindow::Create(wxWindow *parent, wxWindowID id,
                                    const wxPoint& pos,
@@ -621,16 +612,7 @@ void wxSplitterWindow::DrawSashTracker(int x, int y)
         sizeSash.y = sashTrackerWidth;
     }
 
-    wxClientDC dc(this);
-    wxDCOverlay overlaydc( m_overlay, &dc );
-    overlaydc.Clear();
-
-    wxBitmap stipple = wxPaneCreateStippleBitmap();
-    wxBrush brush(stipple);
-    dc.SetBrush(brush);
-    dc.SetPen(*wxTRANSPARENT_PEN);
-
-    dc.DrawRectangle(posSash, sizeSash);
+    wxDrawOverlayResizeHint(this, m_overlay, wxRect(posSash, sizeSash));
 }
 
 int wxSplitterWindow::GetWindowSize() const

--- a/src/msw/overlay.cpp
+++ b/src/msw/overlay.cpp
@@ -46,6 +46,15 @@
 
 namespace // anonymous
 {
+
+inline COLORREF GetTransparentColor()
+{
+    // Use some unlikely colour as the transparent one. Notably do not use
+    // black, as we don't want everything drawn with black on the overlay to be
+    // transparent.
+    return RGB(0, 1, 2);
+}
+
 wxWindow* wxCreateOverlayWindow(const wxRect& rect, int alpha, HWND hWndInsertAfter)
 {
     auto overlayWin = new wxWindow();
@@ -66,7 +75,9 @@ wxWindow* wxCreateOverlayWindow(const wxRect& rect, int alpha, HWND hWndInsertAf
 
     if ( alpha >= 0 )
     {
-        if ( !::SetLayeredWindowAttributes(GetHwndOf(overlayWin), 0, alpha,
+        if ( !::SetLayeredWindowAttributes(GetHwndOf(overlayWin),
+                                           GetTransparentColor(),
+                                           alpha,
                                            LWA_COLORKEY | LWA_ALPHA) )
         {
             wxLogLastError(wxS("SetLayeredWindowAttributes()"));
@@ -225,10 +236,7 @@ void wxOverlayImpl::Clear(wxDC* WXUNUSED(dc))
 {
     wxCHECK_RET( IsOk(), wxS("overlay not initialized") );
 
-    // Note that the colour used here is the same one that we specify as
-    // LWA_COLORKEY when creating the layered window, so it is actually
-    // transparent.
-    m_memDC.SetBackground(*wxBLACK);
+    m_memDC.SetBackground(wxColour(GetTransparentColor()));
     m_memDC.Clear();
 }
 
@@ -255,7 +263,9 @@ void wxOverlayImpl::SetOpacity(int alpha)
     {
         m_alpha = wxClip(alpha, 0, 255);
 
-        if ( !::SetLayeredWindowAttributes(GetHwndOf(m_overlayWindow), 0, m_alpha,
+        if ( !::SetLayeredWindowAttributes(GetHwndOf(m_overlayWindow),
+                                           GetTransparentColor(),
+                                           m_alpha,
                                            LWA_COLORKEY | LWA_ALPHA) )
         {
             wxLogLastError(wxS("SetLayeredWindowAttributes()"));


### PR DESCRIPTION
Using black as the transparent colour is not a great idea as everything drawn using it on the overlay just doesn't appear at all then.

Use a different colour that will hopefully be much less common.

---

@AliKet please let me know if you have any comments.