### PR TITLE
wxMAC scrolbar: use doubleValue instead of floatValue

### DIFF
--- a/src/osx/cocoa/scrolbar.mm
+++ b/src/osx/cocoa/scrolbar.mm
@@ -62,7 +62,7 @@ public :
 
     virtual wxInt32 GetValue() const override
     {
-        return wxRound([(wxNSScroller*) m_osxView floatValue] * m_maximum);
+        return wxRound([(wxNSScroller*) m_osxView doubleValue] * m_maximum);
     }
 
     virtual wxInt32 GetMaximum() const override


### PR DESCRIPTION

Use doubleValue instead of floatValue to improve precision of GetValue().

Address issue #24669