### PR TITLE
CMake: Set hidden symbol visibility properties

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -111,6 +111,14 @@ function(wx_set_common_target_properties target_name)
         set_target_properties(${target_name} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
     endif()
 
+    if(NOT WIN32 AND wxBUILD_SHARED AND wxUSE_VISIBILITY)
+        set_target_properties(${target_name} PROPERTIES
+            C_VISIBILITY_PRESET hidden
+            CXX_VISIBILITY_PRESET hidden
+            VISIBILITY_INLINES_HIDDEN TRUE
+        )
+    endif()
+
     if(MSVC)
         if(wxCOMMON_TARGET_PROPS_DEFAULT_WARNINGS)
             set(MSVC_WARNING_LEVEL "/W3")

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -111,7 +111,7 @@ function(wx_set_common_target_properties target_name)
         set_target_properties(${target_name} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
     endif()
 
-    if(NOT WIN32 AND wxBUILD_SHARED AND wxUSE_VISIBILITY)
+    if(NOT WIN32 AND wxUSE_VISIBILITY)
         set_target_properties(${target_name} PROPERTIES
             C_VISIBILITY_PRESET hidden
             CXX_VISIBILITY_PRESET hidden

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -76,11 +76,11 @@ set(wxINSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 
 check_include_files("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS)
 
-if(wxBUILD_SHARED)
-    if(wxUSE_VISIBILITY)
-        check_cxx_compiler_flag(-fvisibility=hidden HAVE_VISIBILITY)
-    endif()
-endif() # wxBUILD_SHARED
+if(NOT WIN32 AND wxBUILD_SHARED AND wxUSE_VISIBILITY)
+    check_cxx_compiler_flag(-fvisibility=hidden HAVE_VISIBILITY)
+else()
+    set(HAVE_VISIBILITY 0)
+endif()
 
 if(MSVC)
     set(DISABLE_ALL_WARNINGS "/w")

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -76,7 +76,7 @@ set(wxINSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 
 check_include_files("stdlib.h;stdarg.h;string.h;float.h" STDC_HEADERS)
 
-if(NOT WIN32 AND wxBUILD_SHARED AND wxUSE_VISIBILITY)
+if(NOT WIN32 AND wxUSE_VISIBILITY)
     check_cxx_compiler_flag(-fvisibility=hidden HAVE_VISIBILITY)
 else()
     set(HAVE_VISIBILITY 0)


### PR DESCRIPTION
CMake caches the HAVE_VISIBILITY result, so disable it when build options change.

Fixes #24378