### PR TITLE
Fix compile issue with credentials dialog

### DIFF
--- a/include/wx/generic/creddlgg.h
+++ b/include/wx/generic/creddlgg.h
@@ -32,9 +32,8 @@ public:
         const wxString& title,
         const wxWebCredentials& cred = wxWebCredentials());
 
-    void SetUser(const wxString& user) { m_userTextCtrl->SetValue(user); }
-    void SetPassword(const wxString& password)
-        { m_passwordTextCtrl->SetValue(password); }
+    void SetUser(const wxString& user);
+    void SetPassword(const wxString& password);
 
     wxWebCredentials GetCredentials() const;
 

--- a/src/generic/creddlgg.cpp
+++ b/src/generic/creddlgg.cpp
@@ -74,6 +74,16 @@ void wxGenericCredentialEntryDialog::Init(const wxString& message,
     m_userTextCtrl->SetFocus();
 }
 
+void wxGenericCredentialEntryDialog::SetUser(const wxString& user)
+{
+    m_userTextCtrl->SetValue(user);
+}
+
+void wxGenericCredentialEntryDialog::SetPassword(const wxString& password)
+{
+    m_passwordTextCtrl->SetValue(password);
+}
+
 wxWebCredentials wxGenericCredentialEntryDialog::GetCredentials() const
 {
     return wxWebCredentials(m_userTextCtrl->GetValue(),


### PR DESCRIPTION
You will get a compile error about `wxTextCtrl` being unknown if you include **creddlg.h** before **textctr.h**. Although `wxTextCtrl` is forward declared in **creddlg.h** (a recent change), that is not enough because `wxTextCtrl` objects are used in this header. Moving that code into the implementation file fixes the compile issue.