### PR TITLE
Fix for potential warnings (C4390 / -Wempty-body and C4706)

### DIFF
--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -847,7 +847,9 @@ wxSizerItem* wxSizer::DoInsert( size_t index, wxSizerItem *item )
         // later, but by this time the stack trace at the moment of assertion
         // won't point out the culprit any longer).
         if ( m_containingWindow )
+        {
             ASSERT_WINDOW_PARENT_IS(w, m_containingWindow);
+        }
     }
 
     if ( item->GetSizer() )
@@ -897,7 +899,9 @@ void wxSizer::SetContainingWindow(wxWindow *win)
         if ( m_containingWindow )
         {
             if ( wxWindow* const w = item->GetWindow() )
+            {
                 ASSERT_WINDOW_PARENT_IS(w, m_containingWindow);
+            }
         }
     }
 }

--- a/src/common/uiactioncmn.cpp
+++ b/src/common/uiactioncmn.cpp
@@ -202,14 +202,18 @@ bool wxUIActionSimulator::Select(const wxString& text)
         container = combo;
 #endif // wxUSE_COMBOBOX
 #if wxUSE_CHOICE
-    wxChoice* choice;
-    if ( !container && (choice = wxDynamicCast(focus, wxChoice)) )
-        container = choice;
+    if ( !container )
+    {
+        if ( wxChoice* choice = wxDynamicCast(focus, wxChoice) )
+            container = choice;
+    }
 #endif // wxUSE_CHOICE
 #if wxUSE_LISTBOX
-    wxListBox* listbox;
-    if ( !container && (listbox = wxDynamicCast(focus, wxListBox)) )
-        container = listbox;
+    if ( !container )
+    {
+        if ( wxListBox* listbox = wxDynamicCast(focus, wxListBox) )
+            container = listbox;
+    }
 #endif // wxUSE_LISTBOX
 #else // !wxNO_RTTI
     wxItemContainer* const container = dynamic_cast<wxItemContainer*>(focus);


### PR DESCRIPTION
A small fix for potential warnings C4390 / -Wempty-body and C4706.

for consistency with the rest of the code I've used actual types instead of auto.

PS: I ended up botching my fork so I had to recreate it.