### PR TITLE
Add __WXFUNCTION_SIG__ macro

### DIFF
--- a/include/wx/cpp.h
+++ b/include/wx/cpp.h
@@ -115,7 +115,7 @@
 #endif /* __WXFUNCTION__ already defined */
 
 /*
-    Display the current function's full signature, if available.
+    Expands to the current function's full signature, if available.
 
     Falls back to the function name (i.e., __func__) if not available.
  */

--- a/include/wx/cpp.h
+++ b/include/wx/cpp.h
@@ -123,7 +123,7 @@
     #if __cplusplus >= 202002L
         #include <source_location>
         // actually displays the signature, not just the name
-        #define __WXFUNCTION_SIG__ std::source_location::current().function_name() 
+        #define __WXFUNCTION_SIG__ std::source_location::current().function_name()
     #elif __VISUALC__
         #define __WXFUNCTION_SIG__ __FUNCSIG__
     #elif defined(__clang__)

--- a/include/wx/cpp.h
+++ b/include/wx/cpp.h
@@ -114,6 +114,26 @@
     #define __WXFUNCTION__ __func__
 #endif /* __WXFUNCTION__ already defined */
 
+/*
+    Display the current function's full signature, if available.
+
+    Falls back to the function name (i.e., __func__) if not available.
+ */
+#ifndef __WXFUNCTION_SIG__
+    #if __cplusplus >= 202002L
+        #include <source_location>
+        // actually displays the signature, not just the name
+        #define __WXFUNCTION_SIG__ std::source_location::current().function_name() 
+    #elif __VISUALC__
+        #define __WXFUNCTION_SIG__ __FUNCSIG__
+    #elif defined(__clang__)
+        __WXFUNCTION_SIG__ __func__
+    #elif defined(__GNUG__)
+        #define __WXFUNCTION_SIG__ __PRETTY_FUNCTION__
+    #else
+        #define __WXFUNCTION_SIG__ __func__
+    #endif
+#endif /* __WXFUNCTION_SIG__ already defined */
 
 /*
    wxCALL_FOR_EACH(what, ...) calls the macro from its first argument, what(pos, x),

--- a/include/wx/cpp.h
+++ b/include/wx/cpp.h
@@ -124,7 +124,7 @@
         #include <source_location>
         // actually displays the signature, not just the name
         #define __WXFUNCTION_SIG__ std::source_location::current().function_name()
-    #elif __VISUALC__
+    #elif defined(__VISUALC__)
         #define __WXFUNCTION_SIG__ __FUNCSIG__
     #elif defined(__clang__)
         __WXFUNCTION_SIG__ __func__

--- a/include/wx/cpp.h
+++ b/include/wx/cpp.h
@@ -127,7 +127,7 @@
     #elif defined(__VISUALC__)
         #define __WXFUNCTION_SIG__ __FUNCSIG__
     #elif defined(__clang__)
-        __WXFUNCTION_SIG__ __func__
+        #define __WXFUNCTION_SIG__ __func__
     #elif defined(__GNUG__)
         #define __WXFUNCTION_SIG__ __PRETTY_FUNCTION__
     #else

--- a/include/wx/cpp.h
+++ b/include/wx/cpp.h
@@ -126,8 +126,6 @@
         #define __WXFUNCTION_SIG__ std::source_location::current().function_name()
     #elif defined(__VISUALC__)
         #define __WXFUNCTION_SIG__ __FUNCSIG__
-    #elif defined(__clang__)
-        #define __WXFUNCTION_SIG__ __func__
     #elif defined(__GNUG__)
         #define __WXFUNCTION_SIG__ __PRETTY_FUNCTION__
     #else

--- a/interface/wx/cpp.h
+++ b/interface/wx/cpp.h
@@ -59,7 +59,7 @@
 #define __WXFUNCTION__ __func__
 
 /**
-    Display the current function's full signature, if available.
+    Expands to the current function's full signature, if available.
 
     Falls back to the function name (i.e., @c \__func__) if not available.
 

--- a/interface/wx/cpp.h
+++ b/interface/wx/cpp.h
@@ -64,6 +64,8 @@
     Falls back to the function name (i.e., @c \__func__) if not available.
 
     @header{wx/cpp.h}
+
+    @since 3.3.0
 */
 #define __WXFUNCTION_SIG__
 

--- a/interface/wx/cpp.h
+++ b/interface/wx/cpp.h
@@ -52,9 +52,20 @@
 
     Please use the standard macro instead.
 
+    @see __WXFUNCTION_SIG__
+
     @header{wx/cpp.h}
 */
 #define __WXFUNCTION__ __func__
+
+/**
+    Display the current function's full signature, if available.
+
+    Falls back to the function name (i.e., @c \__func__) if not available.
+
+    @header{wx/cpp.h}
+*/
+#define __WXFUNCTION_SIG__
 
 ///@}
 

--- a/interface/wx/cpp.h
+++ b/interface/wx/cpp.h
@@ -63,6 +63,16 @@
 
     Falls back to the function name (i.e., @c \__func__) if not available.
 
+    As an example, if you have a class named `Calculator` with a
+    `double Add(double, double) const` member function,
+    `__WXFUNCTION_SIG__` may expand to the following:
+
+    `double Calculator::Add(double, double) const`
+
+    While `__func__` will simply expand to:
+
+    `Add`
+
     @header{wx/cpp.h}
 
     @since 3.3.0


### PR DESCRIPTION
If compiling as C++20 or using GCC/clang or MSVC, expands to function signature. Falls back to the function name (using `__func__`) otherwise.

The rationale behind this is that `__func__` can yield names such as `operator()`, which (IMO) is not all that useful. This macro can be much more informative.