### PR TITLE
Fix touch gestures test navigation in event sample, wxQt gesture fix.

### DIFF
--- a/samples/event/gestures.h
+++ b/samples/event/gestures.h
@@ -35,6 +35,7 @@ private:
     wxAffineMatrix2D m_affineMatrix;
     double m_lastZoomFactor;
     double m_lastRotationAngle;
+    wxPoint m_lastGesturePos;
 };
 
 #endif // _WX_GESTURES_H_


### PR DESCRIPTION
In the `event` sample:
- Panning while scaled didn't pan by the correct amount.
- Combination of gesture events didn't work correctly.

This also allows panning via zoom event position.

In wxQt:
- Fixes the zoom factor that was not set correctly (we need total scale factor, not relative).
- Implements the rotate gesture call.
- Minor simplification in panTriggered.
