### PR TITLE
grid: enable row/col selection and drag-move at the same time

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4269,59 +4269,57 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
                 if ( oper.CanDragMove(this) )
                 {
                     ChangeCursorMode(oper.GetCursorModeMove(), headerWin);
-
-                    // Show button as pressed
                     m_dragMoveRowOrCol = line;
+                    // Show button as pressed
                     wxClientDC dc( headerWin );
                     oper.PrepareDCForLabels(this, dc);
                     oper.DrawLineLabel(this, dc, line);
                 }
-                else
-                {
-                    // Check if row/col selection is possible and allowed, before doing
-                    // anything else, including changing the cursor mode to "select
-                    // row"/"select col".
-                    if ( m_selection && m_numRows > 0 && m_numCols > 0 &&
-                            m_selection->GetSelectionMode() != dual.GetSelectionMode() )
-                    {
-                        bool selectNewLine = false,
-                             makeLineCurrent = false;
 
-                        if ( event.ShiftDown() && !event.CmdDown() )
+                // Check if row/col selection is possible and allowed, before doing
+                // anything else, including changing the cursor mode to "select
+                // row"/"select col".
+                if ( m_selection && m_numRows > 0 && m_numCols > 0 &&
+                        m_selection->GetSelectionMode() != dual.GetSelectionMode() )
+                {
+                    bool selectNewLine = false,
+                         makeLineCurrent = false;
+
+                    if ( event.ShiftDown() && !event.CmdDown() )
+                    {
+                        // Continue editing the current selection and don't
+                        // move the grid cursor.
+                        oper.SelectionExtendCurrentBlock(this, line, event);
+                        oper.MakeLineVisible(this, line);
+                    }
+                    else if ( event.CmdDown() && !event.ShiftDown() )
+                    {
+                        if ( oper.IsLineInSelection(this, line) )
                         {
-                            // Continue editing the current selection and don't
-                            // move the grid cursor.
-                            oper.SelectionExtendCurrentBlock(this, line, event);
-                            oper.MakeLineVisible(this, line);
-                        }
-                        else if ( event.CmdDown() && !event.ShiftDown() )
-                        {
-                            if ( oper.IsLineInSelection(this, line) )
-                            {
-                                oper.DeselectLine(this, line);
-                                makeLineCurrent = true;
-                            }
-                            else
-                            {
-                                makeLineCurrent =
-                                selectNewLine = true;
-                            }
+                            oper.DeselectLine(this, line);
+                            makeLineCurrent = true;
                         }
                         else
                         {
-                            ClearSelection();
                             makeLineCurrent =
                             selectNewLine = true;
                         }
-
-                        if ( selectNewLine )
-                            oper.SelectLine(this, line, event);
-
-                        if ( makeLineCurrent )
-                            oper.MakeLineCurrent(this, line);
-
-                        ChangeCursorMode(oper.GetCursorModeSelect(), labelWin);
                     }
+                    else
+                    {
+                        ClearSelection();
+                        makeLineCurrent =
+                        selectNewLine = true;
+                    }
+
+                    if ( selectNewLine )
+                        oper.SelectLine(this, line, event);
+
+                    if ( makeLineCurrent )
+                        oper.MakeLineCurrent(this, line);
+
+                    if ( !oper.CanDragMove(this) )
+                        ChangeCursorMode(oper.GetCursorModeSelect(), labelWin);
                 }
             }
         }


### PR DESCRIPTION
At the moment, enabling drag-move of rows/cols inhibits row/col selection.
This is due to the `LeftDown` down handler inside `ProcessRowColLabelMouseEvent` using `if { } else { if`.
This PR removes the `else`.

The diff looks rather wild, but actually the only change is the removal of `else` and that the selection cursor is not used if it has been set to MOVE already:
```
if ( !oper.CanDragMove(this) )
    ChangeCursorMode(oper.GetCursorModeSelect(), labelWin);
```

I have experimented with changing the cursor mode to `WXGRID_CURSOR_MOVE_ROW/COL` only after the mouse has moved by some pixels, but I prefered the immediate change of the label to 'pressed'. A delayed setting of the cursor mode is too complicated with the current grid implementation (a proper state and state machine data structure would be needed).