### PR TITLE
Cygwin 64 bit build fixes for wx3.0

### DIFF
--- a/include/wx/private/socket.h
+++ b/include/wx/private/socket.h
@@ -66,6 +66,15 @@
     #include <sys/time.h>   // for timeval
 #endif
 
+// 64 bit Cygwin can't use the standard struct timeval because it has long
+// fields, which are supposed to be 32 bits in Win64 API, but long is 64 bits
+// in 64 bit Cygwin, so we need to use its special __ms_timeval instead.
+#if defined(__CYGWIN__) && defined(__LP64__)
+    typedef __ms_timeval wxTimeVal_t;
+#else
+    typedef timeval wxTimeVal_t;
+#endif
+
 // these definitions are for MSW when we don't use configure, otherwise these
 // symbols are defined by configure
 #ifndef WX_SOCKLEN_T
@@ -258,7 +267,7 @@ public:
     // flags defines what kind of conditions we're interested in, the return
     // value is composed of a (possibly empty) subset of the bits set in flags
     wxSocketEventFlags Select(wxSocketEventFlags flags,
-                              const timeval *timeout = NULL);
+                              wxTimeVal_t *timeout = NULL);
 
     // convenient wrapper calling Select() with our default timeout
     wxSocketEventFlags SelectWithTimeout(wxSocketEventFlags flags)
@@ -303,7 +312,7 @@ public:
     bool m_broadcast;
     bool m_dobind;
 
-    struct timeval m_timeout;
+    wxTimeVal_t m_timeout;
 
 protected:
     wxSocketImpl(wxSocketBase& wxsocket);

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -133,7 +133,7 @@ IMPLEMENT_DYNAMIC_CLASS(wxSocketEvent, wxEvent)
 namespace
 {
 
-void SetTimeValFromMS(timeval& tv, unsigned long ms)
+void SetTimeValFromMS(wxTimeVal_t& tv, unsigned long ms)
 {
     tv.tv_sec  = (ms / 1000);
     tv.tv_usec = (ms % 1000) * 1000;
@@ -1290,12 +1290,12 @@ wxSocketBase& wxSocketBase::Discard()
     and it will return a mask indicating which operations can be performed.
  */
 wxSocketEventFlags wxSocketImpl::Select(wxSocketEventFlags flags,
-                                        const timeval *timeout)
+                                        wxTimeVal_t *timeout)
 {
     if ( m_fd == INVALID_SOCKET )
         return (wxSOCKET_LOST_FLAG & flags);
 
-    struct timeval tv;
+    wxTimeVal_t tv;
     if ( timeout )
         tv = *timeout;
     else
@@ -1488,7 +1488,7 @@ wxSocketBase::DoWait(long timeout, wxSocketEventFlags flags)
         else // no event loop or waiting in another thread
         {
             // as explained below, we should always check for wxSOCKET_LOST_FLAG
-            timeval tv;
+            wxTimeVal_t tv;
             SetTimeValFromMS(tv, timeLeft);
             events = m_impl->Select(flags | wxSOCKET_LOST_FLAG, &tv);
         }

--- a/src/msw/sockmsw.cpp
+++ b/src/msw/sockmsw.cpp
@@ -344,7 +344,7 @@ LRESULT CALLBACK wxSocket_Internal_WinProc(HWND hWnd,
                 // only then). Ignore such dummy notifications.
                 {
                     fd_set fds;
-                    timeval tv = { 0, 0 };
+                    wxTimeVal_t tv = { 0, 0 };
 
                     wxFD_ZERO(&fds);
                     wxFD_SET(socket->m_fd, &fds);

--- a/src/msw/volume.cpp
+++ b/src/msw/volume.cpp
@@ -68,7 +68,18 @@ static WNetCloseEnumPtr s_pWNetCloseEnum;
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Globals/Statics
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-static long s_cancelSearch = FALSE;
+
+#if defined(__CYGWIN__) && defined(__LP64__)
+    // We can't use long in 64 bit Cygwin build because Cygwin uses LP64 model
+    // (unlike all the other MSW compilers) and long is 64 bits, while
+    // InterlockedExchange(), with which this variable is used, requires a 32
+    // bit-sized value, so use Cygwin-specific type with the right size.
+    typedef __LONG32 wxInterlockedArg_t;
+#else
+    typedef long wxInterlockedArg_t;
+#endif
+
+static wxInterlockedArg_t s_cancelSearch = FALSE;
 
 struct FileInfo
 {


### PR DESCRIPTION
Two patches from 3.2 branch applied to fix building Cygwin 64 bit in 3.0 branch; the descriptions look okay to me; but, I think they need reviewed.

The local configure command used to test under Cygwin
`export CXXFLAGS="-std=gnu++14" && mkdir -p build-cygwin && cd build-cygwin && ../configure --with-msw --disable-shared --enable-unicode
`

Tim S.