### PR TITLE
Use bilinear quality when downscaling in wxBitmapHelpers::Rescale.

### DIFF
--- a/src/common/bmpbase.cpp
+++ b/src/common/bmpbase.cpp
@@ -79,7 +79,14 @@ void wxBitmapHelpers::Rescale(wxBitmap& bmp, const wxSize& sizeNeeded)
     // the icons for which this function is often used. It's also consistent
     // with what wxDC::DrawBitmap() does, i.e. the fallback method below.
     wxImage img = bmp.ConvertToImage();
-    img.Rescale(sizeNeeded.x, sizeNeeded.y, wxIMAGE_QUALITY_NEAREST);
+    wxImageResizeQuality quality = wxIMAGE_QUALITY_NEAREST;
+
+    // If we're downscaling, bilinear interpolation gives best results.
+    if( img.GetWidth() > sizeNeeded.x && img.GetHeight() > sizeNeeded.y )
+        quality = wxIMAGE_QUALITY_BILINEAR;
+
+    img.Rescale(sizeNeeded.x, sizeNeeded.y, quality);
+
     bmp = wxBitmap(img);
 #else // !wxUSE_IMAGE
     // Fallback method of scaling the bitmap


### PR DESCRIPTION
This gives the best quality when downscaling.

See KiCad project manager icons:

Nearest:
![nearest](https://github.com/wxWidgets/wxWidgets/assets/37658952/72502066-0849-41c8-9296-3e2fd1e2deb4)

Bilinear:
![bilinear](https://github.com/wxWidgets/wxWidgets/assets/37658952/b53d94bc-21d0-4444-800b-d4dfaeaa54fe)

Bicubic:
![bicubic](https://github.com/wxWidgets/wxWidgets/assets/37658952/943380ca-3ba1-41e3-b02f-b29819a3ec47)

Box average:
![box](https://github.com/wxWidgets/wxWidgets/assets/37658952/cb32bbcf-d577-4a58-8b1f-2be92bd33740)


