### PR TITLE
Check wxXRC_NO_RELOADING out of the loop

### DIFF
--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -723,7 +723,7 @@ bool wxXmlResource::UpdateResources()
 
     // We never do it if this flag is specified.
     if ( m_flags & wxXRC_NO_RELOADING )
-        return;
+        return rt;
 
     for ( wxXmlResourceDataRecord& rec : Data() )
     {

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -724,6 +724,7 @@ bool wxXmlResource::UpdateResources()
     // We never do it if this flag is specified.
     if ( m_flags & wxXRC_NO_RELOADING )
         return;
+
     for ( wxXmlResourceDataRecord& rec : Data() )
     {
         // Check if we need to reload this one.

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -722,53 +722,52 @@ bool wxXmlResource::UpdateResources()
     bool rt = true;
 
     // We never do it if this flag is specified.
-    if ( !(m_flags & wxXRC_NO_RELOADING) )
+    if ( m_flags & wxXRC_NO_RELOADING )
+        return;
+    for ( wxXmlResourceDataRecord& rec : Data() )
     {
-        for ( wxXmlResourceDataRecord& rec : Data() )
-        {
-            // Check if we need to reload this one.
+        // Check if we need to reload this one.
 
-            // And we don't do it for the records that were not loaded from a
-            // file/URI (or at least not directly) in the first place.
-            if ( !rec.Time.IsValid() )
-                continue;
+        // And we don't do it for the records that were not loaded from a
+        // file/URI (or at least not directly) in the first place.
+        if ( !rec.Time.IsValid() )
+            continue;
 
-            // Otherwise check its modification time if we can.
+        // Otherwise check its modification time if we can.
 #if wxUSE_DATETIME
-            wxDateTime lastModTime = GetXRCFileModTime(rec.File);
+        wxDateTime lastModTime = GetXRCFileModTime(rec.File);
 
-            if ( lastModTime.IsValid() && lastModTime <= rec.Time )
+        if ( lastModTime.IsValid() && lastModTime <= rec.Time )
 #else // !wxUSE_DATETIME
-            // Never reload the file contents: we can't know whether it changed or
-            // not in this build configuration and it would be unexpected and
-            // counter-productive to get a performance hit (due to constant
-            // reloading of XRC files) in a minimal wx build which is presumably
-            // used because of resource constraints of the current platform.
+        // Never reload the file contents: we can't know whether it changed or
+        // not in this build configuration and it would be unexpected and
+        // counter-productive to get a performance hit (due to constant
+        // reloading of XRC files) in a minimal wx build which is presumably
+        // used because of resource constraints of the current platform.
 #endif // wxUSE_DATETIME/!wxUSE_DATETIME
-            {
-                // No need to reload, the file wasn't modified since we did it
-                // last.
-                continue;
-            }
-
-            wxXmlDocument * const doc = DoLoadFile(rec.File);
-            if ( !doc )
-            {
-                // Notice that we keep the old XML document: it seems better to
-                // preserve it instead of throwing it away if we have nothing to
-                // replace it with.
-                rt = false;
-                continue;
-            }
-
-            // Replace the old resource contents with the new one.
-            rec.Doc.reset(doc);
-
-            // And, now that we loaded it successfully, update the last load time.
-#if wxUSE_DATETIME
-            rec.Time = lastModTime.IsValid() ? lastModTime : wxDateTime::Now();
-#endif // wxUSE_DATETIME
+        {
+            // No need to reload, the file wasn't modified since we did it
+            // last.
+            continue;
         }
+
+        wxXmlDocument * const doc = DoLoadFile(rec.File);
+        if ( !doc )
+        {
+            // Notice that we keep the old XML document: it seems better to
+            // preserve it instead of throwing it away if we have nothing to
+            // replace it with.
+            rt = false;
+            continue;
+        }
+
+        // Replace the old resource contents with the new one.
+        rec.Doc.reset(doc);
+
+        // And, now that we loaded it successfully, update the last load time.
+#if wxUSE_DATETIME
+        rec.Time = lastModTime.IsValid() ? lastModTime : wxDateTime::Now();
+#endif // wxUSE_DATETIME
     }
 
     return rt;


### PR DESCRIPTION
Small optimisation:
Instead of checking if the wxXRC_NO_RELOADING flag is set, inside the loop that checks each XmlResource record, this will check the flag before the loop itself is even started.