### PR TITLE
Fixes for `wxDateTime` and generic `wxDatePickerCtrl` date parsing

### DIFF
--- a/interface/wx/datetime.h
+++ b/interface/wx/datetime.h
@@ -1003,14 +1003,12 @@ public:
     bool ParseDateTime(const wxString& datetime, wxString::const_iterator *end);
 
     /**
-        This function parses the string @a date according to the given
-        @e format. The system @c strptime(3) function is used whenever
-        available, but even if it is not, this function is still implemented,
-        although support for locale-dependent format specifiers such as
-        @c "%c", @c "%x" or @c "%X" may not be perfect and GNU extensions such
-        as @c "%z" and @c "%Z" are not implemented. This function does handle
-        the month and weekday names in the current locale on all platforms,
-        however.
+        Parses the string @a date according to the given @e format.
+
+        This function is similar to @c strptime(3) but doesn't use it and
+        implements the parsing itself, with support for all the standard
+        (POSIX) formatting specifiers as well as a number of GNU extensions
+        such as `%l`, `%F`, `%z` (but not `%Z`, currently) etc.
 
         Please see the description of the ANSI C function @c strftime(3) for
         the syntax of the format string.

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -1106,13 +1106,20 @@ wxDateTime::ParseFormat(const wxString& date,
         }
 
         // start of a format specification
+        ++fmt;
+
+        // skip the optional character specifying the padding: this is a GNU
+        // extension which we need to support as this is used in the default
+        // date formats for some locales (but luckily this is simple to do)
+        if ( *fmt == '-' || *fmt == '_' || *fmt == '0' )
+            ++fmt;
 
         // parse the optional width
         size_t width = 0;
-        while ( wxIsdigit(*++fmt) )
+        while ( wxIsdigit(*fmt) )
         {
             width *= 10;
-            width += *fmt - '0';
+            width += *fmt++ - '0';
         }
 
         // the default widths for the various fields

--- a/src/generic/datectlg.cpp
+++ b/src/generic/datectlg.cpp
@@ -24,6 +24,7 @@
     #include "wx/dialog.h"
     #include "wx/dcmemory.h"
     #include "wx/intl.h"
+    #include "wx/log.h"
     #include "wx/msgdlg.h"
     #include "wx/panel.h"
     #include "wx/textctrl.h"
@@ -307,11 +308,32 @@ private:
         wxString fmt = wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT);
         if ( HasDPFlag(wxDP_SHOWCENTURY) )
             fmt.Replace("%y", "%Y");
+#else // !wxUSE_INTL
+        wxString fmt = wxS("%x");
+#endif // wxUSE_INTL/!wxUSE_INTL
+
+        // Also check if we can actually parse dates in this format because we
+        // had several problems with unsupported format specifiers being used
+        // in some locales date format strings in the past, and in this case
+        // we'd just annoy the user with senseless messages about invalid dates
+        // being entered when it's actually just our own bug.
+        wxDateTime dt;
+        if ( !dt.ParseFormat(wxDateTime::Now().Format(fmt), fmt) )
+        {
+            // If we can't parse the date in the format we're going to use, we
+            // can't use it and have to fallback to something else -- this is
+            // not ideal, but better than not allowing the user to enter any
+            // dates at all.
+            wxLogTrace("datectrl",
+                       "Can't parse dates in format \"%s\", "
+                       "using ISO 8601 as fallback",
+                       fmt);
+
+            fmt = HasDPFlag(wxDP_SHOWCENTURY) ? wxS("%Y-%m-%d")
+                                              : wxS("%y-%m-%d");
+        }
 
         return fmt;
-#else // !wxUSE_INTL
-        return wxS("%x");
-#endif // wxUSE_INTL/!wxUSE_INTL
     }
 
     bool SetFormat(const wxString& fmt)

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -795,7 +795,10 @@ TEST_CASE("wxDateTime::Format", "[datetime]")
     }
 
     CHECK(wxDateTime::Now().Format("%%") == "%");
+}
 
+TEST_CASE("wxDateTime::ParseFormat", "[datetime]")
+{
     wxDateTime dt;
 
 #if 0

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -202,73 +202,12 @@ static const Date testDates[] =
 };
 
 
-// ----------------------------------------------------------------------------
-// test class
-// ----------------------------------------------------------------------------
-
-class DateTimeTestCase : public CppUnit::TestCase
-{
-public:
-    DateTimeTestCase() { }
-
-private:
-    CPPUNIT_TEST_SUITE( DateTimeTestCase );
-        CPPUNIT_TEST( TestLeapYears );
-        CPPUNIT_TEST( TestTimeSet );
-        CPPUNIT_TEST( TestTimeJDN );
-        CPPUNIT_TEST( TestTimeWNumber );
-        CPPUNIT_TEST( TestTimeWDays );
-        CPPUNIT_TEST( TestTimeDST );
-        CPPUNIT_TEST( TestTimeFormat );
-        CPPUNIT_TEST( TestTimeParse );
-        CPPUNIT_TEST( TestTimeZoneParse );
-        CPPUNIT_TEST( TestTimeSpanFormat );
-        CPPUNIT_TEST( TestTimeTicks );
-        CPPUNIT_TEST( TestParseRFC822 );
-        CPPUNIT_TEST( TestDateParse );
-        CPPUNIT_TEST( TestDateParseISO );
-        CPPUNIT_TEST( TestDateTimeParse );
-        CPPUNIT_TEST( TestDateWeekFormat );
-        CPPUNIT_TEST( TestTimeArithmetics );
-        CPPUNIT_TEST( TestDSTBug );
-        CPPUNIT_TEST( TestDateOnly );
-        CPPUNIT_TEST( TestTranslateFromUnicodeFormat );
-        CPPUNIT_TEST( TestConvToFromLocalTZ );
-    CPPUNIT_TEST_SUITE_END();
-
-    void TestLeapYears();
-    void TestTimeSet();
-    void TestTimeJDN();
-    void TestTimeWNumber();
-    void TestTimeWDays();
-    void TestTimeDST();
-    void TestTimeFormat();
-    void TestTimeParse();
-    void TestTimeZoneParse();
-    void TestTimeSpanFormat();
-    void TestTimeTicks();
-    void TestParseRFC822();
-    void TestDateParse();
-    void TestDateParseISO();
-    void TestDateTimeParse();
-    void TestDateWeekFormat();
-    void TestTimeArithmetics();
-    void TestDSTBug();
-    void TestDateOnly();
-    void TestTranslateFromUnicodeFormat();
-    void TestConvToFromLocalTZ();
-
-    wxDECLARE_NO_COPY_CLASS(DateTimeTestCase);
-};
-
-wxREGISTER_UNIT_TEST_WITH_TAGS(DateTimeTestCase, "[datetime]");
-
 // ============================================================================
-// implementation
+// the tests themselves
 // ============================================================================
 
 // test leap years detection
-void DateTimeTestCase::TestLeapYears()
+TEST_CASE("wxDateTime::Leap", "[datetime][leap]")
 {
     static const struct LeapYearTestData
     {
@@ -290,12 +229,12 @@ void DateTimeTestCase::TestLeapYears()
     {
         const LeapYearTestData& y = years[n];
 
-        CPPUNIT_ASSERT_EQUAL( y.isLeap, wxDateTime::IsLeapYear(y.year) );
+        CHECK( wxDateTime::IsLeapYear(y.year) == y.isLeap );
     }
 }
 
 // test constructing wxDateTime objects
-void DateTimeTestCase::TestTimeSet()
+TEST_CASE("wxDateTime::Set", "[datetime]")
 {
     for ( size_t n = 0; n < WXSIZEOF(testDates); n++ )
     {
@@ -311,7 +250,7 @@ void DateTimeTestCase::TestTimeSet()
 }
 
 // test conversions to JDN &c
-void DateTimeTestCase::TestTimeJDN()
+TEST_CASE("wxDateTime::JDN", "[datetime]")
 {
     for ( size_t n = 0; n < WXSIZEOF(testDates); n++ )
     {
@@ -330,7 +269,7 @@ void DateTimeTestCase::TestTimeJDN()
 }
 
 // test week days computation
-void DateTimeTestCase::TestTimeWDays()
+TEST_CASE("wxDateTime::WDays", "[datetime]")
 {
     // test GetWeekDay()
     size_t n;
@@ -446,12 +385,12 @@ for n in range(20):
         dt.SetToWeekDay(wd.wday, wd.nWeek, wd.month, wd.year);
 
         const Date& d = wd.date;
-        CPPUNIT_ASSERT( d.SameDay(dt.GetTm()) );
+        CHECK( d.SameDay(dt.GetTm()) );
     }
 }
 
 // test the computation of (ISO) week numbers
-void DateTimeTestCase::TestTimeWNumber()
+TEST_CASE("wxDateTime::WNumber", "[datetime]")
 {
     struct WeekNumberTestData
     {
@@ -580,12 +519,12 @@ for n in range(20):
 
         wxDateTime
             dt2 = wxDateTime::SetToWeekOfYear(year, week, dt.GetWeekDay());
-        CPPUNIT_ASSERT_EQUAL( dt, dt2 );
+        CHECK( dt2  == dt );
     }
 }
 
 // test DST applicability
-void DateTimeTestCase::TestTimeDST()
+TEST_CASE("wxDateTime::DST", "[datetime]")
 {
     // taken from http://www.energy.ca.gov/daylightsaving.html
     static const Date datesDST[2][2009 - 1990 + 1] =
@@ -646,13 +585,13 @@ void DateTimeTestCase::TestTimeDST()
         const Date& dBegin = datesDST[0][n];
         const Date& dEnd = datesDST[1][n];
 
-        CPPUNIT_ASSERT_EQUAL( dBegin.DT().FormatDate(), dtBegin.FormatDate() );
-        CPPUNIT_ASSERT_EQUAL( dEnd.DT().FormatDate(), dtEnd.FormatDate() );
+        CHECK( dtBegin.FormatDate() == dBegin.DT().FormatDate() );
+        CHECK( dtEnd.FormatDate() == dEnd.DT().FormatDate() );
     }
 }
 
 // test wxDateTime -> text conversion
-void DateTimeTestCase::TestTimeFormat()
+TEST_CASE("wxDateTime::Format", "[datetime]")
 {
     // some information may be lost during conversion, so store what kind
     // of info should we recover after a round trip
@@ -855,103 +794,103 @@ void DateTimeTestCase::TestTimeFormat()
         }
     }
 
-    CPPUNIT_ASSERT(wxDateTime::Now().Format("%%") == "%");
+    CHECK(wxDateTime::Now().Format("%%") == "%");
 
     wxDateTime dt;
 
 #if 0
     // special case which was known to fail
-    CPPUNIT_ASSERT( dt.ParseFormat("02/06/1856", "%x") );
-    CPPUNIT_ASSERT_EQUAL( 1856, dt.GetYear() );
+    CHECK( dt.ParseFormat("02/06/1856", "%x") );
+    CHECK( dt.GetYear()  == 1856 );
 #endif
 
     // also test %l separately
-    CPPUNIT_ASSERT( dt.ParseFormat("12:23:45.678", "%H:%M:%S.%l") );
-    CPPUNIT_ASSERT_EQUAL( 678, dt.GetMillisecond() );
+    CHECK( dt.ParseFormat("12:23:45.678", "%H:%M:%S.%l") );
+    CHECK( dt.GetMillisecond()  == 678 );
 
     // test special case of %l matching 0 milliseconds
-    CPPUNIT_ASSERT( dt.ParseFormat("12:23:45.000", "%H:%M:%S.%l") );
-    CPPUNIT_ASSERT_EQUAL( 0, dt.GetMillisecond() );
+    CHECK( dt.ParseFormat("12:23:45.000", "%H:%M:%S.%l") );
+    CHECK( dt.GetMillisecond()  == 0 );
 
     // test another format modifier not tested above.
-    CPPUNIT_ASSERT( dt.ParseFormat("23", "%e") );
-    CPPUNIT_ASSERT_EQUAL( 23, dt.GetDay() );
+    CHECK( dt.ParseFormat("23", "%e") );
+    CHECK( dt.GetDay()  == 23 );
 
     // test partially specified dates too
     wxDateTime dtDef(26, wxDateTime::Sep, 2008);
-    CPPUNIT_ASSERT( dt.ParseFormat("17", "%d", dtDef) );
-    CPPUNIT_ASSERT_EQUAL( 17, dt.GetDay() );
-    CPPUNIT_ASSERT_EQUAL( wxDateTime::Sep, dt.GetMonth() );
-    CPPUNIT_ASSERT_EQUAL( 2008, dt.GetYear() );
+    CHECK( dt.ParseFormat("17", "%d", dtDef) );
+    CHECK( dt.GetDay()  == 17 );
+    CHECK( dt.GetMonth()  == wxDateTime::Sep );
+    CHECK( dt.GetYear()  == 2008 );
 
     // test some degenerate cases
-    CPPUNIT_ASSERT( !dt.ParseFormat("", "%z") );
-    CPPUNIT_ASSERT( !dt.ParseFormat("", "%%") );
+    CHECK( !dt.ParseFormat("", "%z") );
+    CHECK( !dt.ParseFormat("", "%%") );
 
     // test compilation of some calls which should compile (and not result in
     // ambiguity because of char*<->wxCStrData<->wxString conversions)
     wxString s("foo");
-    CPPUNIT_ASSERT( !dt.ParseFormat("foo") );
-    CPPUNIT_ASSERT( !dt.ParseFormat(wxT("foo")) );
-    CPPUNIT_ASSERT( !dt.ParseFormat(s) );
+    CHECK( !dt.ParseFormat("foo") );
+    CHECK( !dt.ParseFormat(wxT("foo")) );
+    CHECK( !dt.ParseFormat(s) );
     dt.ParseFormat(s.c_str()); // Simply test compilation of this one.
 
-    CPPUNIT_ASSERT( !dt.ParseFormat("foo", "%c") );
-    CPPUNIT_ASSERT( !dt.ParseFormat(wxT("foo"), "%c") );
-    CPPUNIT_ASSERT( !dt.ParseFormat(s, "%c") );
+    CHECK( !dt.ParseFormat("foo", "%c") );
+    CHECK( !dt.ParseFormat(wxT("foo"), "%c") );
+    CHECK( !dt.ParseFormat(s, "%c") );
     dt.ParseFormat(s.c_str(), "%c");
 
-    CPPUNIT_ASSERT( !dt.ParseFormat("foo", wxT("%c")) );
-    CPPUNIT_ASSERT( !dt.ParseFormat(wxT("foo"), wxT("%c")) );
-    CPPUNIT_ASSERT( !dt.ParseFormat(s, "%c") );
+    CHECK( !dt.ParseFormat("foo", wxT("%c")) );
+    CHECK( !dt.ParseFormat(wxT("foo"), wxT("%c")) );
+    CHECK( !dt.ParseFormat(s, "%c") );
     dt.ParseFormat(s.c_str(), wxT("%c"));
 
     wxString spec("%c");
-    CPPUNIT_ASSERT( !dt.ParseFormat("foo", spec) );
-    CPPUNIT_ASSERT( !dt.ParseFormat(wxT("foo"), spec) );
-    CPPUNIT_ASSERT( !dt.ParseFormat(s, spec) );
+    CHECK( !dt.ParseFormat("foo", spec) );
+    CHECK( !dt.ParseFormat(wxT("foo"), spec) );
+    CHECK( !dt.ParseFormat(s, spec) );
     dt.ParseFormat(s.c_str(), spec);
 }
 
 // Test parsing time in free format.
-void DateTimeTestCase::TestTimeParse()
+TEST_CASE("wxDateTime::TimeParse", "[datetime]")
 {
     wxDateTime dt;
 
     // Parsing standard formats should work.
     const char* end = dt.ParseTime("12:34:56");
-    CPPUNIT_ASSERT( end );
+    CHECK( end );
     if ( end )
     {
-        CPPUNIT_ASSERT_EQUAL( "12:34:56", dt.FormatISOTime() );
-        CPPUNIT_ASSERT_EQUAL( "", wxString(end) );
+        CHECK( dt.FormatISOTime() == "12:34:56" );
+        CHECK( wxString(end) == "" );
     }
     dt.ResetTime();
 
     // Valid, but followed by something.
     end = dt.ParseTime("12:34:56 0123 something");
-    CPPUNIT_ASSERT( end );
+    CHECK( end );
     if ( end )
     {
-        CPPUNIT_ASSERT_EQUAL( "12:34:56", dt.FormatISOTime() );
-        CPPUNIT_ASSERT_EQUAL( " 0123 something", wxString(end) );
+        CHECK( dt.FormatISOTime() == "12:34:56" );
+        CHECK( wxString(end) == " 0123 something" );
     }
     dt.ResetTime();
 
     // Parsing just hours should work too.
     end = dt.ParseTime("17");
-    CPPUNIT_ASSERT( end );
+    CHECK( end );
     if ( end )
     {
-        CPPUNIT_ASSERT_EQUAL( "17:00:00", dt.FormatISOTime() );
-        CPPUNIT_ASSERT_EQUAL( "", wxString(end) );
+        CHECK( dt.FormatISOTime() == "17:00:00" );
+        CHECK( wxString(end) == "" );
     }
 
     // Parsing gibberish shouldn't work.
-    CPPUNIT_ASSERT( !dt.ParseTime("bloordyblop") );
+    CHECK( !dt.ParseTime("bloordyblop") );
 }
 
-void DateTimeTestCase::TestTimeZoneParse()
+TEST_CASE("wxDateTime::ParseTZ", "[datetime]")
 {
     wxGCC_WARNING_SUPPRESS(missing-field-initializers)
 
@@ -1010,19 +949,19 @@ void DateTimeTestCase::TestTimeZoneParse()
         if ( dt.ParseFormat(sTimeZone, wxS("%H:%M%z"), &end)
              && end == sTimeZone.end() )
         {
-            CPPUNIT_ASSERT( parseTestTimeZones[n].good );
-            CPPUNIT_ASSERT_EQUAL( 13, dt.GetHour(wxDateTime::UTC));
-            CPPUNIT_ASSERT_EQUAL( 37, dt.GetMinute(wxDateTime::UTC));
+            CHECK( parseTestTimeZones[n].good );
+            CHECK( dt.GetHour(wxDateTime::UTC) == 13 );
+            CHECK( dt.GetMinute(wxDateTime::UTC) == 37 );
         }
         else
         {
             // Failed to parse time zone.
-            CPPUNIT_ASSERT( !parseTestTimeZones[n].good );
+            CHECK( !parseTestTimeZones[n].good );
         }
     }
 }
 
-void DateTimeTestCase::TestTimeSpanFormat()
+TEST_CASE("wxTimeSpan::Format", "[datetime]")
 {
     wxGCC_WARNING_SUPPRESS(missing-field-initializers)
 
@@ -1055,11 +994,11 @@ void DateTimeTestCase::TestTimeSpanFormat()
     {
         const TimeSpanFormatTestData& td = testSpans[n];
         wxTimeSpan ts(td.h, td.min, td.sec, td.msec);
-        CPPUNIT_ASSERT_EQUAL( td.result, ts.Format(td.fmt) );
+        CHECK( ts.Format(td.fmt) == td.result );
     }
 }
 
-void DateTimeTestCase::TestTimeTicks()
+TEST_CASE("wxDateTime::Ticks", "[datetime]")
 {
     for ( size_t n = 0; n < WXSIZEOF(testDates); n++ )
     {
@@ -1077,7 +1016,7 @@ void DateTimeTestCase::TestTimeTicks()
 }
 
 // test parsing dates in RFC822 format
-void DateTimeTestCase::TestParseRFC822()
+TEST_CASE("wxDateTime::ParseRFC822", "[datetime]")
 {
     wxGCC_WARNING_SUPPRESS(missing-field-initializers)
 
@@ -1257,7 +1196,7 @@ void DateTimeTestCase::TestParseRFC822()
             );
 
             wxDateTime dtReal = parseTestDates[n].date.DT().FromUTC();
-            CPPUNIT_ASSERT_EQUAL( dtReal, dt );
+            CHECK( dt  == dtReal );
         }
         else // failed to parse
         {
@@ -1270,7 +1209,7 @@ void DateTimeTestCase::TestParseRFC822()
 }
 
 // test parsing dates in free format
-void DateTimeTestCase::TestDateParse()
+TEST_CASE("wxDateTime::DateParse", "[datetime]")
 {
     wxGCC_WARNING_SUPPRESS(missing-field-initializers)
 
@@ -1310,8 +1249,8 @@ void DateTimeTestCase::TestDateParse()
 
     // special cases
     wxDateTime dt;
-    CPPUNIT_ASSERT( dt.ParseDate(wxT("today")) );
-    CPPUNIT_ASSERT_EQUAL( wxDateTime::Today(), dt );
+    CHECK( dt.ParseDate(wxT("today")) );
+    CHECK( dt  == wxDateTime::Today() );
 
     for ( size_t n = 0; n < WXSIZEOF(parseTestDates); n++ )
     {
@@ -1325,8 +1264,8 @@ void DateTimeTestCase::TestDateParse()
                 parseTestDates[n].good
             );
 
-            CPPUNIT_ASSERT_EQUAL( parseTestDates[n].date.DT(), dt );
-            CPPUNIT_ASSERT_EQUAL( wxString(parseTestDates[n].beyondEnd), wxString(end) );
+            CHECK( dt  == parseTestDates[n].date.DT() );
+            CHECK( wxString(end) == wxString(parseTestDates[n].beyondEnd) );
         }
         else // failed to parse
         {
@@ -1339,10 +1278,10 @@ void DateTimeTestCase::TestDateParse()
 
     // Check that incomplete parse works correctly.
     const char* p = dt.ParseFormat("2012-03-23 12:34:56", "%Y-%m-%d");
-    CPPUNIT_ASSERT_EQUAL( " 12:34:56", wxString(p) );
+    CHECK( wxString(p) == " 12:34:56" );
 }
 
-void DateTimeTestCase::TestDateParseISO()
+TEST_CASE("wxDateTime::ParseISO", "[datetime]")
 {
     wxGCC_WARNING_SUPPRESS(missing-field-initializers)
 
@@ -1388,9 +1327,9 @@ void DateTimeTestCase::TestDateParseISO()
         wxDateTime dt;
         if ( dt.ParseISODate(parseTestDates[n].str) )
         {
-            CPPUNIT_ASSERT( parseTestDates[n].good );
+            CHECK( parseTestDates[n].good );
 
-            CPPUNIT_ASSERT_EQUAL( parseTestDates[n].date.DT(), dt );
+            CHECK( dt  == parseTestDates[n].date.DT() );
 
             for ( size_t m = 0; m < WXSIZEOF(parseTestTimes); m++ )
             {
@@ -1401,26 +1340,26 @@ void DateTimeTestCase::TestDateParseISO()
 
                 if ( dt.ParseISOCombined(dtCombined) )
                 {
-                    CPPUNIT_ASSERT( parseTestTimes[m].good );
+                    CHECK( parseTestTimes[m].good );
 
-                    CPPUNIT_ASSERT_EQUAL( parseTestTimes[m].hour, dt.GetHour()) ;
-                    CPPUNIT_ASSERT_EQUAL( parseTestTimes[m].min, dt.GetMinute()) ;
-                    CPPUNIT_ASSERT_EQUAL( parseTestTimes[m].sec, dt.GetSecond()) ;
+                    CHECK( dt.GetHour()   == parseTestTimes[m].hour);
+                    CHECK( dt.GetMinute() == parseTestTimes[m].min );
+                    CHECK( dt.GetSecond() == parseTestTimes[m].sec );
                 }
                 else // failed to parse combined date/time
                 {
-                    CPPUNIT_ASSERT( !parseTestTimes[m].good );
+                    CHECK( !parseTestTimes[m].good );
                 }
             }
         }
         else // failed to parse
         {
-            CPPUNIT_ASSERT( !parseTestDates[n].good );
+            CHECK( !parseTestDates[n].good );
         }
     }
 }
 
-void DateTimeTestCase::TestDateTimeParse()
+TEST_CASE("wxDateTime::ParseDateTime", "[datetime]")
 {
     wxGCC_WARNING_SUPPRESS(missing-field-initializers)
 
@@ -1607,8 +1546,8 @@ void DateTimeTestCase::TestDateTimeParse()
             wxDateTime dtReal = parseTestDates[n].dateIsUTC ?
                 parseTestDates[n].date.DT().FromUTC() :
                 parseTestDates[n].date.DT();
-            CPPUNIT_ASSERT_EQUAL( dtReal, dt );
-            CPPUNIT_ASSERT_EQUAL( wxString(parseTestDates[n].beyondEnd), wxString(end) );
+            CHECK( dt  == dtReal );
+            CHECK( wxString(end) == wxString(parseTestDates[n].beyondEnd) );
         }
         else // failed to parse
         {
@@ -1617,12 +1556,12 @@ void DateTimeTestCase::TestDateTimeParse()
                 !parseTestDates[n].good
             );
 
-            CPPUNIT_ASSERT( !parseTestDates[n].good );
+            CHECK( !parseTestDates[n].good );
         }
     }
 }
 
-void DateTimeTestCase::TestDateWeekFormat()
+TEST_CASE("wxDateTime::FormatWeek", "[datetime]")
 {
     static const struct DateWeekTestData
     {
@@ -1694,14 +1633,14 @@ void DateTimeTestCase::TestDateWeekFormat()
         const DateWeekTestData& td = testWeeks[n];
         wxDateTime d(td.d, wxDateTime::Month(td.m - 1), td.y);
 
-        CPPUNIT_ASSERT_EQUAL( td.result, d.Format("%G-%V") );
+        CHECK( d.Format("%G-%V") == td.result );
 
         if ( td.y > 2000 )
-            CPPUNIT_ASSERT_EQUAL( td.result + 2, d.Format("%g-%V") );
+            CHECK( d.Format("%g-%V") == td.result + 2 );
     }
 }
 
-void DateTimeTestCase::TestTimeArithmetics()
+TEST_CASE("wxDateTime::TimeArithmetics", "[datetime]")
 {
     static const wxDateSpan testArithmData[] =
     {
@@ -1722,10 +1661,10 @@ void DateTimeTestCase::TestTimeArithmetics()
         dt1 = dt + span;
         dt2 = dt - span;
 
-        CPPUNIT_ASSERT_EQUAL( dt, dt1 - span );
-        CPPUNIT_ASSERT_EQUAL( dt, dt2 + span );
-        CPPUNIT_ASSERT_EQUAL( dt1, dt2 + 2*span );
-        CPPUNIT_ASSERT_EQUAL( span, dt1.DiffAsDateSpan(dt) );
+        CHECK( dt1 - span  == dt );
+        CHECK( dt2 + span  == dt );
+        CHECK( dt2 + 2*span  == dt1 );
+        CHECK( dt1.DiffAsDateSpan(dt) == span );
     }
 
     // More date span arithmetics tests
@@ -1733,59 +1672,59 @@ void DateTimeTestCase::TestTimeArithmetics()
     wxDateTime dtd2(6, wxDateTime::Aug, 1999);
 
     // All parts in dtd2 is after dtd1
-    CPPUNIT_ASSERT_EQUAL( wxDateSpan(1, 2, 0, 1), dtd2.DiffAsDateSpan(dtd1) );
+    CHECK( dtd2.DiffAsDateSpan(dtd1) == wxDateSpan(1, 2, 0, 1) );
 
     // Year and month after, day earlier, so no full month
     // Jul has 31 days, so it's 31 - 5 + 4 = 30, or 4w 2d
     dtd2.Set(4, wxDateTime::Aug, 1999);
-    CPPUNIT_ASSERT_EQUAL( wxDateSpan(1, 1, 4, 2), dtd2.DiffAsDateSpan(dtd1) );
+    CHECK( dtd2.DiffAsDateSpan(dtd1) == wxDateSpan(1, 1, 4, 2) );
 
     // Year and day after, month earlier, so no full year, but same day diff as
     // first example
     dtd2.Set(6, wxDateTime::May, 1999);
-    CPPUNIT_ASSERT_EQUAL( wxDateSpan(0, 11, 0, 1), dtd2.DiffAsDateSpan(dtd1) );
+    CHECK( dtd2.DiffAsDateSpan(dtd1) == wxDateSpan(0, 11, 0, 1) );
 
     // Year after, month and day earlier, so no full month and no full year
     // April has 30 days, so it's 30 - 5 + 4 = 29, or 4w 1d
     dtd2.Set(4, wxDateTime::May, 1999);
-    CPPUNIT_ASSERT_EQUAL( wxDateSpan(0, 10, 4, 1), dtd2.DiffAsDateSpan(dtd1) );
+    CHECK( dtd2.DiffAsDateSpan(dtd1) == wxDateSpan(0, 10, 4, 1) );
 
     // And a reverse. Now we should use days in Jun (again 30 => 4w 1d)
-    CPPUNIT_ASSERT_EQUAL( wxDateSpan(0, -10, -4, -1), dtd1.DiffAsDateSpan(dtd2) );
+    CHECK( dtd1.DiffAsDateSpan(dtd2) == wxDateSpan(0, -10, -4, -1) );
 
     const wxTimeSpan ts1 = wxTimeSpan::Seconds(30);
     const wxTimeSpan ts2 = wxTimeSpan::Seconds(5);
-    CPPUNIT_ASSERT_EQUAL( wxTimeSpan::Seconds(25), ts1 - ts2 );
+    CHECK( ts1 - ts2  == wxTimeSpan::Seconds(25) );
 }
 
-void DateTimeTestCase::TestDSTBug()
+TEST_CASE("wxDateTime::DSTBug", "[datetime]")
 {
     /////////////////////////
     // Test GetEndDST()
     wxDateTime dt = wxDateTime::GetEndDST(2004, wxDateTime::France);
-    CPPUNIT_ASSERT_EQUAL(31, (int)dt.GetDay());
-    CPPUNIT_ASSERT_EQUAL(wxDateTime::Oct, dt.GetMonth());
-    CPPUNIT_ASSERT_EQUAL(2004, (int)dt.GetYear());
-    CPPUNIT_ASSERT_EQUAL(1, (int)dt.GetHour());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetMinute());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetSecond());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetMillisecond());
+    CHECK( (int)dt.GetDay() == 31 );
+    CHECK( dt.GetMonth() == wxDateTime::Oct );
+    CHECK( (int)dt.GetYear() == 2004 );
+    CHECK( (int)dt.GetHour() == 1 );
+    CHECK( (int)dt.GetMinute() == 0 );
+    CHECK( (int)dt.GetSecond() == 0 );
+    CHECK( (int)dt.GetMillisecond() == 0 );
 
     /////////////////////////
     // Test ResetTime()
     dt.SetHour(5);
-    CPPUNIT_ASSERT_EQUAL(5, (int)dt.GetHour());
+    CHECK( (int)dt.GetHour() == 5 );
     dt.ResetTime();
-    CPPUNIT_ASSERT_EQUAL(31, (int)dt.GetDay());
-    CPPUNIT_ASSERT_EQUAL(wxDateTime::Oct, dt.GetMonth());
-    CPPUNIT_ASSERT_EQUAL(2004, (int)dt.GetYear());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetHour());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetMinute());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetSecond());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetMillisecond());
+    CHECK( (int)dt.GetDay() == 31 );
+    CHECK( dt.GetMonth() == wxDateTime::Oct );
+    CHECK( (int)dt.GetYear() == 2004 );
+    CHECK( (int)dt.GetHour() == 0 );
+    CHECK( (int)dt.GetMinute() == 0 );
+    CHECK( (int)dt.GetSecond() == 0 );
+    CHECK( (int)dt.GetMillisecond() == 0 );
 
     dt.Set(1, 0, 0, 0);
-    CPPUNIT_ASSERT_EQUAL(1, (int)dt.GetHour());
+    CHECK( (int)dt.GetHour() == 1 );
 
     /////////////////////////
     // Test Today()
@@ -1795,13 +1734,13 @@ void DateTimeTestCase::TestDSTBug()
         dt = wxDateTime::Today();
     }
 
-    CPPUNIT_ASSERT_EQUAL(31, (int)dt.GetDay());
-    CPPUNIT_ASSERT_EQUAL(wxDateTime::Oct, dt.GetMonth());
-    CPPUNIT_ASSERT_EQUAL(2004, (int)dt.GetYear());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetHour());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetMinute());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetSecond());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetMillisecond());
+    CHECK( (int)dt.GetDay() == 31 );
+    CHECK( dt.GetMonth() == wxDateTime::Oct );
+    CHECK( (int)dt.GetYear() == 2004 );
+    CHECK( (int)dt.GetHour() == 0 );
+    CHECK( (int)dt.GetMinute() == 0 );
+    CHECK( (int)dt.GetSecond() == 0 );
+    CHECK( (int)dt.GetMillisecond() == 0 );
 
     /////////////////////////
     // Test Set(hour, minute, second, milli)
@@ -1812,21 +1751,21 @@ void DateTimeTestCase::TestDSTBug()
         dt2.Set(5, 30, 0, 0);
     }
 
-    CPPUNIT_ASSERT_EQUAL(31, (int)dt.GetDay());
-    CPPUNIT_ASSERT_EQUAL(wxDateTime::Oct, dt.GetMonth());
-    CPPUNIT_ASSERT_EQUAL(2004, (int)dt.GetYear());
-    CPPUNIT_ASSERT_EQUAL(1, (int)dt.GetHour());
-    CPPUNIT_ASSERT_EQUAL(30, (int)dt.GetMinute());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetSecond());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt.GetMillisecond());
+    CHECK( (int)dt.GetDay() == 31 );
+    CHECK( dt.GetMonth() == wxDateTime::Oct );
+    CHECK( (int)dt.GetYear() == 2004 );
+    CHECK( (int)dt.GetHour() == 1 );
+    CHECK( (int)dt.GetMinute() == 30 );
+    CHECK( (int)dt.GetSecond() == 0 );
+    CHECK( (int)dt.GetMillisecond() == 0 );
 
-    CPPUNIT_ASSERT_EQUAL(31, (int)dt2.GetDay());
-    CPPUNIT_ASSERT_EQUAL(wxDateTime::Oct, dt2.GetMonth());
-    CPPUNIT_ASSERT_EQUAL(2004, (int)dt2.GetYear());
-    CPPUNIT_ASSERT_EQUAL(5, (int)dt2.GetHour());
-    CPPUNIT_ASSERT_EQUAL(30, (int)dt2.GetMinute());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt2.GetSecond());
-    CPPUNIT_ASSERT_EQUAL(0, (int)dt2.GetMillisecond());
+    CHECK( (int)dt2.GetDay() == 31 );
+    CHECK( dt2.GetMonth() == wxDateTime::Oct );
+    CHECK( (int)dt2.GetYear() == 2004 );
+    CHECK( (int)dt2.GetHour() == 5 );
+    CHECK( (int)dt2.GetMinute() == 30 );
+    CHECK( (int)dt2.GetSecond() == 0 );
+    CHECK( (int)dt2.GetMillisecond() == 0 );
 #endif // CHANGE_SYSTEM_DATE
 
     // Verify that setting the date to the beginning of the DST period moves it
@@ -1836,30 +1775,30 @@ void DateTimeTestCase::TestDSTBug()
     // either unchanged or moved forward.
     wxDateTime dtDST(10, wxDateTime::Mar, 2013, 2, 0, 0);
     if ( dtDST.GetHour() != 2 )
-        CPPUNIT_ASSERT_EQUAL( 3, dtDST.GetHour() );
+        CHECK( dtDST.GetHour() == 3 );
 
     dtDST = wxDateTime(31, wxDateTime::Mar, 2013, 2, 0, 0);
     if ( dtDST.GetHour() != 2 )
-        CPPUNIT_ASSERT_EQUAL( 3, dtDST.GetHour() );
+        CHECK( dtDST.GetHour() == 3 );
 }
 
-void DateTimeTestCase::TestDateOnly()
+TEST_CASE("wxDateTime::DateOnly", "[datetime]")
 {
     wxDateTime dt(19, wxDateTime::Jan, 2007, 15, 01, 00);
 
     static const wxDateTime::wxDateTime_t DATE_ZERO = 0;
-    CPPUNIT_ASSERT_EQUAL( DATE_ZERO, dt.GetDateOnly().GetHour() );
-    CPPUNIT_ASSERT_EQUAL( DATE_ZERO, dt.GetDateOnly().GetMinute() );
-    CPPUNIT_ASSERT_EQUAL( DATE_ZERO, dt.GetDateOnly().GetSecond() );
-    CPPUNIT_ASSERT_EQUAL( DATE_ZERO, dt.GetDateOnly().GetMillisecond() );
+    CHECK( dt.GetDateOnly().GetHour() == DATE_ZERO );
+    CHECK( dt.GetDateOnly().GetMinute() == DATE_ZERO );
+    CHECK( dt.GetDateOnly().GetSecond() == DATE_ZERO );
+    CHECK( dt.GetDateOnly().GetMillisecond() == DATE_ZERO );
 
     dt.ResetTime();
-    CPPUNIT_ASSERT_EQUAL( wxDateTime(19, wxDateTime::Jan, 2007), dt );
+    CHECK( dt == wxDateTime(19, wxDateTime::Jan, 2007) );
 
-    CPPUNIT_ASSERT_EQUAL( wxDateTime::Today(), wxDateTime::Now().GetDateOnly() );
+    CHECK( wxDateTime::Now().GetDateOnly() == wxDateTime::Today() );
 }
 
-void DateTimeTestCase::TestTranslateFromUnicodeFormat()
+TEST_CASE("wxDateTime::TranslateFromUnicodeFormat", "[datetime]")
 {
 #if defined(__WINDOWS__) || defined(__WXOSX__)
     // This function is defined in src/common/intl.cpp and as it is not public we
@@ -1870,34 +1809,38 @@ void DateTimeTestCase::TestTranslateFromUnicodeFormat()
 
     // Test single quote handling...
 
-    CPPUNIT_ASSERT_EQUAL("",   wxTranslateFromUnicodeFormat("'"));
-    CPPUNIT_ASSERT_EQUAL("%H", wxTranslateFromUnicodeFormat("H'"));
-    CPPUNIT_ASSERT_EQUAL("H",  wxTranslateFromUnicodeFormat("'H"));
+    CHECK(   wxTranslateFromUnicodeFormat("'") == "" );
+    CHECK( wxTranslateFromUnicodeFormat("H'") == "%H" );
+    CHECK(  wxTranslateFromUnicodeFormat("'H") == "H" );
 
-    CPPUNIT_ASSERT_EQUAL("'",   wxTranslateFromUnicodeFormat("''"));
-    CPPUNIT_ASSERT_EQUAL("%H'", wxTranslateFromUnicodeFormat("H''"));
-    CPPUNIT_ASSERT_EQUAL("H",   wxTranslateFromUnicodeFormat("'H'"));
-    CPPUNIT_ASSERT_EQUAL("'%H", wxTranslateFromUnicodeFormat("''H"));
+    CHECK(   wxTranslateFromUnicodeFormat("''") == "'" );
+    CHECK( wxTranslateFromUnicodeFormat("H''") == "%H'" );
+    CHECK(   wxTranslateFromUnicodeFormat("'H'") == "H" );
+    CHECK( wxTranslateFromUnicodeFormat("''H") == "'%H" );
 
-    CPPUNIT_ASSERT_EQUAL("'",   wxTranslateFromUnicodeFormat("'''"));
-    CPPUNIT_ASSERT_EQUAL("%H'", wxTranslateFromUnicodeFormat("H'''"));
-    CPPUNIT_ASSERT_EQUAL("H'",  wxTranslateFromUnicodeFormat("'H''"));
-    CPPUNIT_ASSERT_EQUAL("'%H", wxTranslateFromUnicodeFormat("''H'"));
-    CPPUNIT_ASSERT_EQUAL("'H",  wxTranslateFromUnicodeFormat("'''H"));
+    CHECK(   wxTranslateFromUnicodeFormat("'''") == "'" );
+    CHECK( wxTranslateFromUnicodeFormat("H'''") == "%H'" );
+    CHECK(  wxTranslateFromUnicodeFormat("'H''") == "H'" );
+    CHECK( wxTranslateFromUnicodeFormat("''H'") == "'%H" );
+    CHECK(  wxTranslateFromUnicodeFormat("'''H") == "'H" );
 
-    CPPUNIT_ASSERT_EQUAL("''",   wxTranslateFromUnicodeFormat("''''"));
-    CPPUNIT_ASSERT_EQUAL("%H''", wxTranslateFromUnicodeFormat("H''''"));
-    CPPUNIT_ASSERT_EQUAL("H'",   wxTranslateFromUnicodeFormat("'H'''"));
-    CPPUNIT_ASSERT_EQUAL("'%H'", wxTranslateFromUnicodeFormat("''H''"));
-    CPPUNIT_ASSERT_EQUAL("'H",   wxTranslateFromUnicodeFormat("'''H'"));
-    CPPUNIT_ASSERT_EQUAL("''%H", wxTranslateFromUnicodeFormat("''''H"));
+    CHECK(   wxTranslateFromUnicodeFormat("''''") == "''" );
+    CHECK( wxTranslateFromUnicodeFormat("H''''") == "%H''" );
+    CHECK(   wxTranslateFromUnicodeFormat("'H'''") == "H'" );
+    CHECK( wxTranslateFromUnicodeFormat("''H''") == "'%H'" );
+    CHECK(   wxTranslateFromUnicodeFormat("'''H'") == "'H" );
+    CHECK( wxTranslateFromUnicodeFormat("''''H") == "''%H" );
 
-    CPPUNIT_ASSERT_EQUAL("'%H o'clock: It's about time'",
-        wxTranslateFromUnicodeFormat("''H 'o''clock: It''s about time'''"));
+    CHECK
+    (
+        wxTranslateFromUnicodeFormat("''H 'o''clock: It''s about time'''")
+        ==
+        "'%H o'clock: It's about time'"
+    );
 #endif // ports having wxTranslateFromUnicodeFormat()
 }
 
-void DateTimeTestCase::TestConvToFromLocalTZ()
+TEST_CASE("wxDateTime::ConvToFromLocalTZ", "[datetime]")
 {
     // Choose a date when the DST is on in many time zones and verify that
     // converting from/to local time zone still doesn't modify time in this

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -804,55 +804,68 @@ TEST_CASE("wxDateTime::ParseFormat", "[datetime]")
 #if 0
     // special case which was known to fail
     CHECK( dt.ParseFormat("02/06/1856", "%x") );
-    CHECK( dt.GetYear()  == 1856 );
+    CHECK( dt.GetYear() == 1856 );
 #endif
 
-    // also test %l separately
-    CHECK( dt.ParseFormat("12:23:45.678", "%H:%M:%S.%l") );
-    CHECK( dt.GetMillisecond()  == 678 );
+    SECTION("%l")
+    {
+        REQUIRE( dt.ParseFormat("12:23:45.678", "%H:%M:%S.%l") );
+        CHECK( dt.GetMillisecond() == 678 );
 
-    // test special case of %l matching 0 milliseconds
-    CHECK( dt.ParseFormat("12:23:45.000", "%H:%M:%S.%l") );
-    CHECK( dt.GetMillisecond()  == 0 );
+        // test special case of %l matching 0 milliseconds
+        REQUIRE( dt.ParseFormat("12:23:45.000", "%H:%M:%S.%l") );
+        CHECK( dt.GetMillisecond() == 0 );
+    }
 
-    // test another format modifier not tested above.
-    CHECK( dt.ParseFormat("23", "%e") );
-    CHECK( dt.GetDay()  == 23 );
+    SECTION("%e")
+    {
+        REQUIRE( dt.ParseFormat("23", "%e") );
+        CHECK( dt.GetDay() == 23 );
+    }
 
     // test partially specified dates too
-    wxDateTime dtDef(26, wxDateTime::Sep, 2008);
-    CHECK( dt.ParseFormat("17", "%d", dtDef) );
-    CHECK( dt.GetDay()  == 17 );
-    CHECK( dt.GetMonth()  == wxDateTime::Sep );
-    CHECK( dt.GetYear()  == 2008 );
+    SECTION("partial")
+    {
+        wxDateTime dtDef(26, wxDateTime::Sep, 2008);
+        REQUIRE( dt.ParseFormat("17", "%d", dtDef) );
+        CHECK( dt.GetDay() == 17 );
+        CHECK( dt.GetMonth() == wxDateTime::Sep );
+        CHECK( dt.GetYear() == 2008 );
+    }
 
     // test some degenerate cases
-    CHECK( !dt.ParseFormat("", "%z") );
-    CHECK( !dt.ParseFormat("", "%%") );
+    SECTION("special")
+    {
+        CHECK( !dt.ParseFormat("", "%z") );
+        CHECK( !dt.ParseFormat("", "%%") );
+    }
 
     // test compilation of some calls which should compile (and not result in
     // ambiguity because of char*<->wxCStrData<->wxString conversions)
-    wxString s("foo");
-    CHECK( !dt.ParseFormat("foo") );
-    CHECK( !dt.ParseFormat(wxT("foo")) );
-    CHECK( !dt.ParseFormat(s) );
-    dt.ParseFormat(s.c_str()); // Simply test compilation of this one.
+    SECTION("compile")
+    {
+        wxString s("foo");
+        CHECK( !dt.ParseFormat("foo") );
+        CHECK( !dt.ParseFormat(wxT("foo")) );
+        CHECK( !dt.ParseFormat(s) );
+        dt.ParseFormat(s.c_str()); // Simply test compilation of this one.
 
-    CHECK( !dt.ParseFormat("foo", "%c") );
-    CHECK( !dt.ParseFormat(wxT("foo"), "%c") );
-    CHECK( !dt.ParseFormat(s, "%c") );
-    dt.ParseFormat(s.c_str(), "%c");
+        CHECK( !dt.ParseFormat("foo", "%c") );
+        CHECK( !dt.ParseFormat(wxT("foo"), "%c") );
+        CHECK( !dt.ParseFormat(s, "%c") );
+        dt.ParseFormat(s.c_str(), "%c");
 
-    CHECK( !dt.ParseFormat("foo", wxT("%c")) );
-    CHECK( !dt.ParseFormat(wxT("foo"), wxT("%c")) );
-    CHECK( !dt.ParseFormat(s, "%c") );
-    dt.ParseFormat(s.c_str(), wxT("%c"));
+        CHECK( !dt.ParseFormat("foo", wxT("%c")) );
+        CHECK( !dt.ParseFormat(wxT("foo"), wxT("%c")) );
+        CHECK( !dt.ParseFormat(s, "%c") );
+        dt.ParseFormat(s.c_str(), wxT("%c"));
 
-    wxString spec("%c");
-    CHECK( !dt.ParseFormat("foo", spec) );
-    CHECK( !dt.ParseFormat(wxT("foo"), spec) );
-    CHECK( !dt.ParseFormat(s, spec) );
-    dt.ParseFormat(s.c_str(), spec);
+        wxString spec("%c");
+        CHECK( !dt.ParseFormat("foo", spec) );
+        CHECK( !dt.ParseFormat(wxT("foo"), spec) );
+        CHECK( !dt.ParseFormat(s, spec) );
+        dt.ParseFormat(s.c_str(), spec);
+    }
 }
 
 // Test parsing time in free format.

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -823,6 +823,20 @@ TEST_CASE("wxDateTime::ParseFormat", "[datetime]")
         CHECK( dt.GetDay() == 23 );
     }
 
+    SECTION("%-")
+    {
+        REQUIRE( dt.ParseFormat("17.5.2024", "%-d.%-m.%Y") );
+        CHECK( dt.GetDay() == 17 );
+        CHECK( dt.GetMonth() == wxDateTime::May );
+        CHECK( dt.GetYear() == 2024 );
+
+        REQUIRE( dt.ParseFormat("8.5.2024", "%-d.%-m.%Y") );
+        CHECK( dt.GetDay() == 8 );
+
+        REQUIRE( dt.ParseFormat("11.11.2024", "%-d.%-m.%Y") );
+        CHECK( dt.GetMonth() == wxDateTime::Nov );
+    }
+
     // test partially specified dates too
     SECTION("partial")
     {


### PR DESCRIPTION
This addresses #24533 and does some small extra cleanup.

Note that this doesn't add support for `%E*` and `%O*` as this is much more involved, as described there.