### PR TITLE
 wxQt: switch to QOpenGLWidget for wxGLCanvas.

### DIFF
--- a/include/wx/qt/glcanvas.h
+++ b/include/wx/qt/glcanvas.h
@@ -10,9 +10,9 @@
 
 #include <GL/gl.h>
 
-class QGLWidget;
-class QGLContext;
-class QGLFormat;
+class QOpenGLWidget;
+class QOpenGLContext;
+class QSurfaceFormat;
 
 class WXDLLIMPEXP_GL wxGLContext : public wxGLContextBase
 {
@@ -25,7 +25,7 @@ public:
     virtual bool SetCurrent(const wxGLCanvas& win) const override;
 
 private:
-    QGLContext* m_glContext = nullptr;
+    QOpenGLContext* m_glContext = nullptr;
 
     wxDECLARE_CLASS(wxGLContext);
 };
@@ -83,7 +83,7 @@ public:
 
     virtual bool QtCanPaintWithoutActivePainter() const override;
 
-    static bool ConvertWXAttrsToQtGL(const wxGLAttributes &glattrs, const wxGLContextAttrs ctxAttrs, QGLFormat &format);
+    static bool ConvertWXAttrsToQtGL(const wxGLAttributes &glattrs, const wxGLContextAttrs ctxAttrs, QSurfaceFormat &format);
 
 private:
     wxDECLARE_CLASS(wxGLCanvas);


### PR DESCRIPTION
Switches from QGLWidget to QOpenGLWidget, since the former stopped working on my Manjaro/KDE6/Wayland install (only showing a transparent surface).

Also it was deprecated (and removed in Qt 6).

QOpenGLWidget was introduced in Qt 5.4; I doubt anyone would want to use older Qt versions.

Parts from https://github.com/wxWidgets/wxWidgets/pull/24345
Closes https://github.com/wxWidgets/wxWidgets/issues/24208