### PR TITLE
BUG FIX #24528 - Widgets Demo

### DIFF
--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -410,7 +410,7 @@ void BitmapComboBoxWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -409,6 +409,8 @@ void BitmapComboBoxWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -390,6 +390,8 @@ void ButtonWidgetsPage::CreateContent()
     CreateButton();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -391,7 +391,7 @@ void ButtonWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -230,7 +230,7 @@ void CheckBoxWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void CheckBoxWidgetsPage::Reset()

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -229,6 +229,8 @@ void CheckBoxWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 void CheckBoxWidgetsPage::Reset()

--- a/samples/widgets/choice.cpp
+++ b/samples/widgets/choice.cpp
@@ -268,7 +268,7 @@ void ChoiceWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/choice.cpp
+++ b/samples/widgets/choice.cpp
@@ -267,6 +267,8 @@ void ChoiceWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -171,6 +171,8 @@ void ColourPickerWidgetsPage::CreateContent()
     sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
 
     SetSizer(sz);
+
+    this->SetContentCreated();
 }
 
 void ColourPickerWidgetsPage::CreatePicker()

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -172,7 +172,7 @@ void ColourPickerWidgetsPage::CreateContent()
 
     SetSizer(sz);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void ColourPickerWidgetsPage::CreatePicker()

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -409,6 +409,8 @@ void ComboboxWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -410,7 +410,7 @@ void ComboboxWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -239,7 +239,7 @@ void DatePickerWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void DatePickerWidgetsPage::Reset()

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -238,6 +238,8 @@ void DatePickerWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 void DatePickerWidgetsPage::Reset()

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -234,6 +234,8 @@ void DirCtrlWidgetsPage::CreateContent()
 
     // final initializations
     Reset();
+
+    this->SetContentCreated();
 }
 
 void DirCtrlWidgetsPage::Reset()

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -235,7 +235,7 @@ void DirCtrlWidgetsPage::CreateContent()
     // final initializations
     Reset();
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void DirCtrlWidgetsPage::Reset()

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -187,7 +187,7 @@ void DirPickerWidgetsPage::CreateContent()
 
     SetSizer(sz);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void DirPickerWidgetsPage::CreatePicker()

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -186,6 +186,8 @@ void DirPickerWidgetsPage::CreateContent()
     sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
 
     SetSizer(sz);
+
+    this->SetContentCreated();
 }
 
 void DirPickerWidgetsPage::CreatePicker()

--- a/samples/widgets/editlbox.cpp
+++ b/samples/widgets/editlbox.cpp
@@ -158,6 +158,8 @@ void EditableListboxWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/editlbox.cpp
+++ b/samples/widgets/editlbox.cpp
@@ -159,7 +159,7 @@ void EditableListboxWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/filectrl.cpp
+++ b/samples/widgets/filectrl.cpp
@@ -212,6 +212,8 @@ void FileCtrlWidgetsPage::CreateContent()
     Reset();
 
     SetSizer( sizerTop );
+
+    this->SetContentCreated();
 }
 
 void FileCtrlWidgetsPage::Reset()

--- a/samples/widgets/filectrl.cpp
+++ b/samples/widgets/filectrl.cpp
@@ -213,7 +213,7 @@ void FileCtrlWidgetsPage::CreateContent()
 
     SetSizer( sizerTop );
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void FileCtrlWidgetsPage::Reset()

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -216,7 +216,7 @@ void FilePickerWidgetsPage::CreateContent()
 
     SetSizer(sz);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void FilePickerWidgetsPage::CreatePicker()

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -215,6 +215,8 @@ void FilePickerWidgetsPage::CreateContent()
     sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
 
     SetSizer(sz);
+
+    this->SetContentCreated();
 }
 
 void FilePickerWidgetsPage::CreatePicker()

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -165,6 +165,8 @@ void FontPickerWidgetsPage::CreateContent()
     sz->Add(m_sizer, 1, wxGROW|wxALL, 5);
 
     SetSizer(sz);
+
+    this->SetContentCreated();
 }
 
 void FontPickerWidgetsPage::CreatePicker()

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -166,7 +166,7 @@ void FontPickerWidgetsPage::CreateContent()
 
     SetSizer(sz);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void FontPickerWidgetsPage::CreatePicker()

--- a/samples/widgets/gauge.cpp
+++ b/samples/widgets/gauge.cpp
@@ -262,6 +262,8 @@ void GaugeWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 GaugeWidgetsPage::~GaugeWidgetsPage()

--- a/samples/widgets/gauge.cpp
+++ b/samples/widgets/gauge.cpp
@@ -263,7 +263,7 @@ void GaugeWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 GaugeWidgetsPage::~GaugeWidgetsPage()

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -243,6 +243,8 @@ void HyperlinkWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 void HyperlinkWidgetsPage::Reset()

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -244,7 +244,7 @@ void HyperlinkWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void HyperlinkWidgetsPage::Reset()

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -407,7 +407,7 @@ void ListboxWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -406,6 +406,8 @@ void ListboxWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -286,7 +286,7 @@ void BookWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 BookWidgetsPage::~BookWidgetsPage()

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -285,6 +285,8 @@ void BookWidgetsPage::CreateContent()
     CreateImageList();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 BookWidgetsPage::~BookWidgetsPage()

--- a/samples/widgets/odcombobox.cpp
+++ b/samples/widgets/odcombobox.cpp
@@ -480,6 +480,8 @@ void ODComboboxWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/odcombobox.cpp
+++ b/samples/widgets/odcombobox.cpp
@@ -481,7 +481,7 @@ void ODComboboxWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/radiobox.cpp
+++ b/samples/widgets/radiobox.cpp
@@ -285,6 +285,8 @@ void RadioWidgetsPage::CreateContent()
 
     // final initializations
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/radiobox.cpp
+++ b/samples/widgets/radiobox.cpp
@@ -286,7 +286,7 @@ void RadioWidgetsPage::CreateContent()
     // final initializations
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/searchctrl.cpp
+++ b/samples/widgets/searchctrl.cpp
@@ -167,6 +167,8 @@ void SearchCtrlWidgetsPage::CreateContent()
     sizer->Add(m_srchCtrl, wxSizerFlags().Centre().TripleBorder());
 
     SetSizer(sizer);
+
+    this->SetContentCreated();
 }
 
 void SearchCtrlWidgetsPage::CreateControl()

--- a/samples/widgets/searchctrl.cpp
+++ b/samples/widgets/searchctrl.cpp
@@ -168,7 +168,7 @@ void SearchCtrlWidgetsPage::CreateContent()
 
     SetSizer(sizer);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void SearchCtrlWidgetsPage::CreateControl()

--- a/samples/widgets/slider.cpp
+++ b/samples/widgets/slider.cpp
@@ -412,7 +412,7 @@ void SliderWidgetsPage::CreateContent()
     // final initializations
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/slider.cpp
+++ b/samples/widgets/slider.cpp
@@ -411,6 +411,8 @@ void SliderWidgetsPage::CreateContent()
 
     // final initializations
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -346,6 +346,8 @@ void SpinBtnWidgetsPage::CreateContent()
 
     // final initializations
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -347,7 +347,7 @@ void SpinBtnWidgetsPage::CreateContent()
     // final initializations
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/statbmp.cpp
+++ b/samples/widgets/statbmp.cpp
@@ -118,6 +118,8 @@ void StatBmpWidgetsPage::CreateContent()
 
     m_statbmp = nullptr;
     RecreateWidget();
+
+    this->SetContentCreated();
 }
 
 void StatBmpWidgetsPage::RecreateWidget()

--- a/samples/widgets/statbmp.cpp
+++ b/samples/widgets/statbmp.cpp
@@ -119,7 +119,7 @@ void StatBmpWidgetsPage::CreateContent()
     m_statbmp = nullptr;
     RecreateWidget();
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void StatBmpWidgetsPage::RecreateWidget()

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -359,6 +359,8 @@ void StaticWidgetsPage::CreateContent()
     sizerTop->Add(sizerRight, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -360,7 +360,7 @@ void StaticWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -620,7 +620,7 @@ void TextWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -619,6 +619,8 @@ void TextWidgetsPage::CreateContent()
     sizerTop->Add(m_sizerText, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/timepick.cpp
+++ b/samples/widgets/timepick.cpp
@@ -170,6 +170,8 @@ void TimePickerWidgetsPage::CreateContent()
     Reset();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 void TimePickerWidgetsPage::Reset()

--- a/samples/widgets/timepick.cpp
+++ b/samples/widgets/timepick.cpp
@@ -171,7 +171,7 @@ void TimePickerWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void TimePickerWidgetsPage::Reset()

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -330,6 +330,8 @@ void ToggleWidgetsPage::CreateContent()
     CreateToggle();
 
     SetSizer(sizerTop);
+
+    this->SetContentCreated();
 }
 
 void ToggleWidgetsPage::Reset()

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -331,7 +331,7 @@ void ToggleWidgetsPage::CreateContent()
 
     SetSizer(sizerTop);
 
-    this->SetContentCreated();
+    SetContentCreated();
 }
 
 void ToggleWidgetsPage::Reset()

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -821,7 +821,7 @@ void WidgetsFrame::OnPageChanged(WidgetsBookCtrlEvent& event)
     // create the pages on demand, otherwise the sample startup is too slow as
     // it creates hundreds of controls
     WidgetsPage *curPage = CurrentPage();
-    if ( curPage->GetChildren().empty() )
+    if ( !curPage->HasCreatedContent() )
     {
         wxWindowUpdateLocker noUpdates(curPage);
         curPage->CreateContent();

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -135,6 +135,12 @@ public:
     // lazy creation of the content
     virtual void CreateContent() = 0;
 
+    // checks if content has already been created
+    bool HasCreatedContent() const
+    {
+        return m_contentCreated;
+    }
+
     // some pages show additional controls, in this case override this one to
     // return all of them (including the one returned by GetWidget())
     virtual Widgets GetWidgets() const
@@ -195,12 +201,20 @@ protected:
                                             wxWindowID id = wxID_ANY,
                                             wxWindow* statBoxParent = nullptr);
 
+    // sets flag that content has been created
+    void SetContentCreated()
+    {
+        m_contentCreated = true;
+    }
+    
 public:
     // the head of the linked list containinginfo about all pages
     static WidgetsPageInfo *ms_widgetPages;
 
 private:
     bool m_notifyRecreate = false;
+
+    bool m_contentCreated = false; // flag indicating if content has already been created
 };
 
 // ----------------------------------------------------------------------------

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -206,7 +206,7 @@ protected:
     {
         m_contentCreated = true;
     }
-    
+
 public:
     // the head of the linked list containinginfo about all pages
     static WidgetsPageInfo *ms_widgetPages;


### PR DESCRIPTION
Widgets demo makes incorrectly assumes that when a page has children its content has been created. This is incorrect because some pages create as a default children (e.g. scrollbars etc.). This patch adds a flag checking if a page's content has been created.