### PR TITLE
Minor improvements to wxCollapsiblePane example

### DIFF
--- a/interface/wx/collpane.h
+++ b/interface/wx/collpane.h
@@ -70,7 +70,8 @@ wxEventType wxEVT_COLLAPSIBLEPANE_CHANGED;
     wxCollapsiblePane *collpane = new wxCollapsiblePane(this, wxID_ANY, "Details:");
 
     // add the pane with a zero proportion value to the 'sz' sizer which contains it
-    sz->Add(collpane, 0, wxGROW|wxALL, 5);
+    sz->Add(collpane,
+            wxSizerFlags().Expand().Border(wxALL, wxSizerFlags::GetDefaultBorder()));
 
     // now add a test label in the collapsible pane using a sizer to layout it:
     wxWindow *win = collpane->GetPane();

--- a/interface/wx/collpane.h
+++ b/interface/wx/collpane.h
@@ -51,15 +51,14 @@ wxEventType wxEVT_COLLAPSIBLEPANE_CHANGED;
     A collapsible pane is a container with an embedded button-like control
     which can be used by the user to collapse or expand the pane's contents.
 
-    Once constructed you should use the GetPane() function to access the pane
-    and add your controls inside it (i.e. use the returned pointer from
-    GetPane() as parent for the controls which must go in the pane, @b not the
+    Once constructed, you should use the GetPane() function to access the pane
+    and add your controls inside it (i.e., use the returned pointer from
+    GetPane() as the parent for the controls which must go in the pane, @b not the
     wxCollapsiblePane itself!).
 
-    Note that because of its nature of control which can dynamically (and
-    drastically) change its size at run-time under user-input, when putting
-    wxCollapsiblePane inside a wxSizer you should be careful to add it with a
-    proportion value of zero; this is because otherwise all other windows with
+    Note that because this control can dynamically (and drastically) change its
+    size at run-time, you should set its proportion to zero if putting it inside 
+    of a sizer. This is because otherwise all other windows with
     non-null proportion values will automatically resize each time the user
     expands or collapse the pane window usually resulting in a weird,
     flickering effect.

--- a/interface/wx/collpane.h
+++ b/interface/wx/collpane.h
@@ -57,7 +57,7 @@ wxEventType wxEVT_COLLAPSIBLEPANE_CHANGED;
     wxCollapsiblePane itself!).
 
     Note that because this control can dynamically (and drastically) change its
-    size at run-time, you should set its proportion to zero if putting it inside 
+    size at run-time, you should set its proportion to zero if putting it inside
     of a sizer. This is because otherwise all other windows with
     non-null proportion values will automatically resize each time the user
     expands or collapse the pane window usually resulting in a weird,


### PR DESCRIPTION
Use `wxSizerFlags()` and remove hard coded 5.