### PR TITLE
Fixes to context menus in wxDVC on macOS

### DIFF
--- a/include/wx/osx/dataview.h
+++ b/include/wx/osx/dataview.h
@@ -291,6 +291,8 @@ private:
   virtual wxDataViewItem DoGetCurrentItem() const override;
   virtual void DoSetCurrentItem(const wxDataViewItem& item) override;
 
+  void OnContextMenu(wxContextMenuEvent& event);
+
  //
  // variables
  //

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -4689,7 +4689,7 @@ gtk_dataview_button_press_callback( GtkWidget *WXUNUSED(widget),
         }
 
         wxDataViewEvent
-            event(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, dv, dv->GTKPathToItem(path));
+            event(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, dv, dv->GTKColumnToWX(column), dv->GTKPathToItem(path));
 #if GTK_CHECK_VERSION(2,12,0)
         if (wx_is_at_least_gtk2(12))
         {

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1664,33 +1664,6 @@ outlineView:(NSOutlineView*)outlineView
 }
 
 //
-// contextual menus
-//
--(NSMenu*) menuForEvent:(NSEvent*)theEvent
-{
-    wxUnusedVar(theEvent);
-
-    // this method does not do any special menu event handling but only sends
-    // an event message; therefore, the user has full control if a context
-    // menu should be shown or not
-    wxDataViewCtrl* const dvc = implementation->GetDataViewCtrl();
-
-    // get the item information;
-    // theoretically more than one ID can be returned but the event can only
-    // handle one item, therefore only the first item of the array is
-    // returned:
-    wxDataViewItem item;
-    wxDataViewItemArray selectedItems;
-    if (dvc->GetSelections(selectedItems) > 0)
-        item = selectedItems[0];
-
-    wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, dvc, item);
-    dvc->GetEventHandler()->ProcessEvent(event);
-    // nothing is done:
-    return nil;
-}
-
-//
 // delegate methods
 //
 -(void) outlineView:(NSOutlineView*)outlineView didClickTableColumn:(NSTableColumn*)tableColumn

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -852,6 +852,21 @@ void wxDataViewCtrl::OnSize(wxSizeEvent& event)
   event.Skip();
 }
 
+void wxDataViewCtrl::OnContextMenu(wxContextMenuEvent& WXUNUSED(e))
+{
+    // get the item information;
+    // theoretically more than one ID can be returned but the event can only
+    // handle one item, therefore only the first item of the array is
+    // returned:
+    wxDataViewItem item;
+    wxDataViewItemArray selectedItems;
+    if (GetSelections(selectedItems) > 0)
+        item = selectedItems[0];
+
+    wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, item);
+    GetEventHandler()->ProcessEvent(event);
+}
+
 wxSize wxDataViewCtrl::DoGetBestSize() const
 {
     wxSize best = wxControl::DoGetBestSize();
@@ -864,6 +879,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxDataViewCtrl,wxDataViewCtrlBase);
 
 wxBEGIN_EVENT_TABLE(wxDataViewCtrl,wxDataViewCtrlBase)
   EVT_SIZE(wxDataViewCtrl::OnSize)
+  EVT_CONTEXT_MENU(wxDataViewCtrl::OnContextMenu)
 wxEND_EVENT_TABLE()
 
 #endif // !wxHAS_GENERIC_DATAVIEWCTRL

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -852,19 +852,15 @@ void wxDataViewCtrl::OnSize(wxSizeEvent& event)
   event.Skip();
 }
 
-void wxDataViewCtrl::OnContextMenu(wxContextMenuEvent& WXUNUSED(e))
+void wxDataViewCtrl::OnContextMenu(wxContextMenuEvent& event)
 {
-    // get the item information;
-    // theoretically more than one ID can be returned but the event can only
-    // handle one item, therefore only the first item of the array is
-    // returned:
+    wxPoint pos = ScreenToClient(event.GetPosition());
     wxDataViewItem item;
-    wxDataViewItemArray selectedItems;
-    if (GetSelections(selectedItems) > 0)
-        item = selectedItems[0];
+    wxDataViewColumn *col;
+    HitTest(pos, item, col);
 
-    wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, item);
-    GetEventHandler()->ProcessEvent(event);
+    wxDataViewEvent event2(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, item);
+    GetEventHandler()->ProcessEvent(event2);
 }
 
 wxSize wxDataViewCtrl::DoGetBestSize() const

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -859,7 +859,7 @@ void wxDataViewCtrl::OnContextMenu(wxContextMenuEvent& event)
     wxDataViewColumn *col;
     HitTest(pos, item, col);
 
-    wxDataViewEvent event2(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, item);
+    wxDataViewEvent event2(wxEVT_DATAVIEW_ITEM_CONTEXT_MENU, this, col, item);
     GetEventHandler()->ProcessEvent(event2);
 }
 

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -866,9 +866,10 @@ bool wxWindowMac::SetCursor(const wxCursor& cursor)
 bool wxWindowMac::DoPopupMenu(wxMenu *menu, int x, int y)
 {
 #ifndef __WXUNIVERSAL__
+    const wxPoint mouse = wxGetMousePosition();
+
     if ( x == wxDefaultCoord && y == wxDefaultCoord )
     {
-        wxPoint mouse = wxGetMousePosition();
         x = mouse.x;
         y = mouse.y;
     }
@@ -876,6 +877,14 @@ bool wxWindowMac::DoPopupMenu(wxMenu *menu, int x, int y)
     {
         ClientToScreen( &x , &y ) ;
     }
+
+    if ( x == mouse.x )
+    {
+        // move the menu just off the cursor so that no menu item is pre-selected,
+        // for consistency with native popups and other platforms
+        x += 1;
+    }
+
     menu->GetPeer()->PopUp(this, x, y);
     return true;
 #else


### PR DESCRIPTION
The primary motivation for this PR was f370e9e8ea5bfbed8a6be0bd4e386ee2a3a4ddfe to fix https://github.com/vslavik/poedit/issues/849, and then I went down the rabbit hole a bit:

1. 37efaacba3dfdfe98520f5a2950ddb75a638b8cd — This is a no-brainer, prevents accidental menu clicks and makes wxOSX consistent with both other ports and native Cocoa context menus. The only question is whether to do it like this or limit oneself to the `wxDefaultPosition` case. I initially did the latter, but this seems more sensible and benefits legacy code that may pass explicit mouse coordinates.

2. f370e9e8ea5bfbed8a6be0bd4e386ee2a3a4ddfe — This fixes the weird behavior when using <kb>control</kbd>-click instead of right-click: there seems to be some corruption of internal state (AppKit, not wx) if `menuForEvent:` doesn't return a menu and we pop one up manually. (When I return a native menu, things behave normally. When I delay `PopupMenu` into next event loop iteration, i.e. after `menuForEvent:` returns, it doesn't help.) This code was there since the very beginning (~2009) and never meaningfully modified, so I don't think there was a particularly deep reason for using `menuForEvent:` [^1]

3. caffdd753a37cecd8be492157e49983a3c6b7f0a — While doing that, I noticed that the mouse position is never used... Apparently, `wxEVT_DATAVIEW_ITEM_CONTEXT_MENU` was always broken and didn't operate on the right-clicked item, but instead used whatever the current selection was. So I fixed that too. 

All of this should be cherry-picked into 3.2 too.

[^1]: In principle, it would be better to use `menuForEvent:` everywhere — see also https://github.com/wxWidgets/wxWidgets/issues/13010#issuecomment-1010846630 — but that would require a new API, e.g. addition of `virtual wxWindow::CreateContextMenu()` to be implementable. 
