### PR TITLE
Add GetHWND() to wxWindowGTK when on Windows

### DIFF
--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -140,8 +140,12 @@ public:
 
     virtual WXWidget GetHandle() const override { return m_widget; }
 #ifdef __WINDOWS__
-    WXHWND GetHWND() const;
+    WXHWND GTKGetWin32Handle() const;
 #endif
+
+    // If the underlying GTK widget hasn't been realized yet, do so.
+    // Does nothing if the widget is already realized.
+    void GTKRealizeWidget();
 
     // many important things are done here, this function must be called
     // regularly

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -139,13 +139,12 @@ public:
     // --------------
 
     virtual WXWidget GetHandle() const override { return m_widget; }
+
 #ifdef __WINDOWS__
+    // If on Windows, cut through the GtkWidget abstraction
+    // to get HWND.
     WXHWND GTKGetWin32Handle() const;
 #endif
-
-    // If the underlying GTK widget hasn't been realized yet, do so.
-    // Does nothing if the widget is already realized.
-    void GTKRealizeWidget();
 
     // many important things are done here, this function must be called
     // regularly

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -139,6 +139,9 @@ public:
     // --------------
 
     virtual WXWidget GetHandle() const override { return m_widget; }
+#ifdef __WINDOWS__
+    WXHWND GetHWND() const;
+#endif
 
     // many important things are done here, this function must be called
     // regularly

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -3890,6 +3890,38 @@ public:
     virtual WXWidget GetHandle() const;
 
     /**
+        This function is used only with wxGTK when running on Windows, to
+        receive a wxWindow's underlying HWND.
+
+        Whereas GetHandle() returns a port-specific handle (a GtkWidget on
+        wxGTK), this function returns the handle which underlies the GtkWidget
+        itself.
+
+        If you do need to use it, please note that this function doesn't exist
+        anywhere besides wxGTK on Windows, and so any code using it must be
+        conditionally guarded against using, for example:
+        @code
+        #if defined(__WINDOWS__) && defined(__WXGTK__)
+        ... code that uses GTKGetWin32Handle() ...
+        #endif
+        @endcode
+
+        Note that this function will return nullptr if the Window has not yet
+        been initialized ("realized" in GTK terms) or is otherwise invalid.
+
+        A Window is generally realized once it has been shown, and code which
+        needs to run as soon as the Window is realized should hook wxWindowCreateEvent
+        to do so.
+
+        @return HWND if the Window is valid, nullptr otherwise.
+
+        @see wxWindowCreateEvent
+
+        @since 3.3.0
+     */
+    WXHWND GTKGetWin32Handle() const;
+
+    /**
         This method should be overridden to return @true if this window has
         multiple pages. All standard class with multiple pages such as
         wxNotebook, wxListbook and wxTreebook already override it to return @true

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4244,7 +4244,8 @@ bool wxWindowGTK::GTKShowFromOnIdle()
 }
 
 #ifdef __WINDOWS__
-WXHWND wxWindowGTK::GetHWND() const {
+WXHWND wxWindowGTK::GetHWND() const
+{
     // There isn't an underlying HWND if the widget hasn't been realized yet.
     gtk_widget_realize(m_widget);
     return static_cast<WXHWND>(gdk_win32_window_get_handle(gtk_widget_get_window(m_widget)));

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -37,6 +37,9 @@
 #ifdef __WXGTK3__
     #include "wx/gtk/dc.h"
 #endif
+#ifdef __WINDOWS__
+    #include <gdk/gdkwin32.h>
+#endif
 
 #include <ctype.h>
 
@@ -4239,6 +4242,14 @@ bool wxWindowGTK::GTKShowFromOnIdle()
 
     return false;
 }
+
+#ifdef __WINDOWS__
+WXHWND wxWindowGTK::GetHWND() const {
+    // There isn't an underlying HWND if the widget hasn't been realized yet.
+    gtk_widget_realize(m_widget);
+    return static_cast<WXHWND>(gdk_win32_window_get_handle(gtk_widget_get_window(m_widget)));
+}
+#endif
 
 void wxWindowGTK::OnInternalIdle()
 {

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4243,12 +4243,19 @@ bool wxWindowGTK::GTKShowFromOnIdle()
     return false;
 }
 
-#ifdef __WINDOWS__
-WXHWND wxWindowGTK::GetHWND() const
+void wxWindowGTK::GTKRealizeWidget()
 {
-    // There isn't an underlying HWND if the widget hasn't been realized yet.
     gtk_widget_realize(m_widget);
-    return static_cast<WXHWND>(gdk_win32_window_get_handle(gtk_widget_get_window(m_widget)));
+}
+
+#ifdef __WINDOWS__
+WXHWND wxWindowGTK::GTKGetWin32Handle() const
+{
+    auto gtkWindow{gtk_widget_get_window(m_widget)};
+    // If widget is not realized, there's no underlying
+    // handle to get.
+    if (!gtkWindow) return nullptr;
+    return static_cast<WXHWND>(gdk_win32_window_get_handle(gtkWindow));
 }
 #endif
 

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4243,11 +4243,6 @@ bool wxWindowGTK::GTKShowFromOnIdle()
     return false;
 }
 
-void wxWindowGTK::GTKRealizeWidget()
-{
-    gtk_widget_realize(m_widget);
-}
-
 #ifdef __WINDOWS__
 WXHWND wxWindowGTK::GTKGetWin32Handle() const
 {


### PR DESCRIPTION
As the title says, when using wxGTK on Windows there's not a way (that I can tell) to get an HWND from a wxWindow. This uses a couple of gdk and gtk helpers to get the HWND from the underlying GtkWidget.

