### PR TITLE
Add wxSystemHardwareInfo class

### DIFF
--- a/include/wx/hwinfo.h
+++ b/include/wx/hwinfo.h
@@ -22,7 +22,7 @@
 class WXDLLIMPEXP_BASE wxSystemHardwareInfo
 {
 public:
-    
+
     static int GetCPUCount();
 
     static wxString GetCPUArchitectureName();

--- a/include/wx/hwinfo.h
+++ b/include/wx/hwinfo.h
@@ -1,0 +1,40 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/hwinfo.h
+// Purpose:     declaration of the wxSystemHardwareInfo class
+// Author:      Blake Madden
+// Created:     07.09.2024
+// Copyright:   (c) 2024 Blake Madden
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_SYSTEMHWINFO_H_
+#define _WX_SYSTEMHWINFO_H_
+
+#include "wx/string.h"
+#include "wx/utils.h"
+#include "wx/power.h"
+
+// ----------------------------------------------------------------------------
+// wxSystemHardwareInfo
+// ----------------------------------------------------------------------------
+
+// Information about the system's hardware
+class WXDLLIMPEXP_BASE wxSystemHardwareInfo
+{
+public:
+    
+    static int GetCPUCount();
+
+    static wxString GetCPUArchitectureName();
+    static wxString GetNativeCPUArchitectureName();
+    static bool IsRunningNatively();
+
+    static wxMemorySize GetPhysicalMemory();
+    static wxMemorySize GetFreePhysicalMemory();
+
+    static wxBatteryState GetBatteryState();
+    static int GetRemainingBatteryLifePercent();
+    static wxPowerType GetPowerType();
+};
+
+#endif // _WX_SYSTEMHWINFO_H_

--- a/include/wx/hwinfo.h
+++ b/include/wx/hwinfo.h
@@ -2,7 +2,7 @@
 // Name:        wx/hwinfo.h
 // Purpose:     declaration of the wxSystemHardwareInfo class
 // Author:      Blake Madden
-// Created:     07.09.2024
+// Created:     2024-07-09
 // Copyright:   (c) 2024 Blake Madden
 // Licence:     wxWindows licence
 ///////////////////////////////////////////////////////////////////////////////

--- a/interface/wx/hwinfo.h
+++ b/interface/wx/hwinfo.h
@@ -77,7 +77,7 @@ public:
     /**
         Returns @c true if the architecture that the program is running
         under is the same as the system's architecture. For example, this
-        will be @c if running a 32-bit application under x64 (Windoes) or
+        will be @c if running a 32-bit application under x64 (Windows) or
         running x86_64 under ARM64 (macOS)
     */
     static bool IsRunningNatively();

--- a/interface/wx/hwinfo.h
+++ b/interface/wx/hwinfo.h
@@ -50,7 +50,7 @@ public:
         The returned string may be empty if the CPU architecture
         couldn't be recognized.
 
-        @see wxGetCpuArchitectureName()
+        @see ::wxGetCpuArchitectureName()
      */
     static wxString GetCPUArchitectureName();
 

--- a/interface/wx/hwinfo.h
+++ b/interface/wx/hwinfo.h
@@ -1,0 +1,140 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        hwinfo.h
+// Purpose:     interface of wxSystemHardwareInfo
+// Author:      wxWidgets team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+
+/**
+    @class wxSystemHardwareInfo
+
+    This class holds information about the client's system hardware
+    (e.g., physical memory, battery, CPU, etc.).
+
+    All member functions are static and can accessed as such:
+    @code
+        wxMemorySize amountOfRAM = wxSystemHardwareInfo::GetPhysicalMemory();
+        wxLogMessage("Total RAM installed: %s.",
+                     wxFileName::GetHumanReadableSize(amountOfRAM.GetValue()));
+    @endcode
+
+    @since 3.3.0
+
+    @library{wxbase}
+    @category{cfg}
+
+    @see wxPlatformInfo(), @ref group_funcmacro_networkuseros
+*/
+class wxSystemHardwareInfo
+{
+public:
+
+    /**
+        @name CPU information
+    */
+    //@{
+
+    /**
+        Returns the number of CPU cores.
+    */
+    static int GetCPUCount();
+
+    /**
+        Returns the CPU architecture name.
+
+        This can be, for example, "x86_64", "arm64", or "i86pc".
+        The name for the same CPU running on the same hardware
+        can vary across operating systems.
+
+        The returned string may be empty if the CPU architecture
+        couldn't be recognized.
+
+        @see wxGetCpuArchitectureName()
+     */
+    static wxString GetCPUArchitectureName();
+
+    /**
+        In some situations, the current process and native CPU
+        architecture may be different.
+
+        This returns the native CPU architecture regardless of
+        the current process CPU architecture.
+
+        Common examples for CPU architecture differences are the following:
+
+        - Win32 process in x64 Windows (WoW)
+        - Win32 or x64 process on ARM64 Windows (WoW64)
+        - x86_64 process on ARM64 macOS (Rosetta 2)
+
+        The returned string may be empty if the CPU architecture
+        couldn't be recognized.
+
+        @see ::wxGetNativeCpuArchitectureName()
+     */
+    static wxString GetNativeCPUArchitectureName();
+
+    /**
+        Returns @c true if the architecture that the program is running
+        under is the same as the system's architecture. For example, this
+        will be @c if running a 32-bit application under x64 (Windoes) or
+        running x86_64 under ARM64 (macOS)
+    */
+    static bool IsRunningNatively();
+
+    //@}
+
+
+    /**
+        @name Physical memory (i.e., RAM) information
+    */
+    //@{
+
+    /**
+        Returns the amount of installed memory in bytes under environments
+        which support it, and -1 if not supported or failed to perform measurement.
+    */
+    static wxMemorySize GetPhysicalMemory();
+    /**
+        Returns the amount of free memory in bytes under environments
+        which support it, and -1 if not supported or failed to perform measurement.
+
+        @see ::wxGetFreeMemory()
+    */
+    static wxMemorySize GetFreePhysicalMemory();
+
+    //@}
+
+    /**
+        @name Battery information
+    */
+    //@{
+
+    /**
+        Returns battery state as one of `wxBATTERY_NORMAL_STATE`,
+        `wxBATTERY_LOW_STATE, wxBATTERY_CRITICAL_STATE`,
+        `wxBATTERY_SHUTDOWN_STATE` or `wxBATTERY_UNKNOWN_STATE`.
+
+        Currently only implemented on MS Windows;
+        returns `wxBATTERY_UNKNOWN_STATE` elsewhere.
+    */
+    static wxBatteryState GetBatteryState();
+    /**
+        Returns the remaining battery life (as a percentage), or -1 if
+        unknown (or not applicable).
+
+        Currently only implemented on MS Windows;
+        returns -1 elsewhere.
+    */
+    static int GetRemainingBatteryLifePercent();
+    /**
+        Returns the type of power source as one of `wxPOWER_SOCKET`,
+        `wxPOWER_BATTERY` or `wxPOWER_UNKNOWN`.
+
+        Currently only implemented on MS Windows;
+        returns `wxPOWER_UNKNOWN` elsewhere.
+    */
+    static wxPowerType GetPowerType();
+
+    //@}
+};

--- a/src/common/hwinfo.cpp
+++ b/src/common/hwinfo.cpp
@@ -69,8 +69,8 @@ wxMemorySize wxSystemHardwareInfo::GetPhysicalMemory()
         physicalMemory = status.ullTotalPhys;
     }
 #elif defined(__APPLE__)
-    int64_t memSize{ 0 };
-    size_t sizeOfRetVal{ sizeof(memSize) };
+    int64_t memSize = 0;
+    size_t sizeOfRetVal = sizeof(memSize);
     if (sysctlbyname("hw.memsize", &memSize, &sizeOfRetVal, nullptr, 0) != -1)
     {
         physicalMemory = memSize;

--- a/src/common/hwinfo.cpp
+++ b/src/common/hwinfo.cpp
@@ -1,0 +1,113 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/hwinfo.h
+// Purpose:     declaration of the wxSystemHardwareInfo class
+// Author:      Blake Madden
+// Created:     07.09.2024
+// Copyright:   (c) 2024 Blake Madden
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+// ============================================================================
+// declarations
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+// for compilers that support precompilation, includes "wx.h".
+#include "wx/wxprec.h"
+
+#include "hwinfo.h"
+
+#ifndef WX_PRECOMP
+    #include "wx/thread.h"
+#endif //WX_PRECOMP
+
+#ifdef __WXMSW__
+    #include <windows.h>
+    #include <sysinfoapi.h>
+#elif defined(__APPLE__)
+    #include <sys/sysctl.h>
+#elif defined(__UNIX__)
+    #include <sys/resource.h>
+    #include <sys/sysinfo.h>
+#endif
+
+int wxSystemHardwareInfo::GetRemainingBatteryLifePercent()
+{
+#ifdef __WXMSW__
+    SYSTEM_POWER_STATUS sps;
+    if (::GetSystemPowerStatus(&sps))
+    {
+        return sps.BatteryLifePercent;
+    }
+#endif
+    // if no battery or unknown
+    return -1;
+}
+
+wxBatteryState wxSystemHardwareInfo::GetBatteryState()
+{
+    return wxGetBatteryState();
+}
+
+wxPowerType wxSystemHardwareInfo::GetPowerType()
+{
+    return wxGetPowerType();
+}
+
+wxMemorySize wxSystemHardwareInfo::GetPhysicalMemory()
+{
+    wxMemorySize physicalMemory = -1;
+
+#ifdef __WXMSW__
+    MEMORYSTATUSEX status{};
+    status.dwLength = sizeof(status);
+    if (::GlobalMemoryStatusEx(&status))
+    {
+        physicalMemory = status.ullTotalPhys;
+    }
+#elif defined(__APPLE__)
+    int64_t memSize{ 0 };
+    size_t sizeOfRetVal{ sizeof(memSize) };
+    if (sysctlbyname("hw.memsize", &memSize, &sizeOfRetVal, nullptr, 0) != -1)
+    {
+        physicalMemory = memSize;
+    }
+#elif defined(__UNIX__)
+    struct sysinfo status{};
+    if (sysinfo(&status) == 0)
+    {
+        physicalMemory = status.totalram;
+    }
+#endif
+
+    return physicalMemory;
+}
+
+wxMemorySize wxSystemHardwareInfo::GetFreePhysicalMemory()
+{
+    return wxGetFreeMemory();
+}
+
+int wxSystemHardwareInfo::GetCPUCount()
+{
+    return 	wxThread::GetCPUCount();
+}
+
+wxString wxSystemHardwareInfo::GetCPUArchitectureName()
+{
+    return wxGetCpuArchitectureName();
+}
+
+wxString wxSystemHardwareInfo::GetNativeCPUArchitectureName()
+{
+    return wxGetNativeCpuArchitectureName();
+}
+
+bool wxSystemHardwareInfo::IsRunningNatively()
+{
+    return wxGetCpuArchitectureName() == wxGetNativeCpuArchitectureName();
+}
+

--- a/src/common/hwinfo.cpp
+++ b/src/common/hwinfo.cpp
@@ -2,7 +2,7 @@
 // Name:        wx/hwinfo.h
 // Purpose:     declaration of the wxSystemHardwareInfo class
 // Author:      Blake Madden
-// Created:     07.09.2024
+// Created:     2024-07-09
 // Copyright:   (c) 2024 Blake Madden
 // Licence:     wxWindows licence
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/common/hwinfo.cpp
+++ b/src/common/hwinfo.cpp
@@ -110,4 +110,3 @@ bool wxSystemHardwareInfo::IsRunningNatively()
 {
     return wxGetCpuArchitectureName() == wxGetNativeCpuArchitectureName();
 }
-


### PR DESCRIPTION
Adds `GetPhysicalMemory()` (all platforms), `IsRunningNatively()` (all platforms), and `GetRemainingBatteryLifePercent()` (MSW).

Also, wraps `wxGetFreeMemory()`, `wxGetCpuArchitectureName()`, `wxGetNativeCpuArchitectureName()`, `wxThread::GetCPUCount()`, `wxGetBatteryState()`, and `wxGetPowerType()` free functions.

Closes #24652

I designed it as a simple collection of static functions because, unlike `wxPlatformInfo`, most of the things in here are constantly changing.