### PR TITLE
Add panel to sizer when not using wxCollapsiblePane in wxLogDialog.

### DIFF
--- a/src/generic/logg.cpp
+++ b/src/generic/logg.cpp
@@ -775,6 +775,8 @@ wxLogDialog::wxLogDialog(wxWindow *parent,
 #else
     wxPanel* win = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                wxBORDER_NONE);
+
+    sizerTop->Add(win, wxSizerFlags(1).Expand().Border());
 #endif
     wxSizer * const paneSz = new wxBoxSizer(wxVERTICAL);
 


### PR DESCRIPTION
Not using `wxCollapsiblePane` in `wxLogDialog` didn't work correctly before this change.