### PR TITLE
Improve battery and wxSecureZeroMemory docs

### DIFF
--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -360,8 +360,8 @@ void wxSecureZeroMemory(void *p, size_t n);
     Returns battery state as one of @c wxBATTERY_NORMAL_STATE,
     @c wxBATTERY_LOW_STATE, @c wxBATTERY_CRITICAL_STATE,
     @c wxBATTERY_SHUTDOWN_STATE or @c wxBATTERY_UNKNOWN_STATE.
-    @c wxBATTERY_UNKNOWN_STATE is also the default on platforms where this
-    feature is not implemented (currently everywhere but MS Windows).
+    
+    Currently only implemented on MS Windows; returns @c wxBATTERY_UNKNOWN_STATE elsewhere.
 
     @header{wx/utils.h}
 */
@@ -369,9 +369,9 @@ wxBatteryState wxGetBatteryState();
 
 /**
     Returns the type of power source as one of @c wxPOWER_SOCKET,
-    @c wxPOWER_BATTERY or @c wxPOWER_UNKNOWN. @c wxPOWER_UNKNOWN is also the
-    default on platforms where this feature is not implemented (currently
-    everywhere but MS Windows).
+    @c wxPOWER_BATTERY or @c wxPOWER_UNKNOWN.
+
+    Currently only implemented on MS Windows; returns @c wxPOWER_UNKNOWN elsewhere.
 
     @header{wx/utils.h}
 */

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -364,7 +364,7 @@ void wxSecureZeroMemory(void *p, size_t n);
     Returns battery state as one of @c wxBATTERY_NORMAL_STATE,
     @c wxBATTERY_LOW_STATE, @c wxBATTERY_CRITICAL_STATE,
     @c wxBATTERY_SHUTDOWN_STATE or @c wxBATTERY_UNKNOWN_STATE.
-    
+
     Currently only implemented on MS Windows; returns @c wxBATTERY_UNKNOWN_STATE elsewhere.
 
     @header{wx/utils.h}

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -346,9 +346,13 @@ bool wxGetEnvMap(wxEnvVariableHashMap *map);
     @param p Pointer to the memory block to be zeroed, must be non-null.
     @param n The number of bytes to zero.
 
-    NOTE: If security is vitally important in your use case, please
+    @note If security is vitally important in your use case, please
     have a look at the implementations and decide whether you trust
-    them to behave as promised.
+    them to behave as promised. Depending on the platform and available libraries,
+    this may be implemented as `RtlSecureZeroMemory` (MS Windows),
+    `explicit_bzero()` (FreeBSD), `memset_s()` (macOS),
+    or a generic method which uses `volatile` to avoid the call from
+    being optimized away.
 
     @header{wx/utils.h}
 


### PR DESCRIPTION
Expand docs about how `wxSecureZeroMemory` may be implemented.
Reword the battery functions descriptions about which platform it words on (it was a bit confusing with how it was worded, IMO). The explanation matches similar wording I see elsewhere in the help.