### PR TITLE
wxQt: QPainter / wxQtDCImpl fixes.

### DIFF
--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -839,7 +839,7 @@ void wxQtDCImpl::DoDrawRotatedText(const wxString& text,
         m_qtPainter->setBackground(QBrush(m_textBackgroundColour.GetQColor()));
 
         //Draw
-        m_qtPainter->drawText(x, y, 1, 1, Qt::TextDontClip, wxQtConvertString(text));
+        m_qtPainter->drawText(0, 0, 1, 1, Qt::TextDontClip, wxQtConvertString(text));
 
         //Restore saved settings
         m_qtPainter->setBackground(savedBrush);
@@ -847,7 +847,7 @@ void wxQtDCImpl::DoDrawRotatedText(const wxString& text,
         m_qtPainter->setBackgroundMode(Qt::TransparentMode);
     }
     else
-        m_qtPainter->drawText(x, y, 1, 1, Qt::TextDontClip, wxQtConvertString(text));
+        m_qtPainter->drawText(0, 0, 1, 1, Qt::TextDontClip, wxQtConvertString(text));
 
     //Reset to default
     ComputeScaleAndOrigin();

--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -141,5 +141,7 @@ wxPaintDCImpl::wxPaintDCImpl( wxDC *owner, wxWindow *win )
 {
     wxCHECK_RET( m_isWindowPainter || win->QtCanPaintWithoutActivePainter(),
                  "wxPaintDC can't be created outside wxEVT_PAINT handler" );
+
+    m_qtPainter->translate( wxQtConvertPoint(win->GetClientAreaOrigin()) );
 }
 

--- a/src/qt/pen.cpp
+++ b/src/qt/pen.cpp
@@ -33,7 +33,7 @@ static Qt::PenStyle ConvertPenStyle(wxPenStyle style)
             return Qt::DashLine;
 
         case wxPENSTYLE_DOT_DASH:
-            return Qt::DotLine;
+            return Qt::DashDotLine;
 
         case wxPENSTYLE_USER_DASH:
             return Qt::CustomDashLine;


### PR DESCRIPTION
wxQt: translate QPainter into window client area.
Otherwise, if a menu bar exists, painting is done at incorrect offset. Patch by AliKet.

Closes #24629.

---

Two commits added to fix rotated text drawing and dash-dot pen style in `printing` sample:

Before:
![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/98fc02a9-f263-467a-b325-f2ca2ea64188)

After:
![image](https://github.com/wxWidgets/wxWidgets/assets/37658952/e72382a2-d16a-452b-8d99-241bb8119f0a)
