### PR TITLE
Replace __FUNCTION__ with __func__, remove __FUNCTION__ warnings from docs

### DIFF
--- a/docs/qt/architecture.md
+++ b/docs/qt/architecture.md
@@ -136,7 +136,7 @@ Generate the 'configure' script in your wxQt root directory with:
 
         void wxSomeClass::SomeMethod()
         {
-            wxMISSING_IMPLEMENTATION( __FUNCTION__ );
+            wxMISSING_IMPLEMENTATION( __func__ );
         }
 
 

--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -423,8 +423,7 @@ public:
     // version does the normal processing (i.e. shows the usual assert failure
     // dialog box)
     //
-    // the arguments are the location of the failed assert (func may be empty
-    // if the compiler doesn't support C99 __FUNCTION__), the text of the
+    // the arguments are the location of the failed assert, the text of the
     // assert itself and the user-specified message
     virtual void OnAssertFailure(const wxChar *file,
                                  int line,

--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -194,8 +194,7 @@ public:
     const char *filename;
     int line;
 
-    // the name of the function where the log record was generated (may be null
-    // if the compiler doesn't support __FUNCTION__)
+    // the name of the function where the log record was generated
     const char *func;
 
     // the name of the component which generated this message, may be null if

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -284,8 +284,7 @@ public:
         @param line
             the line number in this file where the assert occurred
         @param func
-            the name of the function where the assert occurred, may be
-            empty if the compiler doesn't support C99 \__FUNCTION__
+            the name of the function where the assert occurred
         @param cond
             the condition of the failed assert in text form
         @param msg

--- a/interface/wx/debug.h
+++ b/interface/wx/debug.h
@@ -143,7 +143,7 @@ typedef void (*wxAssertHandler_t)(const wxString& file,
     default.
 
     It is mostly useful for asserting inside functions called from macros, as
-    by passing the usual @c \__FILE__, @c \__LINE__ and @c \__FUNCTION__ values to
+    by passing the usual @c \__FILE__, @c \__LINE__ and @c \__func__ values to
     a function, it's possible to pretend that the assert happens at the
     location of the macro in the source code (which can be useful) instead of
     inside the function itself (which is never useful as these values are

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -48,9 +48,6 @@ public:
 
     /**
         The name of the function where the log record was generated.
-
-        This field may be @NULL if the compiler doesn't support @c \__FUNCTION__
-        (but most modern compilers do).
      */
     const char *func;
 

--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -87,7 +87,7 @@ namespace
 
 constexpr const char* TRACE_CEF = "cef";
 
-#define TRACE_CEF_FUNCTION() wxLogTrace(TRACE_CEF, "%s called", __FUNCTION__)
+#define TRACE_CEF_FUNCTION() wxLogTrace(TRACE_CEF, "%s called", __func__)
 
 } // anonymous namespace
 

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -285,7 +285,7 @@ void wxQtDCImpl::SetBackgroundMode(int mode)
 #if wxUSE_PALETTE
 void wxQtDCImpl::SetPalette(const wxPalette& WXUNUSED(palette))
 {
-    wxMISSING_IMPLEMENTATION(__FUNCTION__);
+    wxMISSING_IMPLEMENTATION(__func__);
 }
 #endif // wxUSE_PALETTE
 

--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -577,7 +577,7 @@ void wxNativeFontInfo::SetFamily(wxFontFamily family)
 
 void wxNativeFontInfo::SetEncoding(wxFontEncoding WXUNUSED(encoding))
 {
-    wxMISSING_IMPLEMENTATION( __FUNCTION__ );
+    wxMISSING_IMPLEMENTATION( __func__ );
 }
 
 bool wxNativeFontInfo::FromString(const wxString& s)

--- a/src/qt/glcanvas.cpp
+++ b/src/qt/glcanvas.cpp
@@ -682,7 +682,7 @@ bool wxGLCanvasBase::IsDisplaySupported(const int *attribList)
 
 bool wxGLApp::InitGLVisual(const int *attribList)
 {
-    wxLogError("Missing implementation of " + wxString(__FUNCTION__));
+    wxLogError("Missing implementation of " + wxString(__func__));
     return false;
 }
 


### PR DESCRIPTION
`__func__` is used internally for logging and assert features now, so remove warnings about `__FUNCTION__` being used and returning `nullptr`,