### PR TITLE
Draw checkboxes and radiobuttons at correct size on high DPI.

### DIFF
--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -754,8 +754,6 @@ wxRendererXP::DoDrawButtonLike(wxUxThemeHandle& hTheme,
 {
     wxCHECK_RET( dc.GetImpl(), wxT("Invalid wxDC") );
 
-    RECT r = ConvertToRECT(dc, rect);
-
     // the base state is always 1, whether it is PBS_NORMAL,
     // {CBS,RBS}_UNCHECKEDNORMAL or CBS_NORMAL
     int state = 1;
@@ -787,6 +785,20 @@ wxRendererXP::DoDrawButtonLike(wxUxThemeHandle& hTheme,
     // wxCONTROL_ISDEFAULT flag is only valid for push buttons
     else if ( part == BP_PUSHBUTTON && (flags & wxCONTROL_ISDEFAULT) )
         state = PBS_DEFAULTED;
+
+    wxRect crect = rect;
+
+    // Checkboxes and radiobuttons must be drawn at native size, otherwise
+    // they get blurry on non-unity display scales
+    if ( part == BP_CHECKBOX || part == BP_RADIOBUTTON )
+    {
+        if ( ::IsThemePartDefined(hTheme, part, 0) )
+        {
+            crect = wxRect(hTheme.GetDrawSize(part, state)).CenterIn(rect);
+        }
+    }
+
+    RECT r = ConvertToRECT(dc, crect);
 
     hTheme.DrawBackground(GetHdcOf(dc.GetTempHDC()), r, part, state);
 }

--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -1555,7 +1555,7 @@ public:
         // Due to SetOwnFont stuff necessary for GTK+ 1.2, we need to have this
         wxControl::SetFont( parent->GetFont() );
 
-        SetBoxHeight(12);
+        SetBoxHeight(13);
         wxControl::SetBackgroundStyle( wxBG_STYLE_PAINT );
     }
 
@@ -1565,10 +1565,7 @@ public:
     {
         m_boxHeight = height;
         // Box rectangle
-        wxRect rect(GetClientSize());
-        rect.y += 1;
-        rect.width += 1;
-        m_boxRect = GetBoxRect(rect, m_boxHeight);
+        m_boxRect = GetBoxRect(GetClientSize(), m_boxHeight);
     }
 
     static wxRect GetBoxRect(const wxRect& r, int box_h)

--- a/src/propgrid/property.cpp
+++ b/src/propgrid/property.cpp
@@ -86,7 +86,7 @@ void wxPGCellRenderer::DrawEditorValue( wxDC& dc, const wxRect& rect,
     {
         wxRect rect2(rect);
         rect2.Offset(xOffset, yOffset);
-        rect2.height -= yOffset;
+        rect2.height -= yOffset * 2;
         editor->DrawValue( dc, rect2, property, text );
     }
     else


### PR DESCRIPTION
When the display scale is not 100%, MSW scales these controls badly. This commit changes the logic to draw them at correct size.

Closes #24651.

---

Fix vertical centering of propgrid checkboxes on high DPI.
Closes https://github.com/wxWidgets/wxWidgets/issues/24650.