### PR TITLE
Add private header wrapping GDK headers inclusion

### DIFF
--- a/include/wx/gtk/private/mediactrl.h
+++ b/include/wx/gtk/private/mediactrl.h
@@ -10,12 +10,7 @@
 #ifndef _WX_GTK_PRIVATE_MEDIACTRL_H_
 #define _WX_GTK_PRIVATE_MEDIACTRL_H_
 
-#ifdef GDK_WINDOWING_X11
-    #include <gdk/gdkx.h>
-#endif
-#ifdef GDK_WINDOWING_WAYLAND
-    #include <gdk/gdkwayland.h>
-#endif
+#include "wx/gtk/private/wrapgdk.h"
 #include "wx/gtk/private/backend.h"
 
 //-----------------------------------------------------------------------------

--- a/include/wx/gtk/private/wrapgdk.h
+++ b/include/wx/gtk/private/wrapgdk.h
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/gtk/private/wrapgdk.h
+// Purpose:     Include GDK header for the appropriate window system
+// Author:      Vadim Zeitlin
+// Created:     2024-07-17
+// Copyright:   (c) 2024 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_GTK_PRIVATE_WRAPGDK_H_
+#define _WX_GTK_PRIVATE_WRAPGDK_H_
+
+#include "wx/gtk/private/wrapgtk.h"
+
+#ifdef GDK_WINDOWING_WAYLAND
+    // Wayland headers included from gdkwayland.h may result in -Wundef due to
+    // __STDC_VERSION__ used there being undefined, suppress this.
+    wxGCC_WARNING_SUPPRESS(undef)
+
+    #include <gdk/gdkwayland.h>
+
+    wxGCC_WARNING_RESTORE(undef)
+#endif // GDK_WINDOWING_WAYLAND
+
+#ifdef GDK_WINDOWING_X11
+    #include <gdk/gdkx.h>
+#endif
+
+#ifdef GDK_WINDOWING_WIN32
+    #include <gdk/gdkwin32.h>
+#endif
+
+#endif // _WX_GTK_PRIVATE_WRAPGDK_H_

--- a/src/gtk/glcanvas.cpp
+++ b/src/gtk/glcanvas.cpp
@@ -14,21 +14,8 @@
 
 #include "wx/glcanvas.h"
 
-#include "wx/gtk/private/wrapgtk.h"
+#include "wx/gtk/private/wrapgdk.h"
 #include "wx/gtk/private/backend.h"
-
-// Under some platforms, Wayland headers included from gdkwayland.h result in
-// -Wundef due to __STDC_VERSION__ used there being undefined, suppress this.
-wxGCC_WARNING_SUPPRESS(undef)
-
-#ifdef GDK_WINDOWING_WAYLAND
-#include <gdk/gdkwayland.h>
-#endif
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
-#endif
-
-wxGCC_WARNING_RESTORE(undef)
 
 #ifdef __WXGTK3__
 extern "C" {

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -35,6 +35,7 @@
 #include "wx/sysopt.h"
 
 #include "wx/gtk/private.h"
+#include "wx/gtk/private/wrapgdk.h"
 #include "wx/gtk/private/gtk3-compat.h"
 #include "wx/gtk/private/stylecontext.h"
 #include "wx/gtk/private/win_gtk.h"
@@ -42,12 +43,8 @@
 #include "wx/gtk/private/threads.h"
 
 #ifdef GDK_WINDOWING_X11
-    #include <gdk/gdkx.h>
     #include <X11/Xatom.h>  // XA_CARDINAL
     #include "wx/unix/utilsx11.h"
-#endif
-#ifdef GDK_WINDOWING_WAYLAND
-    #include <gdk/gdkwayland.h>
 #endif
 
 #define TRACE_TLWSIZE "tlwsize"

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -25,17 +25,8 @@
 #include "wx/gtk/private/timer.h"
 #include "wx/evtloop.h"
 
-#include "wx/gtk/private/wrapgtk.h"
+#include "wx/gtk/private/wrapgdk.h"
 #include "wx/gtk/private/backend.h"
-#ifdef GDK_WINDOWING_WAYLAND
-#include <gdk/gdkwayland.h>
-#endif
-#ifdef GDK_WINDOWING_WIN32
-#include <gdk/gdkwin32.h>
-#endif
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
-#endif
 
 #if wxDEBUG_LEVEL
     #include "wx/gtk/assertdlg_gtk.h"

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -26,14 +26,10 @@
     #include "wx/log.h"
 #endif //WX_PRECOMP
 
-#include "wx/gtk/private/wrapgtk.h"
+#include "wx/gtk/private/wrapgdk.h"
 #include "wx/gtk/private/backend.h"
 #ifdef GDK_WINDOWING_WAYLAND
-#include <gdk/gdkwayland.h>
 #include <wayland-egl.h>
-#endif
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
 #endif
 
 #include <EGL/egl.h>


### PR DESCRIPTION
This allows to have the code checking for the various backends in one place only and also ensures that we can disable -Wundef in gdkwayland.h just once instead of doing it in every place where it is included, because the changes of aba1c66575 (Suppress harmless -Wundef in Wayland headers, 2024-07-16) were insufficient to fix the FreeBSD CI build, as the same warning still happens elsewhere.

----

@paulcor We could also add this to the existing "wx/gtk/private/backend.h", as this header is always included when "wrapgdk.h" is, but it seemed a bit cleaner to keep them separate — please let me know if you disagree.