### PR TITLE
Timer doc updates

### DIFF
--- a/interface/wx/stopwatch.h
+++ b/interface/wx/stopwatch.h
@@ -25,11 +25,8 @@
     @endcode
 
     Since wxWidgets 2.9.3 this class uses @c QueryPerformanceCounter()
-    function under MSW to measure the elapsed time. It provides higher
-    precision than the usual timer functions but can suffer from bugs in its
-    implementation in some Windows XP versions. If you encounter such problems,
-    installing a Microsoft hot fix from http://support.microsoft.com/?id=896256
-    could be necessary.
+    function under MSW to measure the elapsed time. This provides higher
+    precision than the usual timer functions.
 
     @library{wxbase}
     @category{misc}

--- a/interface/wx/timer.h
+++ b/interface/wx/timer.h
@@ -27,9 +27,9 @@ wxEventType wxEVT_TIMER;
       wxTimer::Notify member to perform the required action.
     - You may redirect the notifications to any wxEvtHandler derived object by
       using the non-default constructor or wxTimer::SetOwner.
-      Then use the @c EVT_TIMER macro to connect it to the event handler which
-      will receive wxTimerEvent notifications.
-    - You may use a derived class and the @c EVT_TIMER macro to connect it to
+      Then Bind() @c wxEVT_TIMER (or use the @c EVT_TIMER macro) to connect it to
+      the event handler which will receive wxTimerEvent notifications.
+    - You may use a derived class and Bind() @c wxEVT_TIMER to connect it to
       an event handler defined in the derived class. If the default constructor
       is used, the timer object will be its own owner object, since it is
       derived from wxEvtHandler.
@@ -125,8 +125,8 @@ public:
         If @true, it will be called only once and the timer will stop automatically.
 
         To make your code more readable you may also use the following symbolic constants:
-        - wxTIMER_CONTINUOUS: Start a normal, continuously running, timer
-        - wxTIMER_ONE_SHOT: Start a one shot timer. Alternatively, and
+        - @c wxTIMER_CONTINUOUS: Start a normal, continuously running, timer
+        - @c wxTIMER_ONE_SHOT: Start a one shot timer. Alternatively, and
         preferably, call StartOnce() instead of this function.
 
         If the timer was already running, it will be stopped by this method before


### PR DESCRIPTION
Remove warning about Windows XP since we don't support that platform anymore. (The support link in the comment doesn't go anywhere now also.)

Mention using the modern method of `Bind()` with `wxEVT_TIMER`.

Format improvement.