### PR TITLE
Fix argvA initialization for wxGTK under Windows

### DIFF
--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -57,6 +57,10 @@ struct WXDLLIMPEXP_BASE wxInitData
     wchar_t** argvMSW = nullptr;
 #endif // __WINDOWS__
 #ifndef __WXMSW__
+    // Builds argvA from argc and argv. This means that argc and argv
+    // MUST be initialized before calling this function.
+    void BuildArgvA();
+
     // Under other platforms (and under windows when not using wxMSW) we
     // typically need the original, non-Unicode command line version, so we
     // keep it too. This pointer may or not need to be freed, as indicated by

--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -55,13 +55,15 @@ struct WXDLLIMPEXP_BASE wxInitData
     // It's also possible to use Initialize(), even under Windows, in which
     // case this pointer remains null and argv must be freed as usual.
     wchar_t** argvMSW = nullptr;
-#else // !__WINDOWS__
-    // Under other platforms we typically need the original, non-Unicode
-    // command line version, so we keep it too. This pointer may or not need to
-    // be freed, as indicated by ownsArgvA flag.
+#endif // __WINDOWS__
+#ifndef __WXMSW__
+    // Under other platforms (and under windows when not using wxMSW) we
+    // typically need the original, non-Unicode command line version, so we
+    // keep it too. This pointer may or not need to be freed, as indicated by
+    // ownsArgvA flag.
     char** argvA = nullptr;
     bool ownsArgvA = false;
-#endif // __WINDOWS__
+#endif // !__WXMSW__
 
     wxDECLARE_NO_COPY_CLASS(wxInitData);
 };

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -183,6 +183,26 @@ void wxInitData::Initialize(int argcIn, char **argvIn)
     argv[wargc] = nullptr;
 }
 
+#ifndef __WXMSW__
+
+// This function builds the argvA
+void wxInitData::BuildArgvA() {
+    // We need to convert from wide arguments back to the narrow ones.
+    argvA = new char*[argc + 1];
+    argvA[argc] = nullptr;
+
+    ownsArgvA = true;
+
+    for ( int i = 0; i < argc; i++ )
+    {
+        // Try to use the current encoding, but if it fails, it's better to
+        // fall back to UTF-8 than lose an argument entirely.
+        argvA[i] = wxConvWhateverWorks.cWC2MB(argv[i]).release();
+    }
+}
+
+#endif // !__WXMSW__
+
 #ifdef __WINDOWS__
 
 void wxInitData::MSWInitialize()
@@ -202,18 +222,7 @@ void wxInitData::MSWInitialize()
     argv = argvMSW;
 
 #ifndef __WXMSW__
-    // We need to convert from wide arguments back to the narrow ones.
-    argvA = new char*[argc + 1];
-    argvA[argc] = nullptr;
-
-    ownsArgvA = true;
-
-    for ( int i = 0; i < argc; i++ )
-    {
-        // Try to use the current encoding, but if it fails, it's better to
-        // fall back to UTF-8 than lose an argument entirely.
-        argvA[i] = wxConvWhateverWorks.cWC2MB(argv[i]).release();
-    }
+    BuildArgvA();
 #endif // !__WXMSW__
 }
 
@@ -245,18 +254,7 @@ void wxInitData::InitIfNecessary(int argcIn, wchar_t** argvIn)
     }
 
 #ifndef __WXMSW__
-    // We need to convert from wide arguments back to the narrow ones.
-    argvA = new char*[argc + 1];
-    argvA[argc] = nullptr;
-
-    ownsArgvA = true;
-
-    for ( int i = 0; i < argc; i++ )
-    {
-        // Try to use the current encoding, but if it fails, it's better to
-        // fall back to UTF-8 than lose an argument entirely.
-        argvA[i] = wxConvWhateverWorks.cWC2MB(argvIn[i]).release();
-    }
+    BuildArgvA();
 #endif // !__WXMSW__
 
 #ifdef __WINDOWS__


### PR DESCRIPTION
Update conditional directives to enable argvA if `!__WXMSW__` instead of if `!__WINDOWS__` (It seems originally there was confusion/misunderstanding of the roles of the two macros as toolkit and platform indicators respectively)

Fix argvA not being initialized in InitIfNecessary due to argc check returning early.

See issue #24611