### PR TITLE
Don't set focus to hidden wxSimplebook current page

### DIFF
--- a/include/wx/simplebook.h
+++ b/include/wx/simplebook.h
@@ -199,8 +199,10 @@ protected:
             page->ShowWithEffect(m_showEffect, m_showTimeout);
 
             // Unlike simple Show(), ShowWithEffect() doesn't necessarily give
-            // focus to the window, but we do expect the new page to have focus.
-            page->SetFocus();
+            // focus to the window, but we do expect the new page to have focus
+            // if it's currently visible.
+            if ( page->IsShownOnScreen() )
+                page->SetFocus();
         }
         else
         {


### PR DESCRIPTION
Unconditionally calling SetFocus() on the current page in wxSimplebook resulted in a weird situation with focus in wxGTK as the hidden window had focus at wx level but not at GTK one, where focus was just lost.

For now, work around this by avoiding calling SetFocus() in this case, even though it might be better to refuse to set focus to a hidden window in SetFocus() itself.

----

I'd like to merge this to fix a bug in my application where a dialog doesn't have focus when initially shown because the code selects the current page in `wxSimplebook` which is, itself, not shown (it's on a non-current page of a parent `wxNotebook`) and I'm almost sure that this is not going to do any harm, but I wonder if we should avoid even trying to set focus to a hidden window in `wxWindowGTK::SetFocus()`, as this clearly can't do anything good. @paulcor Please let me know if you have any thoughts about this, TIA!