### PR TITLE
Update macos-11 runners to macos-12

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -66,11 +66,11 @@ jobs:
             runner: ubuntu-22.04
             cmake_generator: Unix Makefiles
             cmake_samples: ALL
-          - name: macOS 11 wxOSX
-            runner: macos-11
+          - name: macOS 12 wxOSX
+            runner: macos-12
             cmake_generator: Xcode
-          - name: macOS 11 wxIOS
-            runner: macos-11
+          - name: macOS 12 wxIOS
+            runner: macos-12
             cmake_generator: Xcode
             cmake_defines: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_FIND_ROOT_PATH=/usr/local -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
             cmake_samples: OFF


### PR DESCRIPTION
Github has deprecated macos-11 runners; update to use the oldest supported runners for CI