### PR TITLE
wxQt: support modern-style wxFileDialog, wxDirDialog on Windows.

### DIFF
--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -255,6 +255,8 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 </set>
 
 <set var="QT_WIN32_SRC" hints="files">
+    src/msw/dirdlg.cpp
+    src/msw/filedlg.cpp
     src/msw/ole/comimpl.cpp
     src/msw/dialup.cpp
     src/msw/dib.cpp
@@ -267,6 +269,8 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 </set>
 
 <set var="QT_WIN32_HDR" hints="files">
+    wx/msw/dirdlg.h
+    wx/msw/filedlg.h
     wx/msw/dib.h
     wx/msw/ole/automtn.h
     wx/msw/joystick.h

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -178,6 +178,8 @@ set(QT_UNIX_HDR
 )
 
 set(QT_WIN32_SRC
+    src/msw/dirdlg.cpp
+    src/msw/filedlg.cpp
     src/msw/ole/automtn.cpp
     src/msw/ole/safearray.cpp
     src/msw/sound.cpp
@@ -190,6 +192,8 @@ set(QT_WIN32_SRC
 )
 
 set(QT_WIN32_HDR
+    wx/msw/dirdlg.h
+    wx/msw/filedlg.h
     wx/msw/ole/automtn.h
     wx/msw/joystick.h
     wx/msw/dib.h

--- a/build/files
+++ b/build/files
@@ -201,6 +201,8 @@ QT_UNIX_HDR=
     wx/unix/sound.h
 
 QT_WIN32_SRC=
+    src/msw/dirdlg.cpp
+    src/msw/filedlg.cpp
     src/msw/ole/automtn.cpp
     src/msw/ole/comimpl.cpp
     src/msw/ole/oleutils.cpp
@@ -212,6 +214,8 @@ QT_WIN32_SRC=
     src/msw/sound.cpp
 
 QT_WIN32_HDR=
+    wx/msw/dirdlg.h
+    wx/msw/filedlg.h
     wx/msw/ole/automtn.h
     wx/msw/ole/comimpl.h
     wx/msw/ole/oleutils.h

--- a/include/wx/qt/app.h
+++ b/include/wx/qt/app.h
@@ -22,6 +22,12 @@ public:
 
     virtual bool Initialize(int& argc, wxChar **argv) override;
 
+#ifdef _WIN32
+    // returns 400, 470, 471 for comctl32.dll 4.00, 4.70, 4.71 or 0 if it
+    // wasn't found at all
+    static int GetComCtl32Version();
+#endif // _WIN32
+
 private:
     std::unique_ptr<QApplication> m_qtApplication;
     int m_qtArgc;

--- a/include/wx/qt/app.h
+++ b/include/wx/qt/app.h
@@ -22,11 +22,11 @@ public:
 
     virtual bool Initialize(int& argc, wxChar **argv) override;
 
-#ifdef _WIN32
+#ifdef __WINDOWS__
     // returns 400, 470, 471 for comctl32.dll 4.00, 4.70, 4.71 or 0 if it
     // wasn't found at all
     static int GetComCtl32Version();
-#endif // _WIN32
+#endif // __WINDOWS__
 
 private:
     std::unique_ptr<QApplication> m_qtApplication;

--- a/include/wx/qt/dirdlg.h
+++ b/include/wx/qt/dirdlg.h
@@ -8,6 +8,11 @@
 #ifndef _WX_QT_DIRDLG_H_
 #define _WX_QT_DIRDLG_H_
 
+// Use MSW implementation to support custom controls in modern-style dialogs.
+#ifdef _WIN32
+#include <wx/msw/dirdlg.h>
+#else
+
 class QFileDialog;
 
 class WXDLLIMPEXP_CORE wxDirDialog : public wxDirDialogBase
@@ -42,5 +47,7 @@ private:
 
     wxDECLARE_DYNAMIC_CLASS(wxDirDialog);
 };
+
+#endif // _WIN32
 
 #endif // _WX_QT_DIRDLG_H_

--- a/include/wx/qt/dirdlg.h
+++ b/include/wx/qt/dirdlg.h
@@ -9,7 +9,7 @@
 #define _WX_QT_DIRDLG_H_
 
 // Use MSW implementation to support custom controls in modern-style dialogs.
-#ifdef _WIN32
+#ifdef __WINDOWS__
 #include <wx/msw/dirdlg.h>
 #else
 
@@ -48,6 +48,6 @@ private:
     wxDECLARE_DYNAMIC_CLASS(wxDirDialog);
 };
 
-#endif // _WIN32
+#endif // __WINDOWS__
 
 #endif // _WX_QT_DIRDLG_H_

--- a/include/wx/qt/filedlg.h
+++ b/include/wx/qt/filedlg.h
@@ -8,6 +8,11 @@
 #ifndef _WX_QT_FILEDLG_H_
 #define _WX_QT_FILEDLG_H_
 
+// Use MSW implementation to support custom controls in modern-style dialogs.
+#ifdef _WIN32
+#include <wx/msw/filedlg.h>
+#else
+
 class QFileDialog;
 
 class WXDLLIMPEXP_CORE wxFileDialog : public wxFileDialogBase
@@ -54,5 +59,7 @@ private:
 
     wxDECLARE_DYNAMIC_CLASS(wxFileDialog);
 };
+
+#endif // _WIN32
 
 #endif // _WX_QT_FILEDLG_H_

--- a/include/wx/qt/filedlg.h
+++ b/include/wx/qt/filedlg.h
@@ -9,7 +9,7 @@
 #define _WX_QT_FILEDLG_H_
 
 // Use MSW implementation to support custom controls in modern-style dialogs.
-#ifdef _WIN32
+#ifdef __WINDOWS__
 #include <wx/msw/filedlg.h>
 #else
 
@@ -60,6 +60,6 @@ private:
     wxDECLARE_DYNAMIC_CLASS(wxFileDialog);
 };
 
-#endif // _WIN32
+#endif // __WINDOWS__
 
 #endif // _WX_QT_FILEDLG_H_

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -135,6 +135,12 @@ public:
 
     QWidget *GetHandle() const override;
 
+#ifdef _WIN32
+    // Only for compatibility with MSW wxFileDialog/wxDirDialog implementation. Do not use.
+    WXHWND GetHWND() const { return m_hWnd; }
+    void SetHWND(WXHWND hWnd) { m_hWnd = hWnd; }
+#endif
+
 #if wxUSE_DRAG_AND_DROP
     virtual void SetDropTarget( wxDropTarget *dropTarget ) override;
 #endif
@@ -248,6 +254,10 @@ private:
     bool m_mouseInside;
 
     wxSize  m_pendingClientSize;
+
+#ifdef _WIN32
+    WXHWND m_hWnd = nullptr;
+#endif
 
 #if wxUSE_ACCEL
     wxVector<QShortcut*> m_qtShortcuts; // owned by whatever GetHandle() returns

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -135,11 +135,11 @@ public:
 
     QWidget *GetHandle() const override;
 
-#ifdef _WIN32
+#ifdef __WINDOWS__
     // Only for compatibility with MSW wxFileDialog/wxDirDialog implementation. Do not use.
     WXHWND GetHWND() const { return m_hWnd; }
     void SetHWND(WXHWND hWnd) { m_hWnd = hWnd; }
-#endif
+#endif // __WINDOWS__
 
 #if wxUSE_DRAG_AND_DROP
     virtual void SetDropTarget( wxDropTarget *dropTarget ) override;
@@ -255,9 +255,9 @@ private:
 
     wxSize  m_pendingClientSize;
 
-#ifdef _WIN32
+#ifdef __WINDOWS__
     WXHWND m_hWnd = nullptr;
-#endif
+#endif // __WINDOWS__
 
 #if wxUSE_ACCEL
     wxVector<QShortcut*> m_qtShortcuts; // owned by whatever GetHandle() returns

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -1141,6 +1141,8 @@ void wxFileDialog::MSWOnInitDone(WXHWND hDlg)
         return;
     }
 
+#ifdef __WXMSW__
+
     // set HWND so that our DoMoveWindow() works correctly
     TempHWNDSetter set(this, hDlg);
 
@@ -1159,6 +1161,8 @@ void wxFileDialog::MSWOnInitDone(WXHWND hDlg)
     {
         SetPosition(gs_rectDialog.GetPosition());
     }
+
+#endif // __WXMSW__
 }
 
 void wxFileDialog::MSWOnSelChange(const wxString& selectedFilename)

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -1141,6 +1141,8 @@ void wxFileDialog::MSWOnInitDone(WXHWND hDlg)
         return;
     }
 
+// Note that this file can also be compiled as part of wxQt and we don't need
+// this code then.
 #ifdef __WXMSW__
 
     // set HWND so that our DoMoveWindow() works correctly

--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -17,7 +17,7 @@
 
 #ifdef __WINDOWS__
     #include "wx/dynlib.h"
-    #include <Shlwapi.h>
+    #include <shlwapi.h>
 #endif // __WINDOWS__
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxEvtHandler);

--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -15,10 +15,10 @@
 #include <QtCore/QStringList>
 #include <QtWidgets/QApplication>
 
-#ifdef _WIN32
+#ifdef __WINDOWS__
     #include "wx/dynlib.h"
     #include <Shlwapi.h>
-#endif // _WIN32
+#endif // __WINDOWS__
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxEvtHandler);
 
@@ -90,7 +90,7 @@ bool wxApp::Initialize( int &argc, wxChar **argv )
 }
 
 // Compatibility for MSW wxFileDialog/wxDirDialog implementations
-#ifdef _WIN32
+#ifdef __WINDOWS__
 
 // ----------------------------------------------------------------------------
 // system DLL versions
@@ -200,4 +200,4 @@ int wxApp::GetComCtl32Version()
     return s_verComCtl32;
 }
 
-#endif // _WIN32
+#endif // __WINDOWS__

--- a/src/qt/filedlg.cpp
+++ b/src/qt/filedlg.cpp
@@ -8,7 +8,9 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
-#if wxUSE_FILEDLG
+// On Windows, the MSW implementation is used to support custom controls in
+// modern-style dialogs.
+#if wxUSE_FILEDLG && !defined( _WIN32 )
 
 #include "wx/filename.h"
 
@@ -260,4 +262,4 @@ QFileDialog *wxDirDialog::GetQFileDialog() const
     return static_cast<QFileDialog *>(m_qtWindow);
 }
 
-#endif // wxUSE_FILEDLG
+#endif // wxUSE_FILEDLG && !defined( _WIN32 )

--- a/src/qt/filedlg.cpp
+++ b/src/qt/filedlg.cpp
@@ -10,7 +10,7 @@
 
 // On Windows, the MSW implementation is used to support custom controls in
 // modern-style dialogs.
-#if wxUSE_FILEDLG && !defined( _WIN32 )
+#if wxUSE_FILEDLG && !defined( __WINDOWS__ )
 
 #include "wx/filename.h"
 
@@ -262,4 +262,4 @@ QFileDialog *wxDirDialog::GetQFileDialog() const
     return static_cast<QFileDialog *>(m_qtWindow);
 }
 
-#endif // wxUSE_FILEDLG && !defined( _WIN32 )
+#endif // wxUSE_FILEDLG && !defined( __WINDOWS__ )

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -36,6 +36,10 @@
 #include "wx/qt/private/compat.h"
 #include "wx/qt/private/winevent.h"
 
+#ifdef _WIN32
+    #include "wx/msw/private/dpiaware.h"
+#endif // _WIN32
+
 
 #define TRACE_QT_WINDOW "qtwindow"
 
@@ -1894,3 +1898,21 @@ bool wxWindowQt::EnableTouchEvents(int eventsMask)
 
     return true;
 }
+
+// Compatibility for MSW wxFileDialog/wxDirDialog implementations
+#ifdef _WIN32
+
+// ---------------------------------------------------------------------------
+// DPI
+// ---------------------------------------------------------------------------
+
+namespace wxMSWImpl
+{
+
+    AutoSystemDpiAware::SetThreadDpiAwarenessContext_t
+        AutoSystemDpiAware::ms_pfnSetThreadDpiAwarenessContext =
+        (AutoSystemDpiAware::SetThreadDpiAwarenessContext_t)-1;
+
+} // namespace wxMSWImpl
+
+#endif // _WIN32

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -36,9 +36,9 @@
 #include "wx/qt/private/compat.h"
 #include "wx/qt/private/winevent.h"
 
-#ifdef _WIN32
+#ifdef __WINDOWS__
     #include "wx/msw/private/dpiaware.h"
-#endif // _WIN32
+#endif // __WINDOWS__
 
 
 #define TRACE_QT_WINDOW "qtwindow"
@@ -1900,7 +1900,7 @@ bool wxWindowQt::EnableTouchEvents(int eventsMask)
 }
 
 // Compatibility for MSW wxFileDialog/wxDirDialog implementations
-#ifdef _WIN32
+#ifdef __WINDOWS__
 
 // ---------------------------------------------------------------------------
 // DPI
@@ -1915,4 +1915,4 @@ namespace wxMSWImpl
 
 } // namespace wxMSWImpl
 
-#endif // _WIN32
+#endif // __WINDOWS__


### PR DESCRIPTION
Uses the MSW implementation that allows adding custom controls to modern-style dialogs. Qt doesn't have an API for this functionality.