### PR TITLE
Fix comparison of wxDataFormat in wxGTK

### DIFF
--- a/include/wx/gtk/dataform.h
+++ b/include/wx/gtk/dataform.h
@@ -42,8 +42,7 @@ public:
         { return m_format == (NativeFormat)format; }
     bool operator!=(NativeFormat format) const
         { return m_format != (NativeFormat)format; }
-    bool operator==(const wxDataFormat& other) const
-        { return m_format == other.m_format; }
+    bool operator==(const wxDataFormat& other) const;
     bool operator!=(const wxDataFormat& other) const
         { return m_format != other.m_format; }
 

--- a/src/gtk/dataobj.cpp
+++ b/src/gtk/dataobj.cpp
@@ -197,6 +197,14 @@ extern bool wxGTKIsSameFormat(GdkAtom atom1, GdkAtom atom2)
     return false;
 }
 
+bool wxDataFormat::operator==(const wxDataFormat& other) const
+{
+    if ( m_type != other.m_type )
+        return false;
+
+    return wxGTKIsSameFormat(m_format, other.m_format);
+}
+
 void wxDataFormat::PrepareFormats()
 {
     // This function is not used any longer, but kept for ABI compatibility.


### PR DESCRIPTION
Their GDK atoms don't need to match, as multiple atoms may correspond to the same format at wx level (e.g. TEXT, STRING and text/plain formats all correspond to wxDF_TEXT).

See #24444, #24505.

(cherry picked from commit d3501b6b7d385d333e1a6a4160a0646080b7c2f5)