### PR TITLE
Correct Kopiëren in nl.po

### DIFF
--- a/locale/nl.po
+++ b/locale/nl.po
@@ -3306,7 +3306,7 @@ msgstr "&Kopiëren"
 
 #: ../src/common/stockitem.cpp:156 ../src/stc/stc_i18n.cpp:18
 msgid "Copy"
-msgstr "Kopi&#235;ren"
+msgstr "Kopiëren"
 
 #: ../src/common/stockitem.cpp:157 ../src/msw/textctrl.cpp:2708
 #: ../src/osx/textctrl_osx.cpp:637 ../src/richtext/richtextctrl.cpp:331


### PR DESCRIPTION
As detected in an app done with wxPython, and reported in https://discuss.wxpython.org/t/context-menu-in-stc-not-showing-e-for-dutch-localization/36958/2