### PR TITLE
Ensure that overlay window is deleted in wxMSW wxOverlay

### DIFF
--- a/src/msw/overlay.cpp
+++ b/src/msw/overlay.cpp
@@ -104,7 +104,7 @@ class wxOverlayImpl : public wxOverlay::Impl
 {
 public:
     wxOverlayImpl() = default;
-    ~wxOverlayImpl() = default;
+    ~wxOverlayImpl() { Reset(); }
 
     virtual void Reset() override;
     virtual bool IsOk() override;


### PR DESCRIPTION
If the application didn't call Reset(), the window was leaked.

Ensure that we delete it in this case too, making the behaviour in this case consistent with the other ports.

----

@AliKet please let me know if I'm missing anything here.