### PR TITLE
Avoid AppearanceResult::Success conflict with X11 constant

### DIFF
--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -686,7 +686,7 @@ public:
     enum class AppearanceResult
     {
         Failure,
-        Success,
+        Ok,
         CannotChange
     };
 

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -985,7 +985,7 @@ public:
     enum class AppearanceResult
     {
         Failure,     ///< Changing the appearance failed.
-        Success,     ///< Appearance was successfully changed.
+        Ok,          ///< Appearance was successfully changed.
         CannotChange ///< Appearance can't be changed any more.
     };
 
@@ -998,7 +998,7 @@ public:
         Appearance::Light or Appearance::Dark parameters if you need to
         override the default system appearance. The effect of calling this
         function is immediate, i.e. this function returns
-        AppearanceResult::Success, and affects all the existing windows as well
+        AppearanceResult::Ok, and affects all the existing windows as well
         as any windows created after this call.
 
         Under MSW, the default appearance is always light and the applications
@@ -1013,7 +1013,7 @@ public:
         Note that to query the current appearance, you can use
         wxSystemAppearance, see wxSystemSettings::GetAppearance().
 
-        @return AppearanceResult::Success if the appearance was successfully
+        @return AppearanceResult::Ok if the appearance was successfully
             changed or had been already set to the requested value,
             AppearanceResult::CannotChange if the appearance can't be changed
             any more because it's too late to do it but could be changed if

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -573,7 +573,7 @@ bool MyApp::DoSetAppearance(int menuId)
             wxLogStatus("Appearance couldn't be changed.");
             break;
 
-        case wxApp::AppearanceResult::Success:
+        case wxApp::AppearanceResult::Ok:
             wxLogStatus("Appearance changed successfully.");
             return true;
 

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -370,7 +370,7 @@ wxApp::AppearanceResult wxApp::SetAppearance(Appearance appearance)
             break;
     }
 
-    return wxGTKImpl::UpdateColorScheme(colorScheme) ? AppearanceResult::Success
+    return wxGTKImpl::UpdateColorScheme(colorScheme) ? AppearanceResult::Ok
                                                      : AppearanceResult::Failure;
 #else
     wxUnusedVar(appearance);

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -271,7 +271,7 @@ wxApp::AppearanceResult wxApp::SetAppearance(Appearance appearance)
 
         case Appearance::Light:
             // Nothing to do, this is the default.
-            return AppearanceResult::Success;
+            return AppearanceResult::Ok;
 
         case Appearance::Dark:
             flags = DarkMode_Always;
@@ -279,7 +279,7 @@ wxApp::AppearanceResult wxApp::SetAppearance(Appearance appearance)
     }
 
     // Do (try to) change it.
-    return MSWEnableDarkMode(flags) ? AppearanceResult::Success
+    return MSWEnableDarkMode(flags) ? AppearanceResult::Ok
                                     : AppearanceResult::Failure;
 }
 

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -492,7 +492,7 @@ wxApp::AppearanceResult wxApp::SetAppearance(Appearance appearance)
 
         [NSApp setAppearance:[NSAppearance appearanceNamed:name]];
 
-        return AppearanceResult::Success;
+        return AppearanceResult::Ok;
     }
 #endif // macOS 10.14+
 


### PR DESCRIPTION
X11/X.h #defines Success as 0, resulting in compilation errors due to a name clash if this header happens to be included before wx/app.h.

We could #undef Success here, but it seems better to avoid the problem by just renaming our constant, which was introduced only recently and so shouldn't be used in many places yet.

Closes #24585.

----

If sufficiently many people (e.g. more than 1) already use this constant in their code, we should probably keep the existing name and add the `#undef`, but if nobody is using it yet, I think it's better to rename it. Please let me know if you do use it!