### PR TITLE
Do not scale the size of bitmap in wxMSW Create(size, dc) overload

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -92,6 +92,10 @@ Changes in behaviour not resulting in compilation errors
   made is behaviour there incompatible with the other platforms. Please call
   wxWebRequest::EnablePersistentStorage() explicitly if you need it.
 
+- In wxMSW, behaviour of wxBitmap::Create(size, dc) overload has changed to
+  not scale the size by the content scale factor of the DC any longer, as the
+  size here is expressed in physical pixels and not in DIPs.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -751,12 +751,10 @@ bool wxBitmap::Create(int width, int height, const wxDC& dc)
 {
     wxCHECK_MSG( dc.IsOk(), false, wxT("invalid HDC in wxBitmap::Create()") );
 
-    const double scale = dc.GetContentScaleFactor();
-
-    if ( !DoCreate(wxRound(width*scale), wxRound(height*scale), -1, dc.GetHDC()) )
+    if ( !DoCreate(width, height, -1, dc.GetHDC()) )
         return false;
 
-    GetBitmapData()->m_scaleFactor = scale;
+    GetBitmapData()->m_scaleFactor = dc.GetContentScaleFactor();
 
     return true;
 }

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -1839,7 +1839,11 @@ TEST_CASE("Bitmap::ScaleFactor", "[bitmap][dc][scale]")
     // A bitmap "compatible" with this DC should also use the same scale factor.
     wxBitmap bmp2(4, 4, dc);
     CHECK( bmp2.GetScaleFactor() == 2 );
+#ifdef wxHAS_DPI_INDEPENDENT_PIXELS
     CHECK( bmp2.GetSize() == wxSize(8, 8) );
+#else
+    CHECK( bmp2.GetSize() == wxSize(4, 4) );
+#endif
 
     // A compatible bitmap created from wxImage and this DC should also inherit
     // the same scale factor, but its size should be still the same as that of


### PR DESCRIPTION
The size passed to Create() should be interpreted in the same way as the size passed to CreateWithLogicalSize() and in wxMSW this means that it should _not_ be scaled.

This makes the size of the bitmap returned by this function overload consistent with wxDC::GetSize(), so it looks like the right thing to do, even if it's a backwards-incompatible change.

----

Please correct me if I'm wrong, but it seems that we have a mistake here, as the size passed to `Create()` is supposed to be in logical == physical (under MSW) pixels and not in DIPs, but this function behaved like `CreateWithDIPSize()` rather than `CreateWithLogicalSize()` as, IMO, it should do. But I know that I've already made several similar mistakes in the past, so please check that I'm not making one again here. TIA!