### PR TITLE
BugFix #24568 for partially wrong fix of issue #24528

### DIFF
--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -825,7 +825,7 @@ void WidgetsFrame::OnPageChanged(WidgetsBookCtrlEvent& event)
     bool hasChildren = false;
     for ( const auto child : curPage->GetChildren() )
     {
-        if ( !IsClientAreaChild(child) )
+        if ( curPage->IsClientAreaChild(child) )
         {
             hasChildren = true;
             break;


### PR DESCRIPTION
The previously applied patch uses IsClientAreaChild incorrectly. IsClientAreaChild should be called from the parent and a window has a real child if it is in the client area.