### PR TITLE
Don't leak surface every time wxOverlay is used in wxGTK

### DIFF
--- a/src/gtk/overlay.cpp
+++ b/src/gtk/overlay.cpp
@@ -167,6 +167,8 @@ void wxOverlayImpl::EndDrawing(wxDC* dc)
         return;
 
     cairo_pattern_t* pattern = cairo_pop_group(m_cr);
+    if (m_surface)
+        cairo_surface_destroy(m_surface);
     cairo_pattern_get_surface(pattern, &m_surface);
     cairo_surface_reference(m_surface);
     cairo_pattern_destroy(pattern);


### PR DESCRIPTION
Free the old surface pointer before overwriting it with the new one in wxOverlayImpl::EndDrawing().

This resulted in huge memory leaks when using wxOverlay repeatedly, e.g. while dragging something around the window.

---

@AliKet please let me know if I'm missing something, but this fixes many leaks like this reported by ASAN (and similar ones with Valgrind) when using `wxOverlay`:

```
Indirect leak of 6072 byte(s) in 23 object(s) allocated from:
    #0 0x7fd354ab89cf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7fd351fe82ba  (/lib/x86_64-linux-gnu/libpixman-1.so.0+0x512ba)
    #2 0x7fd351fb22e5  (/lib/x86_64-linux-gnu/libpixman-1.so.0+0x1b2e5)
    #3 0x7fd352d13a9e  (/lib/x86_64-linux-gnu/libcairo.so.2+0x37a9e)
    #4 0x7fd352d52ce3  (/lib/x86_64-linux-gnu/libcairo.so.2+0x76ce3)
    #5 0x7fd352d03880  (/lib/x86_64-linux-gnu/libcairo.so.2+0x27880)
    #6 0x7fd352d5de8b in cairo_push_group (/lib/x86_64-linux-gnu/libcairo.so.2+0x81e8b)
    #7 0x7fd3545524d8 in wxOverlayImpl::BeginDrawing(wxDC*) $wx/src/gtk/overlay.cpp:161
    #8 0x7fd35474310f in wxOverlay::BeginDrawing(wxDC*) $wx/src/common/overlaycmn.cpp:57
    #9 0x7fd3547434e8 in wxDCOverlay::Init(wxDC*, int, int, int, int) $wx/src/common/overlaycmn.cpp:133
    #10 0x7fd3547433f9 in wxDCOverlay::wxDCOverlay(wxOverlay&, wxDC*) $wx/src/common/overlaycmn.cpp:114
...
```