### PR TITLE
wxrc: `GetInternalFileName`: Call to `Printf`: Format string arg is now constant.

### DIFF
--- a/utils/wxrc/wxrc.cpp
+++ b/utils/wxrc/wxrc.cpp
@@ -354,13 +354,14 @@ wxString XmlResApp::GetInternalFileName(const wxString& name, const wxArrayStrin
     name2.Replace(wxT("*"), wxT("_"));
     name2.Replace(wxT("?"), wxT("_"));
 
-    wxString s = wxFileNameFromPath(parOutput) + wxT("$") + name2;
+    const wxString parOutput_fileName{wxFileNameFromPath(parOutput)};
+    wxString s{wxString::Format(wxT("%s$%s"), parOutput_fileName, name2)};
 
     if (wxFileExists(s) && flist.Index(s) == wxNOT_FOUND)
     {
         for (int i = 0;; i++)
         {
-            s.Printf(wxFileNameFromPath(parOutput) + wxT("$%03i-") + name2, i);
+            s.Printf(wxT("%s$%03i-%s"), parOutput_fileName, i, name2);
             if (!wxFileExists(s) || flist.Index(s) != wxNOT_FOUND)
                 break;
         }


### PR DESCRIPTION
In the original code:

```
s.Printf(wxFileNameFromPath(parOutput) + wxT("$%03i-") + name2, i);
```

if `wxFileNameFromPath(parOutput2)` or `name2` had contained `'%'` (format specifiers), the results would have been bad.

These strings are now given as additional arguments to `Printf` (corresponding to `"%s"` format specifiers),
and the format string argument itself is now constant.

This is a replacement of https://github.com/wxWidgets/wxWidgets/commit/9a5d32db95adc191b24fd39217838f6b7f2c091e as per https://github.com/wxWidgets/wxWidgets/pull/24437#issuecomment-2077394039.