### PR TITLE
Explicitly define copy ctors etc in classes with virtual dtors

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -298,6 +298,7 @@ wxGTK:
 - Fix handling binary data in wxSecretStore (Martin Corino, #24351).
 - Make GTKSuppressDiagnostics(), broken since 3.2.1, work again (#24432).
 - Fix wxTE_PROCESS_ENTER in wxGTK comboboxes with autocomplete (#24394).
+- Fix -Wdeprecated-copy-dtor warnings in the headers with gcc 14 (#24502).
 
 wxMSW:
 

--- a/include/wx/brush.h
+++ b/include/wx/brush.h
@@ -41,6 +41,7 @@ enum wxBrushStyle
 class WXDLLIMPEXP_CORE wxBrushBase: public wxGDIObject
 {
 public:
+    wxDECLARE_DEFAULT_COPY_AND_DEF(wxBrushBase)
     virtual ~wxBrushBase() { }
 
     virtual void SetColour(const wxColour& col) = 0;

--- a/include/wx/colour.h
+++ b/include/wx/colour.h
@@ -88,7 +88,8 @@ public:
     // type of a single colour component
     typedef unsigned char ChannelType;
 
-    wxColourBase() {}
+    wxDECLARE_DEFAULT_COPY_AND_DEF(wxColourBase)
+
     virtual ~wxColourBase() {}
 
 

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -3232,14 +3232,28 @@ typedef const void* WXWidget;
 
 #if defined(__cplusplus) && (__cplusplus >= 201103L || wxCHECK_VISUALC_VERSION(14))
     #define wxMEMBER_DELETE = delete
+
+    // Note that all these macros don't require a semicolon after them because
+    // they are empty in the "#else" branch and can't be followed by a
+    // semicolon in that case.
     #define wxDECLARE_DEFAULT_COPY_CTOR(classname) \
         public:                                    \
             classname(const classname&) = default;
+
+    #define wxDECLARE_DEFAULT_COPY(classname)  \
+        wxDECLARE_DEFAULT_COPY_CTOR(classname) \
+        classname& operator=(const classname&) = default;
+
+    #define wxDECLARE_DEFAULT_COPY_AND_DEF(classname) \
+        classname() = default;                        \
+        wxDECLARE_DEFAULT_COPY(classname)
 #else
     #define wxMEMBER_DELETE
 
     // We can't do this without C++11 "= default".
     #define wxDECLARE_DEFAULT_COPY_CTOR(classname)
+    #define wxDECLARE_DEFAULT_COPY(classname)
+    #define wxDECLARE_DEFAULT_COPY_AND_DEF(classname)
 #endif
 
 #define wxDECLARE_NO_COPY_CLASS(classname)      \

--- a/include/wx/font.h
+++ b/include/wx/font.h
@@ -341,7 +341,8 @@ public:
            wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
     */
 
-    // creator function
+    wxDECLARE_DEFAULT_COPY_AND_DEF(wxFontBase)
+
     virtual ~wxFontBase();
 
 

--- a/include/wx/generic/accel.h
+++ b/include/wx/generic/accel.h
@@ -20,6 +20,9 @@ class WXDLLIMPEXP_CORE wxAcceleratorTable : public wxObject
 public:
     wxAcceleratorTable();
     wxAcceleratorTable(int n, const wxAcceleratorEntry entries[]);
+
+    wxDECLARE_DEFAULT_COPY(wxAcceleratorTable)
+
     virtual ~wxAcceleratorTable();
 
     bool Ok() const { return IsOk(); }

--- a/include/wx/generic/colour.h
+++ b/include/wx/generic/colour.h
@@ -22,10 +22,7 @@ public:
     DEFINE_STD_WXCOLOUR_CONSTRUCTORS
 
     // copy ctors and assignment operators
-    wxColour(const wxColour& col)
-    {
-        *this = col;
-    }
+    wxDECLARE_DEFAULT_COPY_CTOR(wxColour)
 
     wxColour& operator=(const wxColour& col);
 

--- a/include/wx/generic/paletteg.h
+++ b/include/wx/generic/paletteg.h
@@ -31,6 +31,9 @@ class WXDLLIMPEXP_CORE wxPalette: public wxPaletteBase
 public:
     wxPalette();
     wxPalette( int n, const unsigned char *red, const unsigned char *green, const unsigned char *blue );
+
+    wxDECLARE_DEFAULT_COPY(wxPalette)
+
     virtual ~wxPalette();
 
     bool Create( int n, const unsigned char *red, const unsigned char *green, const unsigned char *blue);

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -129,6 +129,9 @@ class WXDLLIMPEXP_CORE wxGraphicsObject : public wxObject
 public:
     wxGraphicsObject();
     wxGraphicsObject( wxGraphicsRenderer* renderer );
+
+    wxDECLARE_DEFAULT_COPY(wxGraphicsObject)
+
     virtual ~wxGraphicsObject();
 
     bool IsNull() const;
@@ -208,6 +211,8 @@ class WXDLLIMPEXP_CORE wxGraphicsMatrix : public wxGraphicsObject
 {
 public:
     wxGraphicsMatrix() {}
+
+    wxDECLARE_DEFAULT_COPY(wxGraphicsMatrix)
 
     virtual ~wxGraphicsMatrix() {}
 

--- a/include/wx/gtk/bitmap.h
+++ b/include/wx/gtk/bitmap.h
@@ -79,6 +79,9 @@ public:
 #endif // wxUSE_IMAGE
     wxBitmap(GdkPixbuf* pixbuf, int depth = 0);
     explicit wxBitmap(const wxCursor& cursor);
+
+    wxDECLARE_DEFAULT_COPY(wxBitmap)
+
     virtual ~wxBitmap();
 
     bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) wxOVERRIDE;

--- a/include/wx/gtk/brush.h
+++ b/include/wx/gtk/brush.h
@@ -23,6 +23,9 @@ public:
 
     wxBrush( const wxColour &colour, wxBrushStyle style = wxBRUSHSTYLE_SOLID );
     wxBrush( const wxBitmap &stippleBitmap );
+
+    wxDECLARE_DEFAULT_COPY(wxBrush)
+
     virtual ~wxBrush();
 
     bool operator==(const wxBrush& brush) const;

--- a/include/wx/gtk/colour.h
+++ b/include/wx/gtk/colour.h
@@ -28,6 +28,8 @@ public:
     wxColour(const GdkRGBA& gdkRGBA);
 #endif
 
+    wxDECLARE_DEFAULT_COPY(wxColour)
+
     virtual ~wxColour();
 
     bool operator==(const wxColour& col) const;

--- a/include/wx/gtk/cursor.h
+++ b/include/wx/gtk/cursor.h
@@ -35,6 +35,8 @@ public:
               const char maskBits[] = NULL,
               const wxColour* fg = NULL, const wxColour* bg = NULL);
 
+    wxDECLARE_DEFAULT_COPY(wxCursor)
+
     virtual wxPoint GetHotSpot() const wxOVERRIDE;
 
     virtual ~wxCursor();

--- a/include/wx/gtk/font.h
+++ b/include/wx/gtk/font.h
@@ -50,6 +50,8 @@ public:
         SetPixelSize(pixelSize);
     }
 
+    wxDECLARE_DEFAULT_COPY(wxFont)
+
     bool Create(int size,
                 wxFontFamily family,
                 wxFontStyle style,

--- a/include/wx/gtk/pen.h
+++ b/include/wx/gtk/pen.h
@@ -22,6 +22,8 @@ public:
 
     wxPen( const wxPenInfo& info );
 
+    wxDECLARE_DEFAULT_COPY(wxPen)
+
     virtual ~wxPen();
 
     bool operator==(const wxPen& pen) const;

--- a/include/wx/palette.h
+++ b/include/wx/palette.h
@@ -22,6 +22,8 @@
 class WXDLLIMPEXP_CORE wxPaletteBase: public wxGDIObject
 {
 public:
+    wxDECLARE_DEFAULT_COPY_AND_DEF(wxPaletteBase)
+
     virtual ~wxPaletteBase() { }
 
     virtual int GetColoursCount() const { wxFAIL_MSG( wxT("not implemented") ); return 0; }

--- a/include/wx/pen.h
+++ b/include/wx/pen.h
@@ -63,6 +63,7 @@ private:
 class WXDLLIMPEXP_CORE wxPenBase : public wxGDIObject
 {
 public:
+    wxDECLARE_DEFAULT_COPY_AND_DEF(wxPenBase)
     virtual ~wxPenBase() { }
 
     virtual void SetColour(const wxColour& col) = 0;


### PR DESCRIPTION
This avoids gcc 14 giving -Wdeprecated-copy-dtor for these classes.

This warning was fixed by fc35ad92bb (Remove unnecessary empty destructors, 2024-01-26) in master, but we can't remove the dtors in this branch, so add copy ctors and assignment operators here using new wxDECLARE_DEFAULT_COPY() and wxDECLARE_DEFAULT_COPY_AND_DEF() macros, which can be fine-tuned later (e.g. to do it only for gcc 14, if it has any adverse effects on some other compiler) if necessary.

Note that this also required adding some default ctors, as adding the copy ctor suppressed the generation of the default compiler-generated default ctor.