### PR TITLE
Fix static box bgcolor when on wxPanel (MSW dark mode)

### DIFF
--- a/src/common/panelcmn.cpp
+++ b/src/common/panelcmn.cpp
@@ -30,7 +30,11 @@
 #endif
 
 #ifdef __WXMSW__
-    #include "wx/msw/private/darkmode.h"
+    #if wxUSE_UXTHEME
+        #include "wx/msw/uxtheme.h"
+        #include "wx/msw/private.h"
+        #include "wx/msw/private/darkmode.h"
+    #endif
 #endif
 
 // ----------------------------------------------------------------------------
@@ -104,11 +108,13 @@ bool wxPanel::Create(wxWindow *parent, wxWindowID id,
     SetThemeEnabled(true);
 
 #ifdef __WXMSW__
-    // explicitly set dark background color for child wxStaticBoxes to inherit
-    if ( wxMSWDarkMode::IsActive() )
-    {
-        SetBackgroundColour(wxSystemSettings::GetColour(wxSystemColour::wxSYS_COLOUR_WINDOW));
-    }
+    #if wxUSE_UXTHEME
+        // explicitly set dark background color for child wxStaticBoxes to inherit
+        if ( wxMSWDarkMode::IsActive() )
+        {
+            SetBackgroundColour(wxSystemSettings::GetColour(wxSystemColour::wxSYS_COLOUR_WINDOW));
+        }
+    #endif
 #endif
 
     return true;

--- a/src/common/panelcmn.cpp
+++ b/src/common/panelcmn.cpp
@@ -29,6 +29,10 @@
     #include "wx/containr.h"
 #endif
 
+#ifdef __WXMSW__
+    #include "wx/msw/private/darkmode.h"
+#endif
+
 // ----------------------------------------------------------------------------
 // XTI
 // ----------------------------------------------------------------------------
@@ -98,6 +102,14 @@ bool wxPanel::Create(wxWindow *parent, wxWindowID id,
 
     // so that non-solid background renders correctly under GTK+:
     SetThemeEnabled(true);
+
+#ifdef __WXMSW__
+    // explicitly set dark background color for child wxStaticBoxes to inherit
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        SetBackgroundColour(wxSystemSettings::GetColour(wxSystemColour::wxSYS_COLOUR_WINDOW));
+    }
+#endif
 
     return true;
 }

--- a/src/msw/dialog.cpp
+++ b/src/msw/dialog.cpp
@@ -178,6 +178,12 @@ bool wxDialog::Create(wxWindow *parent,
         Bind(wxEVT_CREATE, &wxDialog::OnWindowCreate, this);
     }
 
+    // explicitly set dark background color for child wxStaticBoxes to inherit
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        SetBackgroundColour(wxSystemSettings::GetColour(wxSystemColour::wxSYS_COLOUR_WINDOW));
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Under MSW dark mode, `wxStaticBox` will have a dark gray background when placed on a `wxPanel`. It seems that this is the color it is pulling from the parent `wxPanel`. Explicitly setting the panel's background color to the proper color under dark mode fixes it.

At first I thought of changing `wxStaticBox` to not use the parent's bgcolor, but perhaps this is a better approach in case their are other controls that also look at the parent's bgcolor. Fixing at the `wxPanel` level will fix all any of those.

BEFORE:

![Before](https://github.com/wxWidgets/wxWidgets/assets/66873089/f4643e23-ac59-49d1-b957-1c3cbbbd195c)

AFTER:

![After](https://github.com/wxWidgets/wxWidgets/assets/66873089/7787910d-45b4-4b02-bc5d-1565e31f8a4f)
