### PR TITLE
Fix __WXFUNCTION_SIG__ under Apple clang 14

### DIFF
--- a/include/wx/cpp.h
+++ b/include/wx/cpp.h
@@ -120,11 +120,7 @@
     Falls back to the function name (i.e., __func__) if not available.
  */
 #ifndef __WXFUNCTION_SIG__
-    #if __cplusplus >= 202002L
-        #include <source_location>
-        // actually displays the signature, not just the name
-        #define __WXFUNCTION_SIG__ std::source_location::current().function_name()
-    #elif defined(__VISUALC__)
+    #if defined(__VISUALC__)
         #define __WXFUNCTION_SIG__ __FUNCSIG__
     #elif defined(__GNUG__)
         #define __WXFUNCTION_SIG__ __PRETTY_FUNCTION__


### PR DESCRIPTION
Don't use C++20 features. Source location feature isn't always available, and `__has_cpp_attribute` is quirky under some compilers and shouldn't be used here (IMO).

Relying on `__FUNC_SIG__` and `__PRETTY_FUNCTION__` covers most compilers anyway (MSVC, GCC, clang, Apple clang, ICC).