### PR TITLE
Update Bakefile instructions to mention Docker

### DIFF
--- a/build/bakefiles/README
+++ b/build/bakefiles/README
@@ -1,5 +1,5 @@
 
-This directory contains Bakefile (see http://bakefile.sourceforge.net)
+This directory contains Bakefile (see https://www.bakefile.org)
 files needed to generate native makefiles for wxWidgets library and
 samples.
 

--- a/docs/contributing/how-to-add-files-to-build-system.md
+++ b/docs/contributing/how-to-add-files-to-build-system.md
@@ -16,6 +16,12 @@ the `bakefile_gen` tool. Run it from `$(wx)/build/bakefiles` directory and it wi
 regenerate all outdated makefiles. See `$(wx)/build/bakefiles/README` for more
 details.
 
+You can also run Bakefile from a Docker or Podman container and avoid the need
+to install it (expanding "$(wx)" to be the path to wx install):
+
+    docker run --rm -v $(wx):$(wx) -w `pwd`
+           ghcr.io/vslavik/bakefile:0.2 bakefile_gen
+
 Note that it generates makefiles for samples, too.
 
 IMPORTANT NOTE: Don't forget to run autoconf in wxWidgets root directory


### PR DESCRIPTION
Because installing Bakefile is increasingly more complicated due to (but not only) Python 2, I figured I can make the situation a little bit less bad by packaging Bakefile as a Docker container. If you already use Docker, as many do, it can be more convenient way of running it, especially for non-core contributors.

The containers are built automatically for both 0.2 and 1.x branches and are always up to date and are documented in bakefile readmes. 

This PR mentions this option in wx's contributor docs. 
