### PR TITLE
Add OSXSetRTFValue() and OSXGetRTFValue() functions to wxTextCtrl

### DIFF
--- a/include/wx/osx/cocoa/private/textimpl.h
+++ b/include/wx/osx/cocoa/private/textimpl.h
@@ -60,8 +60,15 @@ public :
 
     virtual wxString GetStringValue() const override ;
     virtual void SetStringValue( const wxString &str) override ;
-    virtual wxString GetRTFValue() const override { return GetStringValue(); };
-    virtual void SetRTFValue(const wxString& str) override { SetStringValue(str); };
+    virtual wxString GetRTFValue() const override
+    {
+        wxFAIL_MSG("GetRTFValue() should only be used with multiline controls.");
+        return GetStringValue();
+    };
+    virtual void SetRTFValue(const wxString& WXUNUSED(str)) override
+    {
+        wxFAIL_MSG("GetRTFValue() should only be used with multiline controls.");
+    };
     virtual void Copy() override ;
     virtual void Cut() override ;
     virtual void Paste() override ;
@@ -112,6 +119,8 @@ public:
 
     virtual wxString GetStringValue() const override ;
     virtual void SetStringValue( const wxString &str) override ;
+    virtual wxString GetRTFValue() const override;
+    virtual void SetRTFValue(const wxString& str) override;
     virtual void Copy() override ;
     virtual void Cut() override ;
     virtual void Paste() override ;

--- a/include/wx/osx/cocoa/private/textimpl.h
+++ b/include/wx/osx/cocoa/private/textimpl.h
@@ -60,6 +60,8 @@ public :
 
     virtual wxString GetStringValue() const override ;
     virtual void SetStringValue( const wxString &str) override ;
+    virtual wxString GetRTFValue() const override { return GetStringValue(); };
+    virtual void SetRTFValue(const wxString& str) override { SetStringValue(str); };
     virtual void Copy() override ;
     virtual void Cut() override ;
     virtual void Paste() override ;

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -709,6 +709,8 @@ public :
 
     virtual wxString GetStringValue() const = 0 ;
     virtual void SetStringValue( const wxString &val ) = 0 ;
+    virtual wxString GetRTFValue() const = 0;
+    virtual void SetRTFValue( const wxString& val ) = 0;
     virtual void SetSelection( long from, long to ) = 0 ;
     virtual void GetSelection( long* from, long* to ) const = 0 ;
     virtual void WriteText( const wxString& str ) = 0 ;

--- a/include/wx/osx/textctrl.h
+++ b/include/wx/osx/textctrl.h
@@ -147,6 +147,9 @@ public:
     void OSXEnableAutomaticDashSubstitution(bool enable);
     void OSXDisableAllSmartSubstitutions();
 
+    wxString OSXGetRTFValue() const;
+    void OSXSetRTFValue(const wxString& val);
+
 protected:
     // common part of all ctors
     void Init();

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1943,6 +1943,32 @@ public:
     */
     void OSXDisableAllSmartSubstitutions();
 
+    /**
+        Returns the content of the text control as RTF (Rich Text Formatted) text.
+
+        @onlyfor{wxosx}
+        @since 3.3.0
+
+        @see OSXSetRTFValue()
+    */
+    wxString OSXGetRTFValue() const;
+
+    /**
+        Sets the content of the text control from a RTF (Rich Text Formatted) buffer.
+
+        This offers more granular control of content formatting, as well as a
+        significant performance benefit with larger content. This also provides the
+        ability read an RTF file and move it directly into the control.
+
+        @onlyfor{wxosx}
+        @since 3.3.0
+
+        @see @ref page_samples_text for a usage example.
+
+        @see OSXGetRTFValue()
+    */
+    void OSXSetRTFValue(const wxString& val);
+
     ///@}
 
     /**

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1944,7 +1944,7 @@ public:
     void OSXDisableAllSmartSubstitutions();
 
     /**
-        Returns the content of the text control as RTF (Rich Text Formatted) text.
+        Returns the content of a multiline text control as RTF (Rich Text Formatted) text.
 
         @onlyfor{wxosx}
         @since 3.3.0
@@ -1954,7 +1954,8 @@ public:
     wxString OSXGetRTFValue() const;
 
     /**
-        Sets the content of the text control from a RTF (Rich Text Formatted) buffer.
+        Sets the content of a multiline text control from an RTF
+        (Rich Text Formatted) buffer.
 
         This offers more granular control of content formatting, as well as a
         significant performance benefit with larger content. This also provides the

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -328,8 +328,8 @@ public:
 #ifdef __WXOSX__
         m_panel->m_textrich->OSXSetRTFValue(R"({\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
 {\colortbl ;\red79\green129\blue189;\red255\green0\blue0;\red192\green192\blue192;}
-{\*\generator Riched20 10.0.22621}\viewkind4\uc1 
-\pard\sa200\sl276\slmult1\cf1\b\i\f0\fs22\lang9 wxWidgets 3.3\cf0\b0\i0\par
+{\*\generator Riched20 10.0.22621}\viewkind4\uc1
+ \pard\sa200\sl276\slmult1\cf1\b\i\f0\fs22\lang9 wxWidgets 3.3\cf0\b0\i0\par
 \cf2 A \highlight3\ul cross-platform \highlight0\ulnone GUI library which uses \ul\b native\ulnone\b0  controls.\cf0\par
 })");
 #endif

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -326,11 +326,11 @@ public:
     void OnSetRTF(wxCommandEvent& WXUNUSED(event))
     {
 #ifdef __WXOSX__
-        m_panel->m_text->SetRTFValue(R"({\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
-{\colortbl ;\red79\green129\blue189;\red192\green192\blue192;}
+        m_panel->m_textrich->OSXSetRTFValue(R"({\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\colortbl ;\red79\green129\blue189;\red255\green0\blue0;\red192\green192\blue192;}
 {\*\generator Riched20 10.0.22621}\viewkind4\uc1 
 \pard\sa200\sl276\slmult1\cf1\b\i\f0\fs22\lang9 wxWidgets 3.3\cf0\b0\i0\par
-A \highlight2\ul cross-platform \highlight0\ulnone GUI library which uses \ul\b native\ulnone\b0  controls.\par
+\cf2 A \highlight3\ul cross-platform \highlight0\ulnone GUI library which uses \ul\b native\ulnone\b0  controls.\cf0\par
 })");
 #endif
     }
@@ -449,7 +449,7 @@ enum
     TEXT_REPLACE,
     TEXT_SELECT,
     TEXT_SET,
-    TEXT_SET_RFT,
+    TEXT_SET_RTF,
     TEXT_CHANGE,
 
     // log menu
@@ -522,10 +522,11 @@ bool MyApp::OnInit()
     menuText->Append(TEXT_REPLACE, "&Replace characters 4 to 8 with ABC\tCtrl-R");
     menuText->Append(TEXT_SELECT, "&Select characters 4 to 8\tCtrl-I");
     menuText->Append(TEXT_SET, "&Set the first text zone value\tCtrl-E");
-#ifdef __WXOSX__
-    menuText->Append(TEXT_SET_RTF, "&Set the first text zone value from rich text formatted content");
-#endif
     menuText->Append(TEXT_CHANGE, "&Change the first text zone value\tShift-Ctrl-E");
+#ifdef __WXOSX__
+    menuText->AppendSeparator();
+    menuText->Append(TEXT_SET_RTF, "Set the rich text zone value from rich text formatted content");
+#endif
     menuText->AppendSeparator();
     menuText->Append(TEXT_MOVE_ENDTEXT, "Move cursor to the end of &text");
     menuText->Append(TEXT_MOVE_ENDENTRY, "Move cursor to the end of &entry");
@@ -1548,7 +1549,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(TEXT_GET_LINELENGTH,     MyFrame::OnGetLineLength)
 
     EVT_MENU(TEXT_SET,                MyFrame::OnSetText)
-    EVT_MENU(TEXT_SET_RFT,            MyFrame::OnSetRTF)
+    EVT_MENU(TEXT_SET_RTF,            MyFrame::OnSetRTF)
     EVT_MENU(TEXT_CHANGE,             MyFrame::OnChangeText)
 
     EVT_IDLE(MyFrame::OnIdle)

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -323,6 +323,18 @@ public:
         m_panel->m_text->SetValue("Hello, world! (what else did you expect?)");
     }
 
+    void OnSetRTF(wxCommandEvent& WXUNUSED(event))
+    {
+#ifdef __WXOSX__
+        m_panel->m_text->SetRTFValue(R"({\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\colortbl ;\red79\green129\blue189;\red192\green192\blue192;}
+{\*\generator Riched20 10.0.22621}\viewkind4\uc1 
+\pard\sa200\sl276\slmult1\cf1\b\i\f0\fs22\lang9 wxWidgets 3.3\cf0\b0\i0\par
+A \highlight2\ul cross-platform \highlight0\ulnone GUI library which uses \ul\b native\ulnone\b0  controls.\par
+})");
+#endif
+    }
+
     void OnChangeText(wxCommandEvent& WXUNUSED(event))
     {
         m_panel->m_text->ChangeValue("Changed, not set: no event");
@@ -437,6 +449,7 @@ enum
     TEXT_REPLACE,
     TEXT_SELECT,
     TEXT_SET,
+    TEXT_SET_RFT,
     TEXT_CHANGE,
 
     // log menu
@@ -509,6 +522,9 @@ bool MyApp::OnInit()
     menuText->Append(TEXT_REPLACE, "&Replace characters 4 to 8 with ABC\tCtrl-R");
     menuText->Append(TEXT_SELECT, "&Select characters 4 to 8\tCtrl-I");
     menuText->Append(TEXT_SET, "&Set the first text zone value\tCtrl-E");
+#ifdef __WXOSX__
+    menuText->Append(TEXT_SET_RTF, "&Set the first text zone value from rich text formatted content");
+#endif
     menuText->Append(TEXT_CHANGE, "&Change the first text zone value\tShift-Ctrl-E");
     menuText->AppendSeparator();
     menuText->Append(TEXT_MOVE_ENDTEXT, "Move cursor to the end of &text");
@@ -1532,6 +1548,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(TEXT_GET_LINELENGTH,     MyFrame::OnGetLineLength)
 
     EVT_MENU(TEXT_SET,                MyFrame::OnSetText)
+    EVT_MENU(TEXT_SET_RFT,            MyFrame::OnSetRTF)
     EVT_MENU(TEXT_CHANGE,             MyFrame::OnChangeText)
 
     EVT_IDLE(MyFrame::OnIdle)

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -840,6 +840,34 @@ void wxNSTextViewControl::SetStringValue( const wxString &str)
     }
 }
 
+wxString wxNSTextViewControl::GetRTFValue() const
+{
+    if (m_textView)
+    {
+        NSData* rtfData = [m_textView RTFFromRange:NSMakeRange(0, [[m_textView textStorage] length])];
+        NSMutableString* rtfString = [[NSMutableString alloc] initWithData:rtfData encoding:NSASCIIStringEncoding];
+        wxString result = wxMacConvertNewlines13To10(wxCFStringRef::AsString(rtfString, m_wxPeer->GetFont().GetEncoding()));
+        [rtfString release];
+        return result;
+    }
+    return wxEmptyString;
+}
+
+void wxNSTextViewControl::SetRTFValue(const wxString &str)
+{
+    wxString st = wxMacConvertNewlines10To13(str);
+    wxMacEditHelper helper(m_textView);
+    
+    if (m_textView)
+    {
+        [m_textView setString: wxCFStringRef( wxEmptyString , m_wxPeer->GetFont().GetEncoding() ).AsNSString()];
+        NSData* rtfData=[wxCFStringRef( st , m_wxPeer->GetFont().GetEncoding() ).AsNSString() dataUsingEncoding:NSASCIIStringEncoding];
+        [m_textView replaceCharactersInRange:NSMakeRange(0,0) withRTF:rtfData];
+    }
+    // Some text styles have to be updated manually.
+    DoUpdateTextStyle();
+}
+
 void wxNSTextViewControl::Copy()
 {
     if (m_textView)

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -857,7 +857,7 @@ void wxNSTextViewControl::SetRTFValue(const wxString &str)
 {
     wxString st = wxMacConvertNewlines10To13(str);
     wxMacEditHelper helper(m_textView);
-    
+
     if (m_textView)
     {
         [m_textView setString: wxCFStringRef( wxEmptyString ).AsNSString()];

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -846,7 +846,7 @@ wxString wxNSTextViewControl::GetRTFValue() const
     {
         NSData* rtfData = [m_textView RTFFromRange:NSMakeRange(0, [[m_textView textStorage] length])];
         NSMutableString* rtfString = [[NSMutableString alloc] initWithData:rtfData encoding:NSASCIIStringEncoding];
-        wxString result = wxMacConvertNewlines13To10(wxCFStringRef::AsString(rtfString, m_wxPeer->GetFont().GetEncoding()));
+        wxString result = wxMacConvertNewlines13To10(wxCFStringRef::AsString(rtfString));
         [rtfString release];
         return result;
     }
@@ -860,9 +860,9 @@ void wxNSTextViewControl::SetRTFValue(const wxString &str)
     
     if (m_textView)
     {
-        [m_textView setString: wxCFStringRef( wxEmptyString , m_wxPeer->GetFont().GetEncoding() ).AsNSString()];
-        NSData* rtfData=[wxCFStringRef( st , m_wxPeer->GetFont().GetEncoding() ).AsNSString() dataUsingEncoding:NSASCIIStringEncoding];
-        [m_textView replaceCharactersInRange:NSMakeRange(0,0) withRTF:rtfData];
+        [m_textView setString: wxCFStringRef( wxEmptyString ).AsNSString()];
+        NSData* rtfData=[wxCFStringRef( st ).AsNSString() dataUsingEncoding:NSASCIIStringEncoding];
+        [m_textView replaceCharactersInRange:NSMakeRange(0, 0) withRTF:rtfData];
     }
     // Some text styles have to be updated manually.
     DoUpdateTextStyle();

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -149,6 +149,16 @@ void wxTextCtrl::OSXDisableAllSmartSubstitutions()
     OSXEnableAutomaticQuoteSubstitution(false);
 }
 
+wxString wxTextCtrl::OSXGetRTFValue() const
+{
+    return GetTextPeer()->GetRTFValue();
+}
+
+void wxTextCtrl::OSXSetRTFValue(const wxString& val)
+{
+    GetTextPeer()->SetRTFValue(val);
+}
+
 bool wxTextCtrl::SetFont( const wxFont& font )
 {
     if ( !wxTextCtrlBase::SetFont( font ) )


### PR DESCRIPTION
This adds new methods to write and read direct RTF data to a `wxTextCtrl` under macOS. The benefit of this is performance and being able to read and write RTF files easily.

[ ] Compile with iPhone
[ ] Add support to Load and Save file methods in `wxTextCtrl`
[ ] Show loading and saving RTF file in sample