### PR TITLE
implement GetNewRow/Col for EVT_GRID_ROW/COL_MOVE

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -3170,6 +3170,8 @@ public:
 
     int GetRow() const { return m_row; }
     int GetCol() const { return m_col; }
+    int GetNewRow() const { return m_col; }
+    int GetNewCol() const { return m_row; }
     wxPoint GetPosition() const { return wxPoint( m_x, m_y ); }
     bool Selecting() const { return m_selecting; }
 

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -6344,28 +6344,30 @@ public:
         Processes a @c wxEVT_GRID_SELECT_CELL event type.
     @event{EVT_GRID_ROW_MOVE(func)}
         The user tries to change the order of the rows in the grid by
-        dragging the row specified by GetRow(). This event can be vetoed to
-        either prevent the user from reordering the row change completely
-        (but notice that if you don't want to allow it at all, you simply
-        shouldn't call wxGrid::EnableDragRowMove() in the first place), vetoed
-        but handled in some way in the handler, e.g. by really moving the
-        row to the new position at the associated table level, or allowed to
-        proceed in which case wxGrid::SetRowPos() is used to reorder the
-        rows display order without affecting the use of the row indices
-        otherwise.
+        dragging the row specified by GetRow() to the position specified
+        by GetNewRow().
+        This event can be vetoed to either prevent the user from reordering
+        the row change completely (but notice that if you don't want to allow
+        it at all, you simply shouldn't call wxGrid::EnableDragRowMove() in
+        the first place), vetoed but handled in some way in the handler,
+        e.g. by really moving the row to the new position at the associated
+        table level, or allowed to proceed in which case wxGrid::SetRowPos()
+        is used to reorder the rows display order without affecting the use
+        of the row indices otherwise.
         This event macro corresponds to @c wxEVT_GRID_ROW_MOVE event type.
         It is only available since wxWidgets 3.1.7.
     @event{EVT_GRID_COL_MOVE(func)}
         The user tries to change the order of the columns in the grid by
-        dragging the column specified by GetCol(). This event can be vetoed to
-        either prevent the user from reordering the column change completely
-        (but notice that if you don't want to allow it at all, you simply
-        shouldn't call wxGrid::EnableDragColMove() in the first place), vetoed
-        but handled in some way in the handler, e.g. by really moving the
-        column to the new position at the associated table level, or allowed to
-        proceed in which case wxGrid::SetColPos() is used to reorder the
-        columns display order without affecting the use of the column indices
-        otherwise.
+        dragging the column specified by GetCol() to the position specified
+        by GetNewCol().
+        This event can be vetoed to either prevent the user from reordering
+        the column change completely (but notice that if you don't want to
+        allow it at all, you simply shouldn't call wxGrid::EnableDragColMove()
+        in the first place), vetoed but handled in some way in the handler,
+        e.g. by really moving the column to the new position at the associated
+        table level, or allowed to proceed in which case wxGrid::SetColPos()
+        is used to reorder the columns display order without affecting the use
+        of the column indices otherwise.
         This event macro corresponds to @c wxEVT_GRID_COL_MOVE event type.
     @event{EVT_GRID_COL_SORT(func)}
         This event is generated when a column is clicked by the user and its
@@ -6434,6 +6436,20 @@ public:
         retrieved using wxGrid::GetGridCursorRow().
     */
     int GetRow() const;
+
+    /**
+        Target row for wxEVT_GRID_ROW_MOVE
+
+        @since 3.3.0
+    */
+    int GetNewRow() const;
+
+    /**
+        Target column for wxEVT_GRID_COL_MOVE
+
+        @since 3.3.0
+    */
+    int GetNewCol() const;
 
     /**
         Returns @true if the Meta key was down at the time of the event.

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -369,6 +369,9 @@ wxBEGIN_EVENT_TABLE( GridFrame, wxFrame )
     EVT_GRID_ROW_SIZE( GridFrame::OnRowSize )
     EVT_GRID_COL_SIZE( GridFrame::OnColSize )
     EVT_GRID_COL_AUTO_SIZE( GridFrame::OnColAutoSize )
+    EVT_GRID_ROW_MOVE( GridFrame::OnRowMove )
+    EVT_GRID_COL_MOVE( GridFrame::OnColMove )
+
     EVT_GRID_SELECT_CELL( GridFrame::OnSelectCell )
     EVT_GRID_RANGE_SELECTING( GridFrame::OnRangeSelecting )
     EVT_GRID_RANGE_SELECTED( GridFrame::OnRangeSelected )
@@ -1710,6 +1713,18 @@ void GridFrame::OnColAutoSize( wxGridSizeEvent &event )
     {
         event.Skip();
     }
+}
+
+void GridFrame::OnRowMove(wxGridEvent& event)
+{
+    wxLogMessage("Moving row %d to %d", event.GetRow(), event.GetNewRow());
+    event.Skip();
+}
+
+void GridFrame::OnColMove(wxGridEvent& event)
+{
+    wxLogMessage("Moving column %d to %d", event.GetCol(), event.GetNewCol());
+    event.Skip();
 }
 
 void GridFrame::OnSelectCell( wxGridEvent& ev )

--- a/samples/grid/griddemo.h
+++ b/samples/grid/griddemo.h
@@ -111,6 +111,8 @@ class GridFrame : public wxFrame
     void OnRowSize( wxGridSizeEvent& );
     void OnColSize( wxGridSizeEvent& );
     void OnColAutoSize( wxGridSizeEvent& );
+    void OnRowMove( wxGridEvent& );
+    void OnColMove( wxGridEvent& );
     void OnSelectCell( wxGridEvent& );
     void OnRangeSelected( wxGridRangeSelectEvent& );
     void OnRangeSelecting( wxGridRangeSelectEvent& );

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5077,8 +5077,9 @@ void wxGrid::DoStartMoveRowOrCol(int col)
 void wxGrid::DoEndMoveRow(int pos)
 {
     wxASSERT_MSG( m_dragMoveRowOrCol != -1, "no matching DoStartMoveRow?" );
-
-    if ( SendEvent(wxEVT_GRID_ROW_MOVE, -1, m_dragMoveRowOrCol) != Event_Vetoed )
+    // col is used for the target row
+    wxGridEvent gridEvt(GetId(), wxEVT_GRID_ROW_MOVE, this, m_dragMoveRowOrCol, pos);
+    if ( DoSendEvent(gridEvt) != Event_Vetoed )
         SetRowPos(m_dragMoveRowOrCol, pos);
 
     m_dragMoveRowOrCol = -1;
@@ -5177,8 +5178,9 @@ bool wxGrid::EnableDragRowMove( bool enable )
 void wxGrid::DoEndMoveCol(int pos)
 {
     wxASSERT_MSG( m_dragMoveRowOrCol != -1, "no matching DoStartMoveCol?" );
-
-    if ( SendEvent(wxEVT_GRID_COL_MOVE, -1, m_dragMoveRowOrCol) != Event_Vetoed )
+    // row is used for the target col
+    wxGridEvent gridEvt(GetId(), wxEVT_GRID_COL_MOVE, this, pos, m_dragMoveRowOrCol);
+    if ( DoSendEvent(gridEvt) != Event_Vetoed )
         SetColPos(m_dragMoveRowOrCol, pos);
 
     m_dragMoveRowOrCol = -1;


### PR DESCRIPTION
replacement for https://github.com/wxWidgets/wxWidgets/pull/24392

This PR implements `GetNewRow()` and `GetNewCol()` for `EVT_GRID_ROW/COL_MOVE` to allow to retrieve the target row/col.
Also, it fixes the bug introduced with https://github.com/wxWidgets/wxWidgets/pull/22260 where `GetRow()` would always return -1.

Implementation detail: e.g. for `EVT_GRID_ROW_MOVE`, m_col is used for the target row.