### PR TITLE
wxQt: Stop overriding wxWindow::GetHandle() in derived classes

### DIFF
--- a/include/wx/qt/anybutton.h
+++ b/include/wx/qt/anybutton.h
@@ -26,17 +26,15 @@ public:
     virtual void SetLabel( const wxString &label ) override;
     virtual wxString GetLabel() const override;
 
-    virtual QWidget *GetHandle() const override;
-
     // implementation only
     void QtUpdateState();
     virtual int QtGetEventType() const = 0;
 
+    QPushButton* GetQPushButton() const;
+
 protected:
     virtual wxBitmap DoGetBitmap(State state) const override;
     virtual void DoSetBitmap(const wxBitmapBundle& bitmap, State which) override;
-
-    QPushButton *m_qtPushButton;
 
     void QtCreate(wxWindow *parent);
     void QtSetBitmap( const wxBitmapBundle &bitmap );

--- a/include/wx/qt/anybutton.h
+++ b/include/wx/qt/anybutton.h
@@ -18,7 +18,7 @@ class QPushButton;
 class WXDLLIMPEXP_CORE wxAnyButton : public wxAnyButtonBase
 {
 public:
-    wxAnyButton();
+    wxAnyButton() = default;
 
     // implementation
     // --------------

--- a/include/wx/qt/bmpbuttn.h
+++ b/include/wx/qt/bmpbuttn.h
@@ -11,7 +11,7 @@
 class WXDLLIMPEXP_CORE wxBitmapButton : public wxBitmapButtonBase
 {
 public:
-    wxBitmapButton();
+    wxBitmapButton() = default;
 
     wxBitmapButton(wxWindow *parent,
                    wxWindowID id,

--- a/include/wx/qt/button.h
+++ b/include/wx/qt/button.h
@@ -14,7 +14,8 @@
 class WXDLLIMPEXP_CORE wxButton : public wxButtonBase
 {
 public:
-    wxButton();
+    wxButton() = default;
+
     wxButton(wxWindow *parent, wxWindowID id,
            const wxString& label = wxEmptyString,
            const wxPoint& pos = wxDefaultPosition,

--- a/include/wx/qt/calctrl.h
+++ b/include/wx/qt/calctrl.h
@@ -70,7 +70,7 @@ public:
 
     using wxCalendarCtrlBase::GenerateAllChangeEvents;
 
-    virtual QWidget *GetHandle() const override;
+    QCalendarWidget* GetQCalendarWidget() const;
 
 protected:
     virtual void RefreshHolidays() override;
@@ -79,7 +79,6 @@ private:
     void Init();
     void UpdateStyle();
 
-    QCalendarWidget *m_qtCalendar;
     wxColour m_colHeaderFg,
              m_colHeaderBg,
              m_colHolidayFg,

--- a/include/wx/qt/checkbox.h
+++ b/include/wx/qt/checkbox.h
@@ -35,14 +35,11 @@ public:
     virtual void SetLabel(const wxString& label) override;
     virtual wxString GetLabel() const override;
 
-    virtual QWidget *GetHandle() const override;
+    QCheckBox* GetQCheckBox() const;
 
 protected:
     virtual void DoSet3StateValue(wxCheckBoxState state) override;
     virtual wxCheckBoxState DoGet3StateValue() const override;
-
-private:
-    QCheckBox *m_qtCheckBox;
 
     wxDECLARE_DYNAMIC_CLASS(wxCheckBox);
 };

--- a/include/wx/qt/checkbox.h
+++ b/include/wx/qt/checkbox.h
@@ -13,7 +13,8 @@ class QCheckBox;
 class WXDLLIMPEXP_CORE wxCheckBox : public wxCheckBoxBase
 {
 public:
-    wxCheckBox();
+    wxCheckBox() = default;
+
     wxCheckBox( wxWindow *parent, wxWindowID id, const wxString& label,
             const wxPoint& pos = wxDefaultPosition,
             const wxSize& size = wxDefaultSize, long style = 0,

--- a/include/wx/qt/checklst.h
+++ b/include/wx/qt/checklst.h
@@ -11,7 +11,8 @@
 class WXDLLIMPEXP_CORE wxCheckListBox : public wxCheckListBoxBase
 {
 public:
-    wxCheckListBox();
+    wxCheckListBox() = default;
+
     wxCheckListBox(wxWindow *parent, wxWindowID id,
             const wxPoint& pos = wxDefaultPosition,
             const wxSize& size = wxDefaultSize,
@@ -48,9 +49,6 @@ public:
 
     virtual bool IsChecked(unsigned int item) const override;
     virtual void Check(unsigned int item, bool check = true) override;
-
-private:
-    virtual void Init() override; //common construction
 
     wxDECLARE_DYNAMIC_CLASS(wxCheckListBox);
 };

--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -56,7 +56,7 @@ public:
     virtual void SetSelection(int n) override;
     virtual int GetSelection() const override;
 
-    virtual QWidget *GetHandle() const override;
+    QComboBox* GetQComboBox() const;
 
 protected:
     virtual int DoInsertItems(const wxArrayStringsAdapter & items,
@@ -72,10 +72,6 @@ protected:
     virtual void DoDeleteOneItem(unsigned int pos) override;
 
     void QtInitSort(QComboBox *combo);
-
-    QComboBox *m_qtComboBox;
-
-private:
 
     wxDECLARE_DYNAMIC_CLASS(wxChoice);
 };

--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -13,7 +13,7 @@ class QComboBox;
 class WXDLLIMPEXP_CORE wxChoice : public wxChoiceBase
 {
 public:
-    wxChoice();
+    wxChoice() = default;
 
     wxChoice( wxWindow *parent, wxWindowID id,
             const wxPoint& pos = wxDefaultPosition,

--- a/include/wx/qt/clrpicker.h
+++ b/include/wx/qt/clrpicker.h
@@ -22,7 +22,8 @@
 class WXDLLIMPEXP_CORE wxColourPickerWidget : public wxGenericColourButton
 {
 public:
-    wxColourPickerWidget();
+    wxColourPickerWidget() = default;
+
     wxColourPickerWidget(wxWindow *parent,
                    wxWindowID id,
                    const wxColour& initial = *wxBLACK,

--- a/include/wx/qt/colordlg.h
+++ b/include/wx/qt/colordlg.h
@@ -16,8 +16,9 @@ class WXDLLIMPEXP_CORE wxColourDialog : public wxDialog
 {
 public:
     wxColourDialog() = default;
-    wxColourDialog(wxWindow *parent,
-                   const wxColourData *data = nullptr) { Create(parent, data); }
+
+    explicit wxColourDialog(wxWindow *parent,
+                            const wxColourData *data = nullptr) { Create(parent, data); }
 
     bool Create(wxWindow *parent, const wxColourData *data = nullptr);
 

--- a/include/wx/qt/combobox.h
+++ b/include/wx/qt/combobox.h
@@ -9,7 +9,6 @@
 #define _WX_QT_COMBOBOX_H_
 
 #include "wx/choice.h"
-class QComboBox;
 
 class WXDLLIMPEXP_CORE wxComboBox : public wxChoice, public wxTextEntry
 {

--- a/include/wx/qt/combobox.h
+++ b/include/wx/qt/combobox.h
@@ -13,7 +13,7 @@
 class WXDLLIMPEXP_CORE wxComboBox : public wxChoice, public wxTextEntry
 {
 public:
-    wxComboBox();
+    wxComboBox() = default;
 
     wxComboBox(wxWindow *parent,
                wxWindowID id,

--- a/include/wx/qt/control.h
+++ b/include/wx/qt/control.h
@@ -11,7 +11,8 @@
 class WXDLLIMPEXP_CORE wxControl : public wxControlBase
 {
 public:
-    wxControl();
+    wxControl() = default;
+
     wxControl(wxWindow *parent, wxWindowID id,
              const wxPoint& pos = wxDefaultPosition,
              const wxSize& size = wxDefaultSize, long style = 0,

--- a/include/wx/qt/dataview.h
+++ b/include/wx/qt/dataview.h
@@ -69,7 +69,7 @@ public:
 class WXDLLIMPEXP_ADV wxDataViewCtrl: public wxDataViewCtrlBase
 {
 public:
-    wxDataViewCtrl();
+    wxDataViewCtrl() = default;
 
     wxDataViewCtrl( wxWindow *parent, wxWindowID id,
            const wxPoint& pos = wxDefaultPosition,

--- a/include/wx/qt/datectrl.h
+++ b/include/wx/qt/datectrl.h
@@ -50,10 +50,7 @@ public:
     virtual void SetRange(const wxDateTime& dt1, const wxDateTime& dt2) override;
     virtual bool GetRange(wxDateTime *dt1, wxDateTime *dt2) const override;
 
-    virtual QWidget *GetHandle() const override;
-
-private:
-    QDateEdit* m_qtDateEdit;
+    QDateEdit* GetQDateEdit() const;
 
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDatePickerCtrl);
 };

--- a/include/wx/qt/dialog.h
+++ b/include/wx/qt/dialog.h
@@ -14,7 +14,8 @@ class QDialog;
 class WXDLLIMPEXP_CORE wxDialog : public wxDialogBase
 {
 public:
-    wxDialog();
+    wxDialog() = default;
+
     wxDialog( wxWindow *parent, wxWindowID id,
             const wxString &title,
             const wxPoint &pos = wxDefaultPosition,

--- a/include/wx/qt/frame.h
+++ b/include/wx/qt/frame.h
@@ -13,11 +13,13 @@
 #include "wx/frame.h"
 
 class QMainWindow;
+class QToolBar;
 
 class WXDLLIMPEXP_CORE wxFrame : public wxFrameBase
 {
 public:
-    wxFrame() { Init(); }
+    wxFrame() = default;
+
     wxFrame(wxWindow *parent,
                wxWindowID id,
                const wxString& title,
@@ -26,8 +28,6 @@ public:
                long style = wxDEFAULT_FRAME_STYLE,
                const wxString& name = wxASCII_STR(wxFrameNameStr))
     {
-        Init();
-
         Create( parent, id, title, pos, size, style, name );
     }
     virtual ~wxFrame();
@@ -65,17 +65,10 @@ protected:
     virtual QWidget* QtGetParentWidget() const override;
 
 private:
-    // Common part of all ctors.
-    void Init()
-    {
-        m_qtToolBar = nullptr;
-    }
-
-
     // Currently active native toolbar.
-    class QToolBar* m_qtToolBar;
+    QToolBar* m_qtToolBar = nullptr;
 
-    wxDECLARE_DYNAMIC_CLASS( wxFrame );
+    wxDECLARE_DYNAMIC_CLASS(wxFrame);
 };
 
 

--- a/include/wx/qt/gauge.h
+++ b/include/wx/qt/gauge.h
@@ -13,7 +13,7 @@ class QProgressBar;
 class WXDLLIMPEXP_CORE wxGauge : public wxGaugeBase
 {
 public:
-    wxGauge();
+    wxGauge() = default;
 
     wxGauge(wxWindow *parent,
             wxWindowID id,

--- a/include/wx/qt/gauge.h
+++ b/include/wx/qt/gauge.h
@@ -33,8 +33,6 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxASCII_STR(wxGaugeNameStr));
 
-    virtual QWidget *GetHandle() const override;
-
     // set/get the control range
     virtual void SetRange(int range) override;
     virtual int GetRange() const override;
@@ -42,8 +40,7 @@ public:
     virtual void SetValue(int pos) override;
     virtual int GetValue() const override;
 
-private:
-    QProgressBar *m_qtProgressBar;
+    QProgressBar* GetQProgressBar() const;
 
     wxDECLARE_DYNAMIC_CLASS(wxGauge);
 };

--- a/include/wx/qt/listbox.h
+++ b/include/wx/qt/listbox.h
@@ -14,7 +14,8 @@ class QModelIndex;
 class WXDLLIMPEXP_CORE wxListBox : public wxListBoxBase
 {
 public:
-    wxListBox();
+    wxListBox() = default;
+
     wxListBox(wxWindow *parent, wxWindowID id,
             const wxPoint& pos = wxDefaultPosition,
             const wxSize& size = wxDefaultSize,
@@ -87,12 +88,10 @@ protected:
     virtual int DoListHitTest(const wxPoint& point) const override;
 
 #if wxUSE_CHECKLISTBOX
-    bool       m_hasCheckBoxes;
+    bool       m_hasCheckBoxes = false;
 #endif // wxUSE_CHECKLISTBOX
 
 private:
-    virtual void Init(); //common construction
-
     // Common part of both Create() overloads.
     void DoCreate(wxWindow* parent, long style);
 

--- a/include/wx/qt/listbox.h
+++ b/include/wx/qt/listbox.h
@@ -63,9 +63,9 @@ public:
 
     virtual int GetCountPerPage() const override;
 
-    virtual QWidget *GetHandle() const override;
-
     void QtSendEvent(wxEventType evtType, int rowIndex, bool selected);
+
+    QListWidget* GetQListWidget() const;
 
 protected:
     virtual void DoSetFirstItem(int n) override;
@@ -89,8 +89,6 @@ protected:
 #if wxUSE_CHECKLISTBOX
     bool       m_hasCheckBoxes;
 #endif // wxUSE_CHECKLISTBOX
-
-    QListWidget *m_qtListWidget;
 
 private:
     virtual void Init(); //common construction

--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -269,7 +269,7 @@ public:
     virtual int GetSortIndicator() const override;
     virtual bool IsAscendingSortIndicator() const override;
 
-    virtual QWidget *GetHandle() const override;
+    wxQtListTreeWidget* GetQListTreeWidget() const;
 
 protected:
     void Init();
@@ -284,8 +284,6 @@ private:
     // Allow access to OnGetItemXXX() method from the virtual model class.
     friend class wxQtVirtualListModel;
 
-
-    wxQtListTreeWidget *m_qtTreeWidget;
     wxQtListModel *m_model;
 
     wxDECLARE_DYNAMIC_CLASS( wxListCtrl );

--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -17,7 +17,7 @@ class wxQtVirtualListModel;
 class WXDLLIMPEXP_CORE wxListCtrl: public wxListCtrlBase
 {
 public:
-    wxListCtrl();
+    wxListCtrl() = default;
 
     wxListCtrl(wxWindow *parent,
                wxWindowID id = wxID_ANY,
@@ -272,21 +272,19 @@ public:
     wxQtListTreeWidget* GetQListTreeWidget() const;
 
 protected:
-    void Init();
-
     // Implement base class pure virtual methods.
     virtual long DoInsertColumn(long col, const wxListItem& info) override;
     void DoUpdateImages(int which) override;
 
-    bool              m_hasCheckBoxes;
+    bool m_hasCheckBoxes = false;
 
 private:
     // Allow access to OnGetItemXXX() method from the virtual model class.
     friend class wxQtVirtualListModel;
 
-    wxQtListModel *m_model;
+    wxQtListModel *m_model = nullptr;
 
-    wxDECLARE_DYNAMIC_CLASS( wxListCtrl );
+    wxDECLARE_DYNAMIC_CLASS(wxListCtrl);
 };
 
 #endif

--- a/include/wx/qt/mdi.h
+++ b/include/wx/qt/mdi.h
@@ -11,7 +11,8 @@
 class WXDLLIMPEXP_CORE wxMDIParentFrame : public wxMDIParentFrameBase
 {
 public:
-    wxMDIParentFrame();
+    wxMDIParentFrame() = default;
+
     wxMDIParentFrame(wxWindow *parent,
                      wxWindowID id,
                      const wxString& title,
@@ -36,8 +37,6 @@ public:
     virtual void ActivateNext() override;
     virtual void ActivatePrevious() override;
 
-protected:
-
 private:
     wxDECLARE_DYNAMIC_CLASS(wxMDIParentFrame);
 };
@@ -47,7 +46,8 @@ private:
 class WXDLLIMPEXP_CORE wxMDIChildFrame : public wxMDIChildFrameBase
 {
 public:
-    wxMDIChildFrame();
+    wxMDIChildFrame() = default;
+
     wxMDIChildFrame(wxMDIParentFrame *parent,
                     wxWindowID id,
                     const wxString& title,
@@ -74,9 +74,10 @@ public:
 class WXDLLIMPEXP_CORE wxMDIClientWindow : public wxMDIClientWindowBase
 {
 public:
-    wxMDIClientWindow();
+    wxMDIClientWindow() = default;
 
     virtual bool CreateClient(wxMDIParentFrame *parent, long style = wxVSCROLL | wxHSCROLL) override;
+
     wxDECLARE_DYNAMIC_CLASS(wxMDIClientWindow);
 };
 

--- a/include/wx/qt/menu.h
+++ b/include/wx/qt/menu.h
@@ -49,15 +49,12 @@ public:
     virtual void SetMenuLabel(size_t pos, const wxString& label) override;
     virtual wxString GetMenuLabel(size_t pos) const override;
 
-    QMenuBar *GetQMenuBar() const { return m_qtMenuBar; }
-    virtual QWidget *GetHandle() const override;
+    QMenuBar* GetQMenuBar() const;
 
     virtual void Attach(wxFrame *frame) override;
     virtual void Detach() override;
 
 private:
-    QMenuBar *m_qtMenuBar;
-
     wxDECLARE_DYNAMIC_CLASS(wxMenuBar);
 };
 

--- a/include/wx/qt/menu.h
+++ b/include/wx/qt/menu.h
@@ -14,8 +14,8 @@ class QMenuBar;
 class WXDLLIMPEXP_CORE wxMenu : public wxMenuBase
 {
 public:
-    wxMenu(long style = 0);
-    wxMenu(const wxString& title, long style = 0);
+    explicit wxMenu(long style = 0);
+    explicit wxMenu(const wxString& title, long style = 0);
 
     virtual QMenu *GetHandle() const;
 
@@ -36,7 +36,7 @@ class WXDLLIMPEXP_CORE wxMenuBar : public wxMenuBarBase
 {
 public:
     wxMenuBar();
-    wxMenuBar(long style);
+    explicit wxMenuBar(long style);
     wxMenuBar(size_t n, wxMenu *menus[], const wxString titles[], long style = 0);
 
     virtual bool Append(wxMenu *menu, const wxString& title) override;

--- a/include/wx/qt/nonownedwnd.h
+++ b/include/wx/qt/nonownedwnd.h
@@ -15,7 +15,7 @@
 class WXDLLIMPEXP_CORE wxNonOwnedWindow : public wxNonOwnedWindowBase
 {
 public:
-    wxNonOwnedWindow();
+    wxNonOwnedWindow() = default;
 
 protected:
     virtual bool DoClearShape() override;

--- a/include/wx/qt/notebook.h
+++ b/include/wx/qt/notebook.h
@@ -47,7 +47,7 @@ public:
 
     virtual bool DeleteAllPages() override;
 
-    virtual QWidget *GetHandle() const override;
+    QTabWidget* GetQTabWidget() const;
 
 protected:
     virtual wxWindow *DoRemovePage(size_t page) override;
@@ -55,8 +55,6 @@ protected:
     virtual void OnImagesChanged() override;
 
 private:
-    QTabWidget *m_qtTabWidget;
-
     // internal array to store imageId for each page:
     wxVector<int> m_images;
 

--- a/include/wx/qt/notebook.h
+++ b/include/wx/qt/notebook.h
@@ -13,7 +13,8 @@ class QTabWidget;
 class WXDLLIMPEXP_CORE wxNotebook : public wxNotebookBase
 {
 public:
-    wxNotebook();
+    wxNotebook() = default;
+
     wxNotebook(wxWindow *parent,
              wxWindowID id,
              const wxPoint& pos = wxDefaultPosition,
@@ -58,7 +59,7 @@ private:
     // internal array to store imageId for each page:
     wxVector<int> m_images;
 
-    wxDECLARE_DYNAMIC_CLASS( wxNotebook );
+    wxDECLARE_DYNAMIC_CLASS(wxNotebook);
 };
 
 

--- a/include/wx/qt/popupwin.h
+++ b/include/wx/qt/popupwin.h
@@ -11,7 +11,8 @@
 class WXDLLIMPEXP_CORE wxPopupWindow : public wxPopupWindowBase
 {
 public:
-    wxPopupWindow();
+    wxPopupWindow() = default;
+
     wxPopupWindow(wxWindow *parent, int flags = wxBORDER_NONE);
 
     bool Create(wxWindow *parent, int flags = wxBORDER_NONE);

--- a/include/wx/qt/printqt.h
+++ b/include/wx/qt/printqt.h
@@ -13,7 +13,7 @@
 class WXDLLIMPEXP_CORE wxQtPrinter : public wxPrinterBase
 {
 public:
-    wxQtPrinter( wxPrintDialogData *data = nullptr );
+    explicit wxQtPrinter( wxPrintDialogData *data = nullptr );
 
     virtual bool Setup(wxWindow *parent) override;
     virtual bool Print(wxWindow *parent, wxPrintout *printout, bool prompt = true) override;

--- a/include/wx/qt/radiobox.h
+++ b/include/wx/qt/radiobox.h
@@ -82,12 +82,10 @@ public:
     virtual void SetLabel(const wxString &label) override;
     virtual wxString GetLabel() const override;
 
-    virtual QWidget *GetHandle() const override;
+    // The 'visual' group box:
+    QGroupBox* GetQGroupBox() const;
 
 private:
-    // The 'visual' group box:
-    QGroupBox *m_qtGroupBox;
-
     // Handles the mutual exclusion of buttons:
     QButtonGroup *m_qtButtonGroup;
 

--- a/include/wx/qt/radiobox.h
+++ b/include/wx/qt/radiobox.h
@@ -15,7 +15,7 @@ class QGridLayout;
 class WXDLLIMPEXP_CORE wxRadioBox : public wxControl, public wxRadioBoxBase
 {
 public:
-    wxRadioBox();
+    wxRadioBox() = default;
 
     wxRadioBox(wxWindow *parent,
                wxWindowID id,
@@ -87,10 +87,10 @@ public:
 
 private:
     // Handles the mutual exclusion of buttons:
-    QButtonGroup *m_qtButtonGroup;
+    QButtonGroup *m_qtButtonGroup = nullptr;
 
     // Autofit layout for buttons (either vert. or horiz.):
-    QGridLayout *m_qtGridLayout;
+    QGridLayout *m_qtGridLayout = nullptr;
 
     wxDECLARE_DYNAMIC_CLASS(wxRadioBox);
 };

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -13,7 +13,8 @@ class QRadioButton;
 class WXDLLIMPEXP_CORE wxRadioButton : public wxRadioButtonBase
 {
 public:
-    wxRadioButton();
+    wxRadioButton() = default;
+
     wxRadioButton( wxWindow *parent,
                    wxWindowID id,
                    const wxString& label,

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -38,12 +38,9 @@ public:
     virtual void SetLabel(const wxString &label) override;
     virtual wxString GetLabel() const override;
 
-    virtual QWidget *GetHandle() const override;
+    QRadioButton* GetQRadioButton() const;
 
-private:
-    QRadioButton *m_qtRadioButton;
-
-    wxDECLARE_DYNAMIC_CLASS( wxRadioButton );
+    wxDECLARE_DYNAMIC_CLASS(wxRadioButton);
 };
 
 #endif // _WX_QT_RADIOBUT_H_

--- a/include/wx/qt/scrolbar.h
+++ b/include/wx/qt/scrolbar.h
@@ -12,8 +12,6 @@
 
 class QScrollBar;
 
-class WXDLLIMPEXP_FWD_CORE wxQtScrollBar;
-
 class WXDLLIMPEXP_CORE wxScrollBar : public wxScrollBarBase
 {
 public:
@@ -42,12 +40,9 @@ public:
                               int range, int pageSize,
                               bool refresh = true) override;
 
-    QScrollBar *GetQScrollBar() const { return m_qtScrollBar; }
-    QWidget *GetHandle() const override;
+    QScrollBar* GetQScrollBar() const;
 
 private:
-    QScrollBar *m_qtScrollBar;
-
     wxDECLARE_DYNAMIC_CLASS(wxScrollBar);
 };
 

--- a/include/wx/qt/scrolbar.h
+++ b/include/wx/qt/scrolbar.h
@@ -15,7 +15,8 @@ class QScrollBar;
 class WXDLLIMPEXP_CORE wxScrollBar : public wxScrollBarBase
 {
 public:
-    wxScrollBar();
+    wxScrollBar() = default;
+
     wxScrollBar( wxWindow *parent, wxWindowID id,
            const wxPoint& pos = wxDefaultPosition,
            const wxSize& size = wxDefaultSize,
@@ -42,7 +43,6 @@ public:
 
     QScrollBar* GetQScrollBar() const;
 
-private:
     wxDECLARE_DYNAMIC_CLASS(wxScrollBar);
 };
 

--- a/include/wx/qt/slider.h
+++ b/include/wx/qt/slider.h
@@ -13,7 +13,8 @@ class QSlider;
 class WXDLLIMPEXP_CORE wxSlider : public wxSliderBase
 {
 public:
-    wxSlider();
+    wxSlider() = default;
+
     wxSlider(wxWindow *parent,
              wxWindowID id,
              int value, int minValue, int maxValue,
@@ -56,7 +57,7 @@ public:
 protected:
     virtual void DoSetTickFreq(int freq) override;
 
-    wxDECLARE_DYNAMIC_CLASS( wxSlider );
+    wxDECLARE_DYNAMIC_CLASS(wxSlider);
 };
 
 #endif // _WX_QT_SLIDER_H_

--- a/include/wx/qt/slider.h
+++ b/include/wx/qt/slider.h
@@ -51,13 +51,10 @@ public:
     virtual void SetThumbLength(int lenPixels) override;
     virtual int GetThumbLength() const override;
 
-    virtual QWidget *GetHandle() const override;
+    QSlider* GetQSlider() const;
 
 protected:
     virtual void DoSetTickFreq(int freq) override;
-
-private:
-    QSlider *m_qtSlider;
 
     wxDECLARE_DYNAMIC_CLASS( wxSlider );
 };

--- a/include/wx/qt/spinbutt.h
+++ b/include/wx/qt/spinbutt.h
@@ -14,7 +14,8 @@ class QSpinBox;
 class WXDLLIMPEXP_CORE wxSpinButton : public wxSpinButtonBase
 {
 public:
-    wxSpinButton();
+    wxSpinButton() = default;
+
     wxSpinButton(wxWindow *parent,
                  wxWindowID id = -1,
                  const wxPoint& pos = wxDefaultPosition,
@@ -35,7 +36,7 @@ public:
 
     QSpinBox* GetQSpinBox() const;
 
-    wxDECLARE_DYNAMIC_CLASS( wxSpinButton );
+    wxDECLARE_DYNAMIC_CLASS(wxSpinButton);
 };
 
 #endif // _WX_QT_SPINBUTT_H_

--- a/include/wx/qt/spinbutt.h
+++ b/include/wx/qt/spinbutt.h
@@ -33,10 +33,7 @@ public:
     virtual void SetValue(int val) override;
     virtual void SetRange(int min, int max) override;
 
-    virtual QWidget *GetHandle() const override;
-
-private:
-    QSpinBox *m_qtSpinBox;
+    QSpinBox* GetQSpinBox() const;
 
     wxDECLARE_DYNAMIC_CLASS( wxSpinButton );
 };

--- a/include/wx/qt/spinctrl.h
+++ b/include/wx/qt/spinctrl.h
@@ -46,10 +46,9 @@ public:
     T GetMax() const;
     T GetIncrement() const;
 
-    virtual QWidget *GetHandle() const override;
-
 protected:
-    Widget *m_qtSpinBox;
+    // QSpinBox / QDoubleSpinBox
+    Widget* GetQtSpinBox() const { return static_cast<Widget*>(this->GetHandle()); }
 
 };
 

--- a/include/wx/qt/spinctrl.h
+++ b/include/wx/qt/spinctrl.h
@@ -18,7 +18,8 @@ template < typename T, typename Widget >
 class WXDLLIMPEXP_CORE wxSpinCtrlQt : public wxSpinCtrlBase
 {
 public:
-    wxSpinCtrlQt();
+    wxSpinCtrlQt() = default;
+
     wxSpinCtrlQt( wxWindow *parent, wxWindowID id, const wxString& value,
         const wxPoint& pos, const wxSize& size, long style,
         T min, T max, T initial, T inc,
@@ -57,7 +58,8 @@ class WXDLLIMPEXP_CORE wxSpinCtrl : public wxSpinCtrlQt< int, QSpinBox >
     using BaseType = wxSpinCtrlQt< int, QSpinBox >;
 
 public:
-    wxSpinCtrl();
+    wxSpinCtrl() = default;
+
     wxSpinCtrl(wxWindow *parent,
                wxWindowID id = wxID_ANY,
                const wxString& value = wxEmptyString,
@@ -81,12 +83,8 @@ public:
     virtual void SetValue(int val) override { BaseType::SetValue(val); }
 
 private:
-    // Common part of all ctors.
-    void Init()
-    {
-        m_base = 10;
-    }
-    int m_base;
+    int m_base = 10;
+
     wxDECLARE_DYNAMIC_CLASS(wxSpinCtrl);
 };
 
@@ -95,7 +93,8 @@ class WXDLLIMPEXP_CORE wxSpinCtrlDouble : public wxSpinCtrlQt< double, QDoubleSp
     using BaseType = wxSpinCtrlQt< double, QDoubleSpinBox >;
 
 public:
-    wxSpinCtrlDouble();
+    wxSpinCtrlDouble() = default;
+
     wxSpinCtrlDouble(wxWindow *parent,
                      wxWindowID id = wxID_ANY,
                      const wxString& value = wxEmptyString,

--- a/include/wx/qt/statbmp.h
+++ b/include/wx/qt/statbmp.h
@@ -13,7 +13,8 @@ class QLabel;
 class WXDLLIMPEXP_CORE wxStaticBitmap : public wxStaticBitmapBase
 {
 public:
-    wxStaticBitmap();
+    wxStaticBitmap() = default;
+
     wxStaticBitmap( wxWindow *parent,
                     wxWindowID id,
                     const wxBitmapBundle& label,

--- a/include/wx/qt/statbmp.h
+++ b/include/wx/qt/statbmp.h
@@ -33,11 +33,7 @@ public:
     virtual void SetBitmap(const wxBitmapBundle& bitmap) override;
     virtual wxBitmap GetBitmap() const override;
 
-    virtual QWidget *GetHandle() const override;
-protected:
-
-private:
-    QLabel *m_qtLabel;
+    QLabel* GetQLabel() const;
 
     wxDECLARE_DYNAMIC_CLASS(wxStaticBitmap);
 };

--- a/include/wx/qt/statbox.h
+++ b/include/wx/qt/statbox.h
@@ -13,7 +13,7 @@ class QGroupBox;
 class WXDLLIMPEXP_CORE wxStaticBox : public wxStaticBoxBase
 {
 public:
-    wxStaticBox();
+    wxStaticBox() = default;
 
     wxStaticBox(wxWindow *parent, wxWindowID id,
                 const wxString& label,

--- a/include/wx/qt/statbox.h
+++ b/include/wx/qt/statbox.h
@@ -31,17 +31,12 @@ public:
 
     virtual void GetBordersForSizer(int *borderTop, int *borderOther) const override;
 
-    virtual QWidget *GetHandle() const override;
-
     virtual void SetLabel(const wxString& label) override;
     virtual wxString GetLabel() const override;
 
-protected:
+    QGroupBox* GetQGroupBox() const;
 
-private:
-    QGroupBox *m_qtGroupBox;
-
-    wxDECLARE_DYNAMIC_CLASS( wxStaticBox );
+    wxDECLARE_DYNAMIC_CLASS(wxStaticBox);
 };
 
 #endif // _WX_QT_STATBOX_H_

--- a/include/wx/qt/statline.h
+++ b/include/wx/qt/statline.h
@@ -13,7 +13,7 @@ class QFrame;
 class WXDLLIMPEXP_CORE wxStaticLine : public wxStaticLineBase
 {
 public:
-    wxStaticLine();
+    wxStaticLine() = default;
 
     wxStaticLine( wxWindow *parent,
                   wxWindowID id = wxID_ANY,

--- a/include/wx/qt/statline.h
+++ b/include/wx/qt/statline.h
@@ -29,12 +29,9 @@ public:
                  long style = wxLI_HORIZONTAL,
                  const wxString &name = wxASCII_STR(wxStaticLineNameStr) );
 
-    virtual QWidget *GetHandle() const override;
+    QFrame* GetQFrame() const;
 
-private:
-    QFrame *m_qtFrame;
-
-    wxDECLARE_DYNAMIC_CLASS( wxStaticLine );
+    wxDECLARE_DYNAMIC_CLASS(wxStaticLine);
 };
 
 #endif // _WX_QT_STATLINE_H_

--- a/include/wx/qt/stattext.h
+++ b/include/wx/qt/stattext.h
@@ -13,7 +13,8 @@ class QLabel;
 class WXDLLIMPEXP_CORE wxStaticText : public wxStaticTextBase
 {
 public:
-    wxStaticText();
+    wxStaticText() = default;
+
     wxStaticText(wxWindow *parent,
                  wxWindowID id,
                  const wxString &label,

--- a/include/wx/qt/stattext.h
+++ b/include/wx/qt/stattext.h
@@ -32,16 +32,13 @@ public:
 
     virtual void SetLabel(const wxString& label) override;
 
-    virtual QWidget *GetHandle() const override;
+    QLabel* GetQLabel() const;
 
 protected:
     virtual wxString WXGetVisibleLabel() const override;
     virtual void WXSetVisibleLabel(const wxString& str) override;
 
-private:
-    QLabel *m_qtLabel;
-
-    wxDECLARE_DYNAMIC_CLASS( wxStaticText );
+    wxDECLARE_DYNAMIC_CLASS(wxStaticText);
 };
 
 #endif // _WX_QT_STATTEXT_H_

--- a/include/wx/qt/statusbar.h
+++ b/include/wx/qt/statusbar.h
@@ -30,8 +30,7 @@ public:
     virtual int GetBorderX() const override;
     virtual int GetBorderY() const override;
 
-    QStatusBar *GetQStatusBar() const { return m_qtStatusBar; }
-    QWidget *GetHandle() const override;
+    QStatusBar* GetQStatusBar() const;
 
 protected:
     virtual void DoUpdateStatusText(int number) override;
@@ -39,7 +38,6 @@ protected:
 private:
     void CreateFieldsIfNeeded();
 
-    QStatusBar *m_qtStatusBar = nullptr;
     std::vector<QWidget*> m_qtPanes;
 
     wxDECLARE_DYNAMIC_CLASS(wxStatusBar);

--- a/include/wx/qt/textctrl.h
+++ b/include/wx/qt/textctrl.h
@@ -84,8 +84,6 @@ public:
 
     virtual void SetMaxLength(unsigned long len) override;
 
-    virtual QWidget *GetHandle() const override;
-
 protected:
     virtual wxSize DoGetBestSize() const override;
 

--- a/include/wx/qt/textctrl.h
+++ b/include/wx/qt/textctrl.h
@@ -13,7 +13,8 @@ class wxQtEdit;
 class WXDLLIMPEXP_CORE wxTextCtrl : public wxTextCtrlBase
 {
 public:
-    wxTextCtrl();
+    wxTextCtrl() = default;
+
     wxTextCtrl(wxWindow *parent,
                wxWindowID id,
                const wxString &value = wxEmptyString,
@@ -94,7 +95,7 @@ protected:
     virtual wxWindow *GetEditableWindow() override { return this; }
 
 private:
-    wxQtEdit *m_qtEdit;
+    wxQtEdit *m_qtEdit = nullptr;
 
     wxDECLARE_DYNAMIC_CLASS( wxTextCtrl );
 };

--- a/include/wx/qt/tglbtn.h
+++ b/include/wx/qt/tglbtn.h
@@ -14,7 +14,8 @@
 class WXDLLIMPEXP_CORE wxToggleButton : public wxToggleButtonBase
 {
 public:
-    wxToggleButton();
+    wxToggleButton() = default;
+
     wxToggleButton(wxWindow *parent,
                    wxWindowID id,
                    const wxString& label,
@@ -48,7 +49,8 @@ private:
 class WXDLLIMPEXP_CORE wxBitmapToggleButton: public wxToggleButton
 {
 public:
-    wxBitmapToggleButton();
+    wxBitmapToggleButton() = default;
+
     wxBitmapToggleButton(wxWindow *parent,
                    wxWindowID id,
                    const wxBitmapBundle& label,

--- a/include/wx/qt/timectrl.h
+++ b/include/wx/qt/timectrl.h
@@ -46,10 +46,7 @@ public:
     virtual void SetValue(const wxDateTime& dt) override;
     virtual wxDateTime GetValue() const override;
 
-    virtual QWidget *GetHandle() const override;
-
-private:
-    QTimeEdit* m_qtTimeEdit;
+    QTimeEdit* GetQTimeEdit() const;
 
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxTimePickerCtrl);
 };

--- a/include/wx/qt/toolbar.h
+++ b/include/wx/qt/toolbar.h
@@ -16,7 +16,8 @@ class WXDLLIMPEXP_CORE wxToolBar : public wxToolBarBase
 {
 public:
 
-    wxToolBar() { Init(); }
+    wxToolBar() = default;
+
     wxToolBar(wxWindow *parent,
               wxWindowID id,
               const wxPoint& pos = wxDefaultPosition,
@@ -24,8 +25,6 @@ public:
               long style = wxTB_DEFAULT_STYLE | wxNO_BORDER,
               const wxString& name = wxASCII_STR(wxToolBarNameStr))
     {
-        Init();
-
         Create(parent, id, pos, size, style, name);
     }
 
@@ -71,8 +70,6 @@ protected:
     virtual void DoSetToggle(wxToolBarToolBase *tool, bool toggle) override;
 
 private:
-    void Init();
-
     long GetButtonStyle();
 
     wxDECLARE_DYNAMIC_CLASS(wxToolBar);

--- a/include/wx/qt/toolbar.h
+++ b/include/wx/qt/toolbar.h
@@ -59,10 +59,8 @@ public:
 
     virtual wxToolBarToolBase *CreateTool(wxControl *control,
                                           const wxString& label) override;
-    QWidget *GetHandle() const override;
 
-    // Private, only used by wxFrame.
-    QToolBar *GetQToolBar() const { return m_qtToolBar; }
+    QToolBar* GetQToolBar() const;
 
 protected:
     QActionGroup* GetActionGroup(size_t pos);
@@ -76,8 +74,6 @@ private:
     void Init();
 
     long GetButtonStyle();
-
-    QToolBar *m_qtToolBar;
 
     wxDECLARE_DYNAMIC_CLASS(wxToolBar);
 };

--- a/include/wx/qt/toplevel.h
+++ b/include/wx/qt/toplevel.h
@@ -12,7 +12,8 @@
 class WXDLLIMPEXP_CORE wxTopLevelWindowQt : public wxTopLevelWindowBase
 {
 public:
-    wxTopLevelWindowQt();
+    wxTopLevelWindowQt() = default;
+
     wxTopLevelWindowQt(wxWindow *parent,
                wxWindowID winid,
                const wxString& title,

--- a/include/wx/qt/treectrl.h
+++ b/include/wx/qt/treectrl.h
@@ -117,7 +117,7 @@ public:
 
     virtual void SetWindowStyleFlag(long styles) override;
 
-    virtual QWidget *GetHandle() const override;
+    wxQTreeWidget* GetQTreeWidget() const;
 
 protected:
     virtual int DoGetItemState(const wxTreeItemId& item) const override;
@@ -148,7 +148,6 @@ private:
 
     void DoUpdateIconsSize(wxImageList *imageList);
 
-    wxQTreeWidget *m_qtTreeWidget;
     wxDECLARE_DYNAMIC_CLASS(wxTreeCtrl);
 };
 

--- a/include/wx/qt/treectrl.h
+++ b/include/wx/qt/treectrl.h
@@ -13,7 +13,8 @@ class wxQTreeWidget;
 class WXDLLIMPEXP_CORE wxTreeCtrl : public wxTreeCtrlBase
 {
 public:
-    wxTreeCtrl();
+    wxTreeCtrl() = default;
+
     wxTreeCtrl(wxWindow *parent, wxWindowID id = wxID_ANY,
                const wxPoint& pos = wxDefaultPosition,
                const wxSize& size = wxDefaultSize,

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -35,10 +35,6 @@ class WXDLLIMPEXP_FWD_CORE wxQtShortcutHandler;
 
 /* wxQt specific notes:
  *
- * Remember to implement the Qt object getters on all subclasses:
- *  - GetHandle() returns the Qt object
- *
- *
  * Event handling is achieved by using the template class wxQtEventSignalHandler
  * found in winevent.h to send all Qt events here to QtHandleXXXEvent() methods.
  * All these methods receive the Qt event and the handler. This is done because

--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -77,8 +77,7 @@ bool wxQtPushButton::event(QEvent* e)
     return QPushButton::event(e);
 }
 
-wxAnyButton::wxAnyButton() :
-    m_qtPushButton(nullptr)
+wxAnyButton::wxAnyButton()
 {
 }
 
@@ -86,13 +85,19 @@ wxAnyButton::wxAnyButton() :
 void wxAnyButton::QtCreate(wxWindow *parent)
 {
     // create the basic push button (used in button and bmp button)
-    m_qtPushButton = new wxQtPushButton(parent, this);
-    m_qtPushButton->setAutoDefault(false);
+    m_qtWindow = new wxQtPushButton(parent, this);
+
+    GetQPushButton()->setAutoDefault(false);
+}
+
+QPushButton* wxAnyButton::GetQPushButton() const
+{
+    return static_cast<QPushButton*>(m_qtWindow);
 }
 
 void wxAnyButton::QtSetBitmap( const wxBitmapBundle &bitmapBundle )
 {
-    wxCHECK_RET(m_qtPushButton, "Invalid button.");
+    wxCHECK_RET(GetHandle(), "Invalid button.");
 
     if ( !bitmapBundle.IsOk() )
         return;
@@ -103,8 +108,8 @@ void wxAnyButton::QtSetBitmap( const wxBitmapBundle &bitmapBundle )
     QPixmap *pixmap = bitmap.GetHandle();
     if ( pixmap != nullptr )
     {
-        m_qtPushButton->setIcon(QIcon(*pixmap));
-        m_qtPushButton->setIconSize(pixmap->rect().size() / pixmap->devicePixelRatio());
+        GetQPushButton()->setIcon(QIcon(*pixmap));
+        GetQPushButton()->setIconSize(pixmap->rect().size() / pixmap->devicePixelRatio());
 
         InvalidateBestSize();
     }
@@ -114,17 +119,12 @@ void wxAnyButton::SetLabel( const wxString &label )
 {
     wxAnyButtonBase::SetLabel( label );
 
-    m_qtPushButton->setText( wxQtConvertString( label ));
+    GetQPushButton()->setText( wxQtConvertString( label ));
 }
 
 wxString wxAnyButton::GetLabel() const
 {
-    return wxQtConvertString( m_qtPushButton->text() );
-}
-
-QWidget *wxAnyButton::GetHandle() const
-{
-    return m_qtPushButton;
+    return wxQtConvertString( GetQPushButton()->text() );
 }
 
 wxBitmap wxAnyButton::DoGetBitmap(State state) const
@@ -148,24 +148,24 @@ void wxAnyButton::DoSetBitmap(const wxBitmapBundle& bitmap, State which)
 
 wxAnyButton::State wxAnyButton::QtGetCurrentState() const
 {
-    wxCHECK_MSG(m_qtPushButton, State_Normal, "Invalid button.");
+    wxCHECK_MSG(GetHandle(), State_Normal, "Invalid button.");
 
-    if ( !m_qtPushButton->isEnabled() )
+    if ( !GetQPushButton()->isEnabled() )
     {
         return State_Disabled;
     }
 
-    if ( m_qtPushButton->isChecked() || m_qtPushButton->isDown() )
+    if ( GetQPushButton()->isChecked() || GetQPushButton()->isDown() )
     {
         return State_Pressed;
     }
 
-    if ( HasCapture() || m_qtPushButton->underMouse() )
+    if ( HasCapture() || GetQPushButton()->underMouse() )
     {
         return State_Current;
     }
 
-    if ( m_qtPushButton->hasFocus() )
+    if ( GetQPushButton()->hasFocus() )
     {
         return State_Focused;
     }

--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -77,11 +77,6 @@ bool wxQtPushButton::event(QEvent* e)
     return QPushButton::event(e);
 }
 
-wxAnyButton::wxAnyButton()
-{
-}
-
-
 void wxAnyButton::QtCreate(wxWindow *parent)
 {
     // create the basic push button (used in button and bmp button)

--- a/src/qt/bmpbuttn.cpp
+++ b/src/qt/bmpbuttn.cpp
@@ -12,11 +12,6 @@
 
 #include "wx/bmpbuttn.h"
 
-wxBitmapButton::wxBitmapButton()
-{
-}
-
-
 wxBitmapButton::wxBitmapButton(wxWindow *parent,
                wxWindowID id,
                const wxBitmapBundle& bitmap,

--- a/src/qt/button.cpp
+++ b/src/qt/button.cpp
@@ -51,7 +51,7 @@ wxWindow *wxButton::SetDefault()
 {
     wxWindow *oldDefault = wxButtonBase::SetDefault();
 
-    m_qtPushButton->setDefault( true );
+    GetQPushButton()->setDefault( true );
 
     return oldDefault;
 

--- a/src/qt/button.cpp
+++ b/src/qt/button.cpp
@@ -20,10 +20,6 @@
 
 #include <QtWidgets/QPushButton>
 
-wxButton::wxButton()
-{
-}
-
 wxButton::wxButton(wxWindow *parent, wxWindowID id,
        const wxString& label,
        const wxPoint& pos,

--- a/src/qt/checkbox.cpp
+++ b/src/qt/checkbox.cpp
@@ -47,11 +47,6 @@ void wxQtCheckBox::clicked( bool checked )
     }
 }
 
-
-wxCheckBox::wxCheckBox()
-{
-}
-
 wxCheckBox::wxCheckBox( wxWindow *parent, wxWindowID id, const wxString& label,
         const wxPoint& pos, const wxSize& size, long style, const wxValidator& validator,
         const wxString& name )

--- a/src/qt/checkbox.cpp
+++ b/src/qt/checkbox.cpp
@@ -48,8 +48,7 @@ void wxQtCheckBox::clicked( bool checked )
 }
 
 
-wxCheckBox::wxCheckBox() :
-    m_qtCheckBox(nullptr)
+wxCheckBox::wxCheckBox()
 {
 }
 
@@ -64,8 +63,9 @@ bool wxCheckBox::Create(wxWindow *parent, wxWindowID id, const wxString& label,
             const wxPoint& pos, const wxSize& size, long style, const wxValidator& validator,
             const wxString& name )
 {
-    m_qtCheckBox = new wxQtCheckBox( parent, this );
-    m_qtCheckBox->setText( wxQtConvertString( label ) );
+    m_qtWindow = new wxQtCheckBox( parent, this );
+
+    GetQCheckBox()->setText( wxQtConvertString( label ) );
 
     // Do the initialization here as WXValidateStyle may fail in unit tests
     bool ok = wxCheckBoxBase::Create( parent, id, pos, size, style, validator, name );
@@ -73,24 +73,28 @@ bool wxCheckBox::Create(wxWindow *parent, wxWindowID id, const wxString& label,
     WXValidateStyle(&style);
 
     if ( style & wxCHK_2STATE )
-        m_qtCheckBox->setTristate( false );
+        GetQCheckBox()->setTristate( false );
     else if ( style & wxCHK_3STATE )
-        m_qtCheckBox->setTristate( true );
+        GetQCheckBox()->setTristate( true );
     if ( style & wxALIGN_RIGHT )
-        m_qtCheckBox->setLayoutDirection( Qt::RightToLeft );
+        GetQCheckBox()->setLayoutDirection( Qt::RightToLeft );
 
     return ok;
 }
 
+QCheckBox* wxCheckBox::GetQCheckBox() const
+{
+    return static_cast<QCheckBox*>(m_qtWindow);
+}
 
 void wxCheckBox::SetValue(bool value)
 {
-    m_qtCheckBox->setChecked( value );
+    GetQCheckBox()->setChecked( value );
 }
 
 bool wxCheckBox::GetValue() const
 {
-    return m_qtCheckBox->isChecked();
+    return GetQCheckBox()->isChecked();
 }
 
 void wxCheckBox::DoSet3StateValue(wxCheckBoxState state)
@@ -98,22 +102,22 @@ void wxCheckBox::DoSet3StateValue(wxCheckBoxState state)
     switch (state)
     {
     case wxCHK_UNCHECKED:
-        m_qtCheckBox->setCheckState(Qt::Unchecked);
+        GetQCheckBox()->setCheckState(Qt::Unchecked);
         break;
 
     case wxCHK_CHECKED:
-        m_qtCheckBox->setCheckState(Qt::Checked);
+        GetQCheckBox()->setCheckState(Qt::Checked);
         break;
 
     case wxCHK_UNDETERMINED:
-        m_qtCheckBox->setCheckState(Qt::PartiallyChecked);
+        GetQCheckBox()->setCheckState(Qt::PartiallyChecked);
         break;
     }
 }
 
 wxCheckBoxState wxCheckBox::DoGet3StateValue() const
 {
-    switch (m_qtCheckBox->checkState())
+    switch (GetQCheckBox()->checkState())
     {
     case Qt::Unchecked:
         return wxCHK_UNCHECKED;
@@ -129,21 +133,16 @@ wxCheckBoxState wxCheckBox::DoGet3StateValue() const
     return wxCHK_UNDETERMINED;
 }
 
-QWidget *wxCheckBox::GetHandle() const
-{
-    return m_qtCheckBox;
-}
-
 wxString wxCheckBox::GetLabel() const
 {
-    return wxQtConvertString( m_qtCheckBox->text() );
+    return wxQtConvertString( GetQCheckBox()->text() );
 }
 
 void wxCheckBox::SetLabel(const wxString& label)
 {
     wxCheckBoxBase::SetLabel( label );
 
-    m_qtCheckBox->setText( wxQtConvertString(label) );
+    GetQCheckBox()->setText( wxQtConvertString(label) );
 }
 
 #endif // wxUSE_CHECKBOX

--- a/src/qt/checklst.cpp
+++ b/src/qt/checklst.cpp
@@ -15,10 +15,6 @@
 
 #include <QtWidgets/QListWidgetItem>
 
-wxCheckListBox::wxCheckListBox()
-{
-}
-
 wxCheckListBox::wxCheckListBox(wxWindow *parent, wxWindowID id,
         const wxPoint& pos,
         const wxSize& size,
@@ -66,12 +62,9 @@ bool wxCheckListBox::Create(wxWindow *parent, wxWindowID id,
               const wxValidator& validator,
               const wxString& name )
 {
-    return wxCheckListBoxBase::Create( parent, id, pos, size, choices, style, validator, name );
-}
-
-void wxCheckListBox::Init()
-{
     m_hasCheckBoxes = true;
+
+    return wxCheckListBoxBase::Create( parent, id, pos, size, choices, style, validator, name );
 }
 
 bool wxCheckListBox::IsChecked(unsigned int n) const

--- a/src/qt/checklst.cpp
+++ b/src/qt/checklst.cpp
@@ -76,7 +76,7 @@ void wxCheckListBox::Init()
 
 bool wxCheckListBox::IsChecked(unsigned int n) const
 {
-    QListWidgetItem* item = m_qtListWidget->item(n);
+    QListWidgetItem* item = GetQListWidget()->item(n);
     wxCHECK_MSG(item != nullptr, false, wxT("wrong listbox index") );
     return item->checkState() == Qt::Checked;
 }
@@ -84,9 +84,9 @@ bool wxCheckListBox::IsChecked(unsigned int n) const
 void wxCheckListBox::Check(unsigned int n, bool check )
 {
     // Prevent the emission of wxEVT_CHECKLISTBOX event by temporarily blocking all
-    // signals on m_qtListWidget object.
-    wxQtEnsureSignalsBlocked blocker(m_qtListWidget);
-    QListWidgetItem* item = m_qtListWidget->item(n);
+    // signals on GetQListWidget() object.
+    wxQtEnsureSignalsBlocked blocker(GetQListWidget());
+    QListWidgetItem* item = GetQListWidget()->item(n);
     wxCHECK_RET(item != nullptr, wxT("wrong listbox index") );
     item->setCheckState(check ? Qt::Checked : Qt::Unchecked);
 }

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -73,11 +73,6 @@ void wxQtChoice::activated(int WXUNUSED(index))
 
 } // anonymous namespace
 
-
-wxChoice::wxChoice()
-{
-}
-
 void wxChoice::QtInitSort( QComboBox *combo )
 {
     QSortFilterProxyModel *proxyModel = new LexicalSortProxyModel(combo);

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -74,8 +74,7 @@ void wxQtChoice::activated(int WXUNUSED(index))
 } // anonymous namespace
 
 
-wxChoice::wxChoice() :
-    m_qtComboBox(nullptr)
+wxChoice::wxChoice()
 {
 }
 
@@ -133,14 +132,21 @@ bool wxChoice::Create( wxWindow *parent, wxWindowID id,
         const wxValidator& validator,
         const wxString& name )
 {
-    m_qtComboBox = new wxQtChoice( parent, this );
+    m_qtWindow = new wxQtChoice( parent, this );
 
-    QtInitSort( m_qtComboBox );
+    QtInitSort( GetQComboBox() );
 
     while ( n-- > 0 )
-        m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
+    {
+        GetQComboBox()->addItem( wxQtConvertString( *choices++ ));
+    }
 
     return wxChoiceBase::Create( parent, id, pos, size, style, validator, name );
+}
+
+QComboBox* wxChoice::GetQComboBox() const
+{
+    return static_cast<QComboBox*>(m_qtWindow);
 }
 
 wxSize wxChoice::DoGetBestSize() const
@@ -158,31 +164,31 @@ wxSize wxChoice::DoGetBestSize() const
 
 unsigned wxChoice::GetCount() const
 {
-    return m_qtComboBox->count();
+    return GetQComboBox()->count();
 }
 
 wxString wxChoice::GetString(unsigned int n) const
 {
     wxCHECK_MSG(n < GetCount(), wxString(), "invalid index");
 
-    return wxQtConvertString( m_qtComboBox->itemText(n) );
+    return wxQtConvertString( GetQComboBox()->itemText(n) );
 }
 
 void wxChoice::SetString(unsigned int n, const wxString& s)
 {
-    m_qtComboBox->setItemText(n, wxQtConvertString(s));
+    GetQComboBox()->setItemText(n, wxQtConvertString(s));
 }
 
 
 void wxChoice::SetSelection(int n)
 {
-    wxQtEnsureSignalsBlocked blocker(m_qtComboBox);
-    m_qtComboBox->setCurrentIndex(n);
+    wxQtEnsureSignalsBlocked blocker(GetQComboBox());
+    GetQComboBox()->setCurrentIndex(n);
 }
 
 int wxChoice::GetSelection() const
 {
-    return m_qtComboBox->currentIndex();
+    return GetQComboBox()->currentIndex();
 }
 
 
@@ -211,7 +217,7 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
         ToggleWindowStyle(wxCB_SORT);
 
         // And actually sort items now.
-        m_qtComboBox->model()->sort(0);
+        GetQComboBox()->model()->sort(0);
     }
 
     return n;
@@ -220,15 +226,15 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
 int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
 {
     // Maintain unselected state
-    const bool unselected = m_qtComboBox->currentIndex() == -1;
+    const bool unselected = GetQComboBox()->currentIndex() == -1;
 
-    m_qtComboBox->insertItem(pos, wxQtConvertString(item));
+    GetQComboBox()->insertItem(pos, wxQtConvertString(item));
 
     if ( IsSorted() )
-        m_qtComboBox->model()->sort(0);
+        GetQComboBox()->model()->sort(0);
 
     if ( unselected )
-        m_qtComboBox->setCurrentIndex(-1);
+        GetQComboBox()->setCurrentIndex(-1);
 
     return pos;
 }
@@ -236,19 +242,19 @@ int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
 void wxChoice::DoSetItemClientData(unsigned int n, void *clientData)
 {
     QVariant variant = QVariant::fromValue(clientData);
-    m_qtComboBox->setItemData(n, variant);
+    GetQComboBox()->setItemData(n, variant);
 }
 
 void *wxChoice::DoGetItemClientData(unsigned int n) const
 {
-    QVariant variant = m_qtComboBox->itemData(n);
+    QVariant variant = GetQComboBox()->itemData(n);
     return variant.value<void *>();
 }
 
 
 void wxChoice::DoClear()
 {
-    m_qtComboBox->clear();
+    GetQComboBox()->clear();
 }
 
 void wxChoice::DoDeleteOneItem(unsigned int pos)
@@ -259,12 +265,7 @@ void wxChoice::DoDeleteOneItem(unsigned int pos)
     {
         SetSelection( wxNOT_FOUND );
     }
-    m_qtComboBox->removeItem(pos);
-}
-
-QWidget *wxChoice::GetHandle() const
-{
-    return m_qtComboBox;
+    GetQComboBox()->removeItem(pos);
 }
 
 #endif // wxUSE_CHOICE

--- a/src/qt/clrpicker.cpp
+++ b/src/qt/clrpicker.cpp
@@ -12,10 +12,6 @@
 
 #include "wx/clrpicker.h"
 
-wxColourPickerWidget::wxColourPickerWidget()
-{
-}
-
 wxColourPickerWidget::wxColourPickerWidget(wxWindow *parent,
                wxWindowID id,
                const wxColour& initial,

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -83,7 +83,7 @@ void wxQtComboBox::editTextChanged(const QString &text)
 
 void wxComboBox::SetSelection( int n )
 {
-    wxQtEnsureSignalsBlocked blocker(m_qtComboBox);
+    wxQtEnsureSignalsBlocked blocker(GetQComboBox());
     wxChoice::SetSelection( n );
 }
 
@@ -143,13 +143,17 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxValidator& validator,
             const wxString& name )
 {
-    m_qtComboBox = new wxQtComboBox( parent, this );
-    m_qtComboBox->setEditable(!(style & wxCB_READONLY));
-    QtInitSort( m_qtComboBox );
+    m_qtWindow = new wxQtComboBox( parent, this );
+
+    GetQComboBox()->setEditable(!(style & wxCB_READONLY));
+    QtInitSort( GetQComboBox() );
 
     while ( n-- > 0 )
-        m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
-    m_qtComboBox->setCurrentText( wxQtConvertString( value ));
+    {
+        GetQComboBox()->addItem( wxQtConvertString( *choices++ ));
+    }
+
+    GetQComboBox()->setCurrentText( wxQtConvertString( value ));
 
     return wxChoiceBase::Create( parent, id, pos, size, style, validator, name );
 }
@@ -162,13 +166,13 @@ bool wxComboBox::IsReadOnly() const
 bool wxComboBox::IsEditable() const
 {
     // Only editable combo boxes have a line edit.
-    QLineEdit* const lineEdit = m_qtComboBox->lineEdit();
+    QLineEdit* const lineEdit = GetQComboBox()->lineEdit();
     return lineEdit && !lineEdit->isReadOnly();
 }
 
 void wxComboBox::SetEditable(bool editable)
 {
-    QLineEdit* const lineEdit = m_qtComboBox->lineEdit();
+    QLineEdit* const lineEdit = GetQComboBox()->lineEdit();
     if ( lineEdit )
         lineEdit->setReadOnly(!editable);
 }
@@ -234,13 +238,13 @@ void wxComboBox::WriteText(const wxString &value)
 {
     if ( IsEditable() )
     {
-        m_qtComboBox->lineEdit()->insert( wxQtConvertString( value ) );
+        GetQComboBox()->lineEdit()->insert( wxQtConvertString( value ) );
     }
 }
 
 wxString wxComboBox::DoGetValue() const
 {
-    return wxQtConvertString( m_qtComboBox->currentText() );
+    return wxQtConvertString( GetQComboBox()->currentText() );
 }
 
 void wxComboBox::Popup()
@@ -262,7 +266,7 @@ bool wxComboBox::QtHandleFocusEvent(QWidget *handler, QFocusEvent *event)
         // generating a lose focus event if the combobox or its drop-down still
         // have focus.
         QWidget* const widget = qApp->focusWidget();
-        if ( widget == m_qtComboBox || widget == m_qtComboBox->view() )
+        if ( widget == GetQComboBox() || widget == GetQComboBox()->view() )
             return false;
     }
 
@@ -290,7 +294,7 @@ void wxComboBox::SetSelection( long from, long to )
 
     SetInsertionPoint( from );
     // use the inner text entry widget (note that can be null if not editable)
-    if ( QLineEdit* const lineEdit = m_qtComboBox->lineEdit() )
+    if ( QLineEdit* const lineEdit = GetQComboBox()->lineEdit() )
     {
         lineEdit->setSelection( from, to - from );
     }
@@ -298,7 +302,7 @@ void wxComboBox::SetSelection( long from, long to )
 
 void wxComboBox::SetInsertionPoint( long pos )
 {
-    if ( QLineEdit* const lineEdit = m_qtComboBox->lineEdit() )
+    if ( QLineEdit* const lineEdit = GetQComboBox()->lineEdit() )
     {
         // check if pos indicates end of text:
         if ( pos == -1 )
@@ -310,7 +314,7 @@ void wxComboBox::SetInsertionPoint( long pos )
 
 long wxComboBox::GetInsertionPoint() const
 {
-    QLineEdit* const lineEdit = m_qtComboBox->lineEdit();
+    QLineEdit* const lineEdit = GetQComboBox()->lineEdit();
 
     if ( !lineEdit )
         return -1;
@@ -326,7 +330,7 @@ long wxComboBox::GetInsertionPoint() const
 void wxComboBox::GetSelection(long* from, long* to) const
 {
     // use the inner text entry widget (note that can be null if not editable)
-    if ( QLineEdit* const lineEdit = m_qtComboBox->lineEdit() )
+    if ( QLineEdit* const lineEdit = GetQComboBox()->lineEdit() )
     {
         *from = lineEdit->selectionStart();
         if ( *from >= 0 )

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -87,11 +87,6 @@ void wxComboBox::SetSelection( int n )
     wxChoice::SetSelection( n );
 }
 
-wxComboBox::wxComboBox()
-{
-}
-
-
 wxComboBox::wxComboBox(wxWindow *parent,
            wxWindowID id,
            const wxString& value,

--- a/src/qt/control.cpp
+++ b/src/qt/control.cpp
@@ -18,10 +18,6 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxControl, wxWindow);
 // Defined in src/qt/window.cpp
 extern wxSize wxQtGetBestSize(QWidget* qtWidget);
 
-wxControl::wxControl()
-{
-}
-
 wxControl::wxControl(wxWindow *parent, wxWindowID id,
          const wxPoint& pos,
          const wxSize& size, long style,

--- a/src/qt/dataview.cpp
+++ b/src/qt/dataview.cpp
@@ -140,10 +140,6 @@ int wxDataViewColumn::GetFlags() const
 //##############################################################################
 
 
-wxDataViewCtrl::wxDataViewCtrl()
-{
-}
-
 wxDataViewCtrl::wxDataViewCtrl( wxWindow *parent, wxWindowID id,
        const wxPoint& pos,
        const wxSize& size, long style,

--- a/src/qt/datectrl.cpp
+++ b/src/qt/datectrl.cpp
@@ -68,13 +68,19 @@ wxDatePickerCtrl::Create(wxWindow *parent,
                          const wxValidator& validator,
                          const wxString& name)
 {
-    m_qtDateEdit = new wxQtDateEdit( parent, this );
-    m_qtDateEdit->setDate( dt.IsValid() ? wxQtConvertDate(dt) :
-                                          wxQtConvertDate(wxDateTime::Today()) );
-    m_qtDateEdit->setCalendarPopup(style & wxDP_DROPDOWN);
-    m_qtDateEdit->setDisplayFormat(QLocale::system().dateFormat(QLocale::ShortFormat));
+    m_qtWindow = new wxQtDateEdit( parent, this );
+
+    GetQDateEdit()->setDate( dt.IsValid() ? wxQtConvertDate(dt) :
+                                            wxQtConvertDate(wxDateTime::Today()) );
+    GetQDateEdit()->setCalendarPopup(style & wxDP_DROPDOWN);
+    GetQDateEdit()->setDisplayFormat(QLocale::system().dateFormat(QLocale::ShortFormat));
 
     return wxDatePickerCtrlBase::Create( parent, id, pos, size, style, validator, name );
+}
+
+QDateEdit* wxDatePickerCtrl::GetQDateEdit() const
+{
+    return static_cast<QDateEdit*>(m_qtWindow);
 }
 
 // ----------------------------------------------------------------------------
@@ -88,38 +94,33 @@ void wxDatePickerCtrl::SetValue(const wxDateTime& dt)
 
     const auto qtDate = wxQtConvertDate(dt);
 
-    if ( qtDate >= m_qtDateEdit->minimumDate() &&
-         qtDate <= m_qtDateEdit->maximumDate() )
+    if ( qtDate >= GetQDateEdit()->minimumDate() &&
+         qtDate <= GetQDateEdit()->maximumDate() )
     {
-        wxQtEnsureSignalsBlocked blocker(m_qtDateEdit);
-        m_qtDateEdit->setDate( qtDate );
+        wxQtEnsureSignalsBlocked blocker(GetQDateEdit());
+        GetQDateEdit()->setDate( qtDate );
     }
 }
 
 wxDateTime wxDatePickerCtrl::GetValue() const
 {
-    return wxQtConvertDate( m_qtDateEdit->date() );
+    return wxQtConvertDate( GetQDateEdit()->date() );
 }
 
 void wxDatePickerCtrl::SetRange(const wxDateTime& dt1, const wxDateTime& dt2)
 {
-    m_qtDateEdit->setDateRange( wxQtConvertDate(dt1), wxQtConvertDate(dt2) );
+    GetQDateEdit()->setDateRange( wxQtConvertDate(dt1), wxQtConvertDate(dt2) );
 }
 
 bool wxDatePickerCtrl::GetRange(wxDateTime *dt1, wxDateTime *dt2) const
 {
     if ( dt1 )
-        *dt1 = wxQtConvertDate( m_qtDateEdit->minimumDate() );
+        *dt1 = wxQtConvertDate( GetQDateEdit()->minimumDate() );
 
     if ( dt2 )
-        *dt2 = wxQtConvertDate( m_qtDateEdit->maximumDate() );
+        *dt2 = wxQtConvertDate( GetQDateEdit()->maximumDate() );
 
     return true;
-}
-
-QWidget* wxDatePickerCtrl::GetHandle() const
-{
-    return m_qtDateEdit;
 }
 
 #endif // wxUSE_DATEPICKCTRL

--- a/src/qt/dialog.cpp
+++ b/src/qt/dialog.cpp
@@ -28,10 +28,6 @@ wxQtDialog::wxQtDialog( wxWindow *parent, wxDialog *handler )
 {
 }
 
-wxDialog::wxDialog()
-{
-}
-
 wxDialog::wxDialog( wxWindow *parent, wxWindowID id,
         const wxString &title,
         const wxPoint &pos,

--- a/src/qt/gauge.cpp
+++ b/src/qt/gauge.cpp
@@ -31,8 +31,7 @@ wxQtProgressBar::wxQtProgressBar( wxWindow *parent, wxGauge *handler )
 }
 
 
-wxGauge::wxGauge() :
-    m_qtProgressBar(nullptr)
+wxGauge::wxGauge()
 {
 }
 
@@ -57,19 +56,19 @@ bool wxGauge::Create(wxWindow *parent,
             const wxValidator& validator,
             const wxString& name)
 {
-    m_qtProgressBar = new wxQtProgressBar( parent, this);
-    m_qtProgressBar->setOrientation( wxQtConvertOrientation( style, wxGA_HORIZONTAL ));
-    m_qtProgressBar->setRange( 0, range );
-    m_qtProgressBar->setTextVisible( style & wxGA_TEXT );
-    m_qtProgressBar->setValue(0);
+    m_qtWindow = new wxQtProgressBar( parent, this);
+
+    GetQProgressBar()->setOrientation( wxQtConvertOrientation( style, wxGA_HORIZONTAL ));
+    GetQProgressBar()->setRange( 0, range );
+    GetQProgressBar()->setTextVisible( style & wxGA_TEXT );
+    GetQProgressBar()->setValue(0);
 
     return wxControl::Create( parent, id, pos, size, style, validator, name );
 }
 
-
-QWidget *wxGauge::GetHandle() const
+QProgressBar* wxGauge::GetQProgressBar() const
 {
-    return m_qtProgressBar;
+    return static_cast<QProgressBar*>(m_qtWindow);
 }
 
 // set/get the control range and value
@@ -77,22 +76,22 @@ QWidget *wxGauge::GetHandle() const
 void wxGauge::SetRange(int range)
 {
     // note that in wx minimun range is fixed at 0
-    m_qtProgressBar->setMaximum(range);
+    GetQProgressBar()->setMaximum(range);
 }
 
 int wxGauge::GetRange() const
 {
-    return m_qtProgressBar->maximum();
+    return GetQProgressBar()->maximum();
 }
 
 void wxGauge::SetValue(int pos)
 {
-    m_qtProgressBar->setValue(pos);
+    GetQProgressBar()->setValue(pos);
 }
 
 int wxGauge::GetValue() const
 {
-    return m_qtProgressBar->value();
+    return GetQProgressBar()->value();
 }
 
 #endif // wxUSE_GAUGE

--- a/src/qt/gauge.cpp
+++ b/src/qt/gauge.cpp
@@ -30,11 +30,6 @@ wxQtProgressBar::wxQtProgressBar( wxWindow *parent, wxGauge *handler )
 {
 }
 
-
-wxGauge::wxGauge()
-{
-}
-
 wxGauge::wxGauge(wxWindow *parent,
         wxWindowID id,
         int range,

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -85,11 +85,6 @@ void wxQtListWidgetItem::setData(int role, const QVariant& value)
     }
 }
 
-wxListBox::wxListBox()
-{
-    Init();
-}
-
 wxListBox::wxListBox(wxWindow *parent, wxWindowID id,
         const wxPoint& pos,
         const wxSize& size,
@@ -180,8 +175,6 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
 
 void wxListBox::DoCreate(wxWindow* parent, long style)
 {
-    Init();
-
     m_qtWindow = new wxQtListWidget( parent, this );
 
     if ( style & wxLB_SORT )

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -85,8 +85,7 @@ void wxQtListWidgetItem::setData(int role, const QVariant& value)
     }
 }
 
-wxListBox::wxListBox() :
-    m_qtListWidget(nullptr)
+wxListBox::wxListBox()
 {
     Init();
 }
@@ -137,7 +136,7 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
             item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             item->setCheckState(Qt::Unchecked);
         }
-        m_qtListWidget->addItem(item);
+        GetQListWidget()->addItem(item);
     }
     return wxListBoxBase::Create( parent, id, pos, size,
                                   style | wxVSCROLL | wxHSCROLL,
@@ -171,7 +170,7 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
             item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             item->setCheckState(Qt::Unchecked);
         }
-        m_qtListWidget->addItem(item);
+        GetQListWidget()->addItem(item);
     }
 
     return wxListBoxBase::Create( parent, id, pos, size,
@@ -183,39 +182,36 @@ void wxListBox::DoCreate(wxWindow* parent, long style)
 {
     Init();
 
-    m_qtWindow =
-    m_qtListWidget = new wxQtListWidget( parent, this );
+    m_qtWindow = new wxQtListWidget( parent, this );
 
     if ( style & wxLB_SORT )
     {
-        m_qtListWidget->setSortingEnabled(true);
+        GetQListWidget()->setSortingEnabled(true);
     }
 
     // The following styles are mutually exclusive
     if ( style & wxLB_SINGLE )
     {
-        m_qtListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+        GetQListWidget()->setSelectionMode(QAbstractItemView::SingleSelection);
     }
     else if ( style & wxLB_MULTIPLE )
     {
-        m_qtListWidget->setSelectionMode(QAbstractItemView::MultiSelection);
+        GetQListWidget()->setSelectionMode(QAbstractItemView::MultiSelection);
     }
     else if ( style & wxLB_EXTENDED )
     {
-        m_qtListWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
+        GetQListWidget()->setSelectionMode(QAbstractItemView::ExtendedSelection);
     }
 }
 
-void wxListBox::Init()
+QListWidget* wxListBox::GetQListWidget() const
 {
-#if wxUSE_CHECKLISTBOX
-    m_hasCheckBoxes = false;
-#endif // wxUSE_CHECKLISTBOX
+    return static_cast<QListWidget*>(m_qtWindow);
 }
 
 bool wxListBox::IsSelected(int n) const
 {
-    QListWidgetItem* item = m_qtListWidget->item(n);
+    QListWidgetItem* item = GetQListWidget()->item(n);
     return item->isSelected();
 }
 
@@ -223,9 +219,9 @@ int wxListBox::GetSelections(wxArrayInt& aSelections) const
 {
     aSelections.clear();
 
-    Q_FOREACH(QListWidgetItem* l, m_qtListWidget->selectedItems())
+    Q_FOREACH(QListWidgetItem* l, GetQListWidget()->selectedItems())
     {
-        aSelections.push_back( m_qtListWidget->row(l) );
+        aSelections.push_back( GetQListWidget()->row(l) );
     }
 
     return aSelections.size();
@@ -233,34 +229,34 @@ int wxListBox::GetSelections(wxArrayInt& aSelections) const
 
 unsigned wxListBox::GetCount() const
 {
-    return m_qtListWidget->count();
+    return GetQListWidget()->count();
 }
 
 wxString wxListBox::GetString(unsigned int n) const
 {
-    QListWidgetItem* item = m_qtListWidget->item(n);
+    QListWidgetItem* item = GetQListWidget()->item(n);
     wxCHECK_MSG(item != nullptr, wxString(), wxT("wrong listbox index") );
     return wxQtConvertString( item->text() );
 }
 
 void wxListBox::SetString(unsigned int n, const wxString& s)
 {
-    QListWidgetItem* item = m_qtListWidget->item(n);
+    QListWidgetItem* item = GetQListWidget()->item(n);
     wxCHECK_RET(item != nullptr, wxT("wrong listbox index") );
     item->setText(wxQtConvertString(s));
 }
 
 int wxListBox::GetSelection() const
 {
-    if ( m_qtListWidget->selectedItems().empty() )
+    if ( GetQListWidget()->selectedItems().empty() )
     {
         return wxNOT_FOUND;
     }
 
 
-    QListWidgetItem* item = m_qtListWidget->selectedItems().first();
+    QListWidgetItem* item = GetQListWidget()->selectedItems().first();
 
-    return m_qtListWidget->row(item);
+    return GetQListWidget()->row(item);
 }
 
 void wxListBox::EnsureVisible(int n)
@@ -268,14 +264,14 @@ void wxListBox::EnsureVisible(int n)
     wxCHECK_RET( n >= 0 && n < static_cast<int>(GetCount()),
                 "invalid index in wxListBox::EnsureVisible" );
 
-    m_qtListWidget->scrollToItem(m_qtListWidget->item(n));
+    GetQListWidget()->scrollToItem(GetQListWidget()->item(n));
 }
 
 int wxListBox::GetTopItem() const
 {
-    const auto item = m_qtListWidget->itemAt(2, 2);
+    const auto item = GetQListWidget()->itemAt(2, 2);
 
-    return item ? m_qtListWidget->row(item) : -1;
+    return item ? GetQListWidget()->row(item) : -1;
 }
 
 int wxListBox::GetCountPerPage() const
@@ -284,17 +280,17 @@ int wxListBox::GetCountPerPage() const
         "wxListBox needs at least one item to calculate the count per page");
 
     // this may not be exact but should be a good approximation:
-    const int h = m_qtListWidget->visualItemRect(
-                    m_qtListWidget->item(0)).height();
+    const int h = GetQListWidget()->visualItemRect(
+                    GetQListWidget()->item(0)).height();
     if ( h )
-        return m_qtListWidget->viewport()->height() / h;
+        return GetQListWidget()->viewport()->height() / h;
 
     return 0;
 }
 
 void wxListBox::DoSetFirstItem(int n)
 {
-    m_qtListWidget->scrollToItem(m_qtListWidget->item(n), QAbstractItemView::PositionAtTop);
+    GetQListWidget()->scrollToItem(GetQListWidget()->item(n), QAbstractItemView::PositionAtTop);
 }
 
 void wxListBox::DoSetSelection(int n, bool select)
@@ -305,7 +301,7 @@ void wxListBox::DoSetSelection(int n, bool select)
         return;
     }
 
-    m_qtListWidget->item(n)->setSelected(select);
+    GetQListWidget()->item(n)->setSelected(select);
 }
 
 int wxListBox::DoInsertItems(const wxArrayStringsAdapter & items,
@@ -328,45 +324,40 @@ int wxListBox::DoInsertOneItem(const wxString& text, unsigned int pos)
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setCheckState(Qt::Unchecked);
     }
-    m_qtListWidget->insertItem(pos, item);
-    return IsSorted() ? m_qtListWidget->row(item) : pos;
+    GetQListWidget()->insertItem(pos, item);
+    return IsSorted() ? GetQListWidget()->row(item) : pos;
 }
 
 void wxListBox::DoSetItemClientData(unsigned int n, void *clientData)
 {
-    QListWidgetItem* item = m_qtListWidget->item(n);
+    QListWidgetItem* item = GetQListWidget()->item(n);
     QVariant variant = QVariant::fromValue(clientData);
     item->setData(Qt::UserRole, variant);
 }
 
 void *wxListBox::DoGetItemClientData(unsigned int n) const
 {
-    QListWidgetItem* item = m_qtListWidget->item(n);
+    QListWidgetItem* item = GetQListWidget()->item(n);
     QVariant variant = item->data(Qt::UserRole);
     return variant.value<void *>();
 }
 
 void wxListBox::DoClear()
 {
-    m_qtListWidget->clear();
+    GetQListWidget()->clear();
 }
 
 void wxListBox::DoDeleteOneItem(unsigned int pos)
 {
-    QListWidgetItem* item = m_qtListWidget->item(pos);
+    QListWidgetItem* item = GetQListWidget()->item(pos);
     delete item;
 }
 
 int wxListBox::DoListHitTest(const wxPoint& point) const
 {
-    QListWidgetItem* item = m_qtListWidget->itemAt( wxQtConvertPoint(point) );
+    QListWidgetItem* item = GetQListWidget()->itemAt( wxQtConvertPoint(point) );
 
-    return item ? m_qtListWidget->row(item) : wxNOT_FOUND;
-}
-
-QWidget *wxListBox::GetHandle() const
-{
-    return m_qtListWidget;
+    return item ? GetQListWidget()->row(item) : wxNOT_FOUND;
 }
 
 void wxListBox::QtSendEvent(wxEventType evtType, int rowIndex, bool selected)
@@ -376,7 +367,7 @@ void wxListBox::QtSendEvent(wxEventType evtType, int rowIndex, bool selected)
 
 void wxListBox::UnSelectAll()
 {
-    Q_FOREACH(QListWidgetItem* l, m_qtListWidget->selectedItems())
+    Q_FOREACH(QListWidgetItem* l, GetQListWidget()->selectedItems())
     {
         l->setSelected(false);
     }

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1336,11 +1336,6 @@ void wxQtEventSignalHandler< QTreeView, wxListCtrl >::HandleDestroyedSignal()
     this->setModel(nullptr);
 }
 
-wxListCtrl::wxListCtrl()
-{
-    Init();
-}
-
 wxListCtrl::wxListCtrl(wxWindow *parent,
            wxWindowID id,
            const wxPoint& pos,
@@ -1349,7 +1344,6 @@ wxListCtrl::wxListCtrl(wxWindow *parent,
            const wxValidator& validator,
            const wxString& name)
 {
-    Init();
     Create( parent, id, pos, size, style, validator, name );
 }
 
@@ -1382,12 +1376,6 @@ bool wxListCtrl::Create(wxWindow *parent,
 
     SetWindowStyleFlag(style);
     return true;
-}
-
-void wxListCtrl::Init()
-{
-    m_hasCheckBoxes = false;
-    m_model = nullptr;
 }
 
 wxListCtrl::~wxListCtrl()

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1366,14 +1366,14 @@ bool wxListCtrl::Create(wxWindow *parent,
         ? new wxQtVirtualListModel(this)
         : new wxQtListModel(this);
 
-    m_qtWindow =
-    m_qtTreeWidget = new wxQtListTreeWidget(parent, this);
-    m_qtTreeWidget->setModel(m_model);
-    m_model->SetView(m_qtTreeWidget);
+    m_qtWindow = new wxQtListTreeWidget(parent, this);
 
-    m_qtTreeWidget->setRootIsDecorated(false);
-    m_qtTreeWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-    m_qtTreeWidget->setTabKeyNavigation(true);
+    GetQListTreeWidget()->setModel(m_model);
+    m_model->SetView(GetQListTreeWidget());
+
+    GetQListTreeWidget()->setRootIsDecorated(false);
+    GetQListTreeWidget()->setSelectionBehavior(QAbstractItemView::SelectRows);
+    GetQListTreeWidget()->setTabKeyNavigation(true);
 
     if ( !wxListCtrlBase::Create(parent, id, pos, size,
                                  style | wxVSCROLL | wxHSCROLL,
@@ -1388,12 +1388,16 @@ void wxListCtrl::Init()
 {
     m_hasCheckBoxes = false;
     m_model = nullptr;
-    m_qtTreeWidget = nullptr;
 }
 
 wxListCtrl::~wxListCtrl()
 {
     m_model->deleteLater();
+}
+
+wxQtListTreeWidget* wxListCtrl::GetQListTreeWidget() const
+{
+    return static_cast<wxQtListTreeWidget*>(m_qtWindow);
 }
 
 bool wxListCtrl::SetForegroundColour(const wxColour& col)
@@ -1424,12 +1428,12 @@ bool wxListCtrl::SetColumn(int col, const wxListItem& info)
 
 int wxListCtrl::GetColumnWidth(int col) const
 {
-    return m_qtTreeWidget->columnWidth(col);
+    return GetQListTreeWidget()->columnWidth(col);
 }
 
 bool wxListCtrl::SetColumnWidth(int col, int width)
 {
-    const auto header = m_qtTreeWidget->header();
+    const auto header = GetQListTreeWidget()->header();
 
     if ( header &&
          col == GetColumnIndexFromOrder(col) &&
@@ -1442,13 +1446,13 @@ bool wxListCtrl::SetColumnWidth(int col, int width)
 
     if ( width >= 0 )
     {
-        m_qtTreeWidget->setColumnWidth(col, width);
+        GetQListTreeWidget()->setColumnWidth(col, width);
     }
     else
     {
         if ( width == wxLIST_AUTOSIZE_USEHEADER )
         {
-            const auto header = m_qtTreeWidget->header();
+            const auto header = GetQListTreeWidget()->header();
             const QHeaderView::ResizeMode oldResizeMode = header->sectionResizeMode(col);
 
             header->setSectionResizeMode(col, QHeaderView::ResizeToContents);
@@ -1460,10 +1464,10 @@ bool wxListCtrl::SetColumnWidth(int col, int width)
             // Temporarily hide the header if it's shown as we don't want the header section
             // to be considered by resizeColumnToContents() because it's size will be honored
             // if it's larger than the column content.
-            const bool wasHidden = m_qtTreeWidget->isHeaderHidden();
-            m_qtTreeWidget->setHeaderHidden(true);
-            m_qtTreeWidget->resizeColumnToContents(col);
-            m_qtTreeWidget->setHeaderHidden(wasHidden);
+            const bool wasHidden = GetQListTreeWidget()->isHeaderHidden();
+            GetQListTreeWidget()->setHeaderHidden(true);
+            GetQListTreeWidget()->resizeColumnToContents(col);
+            GetQListTreeWidget()->setHeaderHidden(wasHidden);
         }
      }
 
@@ -1492,16 +1496,16 @@ bool wxListCtrl::SetColumnsOrder(const wxArrayInt& WXUNUSED(orders))
 
 int wxListCtrl::GetCountPerPage() const
 {
-    wxCHECK_MSG(m_qtTreeWidget->GetRowCount() > 0, 0,
+    wxCHECK_MSG(GetQListTreeWidget()->GetRowCount() > 0, 0,
         "wxListCtrl needs at least one item to calculate the count per page");
-    return m_qtTreeWidget->GetCountPerPage();
+    return GetQListTreeWidget()->GetCountPerPage();
 }
 
 wxRect wxListCtrl::GetViewRect() const
 {
     // this may not be exact but should be a good approximation:
-    wxRect rect = wxQtConvertRect(m_qtTreeWidget->rect());
-    const int h = m_qtTreeWidget->header()->defaultSectionSize();
+    wxRect rect = wxQtConvertRect(GetQListTreeWidget()->rect());
+    const int h = GetQListTreeWidget()->header()->defaultSectionSize();
     rect.SetTop(h);
     rect.SetHeight(rect.GetHeight() - h);
     return rect;
@@ -1509,7 +1513,7 @@ wxRect wxListCtrl::GetViewRect() const
 
 wxTextCtrl* wxListCtrl::GetEditControl() const
 {
-    return m_qtTreeWidget->GetEditControl();
+    return GetQListTreeWidget()->GetEditControl();
 }
 
 bool wxListCtrl::GetItem(wxListItem& info) const
@@ -1633,10 +1637,10 @@ bool wxListCtrl::GetItemRect(long item, wxRect& rect, int WXUNUSED(code)) const
 
     // Calculate the union of the bounds of the items in the first and last
     // column for the given row.
-    QRect first = m_qtTreeWidget->visualRect(m_model->index(item, 0));
-    QRect last = m_qtTreeWidget->visualRect(m_model->index(item, columnCount-1));
+    QRect first = GetQListTreeWidget()->visualRect(m_model->index(item, 0));
+    QRect last = GetQListTreeWidget()->visualRect(m_model->index(item, columnCount-1));
     rect = wxQtConvertRect(first.united(last));
-    rect.Offset(0, m_qtTreeWidget->GetHeaderHeight());
+    rect.Offset(0, GetQListTreeWidget()->GetHeaderHeight());
 
     return true;
 }
@@ -1652,9 +1656,9 @@ bool wxListCtrl::GetSubItemRect(long item,
     wxCHECK_MSG(subItem >= 0 && subItem < GetColumnCount(),
         false, "invalid column index in GetSubItemRect");
 
-    const QModelIndex index = m_qtTreeWidget->model()->index(item, subItem);
-    rect = wxQtConvertRect(m_qtTreeWidget->visualRect(index));
-    rect.Offset(0, m_qtTreeWidget->GetHeaderHeight());
+    const QModelIndex index = GetQListTreeWidget()->model()->index(item, subItem);
+    rect = wxQtConvertRect(GetQListTreeWidget()->visualRect(index));
+    rect.Offset(0, GetQListTreeWidget()->GetHeaderHeight());
 
     switch ( code )
     {
@@ -1668,7 +1672,7 @@ bool wxListCtrl::GetSubItemRect(long item,
                 QVariant var = index.data(Qt::DecorationRole);
                 if ( var.isValid() )
                 {
-                    const int iconWidth = m_qtTreeWidget->iconSize().width();
+                    const int iconWidth = GetQListTreeWidget()->iconSize().width();
 
                     if ( code == wxLIST_RECT_ICON )
                     {
@@ -1796,23 +1800,23 @@ wxFont wxListCtrl::GetItemFont( long item ) const
 
 int wxListCtrl::GetSelectedItemCount() const
 {
-    QItemSelectionModel *selectionModel = m_qtTreeWidget->selectionModel();
+    QItemSelectionModel *selectionModel = GetQListTreeWidget()->selectionModel();
     QModelIndexList selectedRows = selectionModel->selectedRows();
     return selectedRows.length();
 }
 
 wxColour wxListCtrl::GetTextColour() const
 {
-    const QPalette palette = m_qtTreeWidget->palette();
+    const QPalette palette = GetQListTreeWidget()->palette();
     const QColor color = palette.color(QPalette::WindowText);
     return wxColour(color);
 }
 
 void wxListCtrl::SetTextColour(const wxColour& col)
 {
-    QPalette palette = m_qtTreeWidget->palette();
+    QPalette palette = GetQListTreeWidget()->palette();
     palette.setColor(QPalette::WindowText, col.GetQColor());
-    m_qtTreeWidget->setPalette(palette);
+    GetQListTreeWidget()->setPalette(palette);
 }
 
 long wxListCtrl::GetTopItem() const
@@ -1880,9 +1884,9 @@ void wxListCtrl::SetSingleStyle(long style, bool add)
 void wxListCtrl::SetWindowStyleFlag(long style)
 {
     m_windowStyle = style;
-    m_qtTreeWidget->setHeaderHidden((style & wxLC_NO_HEADER) != 0 || (style & wxLC_REPORT) == 0);
-    m_qtTreeWidget->EnableEditLabel((style & wxLC_EDIT_LABELS) != 0);
-    m_qtTreeWidget->setSelectionMode((style & wxLC_SINGLE_SEL) != 0
+    GetQListTreeWidget()->setHeaderHidden((style & wxLC_NO_HEADER) != 0 || (style & wxLC_REPORT) == 0);
+    GetQListTreeWidget()->EnableEditLabel((style & wxLC_EDIT_LABELS) != 0);
+    GetQListTreeWidget()->setSelectionMode((style & wxLC_SINGLE_SEL) != 0
         ? QAbstractItemView::SingleSelection
         : QAbstractItemView::ExtendedSelection
     );
@@ -1894,8 +1898,8 @@ void wxListCtrl::SetWindowStyleFlag(long style)
         m_model = needVirtual
             ? new wxQtVirtualListModel(this)
             : new wxQtListModel(this);
-        m_model->SetView(m_qtTreeWidget);
-        m_qtTreeWidget->setModel(m_model);
+        m_model->SetView(GetQListTreeWidget());
+        GetQListTreeWidget()->setModel(m_model);
         delete oldModel;
     }
 }
@@ -1936,8 +1940,8 @@ void wxListCtrl::DoUpdateImages(int which)
     if ( imageList )
     {
         const wxBitmap bitmap = imageList->GetBitmap(0);
-        m_qtTreeWidget->setIconSize(wxQtConvertSize(bitmap.GetLogicalSize()));
-        m_qtTreeWidget->update();
+        GetQListTreeWidget()->setIconSize(wxQtConvertSize(bitmap.GetLogicalSize()));
+        GetQListTreeWidget()->update();
     }
 }
 
@@ -2025,17 +2029,17 @@ wxTextCtrl* wxListCtrl::EditLabel(long item,
     // Open the editor first so that it's available when handling events as per
     // wx standard.
     const QModelIndex index = m_model->index(item, 0);
-    m_qtTreeWidget->selectionModel()->setCurrentIndex(index, QItemSelectionModel::Select);
-    m_qtTreeWidget->openPersistentEditor(index);
+    GetQListTreeWidget()->selectionModel()->setCurrentIndex(index, QItemSelectionModel::Select);
+    GetQListTreeWidget()->openPersistentEditor(index);
 
     wxListEvent event;
     InitListEvent(event, this, wxEVT_LIST_BEGIN_LABEL_EDIT, index);
 
     // close the editor again if event is vetoed
     if (HandleWindowEvent(event) && !event.IsAllowed())
-        m_qtTreeWidget->closePersistentEditor(index);
+        GetQListTreeWidget()->closePersistentEditor(index);
 
-    return m_qtTreeWidget->GetEditControl();
+    return GetQListTreeWidget()->GetEditControl();
 }
 
 bool wxListCtrl::EndEditLabel(bool WXUNUSED(cancel))
@@ -2044,7 +2048,7 @@ bool wxListCtrl::EndEditLabel(bool WXUNUSED(cancel))
     if ( item < 0 )
         return false;
 
-    m_qtTreeWidget->closePersistentEditor(m_model->index(item, 0));
+    GetQListTreeWidget()->closePersistentEditor(m_model->index(item, 0));
     return true;
 }
 
@@ -2053,7 +2057,7 @@ bool wxListCtrl::EnsureVisible(long item)
     if ( item < 0 || item >= GetItemCount() )
         return false;
 
-    m_qtTreeWidget->scrollTo(m_model->index(item, 0));
+    GetQListTreeWidget()->scrollTo(m_model->index(item, 0));
     return true;
 }
 
@@ -2063,8 +2067,8 @@ bool wxListCtrl::IsVisible(long item) const
     if ( !GetItemRect(item, itemRect) )
         return false;
 
-    wxRect viewportRect = wxQtConvertRect( m_qtTreeWidget->viewport()->rect() );
-    viewportRect.y += m_qtTreeWidget->GetHeaderHeight();
+    wxRect viewportRect = wxQtConvertRect( GetQListTreeWidget()->viewport()->rect() );
+    viewportRect.y += GetQListTreeWidget()->GetHeaderHeight();
     return !viewportRect.Intersect(itemRect).IsEmpty();
 }
 
@@ -2095,9 +2099,9 @@ long wxListCtrl::HitTest(
 {
     // Remove the header height as qt expects point relative to the table sub widget
     QPoint qPoint = wxQtConvertPoint(point);
-    qPoint.setY(qPoint.y() - m_qtTreeWidget->GetHeaderHeight());
+    qPoint.setY(qPoint.y() - GetQListTreeWidget()->GetHeaderHeight());
 
-    QModelIndex index = m_qtTreeWidget->indexAt(qPoint);
+    QModelIndex index = GetQListTreeWidget()->indexAt(qPoint);
     if ( index.isValid() )
     {
         flags = wxLIST_HITTEST_ONITEM;
@@ -2167,7 +2171,7 @@ void wxListCtrl::SetItemCount(long count)
 bool wxListCtrl::ScrollList(int dx, int dy)
 {
     // approximate, as scrollContentsBy is protected
-    m_qtTreeWidget->scroll(dx, dy);
+    GetQListTreeWidget()->scroll(dx, dy);
     return true;
 }
 
@@ -2182,7 +2186,7 @@ void wxListCtrl::ShowSortIndicator(int col, bool ascending)
     // It seems that wx and Qt are not using the same meaning for the
     // "ascending" order, for that we pass to setSortIndicator() the
     // inverted logic to make things work correctly.
-    const auto header = m_qtTreeWidget->header();
+    const auto header = GetQListTreeWidget()->header();
     if ( header )
         header->setSortIndicator(col, ascending ? Qt::DescendingOrder
                                                 : Qt::AscendingOrder);
@@ -2190,7 +2194,7 @@ void wxListCtrl::ShowSortIndicator(int col, bool ascending)
 
 int wxListCtrl::GetSortIndicator() const
 {
-    const auto header = m_qtTreeWidget->header();
+    const auto header = GetQListTreeWidget()->header();
     if ( header && header->isSortIndicatorShown() )
     {
         // If no section has a sort indicator, sortIndicatorSection()
@@ -2203,16 +2207,11 @@ int wxListCtrl::GetSortIndicator() const
 
 bool wxListCtrl::IsAscendingSortIndicator() const
 {
-    const auto header = m_qtTreeWidget->header();
+    const auto header = GetQListTreeWidget()->header();
     if ( header )
         return header->sortIndicatorOrder() == Qt::AscendingOrder;
 
     return true;
-}
-
-QWidget *wxListCtrl::GetHandle() const
-{
-    return m_qtTreeWidget;
 }
 
 #endif // wxUSE_LISTCTRL

--- a/src/qt/mdi.cpp
+++ b/src/qt/mdi.cpp
@@ -38,10 +38,6 @@ class wxQtMdiArea : public wxQtEventSignalHandler< QMdiArea, wxMDIClientWindow >
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxMDIParentFrame, wxFrame);
 
-wxMDIParentFrame::wxMDIParentFrame()
-{
-}
-
 wxMDIParentFrame::wxMDIParentFrame(wxWindow *parent,
                  wxWindowID id,
                  const wxString& title,
@@ -90,10 +86,6 @@ void wxMDIParentFrame::ActivatePrevious()
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxMDIChildFrame,wxMDIChildFrameBase)
 
-wxMDIChildFrame::wxMDIChildFrame()
-{
-}
-
 wxMDIChildFrame::wxMDIChildFrame(wxMDIParentFrame *parent,
                 wxWindowID id,
                 const wxString& title,
@@ -132,10 +124,6 @@ void wxMDIChildFrame::Activate()
 //##############################################################################
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxMDIClientWindow,wxMDIClientWindowBase)
-
-wxMDIClientWindow::wxMDIClientWindow()
-{
-}
 
 bool wxMDIClientWindow::CreateClient(wxMDIParentFrame *parent, long WXUNUSED(style))
 {

--- a/src/qt/menu.cpp
+++ b/src/qt/menu.cpp
@@ -226,28 +226,34 @@ QMenu *wxMenu::GetHandle() const
 
 wxMenuBar::wxMenuBar()
 {
-    m_qtMenuBar  = new QMenuBar();
+    m_qtWindow = new QMenuBar();
 
     wxMenuBarBase::Create(nullptr, wxID_ANY);
 }
 
 wxMenuBar::wxMenuBar( long style )
 {
-    m_qtMenuBar = new QMenuBar();
+    m_qtWindow = new QMenuBar();
 
     wxMenuBarBase::Create(nullptr, wxID_ANY, wxDefaultPosition, wxDefaultSize, style);
 }
 
 wxMenuBar::wxMenuBar(size_t count, wxMenu *menus[], const wxString titles[], long style)
 {
-    m_qtMenuBar = new QMenuBar();
+    m_qtWindow = new QMenuBar();
 
     for ( size_t i = 0; i < count; ++i )
+    {
         Append( menus[ i ], titles[ i ] );
+    }
 
     wxMenuBarBase::Create(nullptr, wxID_ANY, wxDefaultPosition, wxDefaultSize, style);
 }
 
+QMenuBar* wxMenuBar::GetQMenuBar() const
+{
+    return static_cast<QMenuBar*>(m_qtWindow);
+}
 
 static QMenu *SetTitle( wxMenu *menu, const wxString &title )
 {
@@ -268,10 +274,10 @@ bool wxMenuBar::Append( wxMenu *menu, const wxString& title )
     // Override the stored menu title with the given one:
 
     QMenu *qtMenu = SetTitle( menu, title );
-    m_qtMenuBar->addMenu( qtMenu );
+    GetQMenuBar()->addMenu( qtMenu );
     // Menus in Qt can be reused as popups, so a menu bar will not take ownership when
     // one is added to it. Take it explicitly, otherwise there will be a memory leak.
-    qtMenu->setParent(m_qtMenuBar, Qt::Popup); // must specify window type for correct display!
+    qtMenu->setParent(GetQMenuBar(), Qt::Popup); // must specify window type for correct display!
 
     return true;
 }
@@ -292,9 +298,9 @@ bool wxMenuBar::Insert(size_t pos, wxMenu *menu, const wxString& title)
     // Override the stored menu title with the given one:
 
     QMenu *qtMenu = SetTitle( menu, title );
-    QAction *qtAction = GetActionAt( m_qtMenuBar, pos );
-    m_qtMenuBar->insertMenu( qtAction, qtMenu );
-    qtMenu->setParent(m_qtMenuBar, Qt::Popup); // must specify window type for correct display!
+    QAction *qtAction = GetActionAt( GetQMenuBar(), pos );
+    GetQMenuBar()->insertMenu( qtAction, qtMenu );
+    qtMenu->setParent(GetQMenuBar(), Qt::Popup); // must specify window type for correct display!
 
     return true;
 }
@@ -306,33 +312,33 @@ wxMenu *wxMenuBar::Remove(size_t pos)
     if (( menu = wxMenuBarBase::Remove( pos )) == nullptr )
         return nullptr;
 
-    m_qtMenuBar->removeAction( GetActionAt( m_qtMenuBar, pos ));
+    GetQMenuBar()->removeAction( GetActionAt( GetQMenuBar(), pos ));
     return menu;
 }
 
 void wxMenuBar::EnableTop(size_t pos, bool enable)
 {
-    QAction *qtAction = GetActionAt( m_qtMenuBar, pos );
+    QAction *qtAction = GetActionAt( GetQMenuBar(), pos );
     qtAction->setEnabled( enable );
 }
 
 bool wxMenuBar::IsEnabledTop(size_t pos) const
 {
-    QAction *qtAction = GetActionAt( m_qtMenuBar, pos );
+    QAction *qtAction = GetActionAt( GetQMenuBar(), pos );
     return qtAction->isEnabled();
 }
 
 
 void wxMenuBar::SetMenuLabel(size_t pos, const wxString& label)
 {
-    QAction *qtAction = GetActionAt( m_qtMenuBar, pos );
+    QAction *qtAction = GetActionAt( GetQMenuBar(), pos );
     QMenu *qtMenu = qtAction->menu();
     qtMenu->setTitle( wxQtConvertString( label ));
 }
 
 wxString wxMenuBar::GetMenuLabel(size_t pos) const
 {
-    QAction *qtAction = GetActionAt( m_qtMenuBar, pos );
+    QAction *qtAction = GetActionAt( GetQMenuBar(), pos );
     QMenu *qtMenu = qtAction->menu();
 
     return wxQtConvertString( qtMenu->title() );
@@ -341,18 +347,13 @@ wxString wxMenuBar::GetMenuLabel(size_t pos) const
 void wxMenuBar::Attach(wxFrame *frame)
 {
     // sanity check as setMenuBar takes ownership
-    wxCHECK_RET( m_qtMenuBar, "Menu bar has been previously deleted by Qt");
+    wxCHECK_RET( GetHandle(), "Menu bar has been previously deleted by Qt");
     wxMenuBarBase::Attach(frame);
 }
 
 void wxMenuBar::Detach()
 {
     // the QMenuBar probably was deleted by Qt as setMenuBar takes ownership
-    m_qtMenuBar = nullptr;
+    m_qtWindow = nullptr;
     wxMenuBarBase::Detach();
-}
-
-QWidget *wxMenuBar::GetHandle() const
-{
-    return m_qtMenuBar;
 }

--- a/src/qt/nonownedwnd.cpp
+++ b/src/qt/nonownedwnd.cpp
@@ -35,10 +35,6 @@
 // wxNonOwnedWindow implementation
 // ============================================================================
 
-wxNonOwnedWindow::wxNonOwnedWindow()
-{
-}
-
 bool wxNonOwnedWindow::DoClearShape()
 {
     GetHandle()->setMask(QBitmap());

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -53,8 +53,7 @@ void wxQtTabWidget::currentChanged(int index)
 }
 
 
-wxNotebook::wxNotebook() :
-    m_qtTabWidget(nullptr)
+wxNotebook::wxNotebook()
 {
 }
 
@@ -75,19 +74,24 @@ bool wxNotebook::Create(wxWindow *parent,
           long style,
           const wxString& name)
 {
-    m_qtTabWidget = new wxQtTabWidget( parent, this );
+    m_qtWindow = new wxQtTabWidget( parent, this );
 
     if ( !wxControl::Create( parent, id, pos, size, style, wxDefaultValidator, name ) )
         return false;
 
     if ( m_windowStyle & wxBK_RIGHT )
-        m_qtTabWidget->setTabPosition( QTabWidget::East );
+        GetQTabWidget()->setTabPosition( QTabWidget::East );
     else if ( m_windowStyle & wxBK_LEFT )
-        m_qtTabWidget->setTabPosition( QTabWidget::West );
+        GetQTabWidget()->setTabPosition( QTabWidget::West );
     else if ( m_windowStyle & wxBK_BOTTOM )
-        m_qtTabWidget->setTabPosition( QTabWidget::South );
+        GetQTabWidget()->setTabPosition( QTabWidget::South );
 
     return true;
+}
+
+QTabWidget* wxNotebook::GetQTabWidget() const
+{
+    return static_cast<QTabWidget*>(m_qtWindow);
 }
 
 void wxNotebook::SetPadding(const wxSize& WXUNUSED(padding))
@@ -101,14 +105,14 @@ void wxNotebook::SetTabSize(const wxSize& WXUNUSED(sz))
 
 bool wxNotebook::SetPageText(size_t n, const wxString &text)
 {
-    m_qtTabWidget->setTabText( n, wxQtConvertString( text ));
+    GetQTabWidget()->setTabText( n, wxQtConvertString( text ));
 
     return true;
 }
 
 wxString wxNotebook::GetPageText(size_t n) const
 {
-    return wxQtConvertString( m_qtTabWidget->tabText( n ));
+    return wxQtConvertString( GetQTabWidget()->tabText( n ));
 }
 
 int wxNotebook::GetPageImage(size_t n) const
@@ -128,12 +132,12 @@ bool wxNotebook::SetPageImage(size_t n, int imageId)
         wxCHECK_MSG(HasImageList(), false, "invalid notebook imagelist");
         const wxBitmap bitmap = GetImageList()->GetBitmap(imageId);
         // set the new image:
-        m_qtTabWidget->setTabIcon( n, QIcon( *bitmap.GetHandle() ));
+        GetQTabWidget()->setTabIcon( n, QIcon( *bitmap.GetHandle() ));
     }
     else
     {
         // remove the image using and empty qt icon:
-        m_qtTabWidget->setTabIcon( n, QIcon() );
+        GetQTabWidget()->setTabIcon( n, QIcon() );
     }
     m_images[n] = imageId;
     return true;
@@ -146,8 +150,8 @@ void wxNotebook::OnImagesChanged()
         wxImageList* const imageList = GetUpdatedImageListFor(this);
 
         const wxBitmap bitmap = imageList->GetBitmap(0);
-        m_qtTabWidget->setIconSize(wxQtConvertSize(bitmap.GetLogicalSize()));
-        m_qtTabWidget->update();
+        GetQTabWidget()->setIconSize(wxQtConvertSize(bitmap.GetLogicalSize()));
+        GetQTabWidget()->update();
     }
 }
 
@@ -155,14 +159,14 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
     bool bSelect, int imageId)
 {
     // disable firing qt signals until wx structures are filled
-    m_qtTabWidget->blockSignals(true);
+    GetQTabWidget()->blockSignals(true);
 
     if (imageId != -1)
     {
         if (HasImageList())
         {
             const wxBitmap bitmap = GetImageList()->GetBitmap(imageId);
-            m_qtTabWidget->insertTab( n, page->GetHandle(), QIcon( *bitmap.GetHandle() ), wxQtConvertString( text ));
+            GetQTabWidget()->insertTab( n, page->GetHandle(), QIcon( *bitmap.GetHandle() ), wxQtConvertString( text ));
         }
         else
         {
@@ -171,14 +175,14 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
     }
     else
     {
-        m_qtTabWidget->insertTab( n, page->GetHandle(), wxQtConvertString( text ));
+        GetQTabWidget()->insertTab( n, page->GetHandle(), wxQtConvertString( text ));
     }
 
     m_pages.insert(m_pages.begin() + n, page);
     m_images.insert(m_images.begin() + n, imageId);
 
     // reenable firing qt signals as internal wx initialization was completed
-    m_qtTabWidget->blockSignals(false);
+    GetQTabWidget()->blockSignals(false);
 
     DoSetSelectionAfterInsertion(n, bSelect);
 
@@ -187,7 +191,7 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
 
 wxSize wxNotebook::CalcSizeFromPage(const wxSize& sizePage) const
 {
-    QTabBar *tabBar = m_qtTabWidget->tabBar();
+    QTabBar *tabBar = GetQTabWidget()->tabBar();
     const QSize &tabBarSize = tabBar->size();
     return wxSize(sizePage.GetWidth(),
         sizePage.GetHeight() + tabBarSize.height());
@@ -197,12 +201,12 @@ bool wxNotebook::DeleteAllPages()
 {
     // Nothing to do if the notebook was not created yet,
     // and return true just like other ports do.
-    if ( !m_qtTabWidget )
+    if ( !GetQTabWidget() )
         return true;
 
     // Block signals to not receive selection changed updates
     // which are sent by Qt after the selected page was deleted.
-    wxQtEnsureSignalsBlocked blocker(m_qtTabWidget);
+    wxQtEnsureSignalsBlocked blocker(GetQTabWidget());
 
     // Pages will be deleted one by one in the base class.
     // There's no need to explicitly clear() the Qt control.
@@ -216,7 +220,7 @@ int wxNotebook::SetSelection(size_t page)
     int selOld = GetSelection();
 
     // change the QTabWidget selected page:
-    m_qtTabWidget->setCurrentIndex( page );
+    GetQTabWidget()->setCurrentIndex( page );
     m_selection = page;
 
     return selOld;
@@ -226,24 +230,19 @@ int wxNotebook::ChangeSelection(size_t nPage)
 {
     // ChangeSelection() is not supposed to generate events, unlike
     // SetSelection().
-    wxQtEnsureSignalsBlocked blocker(m_qtTabWidget);
+    wxQtEnsureSignalsBlocked blocker(GetQTabWidget());
 
     return SetSelection(nPage);
 }
 
 wxWindow *wxNotebook::DoRemovePage(size_t page)
 {
-    QWidget *qtWidget = m_qtTabWidget->widget( page );
-    m_qtTabWidget->removeTab( page );
+    QWidget *qtWidget = GetQTabWidget()->widget( page );
+    GetQTabWidget()->removeTab( page );
     wxNotebookBase::DoRemovePage(page);
     m_images.erase( m_images.begin() + page );
 
     return QtRetrieveWindowPointer( qtWidget );
-}
-
-QWidget *wxNotebook::GetHandle() const
-{
-    return m_qtTabWidget;
 }
 
 #endif // wxUSE_NOTEBOOK

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -53,10 +53,6 @@ void wxQtTabWidget::currentChanged(int index)
 }
 
 
-wxNotebook::wxNotebook()
-{
-}
-
 wxNotebook::wxNotebook(wxWindow *parent,
          wxWindowID id,
          const wxPoint& pos,

--- a/src/qt/popupwin.cpp
+++ b/src/qt/popupwin.cpp
@@ -33,10 +33,6 @@ wxQtPopupWindow::wxQtPopupWindow(wxWindow* parent, wxPopupWindow* handler)
 {
 }
 
-wxPopupWindow::wxPopupWindow()
-{
-}
-
 wxPopupWindow::wxPopupWindow(wxWindow *parent, int flags)
 {
    Create(parent, flags);

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -66,7 +66,6 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxRadioBox, wxControl);
 
 
 wxRadioBox::wxRadioBox() :
-    m_qtGroupBox(nullptr),
     m_qtButtonGroup(nullptr),
     m_qtGridLayout(nullptr)
 {
@@ -118,6 +117,10 @@ bool wxRadioBox::Create(wxWindow *parent,
 
 }
 
+QGroupBox* wxRadioBox::GetQGroupBox() const
+{
+    return static_cast<QGroupBox*>(m_qtWindow);
+}
 
 static void AddChoices( QButtonGroup *qtButtonGroup, QGridLayout *qtGridLayout, int count, const wxString choices[], int style, int majorDim )
 {
@@ -176,9 +179,10 @@ bool wxRadioBox::Create(wxWindow *parent,
             const wxValidator& val,
             const wxString& name)
 {
-    m_qtGroupBox = new wxQtRadioBox( parent, this );
-    m_qtGroupBox->setTitle( wxQtConvertString( title ) );
-    m_qtButtonGroup = new wxQtButtonGroup( m_qtGroupBox, this );
+    m_qtWindow = new wxQtRadioBox( parent, this );
+
+    GetQGroupBox()->setTitle( wxQtConvertString( title ) );
+    m_qtButtonGroup = new wxQtButtonGroup( GetQGroupBox(), this );
 
     if ( !(style & (wxRA_SPECIFY_ROWS | wxRA_SPECIFY_COLS)) )
         style |= wxRA_SPECIFY_COLS;
@@ -195,7 +199,7 @@ bool wxRadioBox::Create(wxWindow *parent,
     horzLayout->addLayout(vertLayout);
     horzLayout->addStretch();
 
-    m_qtGroupBox->setLayout(horzLayout);
+    GetQGroupBox()->setLayout(horzLayout);
 
     SetMajorDim(majorDim == 0 ? n : majorDim, style);
     return wxControl::Create( parent, id, pos, size, style, val, name );
@@ -218,9 +222,9 @@ static QAbstractButton *GetButtonAt( const QButtonGroup *group, unsigned int n )
 
 bool wxRadioBox::Enable(unsigned int n, bool enable)
 {
-    if ( enable && !m_qtGroupBox->isEnabled() )
+    if ( enable && !GetQGroupBox()->isEnabled() )
     {
-        m_qtGroupBox->setEnabled( true );
+        GetQGroupBox()->setEnabled( true );
 
         for ( unsigned int i = 0; i < GetCount(); ++i )
         {
@@ -242,7 +246,7 @@ bool wxRadioBox::Enable(unsigned int n, bool enable)
 
 bool wxRadioBox::Enable( bool enable )
 {
-    if ( m_qtGroupBox->isEnabled() == enable )
+    if ( GetQGroupBox()->isEnabled() == enable )
     {
         for ( unsigned int i = 0; i < GetCount(); ++i )
         {
@@ -252,16 +256,16 @@ bool wxRadioBox::Enable( bool enable )
         }
     }
 
-    m_qtGroupBox->setEnabled( enable );
+    GetQGroupBox()->setEnabled( enable );
 
     return true;
 }
 
 bool wxRadioBox::Show(unsigned int n, bool show)
 {
-    if ( show && !m_qtGroupBox->isVisible() )
+    if ( show && !GetQGroupBox()->isVisible() )
     {
-        m_qtGroupBox->setVisible(true);
+        GetQGroupBox()->setVisible(true);
 
         for ( unsigned int i = 0; i < GetCount(); ++i )
         {
@@ -287,10 +291,10 @@ bool wxRadioBox::Show( bool show )
     if ( !wxControl::Show(show) )
         return false;
 
-    if ( !m_qtGroupBox )
+    if ( !GetQGroupBox() )
         return false;
 
-    if( m_qtGroupBox->isVisible() == show )
+    if( GetQGroupBox()->isVisible() == show )
     {
         for( unsigned int i = 0; i < GetCount(); ++i )
         {
@@ -300,7 +304,7 @@ bool wxRadioBox::Show( bool show )
         }
     }
 
-    m_qtGroupBox->setVisible( show );
+    GetQGroupBox()->setVisible( show );
 
     return true;
 }
@@ -362,21 +366,16 @@ int wxRadioBox::GetSelection() const
         return wxNOT_FOUND;
 }
 
-QWidget *wxRadioBox::GetHandle() const
-{
-    return m_qtGroupBox;
-}
-
 void wxRadioBox::SetLabel(const wxString& label)
 {
     wxControlBase::SetLabel( label );
 
-    m_qtGroupBox->setTitle( wxQtConvertString( label ) );
+    GetQGroupBox()->setTitle( wxQtConvertString( label ) );
 }
 
 wxString wxRadioBox::GetLabel() const
 {
-    return wxQtConvertString( m_qtGroupBox->title() );
+    return wxQtConvertString( GetQGroupBox()->title() );
 }
 
 #endif // wxUSE_RADIOBOX

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -65,12 +65,6 @@ void wxQtButtonGroup::buttonClicked(QAbstractButton *qbutton)
 wxIMPLEMENT_DYNAMIC_CLASS(wxRadioBox, wxControl);
 
 
-wxRadioBox::wxRadioBox() :
-    m_qtButtonGroup(nullptr),
-    m_qtGridLayout(nullptr)
-{
-}
-
 wxRadioBox::wxRadioBox(wxWindow *parent,
            wxWindowID id,
            const wxString& title,

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -100,8 +100,7 @@ public:
     }
 };
 
-wxRadioButton::wxRadioButton() :
-    m_qtRadioButton(nullptr)
+wxRadioButton::wxRadioButton()
 {
 }
 
@@ -126,8 +125,9 @@ bool wxRadioButton::Create( wxWindow *parent,
              const wxValidator& validator,
              const wxString& name)
 {
-    m_qtRadioButton = new wxQtRadioButton( parent, this );
-    m_qtRadioButton->setText( wxQtConvertString( label ));
+    m_qtWindow = new wxQtRadioButton( parent, this );
+
+    GetQRadioButton()->setText( wxQtConvertString( label ));
 
     if ( !wxRadioButtonBase::Create(parent, id, pos, size, style, validator, name) )
         return false;
@@ -137,7 +137,7 @@ bool wxRadioButton::Create( wxWindow *parent,
     // buttons to prevent them implicitly becoming part of an existing group.
     if ( (style & wxRB_GROUP) || (style & wxRB_SINGLE) )
     {
-        QtStartNewGroup(m_qtRadioButton);
+        QtStartNewGroup(GetQRadioButton());
     }
     else
     {
@@ -152,31 +152,31 @@ bool wxRadioButton::Create( wxWindow *parent,
     return true;
 }
 
+QRadioButton* wxRadioButton::GetQRadioButton() const
+{
+    return static_cast<QRadioButton*>(m_qtWindow);
+}
+
 void wxRadioButton::SetValue(bool value)
 {
-    m_qtRadioButton->setChecked( value );
+    GetQRadioButton()->setChecked( value );
 }
 
 bool wxRadioButton::GetValue() const
 {
-    return m_qtRadioButton->isChecked();
-}
-
-QWidget *wxRadioButton::GetHandle() const
-{
-    return m_qtRadioButton;
+    return GetQRadioButton()->isChecked();
 }
 
 wxString wxRadioButton::GetLabel() const
 {
-    return wxQtConvertString( m_qtRadioButton->text() );
+    return wxQtConvertString( GetQRadioButton()->text() );
 }
 
 void wxRadioButton::SetLabel(const wxString& label)
 {
     wxRadioButtonBase::SetLabel(label);
 
-    m_qtRadioButton->setText( wxQtConvertString(label) );
+    GetQRadioButton()->setText( wxQtConvertString(label) );
 }
 
 #endif // wxUSE_RADIOBTN

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -100,10 +100,6 @@ public:
     }
 };
 
-wxRadioButton::wxRadioButton()
-{
-}
-
 wxRadioButton::wxRadioButton( wxWindow *parent,
                wxWindowID id,
                const wxString& label,

--- a/src/qt/scrolbar.cpp
+++ b/src/qt/scrolbar.cpp
@@ -29,8 +29,7 @@ class wxQtScrollBar : public wxQtEventSignalHandler< QScrollBar, wxScrollBar >
 };
 
 
-wxScrollBar::wxScrollBar() :
-    m_qtScrollBar(nullptr)
+wxScrollBar::wxScrollBar()
 {
 }
 
@@ -51,74 +50,75 @@ bool wxScrollBar::Create( wxWindow *parent, wxWindowID id,
        const wxValidator& validator,
        const wxString& name)
 {
-    m_qtScrollBar = new wxQtScrollBar( parent, this );
-    m_qtScrollBar->setOrientation( wxQtConvertOrientation( style, wxSB_HORIZONTAL ));
+    m_qtWindow = new wxQtScrollBar( parent, this );
+
+    GetQScrollBar()->setOrientation( wxQtConvertOrientation( style, wxSB_HORIZONTAL ));
 
     return wxScrollBarBase::Create( parent, id, pos, size, style, validator, name );
 }
 
+QScrollBar* wxScrollBar::GetQScrollBar() const
+{
+    return static_cast<QScrollBar*>(m_qtWindow);
+}
+
 int wxScrollBar::GetThumbPosition() const
 {
-    wxCHECK_MSG( m_qtScrollBar, 0, "Invalid QScrollbar" );
+    wxCHECK_MSG( GetHandle(), 0, "Invalid QScrollbar" );
 
-    return m_qtScrollBar->value();
+    return GetQScrollBar()->value();
 }
 
 int wxScrollBar::GetThumbSize() const
 {
-    wxCHECK_MSG( m_qtScrollBar, 0, "Invalid QScrollbar" );
+    wxCHECK_MSG( GetHandle(), 0, "Invalid QScrollbar" );
 
-    return m_qtScrollBar->pageStep();
+    return GetQScrollBar()->pageStep();
 }
 
 int wxScrollBar::GetPageSize() const
 {
-    wxCHECK_MSG( m_qtScrollBar, 0, "Invalid QScrollbar" );
+    wxCHECK_MSG( GetHandle(), 0, "Invalid QScrollbar" );
 
-    return m_qtScrollBar->pageStep();
+    return GetQScrollBar()->pageStep();
 }
 
 int wxScrollBar::GetRange() const
 {
-    wxCHECK_MSG( m_qtScrollBar, 0, "Invalid QScrollbar" );
+    wxCHECK_MSG( GetHandle(), 0, "Invalid QScrollbar" );
 
-    return m_qtScrollBar->maximum();
+    return GetQScrollBar()->maximum();
 }
 
 void wxScrollBar::SetThumbPosition(int viewStart)
 {
-    wxCHECK_RET( m_qtScrollBar, "Invalid QScrollbar" );
+    wxCHECK_RET( GetHandle(), "Invalid QScrollbar" );
 
-    m_qtScrollBar->setValue( viewStart );
+    GetQScrollBar()->setValue( viewStart );
 }
 
 void wxScrollBar::SetScrollbar(int position, int WXUNUSED(thumbSize),
                           int range, int pageSize,
                           bool WXUNUSED(refresh))
 {
-    wxCHECK_RET( m_qtScrollBar, "Invalid QScrollbar" );
+    wxCHECK_RET( GetHandle(), "Invalid QScrollbar" );
 
     // Configure the scrollbar
     if (range != 0 )
     {
-        m_qtScrollBar->setRange( 0, range - pageSize );
-        m_qtScrollBar->setPageStep( pageSize );
+        GetQScrollBar()->setRange( 0, range - pageSize );
+        GetQScrollBar()->setPageStep( pageSize );
         {
-            wxQtEnsureSignalsBlocked blocker(m_qtScrollBar);
-            m_qtScrollBar->setValue( position );
+            wxQtEnsureSignalsBlocked blocker(GetQScrollBar());
+            GetQScrollBar()->setValue( position );
         }
-        m_qtScrollBar->show();
+        GetQScrollBar()->show();
     }
     else
     {
         // If range is zero, hide it
-        m_qtScrollBar->hide();
+        GetQScrollBar()->hide();
     }
-}
-
-QWidget *wxScrollBar::GetHandle() const
-{
-    return m_qtScrollBar;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/qt/scrolbar.cpp
+++ b/src/qt/scrolbar.cpp
@@ -29,10 +29,6 @@ class wxQtScrollBar : public wxQtEventSignalHandler< QScrollBar, wxScrollBar >
 };
 
 
-wxScrollBar::wxScrollBar()
-{
-}
-
 wxScrollBar::wxScrollBar( wxWindow *parent, wxWindowID id,
        const wxPoint& pos,
        const wxSize& size,

--- a/src/qt/slider.cpp
+++ b/src/qt/slider.cpp
@@ -136,10 +136,6 @@ void wxQtSlider::sliderReleased()
     }
 }
 
-wxSlider::wxSlider()
-{
-}
-
 wxSlider::wxSlider(wxWindow *parent,
          wxWindowID id,
          int value, int minValue, int maxValue,

--- a/src/qt/slider.cpp
+++ b/src/qt/slider.cpp
@@ -136,8 +136,7 @@ void wxQtSlider::sliderReleased()
     }
 }
 
-wxSlider::wxSlider() :
-    m_qtSlider(nullptr)
+wxSlider::wxSlider()
 {
 }
 
@@ -162,16 +161,17 @@ bool wxSlider::Create(wxWindow *parent,
             const wxValidator& validator,
             const wxString& name)
 {
-    m_qtSlider = new wxQtSlider( parent, this );
-    m_qtSlider->setOrientation( wxQtConvertOrientation( style, wxSL_HORIZONTAL ) );
+    m_qtWindow = new wxQtSlider( parent, this );
 
-    m_qtSlider->setInvertedAppearance( style & wxSL_INVERSE );
+    GetQSlider()->setOrientation( wxQtConvertOrientation( style, wxSL_HORIZONTAL ) );
+
+    GetQSlider()->setInvertedAppearance( style & wxSL_INVERSE );
 
     // For compatibility with the other ports, pressing PageUp should move value
     // towards the slider's minimum.
-    m_qtSlider->setInvertedControls(true);
+    GetQSlider()->setInvertedControls(true);
 
-    wxQtEnsureSignalsBlocked blocker(m_qtSlider);
+    wxQtEnsureSignalsBlocked blocker(GetQSlider());
     SetRange( minValue, maxValue );
     SetValue( value );
     SetPageSize(wxMax(1, (maxValue - minValue) / 10));
@@ -186,46 +186,51 @@ bool wxSlider::Create(wxWindow *parent,
     return true;
 }
 
+QSlider* wxSlider::GetQSlider() const
+{
+    return static_cast<QSlider*>(m_qtWindow);
+}
+
 int wxSlider::GetValue() const
 {
-    return m_qtSlider->value();
+    return GetQSlider()->value();
 }
 
 void wxSlider::SetValue(int value)
 {
-    wxQtEnsureSignalsBlocked blocker(m_qtSlider);
-    m_qtSlider->setValue( value );
+    wxQtEnsureSignalsBlocked blocker(GetQSlider());
+    GetQSlider()->setValue( value );
 }
 
 void wxSlider::SetRange(int minValue, int maxValue)
 {
-    wxQtEnsureSignalsBlocked blocker(m_qtSlider);
-    m_qtSlider->setRange( minValue, maxValue );
+    wxQtEnsureSignalsBlocked blocker(GetQSlider());
+    GetQSlider()->setRange( minValue, maxValue );
 }
 
 int wxSlider::GetMin() const
 {
-    return m_qtSlider->minimum();
+    return GetQSlider()->minimum();
 }
 
 int wxSlider::GetMax() const
 {
-    return m_qtSlider->maximum();
+    return GetQSlider()->maximum();
 }
 
 void wxSlider::DoSetTickFreq(int freq)
 {
-    m_qtSlider->setTickInterval(freq);
+    GetQSlider()->setTickInterval(freq);
 }
 
 int wxSlider::GetTickFreq() const
 {
-    return m_qtSlider->tickInterval();
+    return GetQSlider()->tickInterval();
 }
 
 void wxSlider::ClearTicks()
 {
-    m_qtSlider->setTickPosition(QSlider::NoTicks);
+    GetQSlider()->setTickPosition(QSlider::NoTicks);
 }
 
 void wxSlider::SetTick(int WXUNUSED(tickPos))
@@ -256,27 +261,27 @@ void wxSlider::SetTick(int WXUNUSED(tickPos))
     }
 
     // Draw ticks marks if posTicks != QSlider::NoTicks. remove them otherwise.
-    m_qtSlider->setTickPosition( posTicks );
+    GetQSlider()->setTickPosition( posTicks );
 }
 
 void wxSlider::SetLineSize(int lineSize)
 {
-    m_qtSlider->setSingleStep(lineSize);
+    GetQSlider()->setSingleStep(lineSize);
 }
 
 void wxSlider::SetPageSize(int pageSize)
 {
-    m_qtSlider->setPageStep(pageSize);
+    GetQSlider()->setPageStep(pageSize);
 }
 
 int wxSlider::GetLineSize() const
 {
-    return m_qtSlider->singleStep();
+    return GetQSlider()->singleStep();
 }
 
 int wxSlider::GetPageSize() const
 {
-    return m_qtSlider->pageStep();
+    return GetQSlider()->pageStep();
 }
 
 void wxSlider::SetThumbLength(int WXUNUSED(lenPixels))
@@ -286,12 +291,6 @@ void wxSlider::SetThumbLength(int WXUNUSED(lenPixels))
 int wxSlider::GetThumbLength() const
 {
     return 0;
-}
-
-
-QWidget *wxSlider::GetHandle() const
-{
-    return m_qtSlider;
 }
 
 #endif // wxUSE_SLIDER

--- a/src/qt/spinbutt.cpp
+++ b/src/qt/spinbutt.cpp
@@ -62,10 +62,6 @@ void wxQtSpinButton::stepBy(int steps)
 }
 
 
-wxSpinButton::wxSpinButton()
-{
-}
-
 wxSpinButton::wxSpinButton(wxWindow *parent,
              wxWindowID id,
              const wxPoint& pos,

--- a/src/qt/spinbutt.cpp
+++ b/src/qt/spinbutt.cpp
@@ -62,8 +62,7 @@ void wxQtSpinButton::stepBy(int steps)
 }
 
 
-wxSpinButton::wxSpinButton() :
-    m_qtSpinBox(nullptr)
+wxSpinButton::wxSpinButton()
 {
 }
 
@@ -84,9 +83,9 @@ bool wxSpinButton::Create(wxWindow *parent,
             long style,
             const wxString& name)
 {
-    m_qtSpinBox = new wxQtSpinButton( parent, this );
+    m_qtWindow = new wxQtSpinButton( parent, this );
 
-    m_qtSpinBox->setRange(wxSpinButtonBase::GetMin(), wxSpinButtonBase::GetMax());
+    GetQSpinBox()->setRange(wxSpinButtonBase::GetMin(), wxSpinButtonBase::GetMax());
 
     // Modify the size so that the text field is not visible.
     // TODO: Find out the width of the buttons i.e. take the style into account (QStyleOptionSpinBox).
@@ -96,29 +95,29 @@ bool wxSpinButton::Create(wxWindow *parent,
     return wxSpinButtonBase::Create( parent, id, pos, newSize, style, wxDefaultValidator, name );
 }
 
+QSpinBox* wxSpinButton::GetQSpinBox() const
+{
+    return static_cast<QSpinBox*>(m_qtWindow);
+}
+
 void wxSpinButton::SetRange(int min, int max)
 {
     wxSpinButtonBase::SetRange(min, max); // cache the values
 
-    if ( m_qtSpinBox )
+    if ( GetQSpinBox() )
     {
-        m_qtSpinBox->setRange(min, max);
+        GetQSpinBox()->setRange(min, max);
     }
 }
 
 int wxSpinButton::GetValue() const
 {
-    return m_qtSpinBox->value();
+    return GetQSpinBox()->value();
 }
 
 void wxSpinButton::SetValue(int val)
 {
-    m_qtSpinBox->setValue( val );
-}
-
-QWidget *wxSpinButton::GetHandle() const
-{
-    return m_qtSpinBox;
+    GetQSpinBox()->setValue( val );
 }
 
 #endif // wxUSE_SPINBTN

--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -19,11 +19,6 @@
 #include <QtWidgets/QSpinBox>
 
 template< typename T, typename Widget >
-wxSpinCtrlQt< T, Widget >::wxSpinCtrlQt()
-{
-}
-
-template< typename T, typename Widget >
 wxSpinCtrlQt< T, Widget >::wxSpinCtrlQt( wxWindow *WXUNUSED(parent), wxWindowID WXUNUSED(id),
     const wxString& WXUNUSED(value), const wxPoint& WXUNUSED(pos), const wxSize& WXUNUSED(size), long WXUNUSED(style),
     T WXUNUSED(min), T WXUNUSED(max), T WXUNUSED(initial), T WXUNUSED(inc), const wxString& WXUNUSED(name) )
@@ -219,11 +214,6 @@ private:
 
 template class wxSpinCtrlQt< int, QSpinBox >;
 
-wxSpinCtrl::wxSpinCtrl()
-{
-    Init();
-}
-
 wxSpinCtrl::wxSpinCtrl(wxWindow *parent, wxWindowID id, const wxString& value,
     const wxPoint& pos, const wxSize& size, long style,
     int min, int max, int initial,
@@ -232,7 +222,6 @@ wxSpinCtrl::wxSpinCtrl(wxWindow *parent, wxWindowID id, const wxString& value,
 : wxSpinCtrlQt< int, QSpinBox >( parent, id, value, pos, size, style,
      min, max, initial, 1, name )
 {
-    Init();
     Create( parent, id, value, pos, size, style, min, max, initial, name );
 }
 
@@ -288,10 +277,6 @@ void wxSpinCtrl::SetValue( const wxString &value )
 template class wxSpinCtrlQt< double, QDoubleSpinBox >;
 
 wxIMPLEMENT_DYNAMIC_CLASS( wxSpinCtrlDouble, wxSpinCtrlBase );
-
-wxSpinCtrlDouble::wxSpinCtrlDouble()
-{
-}
 
 wxSpinCtrlDouble::wxSpinCtrlDouble(wxWindow *parent, wxWindowID id, const wxString& value,
     const wxPoint& pos, const wxSize& size, long style,

--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -19,8 +19,7 @@
 #include <QtWidgets/QSpinBox>
 
 template< typename T, typename Widget >
-wxSpinCtrlQt< T, Widget >::wxSpinCtrlQt() :
-    m_qtSpinBox(nullptr)
+wxSpinCtrlQt< T, Widget >::wxSpinCtrlQt()
 {
 }
 
@@ -37,17 +36,17 @@ bool wxSpinCtrlQt< T, Widget >::Create( wxWindow *parent, wxWindowID id,
     T min, T max, T initial, T inc, const wxString& name )
 {
     if ( !(style & wxSP_ARROW_KEYS) )
-        m_qtSpinBox->setButtonSymbols(QAbstractSpinBox::NoButtons);
+        GetQtSpinBox()->setButtonSymbols(QAbstractSpinBox::NoButtons);
 
     if ( style & wxSP_WRAP )
-        m_qtSpinBox->setWrapping(true);
+        GetQtSpinBox()->setWrapping(true);
 
     if ( style & wxALIGN_CENTRE_HORIZONTAL )
-        m_qtSpinBox->setAlignment(Qt::AlignHCenter);
+        GetQtSpinBox()->setAlignment(Qt::AlignHCenter);
     else if ( style & wxALIGN_RIGHT )
-        m_qtSpinBox->setAlignment(Qt::AlignRight);
+        GetQtSpinBox()->setAlignment(Qt::AlignRight);
 
-    m_qtSpinBox->setAccelerated(true); // to match gtk behavior
+    GetQtSpinBox()->setAccelerated(true); // to match gtk behavior
 
     SetRange( min, max );
     SetValue( initial );
@@ -62,55 +61,55 @@ bool wxSpinCtrlQt< T, Widget >::Create( wxWindow *parent, wxWindowID id,
 template< typename T, typename Widget >
 wxString wxSpinCtrlQt< T, Widget >::GetTextValue() const
 {
-    return wxQtConvertString(m_qtSpinBox->text());
+    return wxQtConvertString(GetQtSpinBox()->text());
 }
 
 template< typename T, typename Widget >
 void wxSpinCtrlQt< T, Widget >::SetValue( T val )
 {
-    wxQtEnsureSignalsBlocked blocker(m_qtSpinBox);
-    m_qtSpinBox->setValue( val );
+    wxQtEnsureSignalsBlocked blocker(GetQtSpinBox());
+    GetQtSpinBox()->setValue( val );
 }
 
 template< typename T, typename Widget >
 void wxSpinCtrlQt< T, Widget >::SetRange( T min, T max )
 {
-    wxQtEnsureSignalsBlocked blocker(m_qtSpinBox);
-    m_qtSpinBox->setRange( min, max );
+    wxQtEnsureSignalsBlocked blocker(GetQtSpinBox());
+    GetQtSpinBox()->setRange( min, max );
 }
 
 template< typename T, typename Widget >
 void wxSpinCtrlQt< T, Widget >::SetIncrement( T inc )
 {
-    m_qtSpinBox->setSingleStep( inc );
+    GetQtSpinBox()->setSingleStep( inc );
 }
 
 template< typename T, typename Widget >
 T wxSpinCtrlQt< T, Widget >::GetValue() const
 {
-    return m_qtSpinBox->value();
+    return GetQtSpinBox()->value();
 }
 
 template< typename T, typename Widget >
 T wxSpinCtrlQt< T, Widget >::GetMin() const
 {
-    return m_qtSpinBox->minimum();
+    return GetQtSpinBox()->minimum();
 }
 
 template< typename T, typename Widget >
 T wxSpinCtrlQt< T, Widget >::GetMax() const
 {
-    return m_qtSpinBox->maximum();
+    return GetQtSpinBox()->maximum();
 }
 
 template< typename T, typename Widget >
 T wxSpinCtrlQt< T, Widget >::GetIncrement() const
 {
-    return m_qtSpinBox->singleStep();
+    return GetQtSpinBox()->singleStep();
 }
 
 template< typename T, typename Widget >
-void wxSpinCtrlQt< T, Widget >::SetSnapToTicks(bool WXUNUSED(WXUNUSED(snap_to_ticks)))
+void wxSpinCtrlQt< T, Widget >::SetSnapToTicks(bool WXUNUSED(snap_to_ticks))
 {
     wxMISSING_FUNCTION();
 }
@@ -124,15 +123,9 @@ bool wxSpinCtrlQt< T, Widget >::GetSnapToTicks() const
 }
 
 template< typename T, typename Widget >
-void wxSpinCtrlQt< T, Widget >::SetSelection(long WXUNUSED(WXUNUSED(from)), long WXUNUSED(WXUNUSED(to)))
+void wxSpinCtrlQt< T, Widget >::SetSelection(long WXUNUSED(from), long WXUNUSED(to))
 {
     wxMISSING_FUNCTION();
-}
-
-template< typename T, typename Widget >
-QWidget *wxSpinCtrlQt< T, Widget >::GetHandle() const
-{
-    return m_qtSpinBox;
 }
 
 // Specializations for QSpinBox
@@ -143,22 +136,22 @@ void wxSpinCtrlQt< int, QSpinBox >::SetRange( int min, int max )
     if ( !wxSpinCtrlImpl::IsBaseCompatibleWithRange(min, max, this->GetBase()) )
         return;
 
-    wxQtEnsureSignalsBlocked blocker(m_qtSpinBox);
-    m_qtSpinBox->setRange( min, max );
+    wxQtEnsureSignalsBlocked blocker(GetQtSpinBox());
+    GetQtSpinBox()->setRange( min, max );
 }
 
 // Specializations for QDoubleSpinBox
 template<>
 void wxSpinCtrlQt< double, QDoubleSpinBox >::SetIncrement( double inc )
 {
-    m_qtSpinBox->setSingleStep( inc );
+    GetQtSpinBox()->setSingleStep( inc );
 
     const int digits = wxSpinCtrlImpl::DetermineDigits(inc);
 
     // Increase the number of digits, if necessary, to show all numbers that
     // can be obtained by using the new increment without loss of precision.
-    if ( digits > m_qtSpinBox->decimals() )
-        m_qtSpinBox->setDecimals( digits );
+    if ( digits > GetQtSpinBox()->decimals() )
+        GetQtSpinBox()->setDecimals( digits );
 }
 
 // Define a derived helper class to get access to valueFromText:
@@ -248,9 +241,10 @@ bool wxSpinCtrl::Create( wxWindow *parent, wxWindowID id, const wxString& value,
     int min, int max, int initial,
     const wxString& name )
 {
-    m_qtSpinBox = new wxQtSpinBox( parent, this );
-    return wxSpinCtrlQt< int, QSpinBox >::Create( parent, id, value,
-        pos, size, style, min, max, initial, 1, name );
+    m_qtWindow = new wxQtSpinBox( parent, this );
+
+    return wxSpinCtrlQt< int, QSpinBox >::Create(
+        parent, id, value, pos, size, style, min, max, initial, 1, name );
 }
 
 
@@ -272,7 +266,7 @@ bool wxSpinCtrl::SetBase(int base)
                                                     static_cast<int>(GetMax()), base) )
         return false;
 
-    m_qtSpinBox->setDisplayIntegerBase(base);
+    GetQtSpinBox()->setDisplayIntegerBase(base);
 #endif
 
     m_base = base;
@@ -282,10 +276,11 @@ bool wxSpinCtrl::SetBase(int base)
 
 void wxSpinCtrl::SetValue( const wxString &value )
 {
-    // valueFromText can be called if m_qtSpinBox is an instance of the helper class
-    wxQtSpinBox * qtSpinBox = dynamic_cast<wxQtSpinBox *> ((QSpinBox *) m_qtSpinBox);
-    if (qtSpinBox != nullptr)
+    // valueFromText can be called if GetQtSpinBox() is an instance of the helper class
+    if ( auto qtSpinBox = dynamic_cast<wxQtSpinBox*>(GetQtSpinBox()) )
+    {
         BaseType::SetValue( qtSpinBox->valueFromText( wxQtConvertString( value )));
+    }
 }
 
 //##############################################################################
@@ -304,7 +299,7 @@ wxSpinCtrlDouble::wxSpinCtrlDouble(wxWindow *parent, wxWindowID id, const wxStri
     const wxString& name )
 
 : wxSpinCtrlQt< double, QDoubleSpinBox >( parent, id, value, pos, size, style,
-        min, max, initial, inc, name )
+                                          min, max, initial, inc, name )
 {
     if ( Create( parent, id, value, pos, size, style, min, max, initial, inc, name ) )
     {
@@ -317,27 +312,29 @@ bool wxSpinCtrlDouble::Create(wxWindow *parent, wxWindowID id, const wxString& v
     double min, double max, double initial, double inc,
     const wxString& name )
 {
-    m_qtSpinBox = new wxQtDoubleSpinBox( parent, this );
+    m_qtWindow = new wxQtDoubleSpinBox( parent, this );
+
     return wxSpinCtrlQt< double, QDoubleSpinBox >::Create( parent, id, value,
         pos, size, style, min, max, initial, inc, name );
 }
 
 void wxSpinCtrlDouble::SetDigits(unsigned digits)
 {
-    m_qtSpinBox->setDecimals( digits );
+    GetQtSpinBox()->setDecimals( digits );
 }
 
 unsigned wxSpinCtrlDouble::GetDigits() const
 {
-    return m_qtSpinBox->decimals();
+    return GetQtSpinBox()->decimals();
 }
 
 void wxSpinCtrlDouble::SetValue( const wxString &value )
 {
-    // valueFromText can be called if m_qtSpinBox is an instance of the helper class
-    wxQtDoubleSpinBox * qtSpinBox = dynamic_cast<wxQtDoubleSpinBox *> ((QDoubleSpinBox *) m_qtSpinBox);
-    if (qtSpinBox != nullptr)
+    // valueFromText can be called if GetQtSpinBox() is an instance of the helper class
+    if ( auto qtSpinBox = dynamic_cast<wxQtDoubleSpinBox*>(GetQtSpinBox()) )
+    {
         BaseType::SetValue( qtSpinBox->valueFromText( wxQtConvertString( value )));
+    }
 }
 
 

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -27,10 +27,6 @@ public:
 };
 
 
-wxStaticBitmap::wxStaticBitmap()
-{
-}
-
 wxStaticBitmap::wxStaticBitmap( wxWindow *parent,
                 wxWindowID id,
                 const wxBitmapBundle& label,

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -27,8 +27,7 @@ public:
 };
 
 
-wxStaticBitmap::wxStaticBitmap() :
-    m_qtLabel(nullptr)
+wxStaticBitmap::wxStaticBitmap()
 {
 }
 
@@ -51,10 +50,16 @@ bool wxStaticBitmap::Create( wxWindow *parent,
              long style,
              const wxString& name)
 {
-    m_qtLabel = new wxQtStaticBmp( parent, this );
+    m_qtWindow = new wxQtStaticBmp( parent, this );
+
     SetBitmap( label );
 
     return wxStaticBitmapBase::Create( parent, id, pos, size, style, wxDefaultValidator, name );
+}
+
+QLabel* wxStaticBitmap::GetQLabel() const
+{
+    return static_cast<QLabel*>(m_qtWindow);
 }
 
 static void SetPixmap( QLabel *label, const QPixmap *pixMap )
@@ -67,7 +72,7 @@ void wxStaticBitmap::SetBitmap(const wxBitmapBundle& bitmap)
 {
     m_bitmapBundle = bitmap;
 
-    SetPixmap( m_qtLabel, bitmap.GetBitmapFor(this).GetHandle() );
+    SetPixmap( GetQLabel(), bitmap.GetBitmapFor(this).GetHandle() );
 
     InvalidateBestSize();
 }
@@ -77,17 +82,12 @@ wxBitmap wxStaticBitmap::GetBitmap() const
     wxBitmap bitmap = m_bitmapBundle.GetBitmapFor(this);
     if ( !bitmap.IsOk() )
     {
-        const QPixmap* pix = m_qtLabel->pixmap();
+        const QPixmap* pix = GetQLabel()->pixmap();
         if ( pix != nullptr )
             bitmap = wxBitmap( *pix );
     }
 
     return bitmap;
-}
-
-QWidget *wxStaticBitmap::GetHandle() const
-{
-    return m_qtLabel;
 }
 
 #endif // wxUSE_STATBMP

--- a/src/qt/statbox.cpp
+++ b/src/qt/statbox.cpp
@@ -25,8 +25,7 @@ public:
 };
 
 
-wxStaticBox::wxStaticBox() :
-    m_qtGroupBox(nullptr)
+wxStaticBox::wxStaticBox()
 {
 }
 
@@ -47,27 +46,28 @@ bool wxStaticBox::Create(wxWindow *parent, wxWindowID id,
             long style,
             const wxString& name)
 {
-    m_qtGroupBox = new wxQtGroupBox( parent, this );
-    m_qtGroupBox->setTitle( wxQtConvertString( label ) );
+    m_qtWindow = new wxQtGroupBox( parent, this );
+
+    GetQGroupBox()->setTitle( wxQtConvertString( label ) );
 
     return wxStaticBoxBase::Create( parent, id, pos, size, style, wxDefaultValidator, name );
 }
 
-QWidget *wxStaticBox::GetHandle() const
+QGroupBox* wxStaticBox::GetQGroupBox() const
 {
-    return m_qtGroupBox;
+    return static_cast<QGroupBox*>(m_qtWindow);
 }
 
 void wxStaticBox::SetLabel(const wxString& label)
 {
     wxStaticBoxBase::SetLabel( label );
 
-    m_qtGroupBox->setTitle( wxQtConvertString( label ) );
+    GetQGroupBox()->setTitle( wxQtConvertString( label ) );
 }
 
 wxString wxStaticBox::GetLabel() const
 {
-    return wxQtConvertString( m_qtGroupBox->title() );
+    return wxQtConvertString( GetQGroupBox()->title() );
 }
 
 void wxStaticBox::GetBordersForSizer(int *borderTop, int *borderOther) const

--- a/src/qt/statbox.cpp
+++ b/src/qt/statbox.cpp
@@ -25,10 +25,6 @@ public:
 };
 
 
-wxStaticBox::wxStaticBox()
-{
-}
-
 wxStaticBox::wxStaticBox(wxWindow *parent, wxWindowID id,
             const wxString& label,
             const wxPoint& pos,

--- a/src/qt/statline.cpp
+++ b/src/qt/statline.cpp
@@ -14,8 +14,7 @@
 
 #include <QtWidgets/QFrame>
 
-wxStaticLine::wxStaticLine() :
-    m_qtFrame(nullptr)
+wxStaticLine::wxStaticLine()
 {
 }
 
@@ -36,18 +35,19 @@ bool wxStaticLine::Create( wxWindow *parent,
              long style,
              const wxString &name)
 {
-    m_qtFrame = new QFrame( parent->GetHandle() );
+    m_qtWindow = new QFrame( parent->GetHandle() );
+
     if ( style & wxLI_HORIZONTAL )
-        m_qtFrame->setFrameStyle( QFrame::HLine );
+        GetQFrame()->setFrameStyle( QFrame::HLine );
     else if ( style & wxLI_VERTICAL )
-        m_qtFrame->setFrameStyle( QFrame::VLine );
+        GetQFrame()->setFrameStyle( QFrame::VLine );
 
     return wxStaticLineBase::Create( parent, id, pos, size, style, wxDefaultValidator, name );
 }
 
-QWidget *wxStaticLine::GetHandle() const
+QFrame* wxStaticLine::GetQFrame() const
 {
-    return m_qtFrame;
+    return static_cast<QFrame*>(m_qtWindow);
 }
 
 #endif // wxUSE_STATLINE

--- a/src/qt/statline.cpp
+++ b/src/qt/statline.cpp
@@ -14,10 +14,6 @@
 
 #include <QtWidgets/QFrame>
 
-wxStaticLine::wxStaticLine()
-{
-}
-
 wxStaticLine::wxStaticLine( wxWindow *parent,
               wxWindowID id,
               const wxPoint& pos,

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -24,8 +24,7 @@ public:
 };
 
 
-wxStaticText::wxStaticText() :
-    m_qtLabel(nullptr)
+wxStaticText::wxStaticText()
 {
 }
 
@@ -48,26 +47,31 @@ bool wxStaticText::Create(wxWindow *parent,
             long style,
             const wxString &name)
 {
-    m_qtLabel = new wxQtStaticText( parent, this );
+    m_qtWindow = new wxQtStaticText( parent, this );
 
     // Set the buddy to itself to get the mnemonic key but ensure that we don't have
     // any unwanted side effects, so disable the interaction:
 
-    m_qtLabel->setBuddy( m_qtLabel );
-    m_qtLabel->setTextInteractionFlags( Qt::NoTextInteraction );
+    GetQLabel()->setBuddy( GetQLabel() );
+    GetQLabel()->setTextInteractionFlags( Qt::NoTextInteraction );
 
     // Translate the WX horizontal alignment flags to Qt alignment flags
     // (notice that wxALIGN_LEFT is default and has the value of 0).
     if ( style & wxALIGN_CENTER_HORIZONTAL )
-        m_qtLabel->setAlignment(Qt::AlignHCenter);
+        GetQLabel()->setAlignment(Qt::AlignHCenter);
     else if ((style & wxALIGN_MASK) == wxALIGN_RIGHT)
-        m_qtLabel->setAlignment(Qt::AlignRight);
+        GetQLabel()->setAlignment(Qt::AlignRight);
     else
-        m_qtLabel->setAlignment(Qt::AlignLeft);
+        GetQLabel()->setAlignment(Qt::AlignLeft);
 
     SetLabel(label);
 
     return wxStaticTextBase::Create(parent, id, pos, size, style, wxDefaultValidator, name);
+}
+
+QLabel* wxStaticText::GetQLabel() const
+{
+    return static_cast<QLabel*>(m_qtWindow);
 }
 
 void wxStaticText::SetLabel(const wxString& label)
@@ -87,17 +91,12 @@ void wxStaticText::SetLabel(const wxString& label)
 
 void wxStaticText::WXSetVisibleLabel(const wxString& label)
 {
-    m_qtLabel->setText( wxQtConvertString( label ) );
+    GetQLabel()->setText( wxQtConvertString( label ) );
 }
 
 wxString wxStaticText::WXGetVisibleLabel() const
 {
-    return wxQtConvertString( m_qtLabel->text() );
-}
-
-QWidget *wxStaticText::GetHandle() const
-{
-    return m_qtLabel;
+    return wxQtConvertString( GetQLabel()->text() );
 }
 
 #endif // wxUSE_STATTEXT

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -24,10 +24,6 @@ public:
 };
 
 
-wxStaticText::wxStaticText()
-{
-}
-
 wxStaticText::wxStaticText(wxWindow *parent,
              wxWindowID id,
              const wxString &label,

--- a/src/qt/statusbar.cpp
+++ b/src/qt/statusbar.cpp
@@ -43,14 +43,14 @@ wxStatusBar::wxStatusBar(wxWindow *parent, wxWindowID winid,
 bool wxStatusBar::Create(wxWindow *parent, wxWindowID id,
                          long style, const wxString& name)
 {
-    m_qtStatusBar = new wxQtStatusBar( parent, this );
+    m_qtWindow = new wxQtStatusBar( parent, this );
 
     if ( !wxStatusBarBase::Create( parent, id, wxDefaultPosition, wxDefaultSize,
                            style, wxDefaultValidator, name ) )
         return false;
 
     if ( style & wxSTB_SIZEGRIP )
-        m_qtStatusBar->setSizeGripEnabled(true);
+        GetQStatusBar()->setSizeGripEnabled(true);
 
     SetFieldsCount(1);
 
@@ -74,6 +74,11 @@ bool wxStatusBar::Create(wxWindow *parent, wxWindowID id,
     return true;
 }
 
+QStatusBar* wxStatusBar::GetQStatusBar() const
+{
+    return static_cast<QStatusBar*>(m_qtWindow);
+}
+
 void wxStatusBar::SetStatusWidths(int number, const int widths[])
 {
     if ( number != (int)m_panes.GetCount() )
@@ -84,7 +89,7 @@ void wxStatusBar::SetStatusWidths(int number, const int widths[])
         int i = 0;
         for ( auto pane : m_qtPanes )
         {
-            m_qtStatusBar->removeWidget(pane);
+            GetQStatusBar()->removeWidget(pane);
 
             // Do not delete user-added controls.
             if ( !m_panes[i++].GetFieldControl() )
@@ -112,7 +117,7 @@ bool wxStatusBar::GetFieldRect(int i, wxRect& rect) const
 
 void wxStatusBar::SetMinHeight(int height)
 {
-    m_qtStatusBar->setMinimumHeight(height);
+    GetQStatusBar()->setMinimumHeight(height);
 }
 
 int wxStatusBar::GetBorderX() const
@@ -205,13 +210,8 @@ void wxStatusBar::CreateFieldsIfNeeded()
 
         m_qtPanes.push_back(pane);
 
-        m_qtStatusBar->addWidget(pane, width < 0 ? -width : 0);
+        GetQStatusBar()->addWidget(pane, width < 0 ? -width : 0);
     }
-}
-
-QWidget *wxStatusBar::GetHandle() const
-{
-    return m_qtStatusBar;
 }
 
 #endif

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -46,7 +46,6 @@ public:
     virtual long XYToPosition(long x, long y) const = 0;
     virtual bool PositionToXY(long pos, long *x, long *y) const = 0;
     virtual wxTextCtrlHitTestResult HitTest(const wxPoint& pt, long *pos) const = 0;
-    virtual QAbstractScrollArea *ScrollBarsContainer() const = 0;
     virtual void WriteText( const wxString &text ) = 0;
     virtual void SetMaxLength(unsigned long len) = 0;
     virtual void MarkDirty() = 0;
@@ -355,11 +354,6 @@ public:
         m_edit->ensureCursorVisible();
     }
 
-    QAbstractScrollArea *ScrollBarsContainer() const override
-    {
-        return static_cast<QAbstractScrollArea*>(m_edit);
-    }
-
     virtual void SetStyleFlags(long flags) override
     {
         ApplyCommonStyles(m_edit, flags);
@@ -564,11 +558,6 @@ public:
         return wxTE_HT_ON_TEXT;
     }
 
-    virtual QAbstractScrollArea *ScrollBarsContainer() const override
-    {
-        return nullptr;
-    }
-
     virtual void SetStyleFlags(long flags) override
     {
         ApplyCommonStyles(m_edit, flags);
@@ -644,8 +633,7 @@ void wxQtTextEdit::textChanged()
 } // anonymous namespace
 
 
-wxTextCtrl::wxTextCtrl() :
-    m_qtEdit(nullptr)
+wxTextCtrl::wxTextCtrl()
 {
 }
 
@@ -686,7 +674,7 @@ bool wxTextCtrl::Create(wxWindow *parent,
 
     m_qtEdit->SetStyleFlags(style);
 
-    m_qtWindow = m_qtEdit->ScrollBarsContainer();
+    m_qtWindow = m_qtEdit->GetHandle();
 
     // set the initial text value without sending the event
     ChangeValue( value );
@@ -697,7 +685,6 @@ bool wxTextCtrl::Create(wxWindow *parent,
 wxTextCtrl::~wxTextCtrl()
 {
     delete m_qtEdit;
-    m_qtEdit = nullptr;
 }
 
 wxSize wxTextCtrl::DoGetBestSize() const
@@ -915,11 +902,6 @@ void wxTextCtrl::DoSetValue( const wxString &text, int flags )
         if ( flags & SetValue_SendEvent )
             SendTextUpdatedEventIfAllowed();
     }
-}
-
-QWidget *wxTextCtrl::GetHandle() const
-{
-    return (QWidget *) m_qtEdit->GetHandle();
 }
 
 #endif // wxUSE_TEXTCTRL

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -633,10 +633,6 @@ void wxQtTextEdit::textChanged()
 } // anonymous namespace
 
 
-wxTextCtrl::wxTextCtrl()
-{
-}
-
 wxTextCtrl::wxTextCtrl(wxWindow *parent,
            wxWindowID id,
            const wxString &value,

--- a/src/qt/tglbtn.cpp
+++ b/src/qt/tglbtn.cpp
@@ -25,10 +25,6 @@ wxDEFINE_EVENT( wxEVT_TOGGLEBUTTON, wxCommandEvent );
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxBitmapToggleButton, wxToggleButton);
 
-wxBitmapToggleButton::wxBitmapToggleButton()
-{
-}
-
 wxBitmapToggleButton::wxBitmapToggleButton(wxWindow *parent,
                wxWindowID id,
                const wxBitmapBundle& label,
@@ -70,10 +66,6 @@ bool wxBitmapToggleButton::Create(wxWindow *parent,
 //##############################################################################
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxToggleButton, wxControl);
-
-wxToggleButton::wxToggleButton()
-{
-}
 
 wxToggleButton::wxToggleButton(wxWindow *parent,
                wxWindowID id,

--- a/src/qt/tglbtn.cpp
+++ b/src/qt/tglbtn.cpp
@@ -97,7 +97,7 @@ bool wxToggleButton::Create(wxWindow *parent,
 {
     // create a checkable push button
     QtCreate(parent);
-    m_qtPushButton->setCheckable(true);
+    GetQPushButton()->setCheckable(true);
 
     // this button is toggleable and has a text label
     SetLabel( wxIsStockID( id ) ? wxGetStockLabel( id ) : label );
@@ -107,12 +107,12 @@ bool wxToggleButton::Create(wxWindow *parent,
 
 void wxToggleButton::SetValue(bool state)
 {
-    m_qtPushButton->setChecked( state );
+    GetQPushButton()->setChecked( state );
 }
 
 bool wxToggleButton::GetValue() const
 {
-    return m_qtPushButton->isChecked();
+    return GetQPushButton()->isChecked();
 }
 
 #endif // wxUSE_TOGGLEBTN

--- a/src/qt/timectrl.cpp
+++ b/src/qt/timectrl.cpp
@@ -70,12 +70,18 @@ wxTimePickerCtrl::Create(wxWindow *parent,
                          const wxValidator& validator,
                          const wxString& name)
 {
-    m_qtTimeEdit = new wxQtTimeEdit( parent, this );
-    m_qtTimeEdit->setTime( dt.IsValid() ? wxQtConvertTime(dt) :
-                                          wxQtConvertTime(wxDateTime::Now()) );
-    m_qtTimeEdit->setDisplayFormat(QLocale::system().timeFormat(QLocale::ShortFormat));
+    m_qtWindow = new wxQtTimeEdit( parent, this );
+
+    GetQTimeEdit()->setTime( dt.IsValid() ? wxQtConvertTime(dt) :
+                                           wxQtConvertTime(wxDateTime::Now()) );
+    GetQTimeEdit()->setDisplayFormat(QLocale::system().timeFormat(QLocale::ShortFormat));
 
     return wxTimePickerCtrlBase::Create( parent, id, pos, size, style, validator, name );
+}
+
+QTimeEdit* wxTimePickerCtrl::GetQTimeEdit() const
+{
+    return static_cast<QTimeEdit*>(m_qtWindow);
 }
 
 // ----------------------------------------------------------------------------
@@ -84,18 +90,13 @@ wxTimePickerCtrl::Create(wxWindow *parent,
 
 void wxTimePickerCtrl::SetValue(const wxDateTime& dt)
 {
-    wxQtEnsureSignalsBlocked blocker(m_qtTimeEdit);
-    m_qtTimeEdit->setTime( dt.IsValid() ? wxQtConvertTime(dt) : QTime() );
+    wxQtEnsureSignalsBlocked blocker(GetQTimeEdit());
+    GetQTimeEdit()->setTime( dt.IsValid() ? wxQtConvertTime(dt) : QTime() );
 }
 
 wxDateTime wxTimePickerCtrl::GetValue() const
 {
-    return wxQtConvertTime( m_qtTimeEdit->time() );
-}
-
-QWidget* wxTimePickerCtrl::GetHandle() const
-{
-    return m_qtTimeEdit;
+    return wxQtConvertTime( GetQTimeEdit()->time() );
 }
 
 #endif // wxUSE_TIMEPICKCTRL

--- a/src/qt/toolbar.cpp
+++ b/src/qt/toolbar.cpp
@@ -147,14 +147,8 @@ wxQtToolbar::wxQtToolbar( wxWindow *parent, wxToolBar *handler )
 }
 
 
-QWidget *wxToolBar::GetHandle() const
-{
-    return m_qtToolBar;
-}
-
 void wxToolBar::Init()
 {
-    m_qtToolBar = nullptr;
 }
 
 wxToolBar::~wxToolBar()
@@ -164,8 +158,9 @@ wxToolBar::~wxToolBar()
 bool wxToolBar::Create(wxWindow *parent, wxWindowID id, const wxPoint& pos,
                        const wxSize& size, long style, const wxString& name)
 {
-    m_qtToolBar = new wxQtToolbar( parent, this );
-    m_qtToolBar->setWindowTitle( wxQtConvertString( name ) );
+    m_qtWindow = new wxQtToolbar( parent, this );
+
+    GetQToolBar()->setWindowTitle( wxQtConvertString( name ) );
 
     if ( !wxControl::Create( parent, id, pos, size, style, wxDefaultValidator, name ) )
     {
@@ -175,6 +170,11 @@ bool wxToolBar::Create(wxWindow *parent, wxWindowID id, const wxPoint& pos,
     SetWindowStyleFlag(style);
 
     return true;
+}
+
+QToolBar* wxToolBar::GetQToolBar() const
+{
+    return static_cast<QToolBar*>(m_qtWindow);
 }
 
 wxToolBarToolBase *wxToolBar::FindToolForPosition(wxCoord WXUNUSED(x),
@@ -224,10 +224,10 @@ void wxToolBar::SetWindowStyleFlag( long style )
 {
     wxToolBarBase::SetWindowStyleFlag(style);
 
-    if ( !m_qtToolBar )
+    if ( !GetQToolBar() )
         return;
 
-    m_qtToolBar->setOrientation( IsVertical() ? Qt::Vertical : Qt::Horizontal);
+    GetQToolBar()->setOrientation( IsVertical() ? Qt::Vertical : Qt::Horizontal);
 
     Qt::ToolButtonStyle buttonStyle = (Qt::ToolButtonStyle)GetButtonStyle();
 
@@ -272,11 +272,11 @@ QActionGroup* wxToolBar::GetActionGroup(size_t pos)
 {
     QActionGroup *actionGroup = nullptr;
     if (pos > 0)
-        actionGroup = m_qtToolBar->actions().at(pos-1)->actionGroup();
-    if (actionGroup == nullptr && (int)pos < m_qtToolBar->actions().size() - 1)
-        actionGroup = m_qtToolBar->actions().at(pos+1)->actionGroup();
+        actionGroup = GetQToolBar()->actions().at(pos-1)->actionGroup();
+    if (actionGroup == nullptr && (int)pos < GetQToolBar()->actions().size() - 1)
+        actionGroup = GetQToolBar()->actions().at(pos+1)->actionGroup();
     if (actionGroup == nullptr)
-        actionGroup = new QActionGroup(m_qtToolBar);
+        actionGroup = new QActionGroup(GetQToolBar());
     return actionGroup;
 }
 
@@ -284,8 +284,8 @@ bool wxToolBar::DoInsertTool(size_t pos, wxToolBarToolBase *toolBase)
 {
     wxToolBarTool* tool = static_cast<wxToolBarTool*>(toolBase);
     QAction *before = nullptr;
-    if (pos < (size_t)m_qtToolBar->actions().size())
-        before = m_qtToolBar->actions().at(pos);
+    if (pos < (size_t)GetQToolBar()->actions().size())
+        before = GetQToolBar()->actions().at(pos);
 
     QAction *action;
     switch ( tool->GetStyle() )
@@ -300,7 +300,7 @@ bool wxToolBar::DoInsertTool(size_t pos, wxToolBarToolBase *toolBase)
             if (!HasFlag(wxTB_NO_TOOLTIPS))
                 tool->SetToolTip();
 
-            action = m_qtToolBar->insertWidget(before, tool->m_qtToolButton);
+            action = GetQToolBar()->insertWidget(before, tool->m_qtToolButton);
 
             switch (tool->GetKind())
             {
@@ -323,14 +323,14 @@ bool wxToolBar::DoInsertTool(size_t pos, wxToolBarToolBase *toolBase)
             if (tool->IsStretchable()) {
                 QWidget* spacer = new QWidget();
                 spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-                m_qtToolBar->insertWidget(before, spacer);
+                GetQToolBar()->insertWidget(before, spacer);
             } else
-                m_qtToolBar->insertSeparator(before);
+                GetQToolBar()->insertSeparator(before);
             break;
 
         case wxTOOL_STYLE_CONTROL:
             wxWindow* control = tool->GetControl();
-            m_qtToolBar->insertWidget(before, control->GetHandle());
+            GetQToolBar()->insertWidget(before, control->GetHandle());
             break;
     }
 

--- a/src/qt/toolbar.cpp
+++ b/src/qt/toolbar.cpp
@@ -147,10 +147,6 @@ wxQtToolbar::wxQtToolbar( wxWindow *parent, wxToolBar *handler )
 }
 
 
-void wxToolBar::Init()
-{
-}
-
 wxToolBar::~wxToolBar()
 {
 }

--- a/src/qt/toplevel.cpp
+++ b/src/qt/toplevel.cpp
@@ -13,10 +13,6 @@
 #include <QtGui/QIcon>
 #include <QtWidgets/QWidget>
 
-wxTopLevelWindowQt::wxTopLevelWindowQt()
-{
-}
-
 wxTopLevelWindowQt::wxTopLevelWindowQt(wxWindow *parent,
            wxWindowID winId,
            const wxString &title,

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -649,10 +649,6 @@ bool wxQItemSelectionModel::IsSelectionChangeAllowed(const QModelIndex& index) c
     return qTreeWidget->EmitSelectChangeEvent(wxEVT_TREE_SEL_CHANGING);
 }
 
-wxTreeCtrl::wxTreeCtrl()
-{
-}
-
 wxTreeCtrl::wxTreeCtrl(wxWindow *parent, wxWindowID id,
            const wxPoint& pos,
            const wxSize& size,

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -649,8 +649,7 @@ bool wxQItemSelectionModel::IsSelectionChangeAllowed(const QModelIndex& index) c
     return qTreeWidget->EmitSelectChangeEvent(wxEVT_TREE_SEL_CHANGING);
 }
 
-wxTreeCtrl::wxTreeCtrl() :
-    m_qtTreeWidget(nullptr)
+wxTreeCtrl::wxTreeCtrl()
 {
 }
 
@@ -671,9 +670,9 @@ bool wxTreeCtrl::Create(wxWindow *parent, wxWindowID id,
             const wxValidator& validator,
             const wxString& name)
 {
-    m_qtWindow =
-    m_qtTreeWidget = new wxQTreeWidget(parent, this);
-    m_qtTreeWidget->header()->hide();
+    m_qtWindow = new wxQTreeWidget(parent, this);
+
+    GetQTreeWidget()->header()->hide();
 
     Bind(wxEVT_KEY_DOWN, &wxTreeCtrl::OnKeyDown, this);
 
@@ -689,13 +688,18 @@ bool wxTreeCtrl::Create(wxWindow *parent, wxWindowID id,
 
 wxTreeCtrl::~wxTreeCtrl()
 {
-    if ( m_qtTreeWidget != nullptr )
-        m_qtTreeWidget->deleteLater();
+    if ( GetQTreeWidget() )
+        GetQTreeWidget()->deleteLater();
+}
+
+wxQTreeWidget* wxTreeCtrl::GetQTreeWidget() const
+{
+    return static_cast<wxQTreeWidget*>(m_qtWindow);
 }
 
 unsigned wxTreeCtrl::GetCount() const
 {
-    QTreeWidgetItem *root = m_qtTreeWidget->invisibleRootItem();
+    QTreeWidgetItem *root = GetQTreeWidget()->invisibleRootItem();
     if ( root->childCount() == 0 )
         return 0;
 
@@ -704,12 +708,12 @@ unsigned wxTreeCtrl::GetCount() const
 
 unsigned wxTreeCtrl::GetIndent() const
 {
-    return m_qtTreeWidget->columnCount();
+    return GetQTreeWidget()->columnCount();
 }
 
 void wxTreeCtrl::SetIndent(unsigned int indent)
 {
-    m_qtTreeWidget->setColumnCount( indent );
+    GetQTreeWidget()->setColumnCount( indent );
 }
 
 void wxTreeCtrl::SetImageList(wxImageList *imageList)
@@ -723,8 +727,8 @@ void wxTreeCtrl::DoUpdateIconsSize(wxImageList *imageList)
 {
     int width, height;
     imageList->GetSize(0, width, height);
-    m_qtTreeWidget->ResizeIcons(QSize(width, height));
-    m_qtTreeWidget->update();
+    GetQTreeWidget()->ResizeIcons(QSize(width, height));
+    GetQTreeWidget()->update();
 }
 
 void wxTreeCtrl::OnImagesChanged()
@@ -738,13 +742,13 @@ void wxTreeCtrl::OnImagesChanged()
 void wxTreeCtrl::SetStateImages(const wxVector<wxBitmapBundle>& images)
 {
     m_imagesState.SetImages(images);
-    m_qtTreeWidget->update();
+    GetQTreeWidget()->update();
 }
 
 void wxTreeCtrl::SetStateImageList(wxImageList *imageList)
 {
     m_imagesState.SetImageList(imageList);
-    m_qtTreeWidget->update();
+    GetQTreeWidget()->update();
 }
 
 wxString wxTreeCtrl::GetItemText(const wxTreeItemId& item) const
@@ -762,7 +766,7 @@ int wxTreeCtrl::GetItemImage(
 ) const
 {
     wxCHECK_MSG(item.IsOk(), -1, "invalid tree item");
-    return m_qtTreeWidget->GetItemImage(wxQtConvertTreeItem(item), which);
+    return GetQTreeWidget()->GetItemImage(wxQtConvertTreeItem(item), which);
 }
 
 wxTreeItemData *wxTreeCtrl::GetItemData(const wxTreeItemId& item) const
@@ -815,7 +819,7 @@ void wxTreeCtrl::SetItemImage(
 {
     wxCHECK_RET(item.IsOk(), "invalid tree item");
 
-    m_qtTreeWidget->SetItemImage(wxQtConvertTreeItem(item), image, which);
+    GetQTreeWidget()->SetItemImage(wxQtConvertTreeItem(item), image, which);
 }
 
 void wxTreeCtrl::SetItemData(const wxTreeItemId& item, wxTreeItemData *data)
@@ -908,8 +912,8 @@ bool wxTreeCtrl::IsVisible(const wxTreeItemId& item) const
     wxCHECK_MSG(item.IsOk(), false, "invalid tree item");
 
     const QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
-    const QRect itemRect = m_qtTreeWidget->visualItemRect(qTreeItem);
-    const QRect clientRect = m_qtTreeWidget->rect();
+    const QRect itemRect = GetQTreeWidget()->visualItemRect(qTreeItem);
+    const QRect clientRect = GetQTreeWidget()->rect();
     return itemRect.isValid() && clientRect.contains(itemRect);
 }
 
@@ -963,7 +967,7 @@ size_t wxTreeCtrl::GetChildrenCount(
 
 wxTreeItemId wxTreeCtrl::GetRootItem() const
 {
-    const QTreeWidgetItem *root = m_qtTreeWidget->invisibleRootItem();
+    const QTreeWidgetItem *root = GetQTreeWidget()->invisibleRootItem();
     return wxQtConvertTreeItem(root->child(0));
 }
 
@@ -977,7 +981,7 @@ wxTreeItemId wxTreeCtrl::GetSelection() const
 
 size_t wxTreeCtrl::GetSelections(wxArrayTreeItemIds& selections) const
 {
-    QList<QTreeWidgetItem*> qtSelections = m_qtTreeWidget->selectedItems();
+    QList<QTreeWidgetItem*> qtSelections = GetQTreeWidget()->selectedItems();
 
     const size_t numberOfSelections = qtSelections.size();
     selections.reserve(numberOfSelections);
@@ -993,17 +997,17 @@ size_t wxTreeCtrl::GetSelections(wxArrayTreeItemIds& selections) const
 void wxTreeCtrl::SetFocusedItem(const wxTreeItemId& item)
 {
     wxCHECK_RET(item.IsOk(), "invalid tree item");
-    m_qtTreeWidget->setCurrentItem(wxQtConvertTreeItem(item), 0);
+    GetQTreeWidget()->setCurrentItem(wxQtConvertTreeItem(item), 0);
 }
 
 void wxTreeCtrl::ClearFocusedItem()
 {
-    m_qtTreeWidget->setCurrentItem(nullptr);
+    GetQTreeWidget()->setCurrentItem(nullptr);
 }
 
 wxTreeItemId wxTreeCtrl::GetFocusedItem() const
 {
-    return wxQtConvertTreeItem(m_qtTreeWidget->currentItem());
+    return wxQtConvertTreeItem(GetQTreeWidget()->currentItem());
 }
 
 wxTreeItemId wxTreeCtrl::GetItemParent(const wxTreeItemId& item) const
@@ -1073,12 +1077,12 @@ wxTreeItemId wxTreeCtrl::GetNextSibling(const wxTreeItemId& item) const
             : wxTreeItemId();
     }
 
-    int index = m_qtTreeWidget->indexOfTopLevelItem(qTreeItem);
+    int index = GetQTreeWidget()->indexOfTopLevelItem(qTreeItem);
     wxASSERT(index != -1);
 
     ++index;
-    return index < m_qtTreeWidget->topLevelItemCount()
-        ? wxQtConvertTreeItem(m_qtTreeWidget->topLevelItem(index))
+    return index < GetQTreeWidget()->topLevelItemCount()
+        ? wxQtConvertTreeItem(GetQTreeWidget()->topLevelItem(index))
         : wxTreeItemId();
 }
 
@@ -1100,12 +1104,12 @@ wxTreeItemId wxTreeCtrl::GetPrevSibling(const wxTreeItemId& item) const
             : wxTreeItemId();
     }
 
-    int index = m_qtTreeWidget->indexOfTopLevelItem(qTreeItem);
+    int index = GetQTreeWidget()->indexOfTopLevelItem(qTreeItem);
     wxASSERT(index != -1);
 
     --index;
     return index >= 0
-        ? wxQtConvertTreeItem(m_qtTreeWidget->topLevelItem(index))
+        ? wxQtConvertTreeItem(GetQTreeWidget()->topLevelItem(index))
         : wxTreeItemId();
 }
 
@@ -1182,7 +1186,7 @@ wxTreeItemId wxTreeCtrl::AddRoot(const wxString& text,
                              int image, int selImage,
                              wxTreeItemData *data)
 {
-    QTreeWidgetItem *root = m_qtTreeWidget->invisibleRootItem();
+    QTreeWidgetItem *root = GetQTreeWidget()->invisibleRootItem();
     wxTreeItemId newItem = DoInsertItem(
         wxQtConvertTreeItem(root),
         0,
@@ -1192,12 +1196,12 @@ wxTreeItemId wxTreeCtrl::AddRoot(const wxString& text,
         data
     );
 
-    m_qtTreeWidget->setCurrentItem(nullptr);
+    GetQTreeWidget()->setCurrentItem(nullptr);
 
     if ( (GetWindowStyleFlag() & wxTR_HIDE_ROOT) != 0 )
-        m_qtTreeWidget->setRootIndex(m_qtTreeWidget->model()->index(0, 0));
+        GetQTreeWidget()->setRootIndex(GetQTreeWidget()->model()->index(0, 0));
     else
-        m_qtTreeWidget->setRootIndex(QModelIndex());
+        GetQTreeWidget()->setRootIndex(QModelIndex());
 
     return newItem;
 }
@@ -1217,7 +1221,7 @@ void wxTreeCtrl::Delete(const wxTreeItemId& item)
     }
     else
     {
-        m_qtTreeWidget->removeItemWidget(qTreeItem, 0);
+        GetQTreeWidget()->removeItemWidget(qTreeItem, 0);
     }
 
     SendDeleteEvent(item);
@@ -1230,7 +1234,7 @@ void wxTreeCtrl::DeleteChildren(const wxTreeItemId& item)
     wxCHECK_RET(item.IsOk(), "invalid tree item");
 
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
-    wxQtEnsureSignalsBlocked ensureSignalsBlock(m_qtTreeWidget);
+    wxQtEnsureSignalsBlocked ensureSignalsBlock(GetQTreeWidget());
     while ( qTreeItem->childCount() > 0 )
     {
         QTreeWidgetItem *child = qTreeItem->child(0);
@@ -1245,7 +1249,7 @@ void wxTreeCtrl::DeleteChildren(const wxTreeItemId& item)
 
 void wxTreeCtrl::DeleteAllItems()
 {
-    DeleteChildren(wxQtConvertTreeItem(m_qtTreeWidget->invisibleRootItem()));
+    DeleteChildren(wxQtConvertTreeItem(GetQTreeWidget()->invisibleRootItem()));
 }
 
 void wxTreeCtrl::Expand(const wxTreeItemId& item)
@@ -1282,14 +1286,14 @@ void wxTreeCtrl::Toggle(const wxTreeItemId& item)
 
 void wxTreeCtrl::Unselect()
 {
-    QTreeWidgetItem *current = m_qtTreeWidget->currentItem();
+    QTreeWidgetItem *current = GetQTreeWidget()->currentItem();
     if ( current != nullptr )
-        m_qtTreeWidget->select(current, QItemSelectionModel::Deselect);
+        GetQTreeWidget()->select(current, QItemSelectionModel::Deselect);
 }
 
 void wxTreeCtrl::UnselectAll()
 {
-    m_qtTreeWidget->selectionModel()->clearSelection();
+    GetQTreeWidget()->selectionModel()->clearSelection();
 }
 
 void wxTreeCtrl::SelectItem(const wxTreeItemId& item, bool select)
@@ -1298,17 +1302,17 @@ void wxTreeCtrl::SelectItem(const wxTreeItemId& item, bool select)
 
     if ( !HasFlag(wxTR_MULTIPLE) )
     {
-        m_qtTreeWidget->clearSelection();
+        GetQTreeWidget()->clearSelection();
     }
 
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
 
     if ( qTreeItem )
     {
-        m_qtTreeWidget->select(qTreeItem, select ? QItemSelectionModel::Select : QItemSelectionModel::Deselect);
-        if ( select && m_qtTreeWidget->selectionMode() == QTreeWidget::SingleSelection )
+        GetQTreeWidget()->select(qTreeItem, select ? QItemSelectionModel::Select : QItemSelectionModel::Deselect);
+        if ( select && GetQTreeWidget()->selectionMode() == QTreeWidget::SingleSelection )
         {
-            m_qtTreeWidget->setCurrentItem(qTreeItem);
+            GetQTreeWidget()->setCurrentItem(qTreeItem);
         }
     }
 }
@@ -1322,7 +1326,7 @@ void wxTreeCtrl::SelectChildren(const wxTreeItemId& parent)
 
     for ( int i = 0; i < childCount; ++i )
     {
-        m_qtTreeWidget->select(qTreeItem->child(i), QItemSelectionModel::Select);
+        GetQTreeWidget()->select(qTreeItem->child(i), QItemSelectionModel::Select);
     }
 }
 
@@ -1347,7 +1351,7 @@ void wxTreeCtrl::ScrollTo(const wxTreeItemId& item)
     wxCHECK_RET(item.IsOk(), "invalid tree item");
 
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
-    m_qtTreeWidget->scrollToItem(qTreeItem);
+    GetQTreeWidget()->scrollToItem(qTreeItem);
 }
 
 wxTextCtrl *wxTreeCtrl::EditLabel(
@@ -1356,13 +1360,13 @@ wxTextCtrl *wxTreeCtrl::EditLabel(
 )
 {
     wxCHECK_MSG(item.IsOk(), nullptr, "invalid tree item");
-    m_qtTreeWidget->editItem(wxQtConvertTreeItem(item));
-    return m_qtTreeWidget->GetEditControl();
+    GetQTreeWidget()->editItem(wxQtConvertTreeItem(item));
+    return GetQTreeWidget()->GetEditControl();
 }
 
 wxTextCtrl *wxTreeCtrl::GetEditControl() const
 {
-    return m_qtTreeWidget->GetEditControl();
+    return GetQTreeWidget()->GetEditControl();
 }
 
 void wxTreeCtrl::EndEditLabel(
@@ -1372,8 +1376,8 @@ void wxTreeCtrl::EndEditLabel(
 {
     wxCHECK_RET(item.IsOk(), "invalid tree item");
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
-    m_qtTreeWidget->closePersistentEditor(qTreeItem);
-    m_qtTreeWidget->selectionModel()->clearCurrentIndex();
+    GetQTreeWidget()->closePersistentEditor(qTreeItem);
+    GetQTreeWidget()->selectionModel()->clearCurrentIndex();
 }
 
 void wxTreeCtrl::SortChildren(const wxTreeItemId& item)
@@ -1393,7 +1397,7 @@ bool wxTreeCtrl::GetBoundingRect(
     wxCHECK_MSG(item.IsOk(), false, "invalid tree item");
 
     const QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
-    const QRect visualRect = m_qtTreeWidget->visualItemRect(qTreeItem);
+    const QRect visualRect = GetQTreeWidget()->visualItemRect(qTreeItem);
     if ( !visualRect.isValid() )
         return false;
 
@@ -1405,34 +1409,34 @@ void wxTreeCtrl::SetWindowStyleFlag(long styles)
 {
     wxControl::SetWindowStyleFlag(styles);
 
-    m_qtTreeWidget->setEditTriggers(
+    GetQTreeWidget()->setEditTriggers(
         styles & wxTR_EDIT_LABELS
         ? (QTreeWidget::SelectedClicked | QTreeWidget::EditKeyPressed)
         : QTreeWidget::NoEditTriggers
     );
 
-    m_qtTreeWidget->setSelectionMode(
+    GetQTreeWidget()->setSelectionMode(
         styles & wxTR_MULTIPLE
             ? QTreeWidget::ExtendedSelection
             : QTreeWidget::SingleSelection
     );
 
     if ( (styles & wxTR_HIDE_ROOT) != 0 )
-        m_qtTreeWidget->setRootIndex(m_qtTreeWidget->model()->index(0, 0));
+        GetQTreeWidget()->setRootIndex(GetQTreeWidget()->model()->index(0, 0));
     else
-        m_qtTreeWidget->setRootIndex(QModelIndex());
+        GetQTreeWidget()->setRootIndex(QModelIndex());
 }
 
 int wxTreeCtrl::DoGetItemState(const wxTreeItemId& item) const
 {
     wxCHECK_MSG(item.IsOk(), wxTREE_ITEMSTATE_NONE, "invalid tree item");
-    return m_qtTreeWidget->GetItemState(wxQtConvertTreeItem(item));
+    return GetQTreeWidget()->GetItemState(wxQtConvertTreeItem(item));
 }
 
 void wxTreeCtrl::DoSetItemState(const wxTreeItemId& item, int state)
 {
     wxCHECK_RET(item.IsOk(), "invalid tree item");
-    m_qtTreeWidget->SetItemState(wxQtConvertTreeItem(item), state);
+    GetQTreeWidget()->SetItemState(wxQtConvertTreeItem(item), state);
 }
 
 wxTreeItemId wxTreeCtrl::DoInsertItem(const wxTreeItemId& parent,
@@ -1452,10 +1456,10 @@ wxTreeItemId wxTreeCtrl::DoInsertItem(const wxTreeItemId& parent,
     TreeItemDataQt treeItemData(data);
     newItem->setData(0, Qt::UserRole, QVariant::fromValue(treeItemData));
 
-    m_qtTreeWidget->SetItemImage(newItem, image, wxTreeItemIcon_Normal);
-    m_qtTreeWidget->SetItemImage(newItem, selImage, wxTreeItemIcon_Selected);
+    GetQTreeWidget()->SetItemImage(newItem, image, wxTreeItemIcon_Normal);
+    GetQTreeWidget()->SetItemImage(newItem, selImage, wxTreeItemIcon_Selected);
 
-    newItem->setIcon(0, m_qtTreeWidget->GetPlaceHolderImage());
+    newItem->setIcon(0, GetQTreeWidget()->GetPlaceHolderImage());
 
     wxTreeItemId wxItem = wxQtConvertTreeItem(newItem);
 
@@ -1506,14 +1510,9 @@ wxTreeItemId wxTreeCtrl::DoTreeHitTest(const wxPoint& point, int& flags) const
     if ( flags != 0 )
         return wxTreeItemId();
 
-    QTreeWidgetItem *hitItem = m_qtTreeWidget->itemAt(wxQtConvertPoint(point));
+    QTreeWidgetItem *hitItem = GetQTreeWidget()->itemAt(wxQtConvertPoint(point));
     flags = hitItem == nullptr ? wxTREE_HITTEST_NOWHERE : wxTREE_HITTEST_ONITEM;
     return wxQtConvertTreeItem(hitItem);
-}
-
-QWidget *wxTreeCtrl::GetHandle() const
-{
-    return m_qtTreeWidget;
 }
 
 void wxTreeCtrl::SendDeleteEvent(const wxTreeItemId &item)


### PR DESCRIPTION
There is no need to do so because assigning to `m_qtWindow` is enough to return a valid handle.

There is also no need to store an extra pointer just to preserve the actual type of the handle because we can simply get it with the added function `GetQtHandle()`.

There are no real changes other than simplifying and normalizing the code base.