### PR TITLE
wxGrid: implement 'pressed' for highlighted row/column headers while drag-moving a row or column

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -614,12 +614,18 @@ public:
                            int vertAlign,
                            int textOrientation) const;
 
+    // argument 'flags' for DrawHighlighted
+    enum DrawFlags
+    {
+        Draw_Pressed = 1
+    };
+
     // Draw highlighted row/col label.
     virtual void DrawHighlighted(const wxGrid& grid,
                                  wxDC& dc,
                                  wxRect& rect,
                                  int rowOrCol,
-                                 bool pressed = false) const;
+                                 int flags = 0) const;
 };
 
 // Currently the row/column/corner renders don't need any methods other than
@@ -655,7 +661,7 @@ public:
                                  wxDC& dc,
                                  wxRect& rect,
                                  int row,
-                                 bool pressed = false) const override;
+                                 int flags = 0) const override;
 };
 
 // Column header cells renderers
@@ -671,7 +677,7 @@ public:
                                  wxDC& dc,
                                  wxRect& rect,
                                  int col,
-                                 bool pressed = false) const override;
+                                 int flags = 0) const override;
 };
 
 // Header corner renderer

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -618,7 +618,8 @@ public:
     virtual void DrawHighlighted(const wxGrid& grid,
                                  wxDC& dc,
                                  wxRect& rect,
-                                 int rowOrCol) const;
+                                 int rowOrCol,
+                                 bool pressed = false) const;
 };
 
 // Currently the row/column/corner renders don't need any methods other than
@@ -653,7 +654,8 @@ public:
     virtual void DrawHighlighted(const wxGrid& grid,
                                  wxDC& dc,
                                  wxRect& rect,
-                                 int row) const override;
+                                 int row,
+                                 bool pressed = false) const override;
 };
 
 // Column header cells renderers
@@ -668,7 +670,8 @@ public:
     virtual void DrawHighlighted(const wxGrid& grid,
                                  wxDC& dc,
                                  wxRect& rect,
-                                 int col) const override;
+                                 int col,
+                                 bool pressed = false) const override;
 };
 
 // Header corner renderer

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -77,7 +77,8 @@ public:
     virtual void DrawHighlighted(const wxGrid& WXUNUSED(grid),
                                  wxDC& dc,
                                  wxRect& rect,
-                                 int WXUNUSED(rowOrCol)) const override
+                                 int WXUNUSED(rowOrCol),
+                                 bool WXUNUSED(pressed)) const override
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(wxBrush(wxColour(240, 20, 15, 180)));

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -78,7 +78,7 @@ public:
                                  wxDC& dc,
                                  wxRect& rect,
                                  int WXUNUSED(rowOrCol),
-                                 bool WXUNUSED(pressed)) const override
+                                 int WXUNUSED(flags)) const override
     {
         dc.SetPen(*wxTRANSPARENT_PEN);
         dc.SetBrush(wxBrush(wxColour(240, 20, 15, 180)));

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -327,7 +327,8 @@ void wxGridHeaderLabelsRenderer::DrawLabel(const wxGrid& grid,
 void wxGridHeaderLabelsRenderer::DrawHighlighted(const wxGrid& WXUNUSED(grid),
                                                  wxDC& WXUNUSED(dc),
                                                  wxRect& WXUNUSED(rect),
-                                                 int WXUNUSED(rowOrCol)) const
+                                                 int WXUNUSED(rowOrCol),
+                                                 bool WXUNUSED(pressed)) const
 {
 }
 
@@ -414,7 +415,8 @@ void wxGridRowHeaderRendererDefault::DrawBorder(const wxGrid& grid,
 void wxGridRowHeaderRendererDefault::DrawHighlighted(const wxGrid& grid,
                                                      wxDC& dc,
                                                      wxRect& rect,
-                                                     int row) const
+                                                     int row,
+                                                     bool pressed) const
 {
     const wxColour colBg = grid.GetSelectionBackground();
 
@@ -422,14 +424,23 @@ void wxGridRowHeaderRendererDefault::DrawHighlighted(const wxGrid& grid,
     dc.SetBrush(wxBrush(colBg.ChangeLightness(130)));
     dc.DrawRectangle(rect);
 
-    const int ofs = wxPrivate::GridRowLabelDrawBorderCommonDefault(
-                        grid, dc, rect, colBg, colBg.ChangeLightness(170));
+    int ofs;
+    if ( !pressed ) {
+        ofs = wxPrivate::GridRowLabelDrawBorderCommonDefault(
+            grid, dc, rect, colBg, colBg.ChangeLightness(170));
 
-    if ( !grid.IsRowLabelHighlighted(row-1) )
+        if ( !grid.IsRowLabelHighlighted(row - 1) )
+        {
+            dc.SetPen(wxPen(colBg));
+            dc.DrawLine(rect.GetLeft() + ofs - 1, rect.GetTop() - 1,
+                rect.GetRight(), rect.GetTop() - 1);
+        }
+    }
+    else
     {
-        dc.SetPen(wxPen(colBg));
-        dc.DrawLine(rect.GetLeft() + ofs - 1, rect.GetTop() - 1,
-                    rect.GetRight(), rect.GetTop() - 1);
+        // swap colors for a 'pressed' look
+        ofs = wxPrivate::GridRowLabelDrawBorderCommonDefault(
+            grid, dc, rect, colBg.ChangeLightness(170), colBg);
     }
 
     rect.Deflate(1 + ofs);
@@ -450,7 +461,8 @@ void wxGridColumnHeaderRendererDefault::DrawBorder(const wxGrid& grid,
 void wxGridColumnHeaderRendererDefault::DrawHighlighted(const wxGrid& grid,
                                                         wxDC& dc,
                                                         wxRect& rect,
-                                                        int col) const
+                                                        int col,
+                                                        bool pressed) const
 {
     const wxColour colBg = grid.GetSelectionBackground();
 
@@ -458,14 +470,23 @@ void wxGridColumnHeaderRendererDefault::DrawHighlighted(const wxGrid& grid,
     dc.SetBrush(wxBrush(colBg.ChangeLightness(130)));
     dc.DrawRectangle(rect);
 
-    const int ofs = wxPrivate::GridColLabelDrawBorderCommonDefault(
-                        grid, dc, rect, colBg, colBg.ChangeLightness(170));
+    int ofs;
+    if ( !pressed ) {
+        ofs = wxPrivate::GridColLabelDrawBorderCommonDefault(
+            grid, dc, rect, colBg, colBg.ChangeLightness(170));
 
-    if ( !grid.IsColLabelHighlighted(col-1) )
+        if ( !grid.IsColLabelHighlighted(col - 1) )
+        {
+            dc.SetPen(wxPen(colBg));
+            dc.DrawLine(rect.GetLeft() - 1, rect.GetTop() + ofs - 1,
+                rect.GetLeft() - 1, rect.GetBottom());
+        }
+    }
+    else
     {
-        dc.SetPen(wxPen(colBg));
-        dc.DrawLine(rect.GetLeft() - 1, rect.GetTop() + ofs - 1,
-                    rect.GetLeft() - 1, rect.GetBottom());
+        // swap colors for a 'pressed' look
+        ofs = wxPrivate::GridColLabelDrawBorderCommonDefault(
+            grid, dc, rect, colBg.ChangeLightness(170), colBg);
     }
 
     rect.Deflate(1 + ofs);
@@ -7311,8 +7332,8 @@ void wxGrid::DrawRowLabel( wxDC& dc, int row )
     else
     {
         // just highlight the current row
-        dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT)));
-        dc.DrawRectangle(rect);
+        rend.DrawHighlighted(*this, dc, rect, row, true);  // pressed
+
         rect.Deflate(GetBorder() == wxBORDER_NONE ? 2 : 1);
     }
 
@@ -7573,8 +7594,7 @@ void wxGrid::DrawColLabel(wxDC& dc, int col)
         else
         {
             // just highlight the current column
-            dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT)));
-            dc.DrawRectangle(rect);
+            rend.DrawHighlighted(*this, dc, rect, col, true); // pressed
             rect.Deflate(GetBorder() == wxBORDER_NONE ? 2 : 1);
         }
     }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -328,7 +328,7 @@ void wxGridHeaderLabelsRenderer::DrawHighlighted(const wxGrid& WXUNUSED(grid),
                                                  wxDC& WXUNUSED(dc),
                                                  wxRect& WXUNUSED(rect),
                                                  int WXUNUSED(rowOrCol),
-                                                 bool WXUNUSED(pressed)) const
+                                                 int WXUNUSED(flags)) const
 {
 }
 
@@ -416,7 +416,7 @@ void wxGridRowHeaderRendererDefault::DrawHighlighted(const wxGrid& grid,
                                                      wxDC& dc,
                                                      wxRect& rect,
                                                      int row,
-                                                     bool pressed) const
+                                                     int flags) const
 {
     const wxColour colBg = grid.GetSelectionBackground();
 
@@ -425,7 +425,7 @@ void wxGridRowHeaderRendererDefault::DrawHighlighted(const wxGrid& grid,
     dc.DrawRectangle(rect);
 
     int ofs;
-    if ( !pressed ) {
+    if ( !(flags & wxGridRowHeaderRendererDefault::Draw_Pressed) ) {
         ofs = wxPrivate::GridRowLabelDrawBorderCommonDefault(
             grid, dc, rect, colBg, colBg.ChangeLightness(170));
 
@@ -462,7 +462,7 @@ void wxGridColumnHeaderRendererDefault::DrawHighlighted(const wxGrid& grid,
                                                         wxDC& dc,
                                                         wxRect& rect,
                                                         int col,
-                                                        bool pressed) const
+                                                        int flags) const
 {
     const wxColour colBg = grid.GetSelectionBackground();
 
@@ -471,7 +471,7 @@ void wxGridColumnHeaderRendererDefault::DrawHighlighted(const wxGrid& grid,
     dc.DrawRectangle(rect);
 
     int ofs;
-    if ( !pressed ) {
+    if ( !(flags & wxGridRowHeaderRendererDefault::Draw_Pressed) ) {
         ofs = wxPrivate::GridColLabelDrawBorderCommonDefault(
             grid, dc, rect, colBg, colBg.ChangeLightness(170));
 
@@ -7594,7 +7594,8 @@ void wxGrid::DrawColLabel(wxDC& dc, int col)
         else
         {
             // just highlight the current column
-            rend.DrawHighlighted(*this, dc, rect, col, true); // pressed
+            rend.DrawHighlighted(*this, dc, rect, col,
+                wxGridRowHeaderRendererDefault::Draw_Pressed);
             rect.Deflate(GetBorder() == wxBORDER_NONE ? 2 : 1);
         }
     }


### PR DESCRIPTION
@AliKet : thanks for implementing PR https://github.com/wxWidgets/wxWidgets/pull/24561

Sorry for being late. I just built wx these days week as I'm working on making row/col drag-move compatible with row/col selection. (At the moment, if selection is possible, you can't drag a row.)


With the new highlighted row and column labels, the visual display of a row being drag-moved does not match the rest any more.

You can check by running the grid sample, `Grid -> Row drag-move` and `Select -> Change selection mode -> Disallow selection` and then drag a row with the mouse.

The current implementation (row 6 is being dragged and the insertion marker is between rows 7 and 8):
![grafik](https://github.com/wxWidgets/wxWidgets/assets/5512021/131e46dd-e4c9-4339-9c6d-3ef867e9bed7)

I added a parameter `pressed`to `DrawHighlighted` and the button edge colors are swapped if `pressed` is `true`:
![grafik](https://github.com/wxWidgets/wxWidgets/assets/5512021/18ca5319-48fe-4137-bb19-f34bac371acf)
I'm not 100% satisfied, but at least it looks better than before. What do you think?


Another minor issue with the new highlighting:
Personally, I don't like that if e.g. a row is selected, all column headers will be highlighted.
I'm often using the row selection to select a dataset in an application. All other forms will then refer to the selected row.