### PR TITLE
Add wxXmlResource::XRCIDCount() to determine the number of known XRCIDs

### DIFF
--- a/include/wx/xrc/xmlres.h
+++ b/include/wx/xrc/xmlres.h
@@ -269,6 +269,9 @@ public:
     // it checks all the IDs used in XRC.
     static wxString FindXRCIDById(int numId);
 
+    // Determine the total number of ID's that are present in the XML
+    // resource.
+    static int XRCIDCount();
 
     // Returns version information (a.b.c.d = d+ 256*c + 256^2*b + 256^3*a).
     long GetVersion() const { return m_version; }

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -3156,17 +3156,21 @@ void AddStdXRCID_Records()
 #undef stdID
 }
 
-} // anonymous namespace
-
-
-/*static*/
-int wxXmlResource::DoGetXRCID(const char *str_id, int value_if_not_found)
+static void CheckAddStdXRCID_Records()
 {
-    if ( !gs_stdIDsAdded )
+    if (!gs_stdIDsAdded)
     {
         gs_stdIDsAdded = true;
         AddStdXRCID_Records();
     }
+}
+
+} // anonymous namespace
+
+/*static*/
+int wxXmlResource::DoGetXRCID(const char *str_id, int value_if_not_found)
+{
+    CheckAddStdXRCID_Records();
 
     return XRCID_Lookup(str_id, value_if_not_found);
 }
@@ -3184,6 +3188,24 @@ wxString wxXmlResource::FindXRCIDById(int numId)
     }
 
     return wxString();
+}
+
+/* static */
+int wxXmlResource::XRCIDCount()
+{
+    int count = 0;
+
+    CheckAddStdXRCID_Records();
+
+    for (int i = 0; i < XRCID_TABLE_SIZE; i++)
+    {
+        for (XRCID_record* rec = XRCID_Records[i]; rec; rec = rec->next)
+        {
+            ++count;
+        }
+    }
+
+    return count;
 }
 
 static void CleanXRCID_Record(XRCID_record *rec)

--- a/tests/xml/xrctest.cpp
+++ b/tests/xml/xrctest.cpp
@@ -212,6 +212,52 @@ TEST_CASE_METHOD(XrcTestCase, "XRC::IDRanges", "[xrc]")
     }
 }
 
+TEST_CASE_METHOD(XrcTestCase, "XRC::XRCIDCount", "[xrc]")
+{
+    int initialXRCIDs = wxXmlResource::Get()->XRCIDCount();
+    // By default the standard ID's are already loaded
+    CHECK( initialXRCIDs > 0 );
+
+    // Adding a few standard ID's, which should already
+    // be available by default.
+    XRCID("wxID_OK");
+    XRCID("wxID_CANCEL");
+    XRCID("wxID_APPLY");
+    XRCID("wxID_YES");
+    XRCID("wxID_NO");
+    // The number of ID should still be the same
+    CHECK( wxXmlResource::Get()->XRCIDCount() == initialXRCIDs );
+
+    // Add 4 new XRCIDs
+    XRCID("testAdditionalXRCID_1");
+    XRCID("testAdditionalXRCID_2");
+    XRCID("testAdditionalXRCID_3");
+    XRCID("testAdditionalXRCID_4");
+    // The count should be 4 higher
+    CHECK( wxXmlResource::Get()->XRCIDCount() == initialXRCIDs + 4 );
+
+    // Adding the same XRCID again should not increment the count
+    XRCID("testAdditionalXRCID_1");
+    // The count should be 4 higher
+    CHECK( wxXmlResource::Get()->XRCIDCount() == initialXRCIDs + 4 );
+
+    // Spaces in front are creating a new unique ID
+    XRCID("     testAdditionalXRCID_1");
+    // The count should now be 5 higher
+    CHECK( wxXmlResource::Get()->XRCIDCount() == initialXRCIDs + 5 );
+
+    // Spaces at the end are creating a new unique ID
+    XRCID("testAdditionalXRCID_1       ");
+    // The count should now be 6 higher
+    CHECK( wxXmlResource::Get()->XRCIDCount() == initialXRCIDs + 6 );
+
+    // A very long XRCID name, should still be added
+    XRCID("testAdditionalXRCID_WithAVeryLongIdentifier_ToTestIfXRCIDsWithLongIdentifiersAreAllowed_AndCanBeAddedWithoutProblems");
+    // The count should now be 7 higher
+    CHECK(wxXmlResource::Get()->XRCIDCount() == initialXRCIDs + 7);
+
+}
+
 TEST_CASE("XRC::PathWithFragment", "[xrc][uri]")
 {
     wxXmlResource::Get()->AddHandler(new wxBitmapXmlHandler);


### PR DESCRIPTION
Added the helper function `XRCIDCount()` to `wxXmlResource` to determine the number of XRCID that are present in the XRC XML Resource. 
This can be helpful to detemine and investigate the number of XRCID in the internal cache. Also tests are added to check the implementation, and other tests that are now possible to verify the internal behaviour of the XRCID functions.
   