### PR TITLE
Fix automatic closing of `wxTipWindow` due to bounding rectangle

### DIFF
--- a/src/generic/tipwin.cpp
+++ b/src/generic/tipwin.cpp
@@ -329,7 +329,7 @@ void wxTipWindowView::OnMouseMove(wxMouseEvent& event)
     const wxRect& rectBound = m_parent->m_rectBound;
 
     if ( rectBound.width &&
-            !rectBound.Contains(ClientToScreen(event.GetPosition())) )
+            !rectBound.Contains(event.GetPosition()) )
     {
         // mouse left the bounding rect, disappear
         m_parent->Close();


### PR DESCRIPTION
Remove incorrect mouse position conversion. No conversion is required since the bounding box is specified in screen coordinates.

----

According to the documentation, the bounding rectangle of a `wxTipWindow` is to be set in screen coordinates

https://github.com/wxWidgets/wxWidgets/blob/fbf4ac52d80d06c523a0a7aad6d1dc369980619c/interface/wx/tipwin.h#L58-L61

and the mouse position returned by `wxMouseEvent::GetPosition()` is also given in screen coordinates

https://github.com/wxWidgets/wxWidgets/blob/fbf4ac52d80d06c523a0a7aad6d1dc369980619c/interface/wx/mousestate.h#L74-L78
