### PR TITLE
Fix incorrect documention for wxString::Clear()

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1502,7 +1502,7 @@ public:
   wxString& Truncate(size_t uiLen);
     // empty string contents
   void Empty() { clear(); }
-    // empty the string and free memory
+    // empty string contents
   void Clear() { clear(); }
 
   // contents test

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -1541,7 +1541,7 @@ public:
         wxStringBuffer and wxStringBufferLength classes may be very useful when working
         with some external API which requires the caller to provide a writable buffer.
 
-        See also the reserve(), resize() and shrink_to_fit() STL-like functions.
+        See also the `reserve()`, `resize()` and `shrink_to_fit()` STL-like functions.
     */
     ///@{
 
@@ -1610,7 +1610,9 @@ public:
     wxString Clone() const;
 
     /**
-        Empties the string and frees memory occupied by it.
+        Clears the string's content, setting its length to zero.
+        To request freeing its memory, call Shrink() or
+        `shrink_to_fit()` afterwards.
 
         @see Empty()
     */
@@ -1635,9 +1637,7 @@ public:
     bool Contains(const wxString& str) const;
 
     /**
-        Makes the string empty, but doesn't free memory occupied by the string.
-
-        @see Clear().
+        This is a synonym for Clear().
     */
     void Empty();
 


### PR DESCRIPTION
The docs say that `wxString::Clear()` frees the string's memory, but that is not correct. It calls the stanards `clear()` function which only sets the string's size to zero.

I added an explanation for needing to call `Shrink()` or `shrink_to_fit()` to actually (request to) shrink the string's capacity.