### PR TITLE
wxQt: improve wxGLCanvas latency.

### DIFF
--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -14,6 +14,7 @@
 #include "wx/qt/private/converter.h"
 #include <QtCore/QStringList>
 #include <QtWidgets/QApplication>
+#include <QSurfaceFormat>
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxEvtHandler);
 
@@ -55,6 +56,11 @@ bool wxApp::Initialize( int &argc, wxChar **argv )
     }
     m_qtArgv[argc] = nullptr;
     m_qtArgc = argc;
+
+    // Use SingleBuffer mode by default to reduce latency.
+    QSurfaceFormat format;
+    format.setSwapBehavior(QSurfaceFormat::SwapBehavior::SingleBuffer);
+    QSurfaceFormat::setDefaultFormat(format);
 
     m_qtApplication.reset(new QApplication(m_qtArgc, m_qtArgv.get()));
 

--- a/src/qt/glcanvas.cpp
+++ b/src/qt/glcanvas.cpp
@@ -460,7 +460,7 @@ bool wxGLCanvas::Create(wxWindow *parent,
     if (!ParseAttribList(attribList, dispAttrs, &ctxAttrs))
         return false;
 
-    QSurfaceFormat format;
+    QSurfaceFormat format = QSurfaceFormat::defaultFormat();
     if (!wxGLCanvas::ConvertWXAttrsToQtGL(dispAttrs, ctxAttrs, format))
         return false;
 
@@ -503,7 +503,6 @@ bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxG
     const int *ctxattrs = wxCtxAttrs.GetGLAttrs();
 
     // set default parameters to false
-    format.setSwapBehavior(QSurfaceFormat::SwapBehavior::SingleBuffer);
     format.setDepthBufferSize(0);
     format.setAlphaBufferSize(0);
     format.setStencilBufferSize(0);
@@ -532,7 +531,9 @@ bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxG
                 break;
 
             case WX_GL_DOUBLEBUFFER:
-                format.setSwapBehavior(QSurfaceFormat::SwapBehavior::DoubleBuffer);
+                // Since QOpenGLWidget copies the framebuffer data to a
+                // texture, we already have tear-free behaviour.
+                // Using SwapBehavior::DoubleBuffer just increases latency.
                 isBoolAttr = true;
                 break;
 
@@ -662,7 +663,7 @@ bool wxGLCanvasBase::IsDisplaySupported(const int *attribList)
     if (!ParseAttribList(attribList, dispAttrs, &ctxAttrs))
         return false;
 
-    QSurfaceFormat format;
+    QSurfaceFormat format = QSurfaceFormat::defaultFormat();
     if (!wxGLCanvas::ConvertWXAttrsToQtGL(dispAttrs, ctxAttrs, format))
         return false;
 


### PR DESCRIPTION
By setting default swap behavior mode to SingleBuffer, we can get much lower latency when working with wxGLCanvas.

Comparison video of `pyramid` (on Linux Mint/X11, 60 Hz monitor, 125 Hz mouse, captured in 240 fps, at 1/8 speed):

"VSync On, Double (buffering)" is before this PR.
"VSync On, Single (buffering)" is after this PR.

https://github.com/wxWidgets/wxWidgets/assets/37658952/1b569639-e0da-44f2-9cb7-06a989607aab

"VSync Off, Single (buffering)" is possible, but needs to be checked if it's better.