### PR TITLE
Always automatically define WX_PRECOMP for MSVC when not disabled

### DIFF
--- a/include/wx/wxprec.h
+++ b/include/wx/wxprec.h
@@ -10,14 +10,10 @@
 // compiler detection; includes setup.h
 #include "wx/defs.h"
 
-// check if to use precompiled headers: do it for most Windows compilers unless
-// explicitly disabled by defining NOPCH
-#if defined(__VISUALC__)
-    // If user did not request NOCPH and we're not building using configure
-    // then assume user wants precompiled headers.
-    #if !defined(NOPCH) && !defined(__WX_SETUP_H__)
-        #define WX_PRECOMP
-    #endif
+// check if to use precompiled headers: do it for MSVC unless explicitly
+// disabled by defining NOPCH
+#if !defined(WX_PRECOMP) && defined(__VISUALC__) && !defined(NOPCH)
+    #define WX_PRECOMP
 #endif
 
 #ifdef WX_PRECOMP


### PR DESCRIPTION
Configure builds were excluded, but this would also exclude CMake because it uses the same `__WX_SETUP_H__` define.

This was done back in 248eaddf7a when there were more Windows compilers, of which some probably used configure. But over time he check has been reduced to only `__VISUALC__` which isn't used with configure. So there is no reason to keep this check.

Fixes #24353