### PR TITLE
Improvements for generic expander icons.

### DIFF
--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -532,24 +532,32 @@ wxRendererGeneric::DrawTreeItemButton(wxWindow * WXUNUSED(win),
     wxDCPenChanger penChanger(dc, *wxGREY_PEN);
     wxDCBrushChanger brushChanger(dc, *wxWHITE_BRUSH);
 
-    dc.DrawRectangle(rect);
+    // make the size odd to keep the cross centered.
+    wxRect oddRect(rect);
+
+    if ( oddRect.width % 2 == 0 )
+        oddRect.width--;
+    if ( oddRect.height % 2 == 0 )
+        oddRect.height--;
+
+    dc.DrawRectangle(oddRect);
 
     // black lines
-    const wxCoord xMiddle = rect.x + rect.width/2;
-    const wxCoord yMiddle = rect.y + rect.height/2;
+    const wxCoord xMiddle = oddRect.x + oddRect.width/2;
+    const wxCoord yMiddle = oddRect.y + oddRect.height/2;
 
     // half of the length of the horz lines in "-" and "+"
-    const wxCoord halfWidth = rect.width/2 - 2;
+    const wxCoord halfWidth = oddRect.width/2 - 2;
     wxDCPenChanger setPen(dc, *wxBLACK_PEN);
     dc.DrawLine(xMiddle - halfWidth, yMiddle,
-                xMiddle + halfWidth + 1, yMiddle);
+                xMiddle + halfWidth, yMiddle);
 
     if ( !(flags & wxCONTROL_EXPANDED) )
     {
         // turn "-" into "+"
-        const wxCoord halfHeight = rect.height/2 - 2;
+        const wxCoord halfHeight = oddRect.height/2 - 2;
         dc.DrawLine(xMiddle, yMiddle - halfHeight,
-                    xMiddle, yMiddle + halfHeight + 1);
+                    xMiddle, yMiddle + halfHeight);
     }
 }
 

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1956,64 +1956,25 @@ void wxPropertyGrid::DrawExpanderButton( wxDC& dc, const wxRect& rect,
     r.Offset(m_gutterWidth, m_buttonSpacingY);
     r.width = m_iconWidth; r.height = m_iconHeight;
 
-#if (wxPG_USE_RENDERER_NATIVE)
-    //
-#elif wxPG_ICON_WIDTH
-    // Drawing expand/collapse button manually
-    dc.SetPen(m_colPropFore);
-    if ( property->IsCategory() )
-        dc.SetBrush(*wxTRANSPARENT_BRUSH);
-    else
-        dc.SetBrush(m_colPropBack);
-
-    dc.DrawRectangle( r );
-    int _y = r.y+(m_iconWidth/2);
-    dc.DrawLine(r.x+2,_y,r.x+m_iconWidth-2,_y);
-#else
-    wxBitmap bmp;
-#endif
-
-    if ( property->IsExpanded() )
-    {
     // wxRenderer functions are non-mutating in nature, so it
     // should be safe to cast "const wxPropertyGrid*" to "wxWindow*".
     // Hopefully this does not cause problems.
-    #if (wxPG_USE_RENDERER_NATIVE)
-        wxRendererNative::Get().DrawTreeItemButton(
-                const_cast<wxPropertyGrid*>(this),
-                dc,
-                r,
-                wxCONTROL_EXPANDED
-            );
-    #elif wxPG_ICON_WIDTH
-        //
-    #else
-        bmp = s_collbmp;
-    #endif
-
-    }
-    else
-    {
-    #if (wxPG_USE_RENDERER_NATIVE)
-        wxRendererNative::Get().DrawTreeItemButton(
-                const_cast<wxPropertyGrid*>(this),
-                dc,
-                r,
-                0
-            );
-    #elif wxPG_ICON_WIDTH
-        int _x = r.x+(m_iconWidth/2);
-        dc.DrawLine(_x,r.y+2,_x,r.y+m_iconWidth-2);
-    #else
-        bmp = s_expandbmp;
-    #endif
-    }
-
-#if (wxPG_USE_RENDERER_NATIVE)
-    //
+#if wxPG_USE_RENDERER_NATIVE
+    wxRendererNative::Get().DrawTreeItemButton(
+            const_cast<wxPropertyGrid*>(this),
+            dc,
+            r,
+            property->IsExpanded() ? wxCONTROL_EXPANDED : 0
+        );
 #elif wxPG_ICON_WIDTH
-    //
+    wxRendererNative::GetGeneric().DrawTreeItemButton(
+            const_cast<wxPropertyGrid*>(this),
+            dc,
+            r,
+            property->IsExpanded() ? wxCONTROL_EXPANDED : 0
+        );
 #else
+    wxBitmap bmp = property->IsExpanded() ? s_collbmp : s_expandbmp;
     dc.DrawBitmap( bmp, r.x, r.y, true );
 #endif
 }


### PR DESCRIPTION
wxGTK:
Before (16px):
![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/80a8831c-4ee8-4c57-b3f7-39cf9cec93a7)

After (16px):
![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/8d194cb3-9178-4b67-9953-a6c1b062bc3b)

After (9px):
![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/ce1d5ba2-0adb-469f-acdd-5108ec03d460)

Also see https://github.com/wxWidgets/wxWidgets/commit/10df4064795b1bc318a88cf775d963fc1b7226be, https://github.com/wxWidgets/wxWidgets/issues/15526

---

wxQt propgrid, `wxPG_ICON_WIDTH  9`

![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/55812c94-f432-4629-9575-82e50b217a87)

`wxPG_ICON_WIDTH  11`:

![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/9cd7ea26-a914-45ad-83f8-a028afa4dc21)

