### PR TITLE
wxQt: avoid SIGPIPE when debugging on X11.

### DIFF
--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -63,7 +63,6 @@ bool wxApp::Initialize( int &argc, wxChar **argv )
     QSurfaceFormat::setDefaultFormat(format);
 
     m_qtApplication.reset(new QApplication(m_qtArgc, m_qtArgv.get()));
-    m_qtApplication->processEvents(); // Avoids SIGPIPE when debugging
 
     if ( m_qtApplication->platformName() == "xcb" )
         m_qtApplication->processEvents(); // Avoids SIGPIPE on X11 when debugging

--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -65,6 +65,9 @@ bool wxApp::Initialize( int &argc, wxChar **argv )
     m_qtApplication.reset(new QApplication(m_qtArgc, m_qtArgv.get()));
     m_qtApplication->processEvents(); // Avoids SIGPIPE when debugging
 
+    if ( m_qtApplication->platformName() == "xcb" )
+        m_qtApplication->processEvents(); // Avoids SIGPIPE on X11 when debugging
+
     // Use the args returned by Qt as it may have deleted (processed) some of them
     // Using QApplication::arguments() forces argument processing
     QStringList qtArgs = m_qtApplication->arguments();

--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -63,6 +63,7 @@ bool wxApp::Initialize( int &argc, wxChar **argv )
     QSurfaceFormat::setDefaultFormat(format);
 
     m_qtApplication.reset(new QApplication(m_qtArgc, m_qtArgv.get()));
+    m_qtApplication->processEvents(); // Avoids SIGPIPE when debugging
 
     // Use the args returned by Qt as it may have deleted (processed) some of them
     // Using QApplication::arguments() forces argument processing


### PR DESCRIPTION
See https://stackoverflow.com/questions/56686603/how-to-avoid-sigpipe-due-to-a-timeout-when-debugging-an-x11-program