### PR TITLE
BUG FIX for ticket #24532 - Ticks were not centered with respect to the slider's line

### DIFF
--- a/src/osx/slider_osx.cpp
+++ b/src/osx/slider_osx.cpp
@@ -378,6 +378,11 @@ wxSize wxSlider::DoGetBestSize() const
 
         if (GetWindowStyle() & wxSL_LABELS)
             size.x += textwidth + wxSLIDER_BORDERTEXT;
+
+        // to let the ticks look good the width of the control has to have an even number,
+        // otherwise, the ticks are not centered with respect to the slider line
+        if ((GetWindowStyle() & wxSL_AUTOTICKS) && ((size.x%2) != 0))
+            size.x += 1;
     }
     else
     {
@@ -393,6 +398,11 @@ wxSize wxSlider::DoGetBestSize() const
             size.y += textheight + wxSLIDER_BORDERTEXT;
             size.x += (mintwidth / 2) + (maxtwidth / 2);
         }
+
+        // to let the ticks look good the height of the control has to have an even number,
+        // otherwise, the ticks are not centered with respect to the slider line
+        if ((GetWindowStyle() & wxSL_AUTOTICKS) && ((size.y%2) != 0))
+            size.y += 1;
     }
 
     return size;


### PR DESCRIPTION
To have a proper centering with respect to the slider's line, the size of the slider in the dimension perpendicular to the slider's line has to be an even number. Therefore, when determining the best size, the size is adjusted to an even number when ticks are shown.