### PR TITLE
Add `wxInfoDC`

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -172,6 +172,11 @@ Changes in behaviour which may result in build errors
 - wxGTK wxDirButton::Create() doesn't have unused "wildcard" parameter any
   longer, please just remove it from your code if you used it.
 
+- Several functions now take wxReadOnlyDC instead of wxDC as argument. While
+  any code calling these functions keeps compiling and working, classes that
+  override these functions must be updated to use the new argument type too.
+  Simply replacing wxDC with wxReadOnlyDC should be sufficient.
+
 
 3.3.0: (released 2022-??-??)
 ----------------------------

--- a/docs/doxygen/overviews/dc.h
+++ b/docs/doxygen/overviews/dc.h
@@ -13,34 +13,55 @@ A wxDC is a @e device context onto which graphics and text can be drawn.
 The device context is intended to represent a number of output devices in a
 generic way, with the same API being used throughout.
 
-Some device contexts are created temporarily in order to draw on a window.
-This is @true of wxScreenDC, wxClientDC, wxPaintDC, and wxWindowDC.
-The following describes the differences between these device contexts and
-when you should use them.
+Objects of wxDC class itself can't be created, instead you should create
+objects of the following classes:
 
-@li @b wxScreenDC. Use this to paint on the screen, as opposed to an individual window.
-@li @b wxClientDC. Use this to paint on the client area of window (the part without
-    borders and other decorations), but do not use it from within an wxPaintEvent.
-@li @b wxPaintDC. Use this to paint on the client area of a window, but @e only from
-    within a wxPaintEvent.
-@li @b wxWindowDC. Use this to paint on the whole area of a window, including decorations.
-    This may not be available on non-Windows platforms.
+@li wxPaintDC for painting on a window from within a paint event handler. This
+    is the most common device context to use.
+@li wxMemoryDC for painting off-screen, i.e. to a bitmap.
+@li wxPrinterDC for printing.
+@li wxInfoDC for obtaining information about the device context without drawing
+    on it.
 
-To use a client, paint or window device context, create an object on the stack with
-the window as argument, for example:
-
+To draw on a window, you need to create a wxPaintDC object in the paint event
+handler:
 @code
-void MyWindow::OnMyCmd(wxCommandEvent& event)
+void MyWindow::OnPaint(wxPaintEvent& event)
 {
-    wxClientDC dc(window);
-    DrawMyPicture(dc);
+    wxPaintDC dc(this);
+
+    dc.DrawText("Hello, world!", 20, 20);
 }
 @endcode
 
-Try to write code so it is parameterised by wxDC - if you do this, the same piece of code may
-write to a number of different devices, by passing a different device context. This doesn't
-work for everything (for example not all device contexts support bitmap drawing) but
-will work most of the time.
+To obtain information about a device context associated with a window outside
+of its paint event handler, you need to use wxInfoDC, e.g.
+the window as argument, for example:
+
+@code
+void MyFrame::SomeFunction()
+{
+    wxInfoDC dc(this);
+
+    // Create control with the width just big enough for the given string.
+    auto* text = new wxStaticText
+                     (
+                        this, wxID_ANY, "",
+                        wxPoint(),
+                        dc.GetTextExtent("String of max length"),
+                        wxST_NO_AUTORESIZE
+                     );
+}
+@endcode
+
+When writing drawing code, it is recommended to extract it into a function
+taking wxDC as an argument. This allows you to reuse the same code for drawing
+and printing, by calling it with either wxPaintDC or wxPrinterDC.
+
+Please note that other device context classes that could previously be used for
+painting on screen cannot be used any more due to the architecture of the
+modern graphics systems. In particular, wxClientDC, wxWindowDC and wxScreenDC
+are not guaranteed to work any longer.
 
 @see @ref group_class_dc
 

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -20,6 +20,7 @@
 #include "wx/pen.h"
 
 class WXDLLIMPEXP_FWD_CORE wxClientDC;
+class WXDLLIMPEXP_FWD_CORE wxReadOnlyDC;
 class WXDLLIMPEXP_FWD_AUI wxAuiPaneInfo;
 
 enum wxAuiToolBarStyle
@@ -326,12 +327,12 @@ public:
                          int state) = 0;
 
     virtual wxSize GetLabelSize(
-                         wxDC& dc,
+                         wxReadOnlyDC& dc,
                          wxWindow* wnd,
                          const wxAuiToolBarItem& item) = 0;
 
     virtual wxSize GetToolSize(
-                         wxDC& dc,
+                         wxReadOnlyDC& dc,
                          wxWindow* wnd,
                          const wxAuiToolBarItem& item) = 0;
 
@@ -417,12 +418,12 @@ public:
                 int state) override;
 
     virtual wxSize GetLabelSize(
-                wxDC& dc,
+                wxReadOnlyDC& dc,
                 wxWindow* wnd,
                 const wxAuiToolBarItem& item) override;
 
     virtual wxSize GetToolSize(
-                wxDC& dc,
+                wxReadOnlyDC& dc,
                 wxWindow* wnd,
                 const wxAuiToolBarItem& item) override;
 
@@ -700,11 +701,7 @@ protected:
     bool m_overflowVisible;
 
     // This function is only kept for compatibility, don't use in the new code.
-    bool RealizeHelper(wxClientDC& dc, bool horizontal)
-    {
-        RealizeHelper(dc, horizontal ? wxHORIZONTAL : wxVERTICAL);
-        return true;
-    }
+    bool RealizeHelper(wxClientDC& dc, bool horizontal);
 
     static bool IsPaneValid(long style, const wxAuiPaneInfo& pane);
     bool IsPaneValid(long style) const;
@@ -717,7 +714,7 @@ private:
     // Common part of OnLeaveWindow() and OnCaptureLost().
     void DoResetMouseState();
 
-    wxSize RealizeHelper(wxClientDC& dc, wxOrientation orientation);
+    wxSize RealizeHelper(wxReadOnlyDC& dc, wxOrientation orientation);
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_CLASS(wxAuiToolBar);

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -171,7 +171,7 @@ public:
     void SetTabOffset(size_t offset);
 
     // Is the tab visible?
-    bool IsTabVisible(int tabPage, int tabOffset, wxDC* dc, wxWindow* wnd);
+    bool IsTabVisible(int tabPage, int tabOffset, wxReadOnlyDC* dc, wxWindow* wnd);
 
     // Make the tab visible if it wasn't already
     void MakeTabVisible(int tabPage, wxWindow* win);

--- a/include/wx/aui/barartmsw.h
+++ b/include/wx/aui/barartmsw.h
@@ -63,12 +63,12 @@ public:
         int state) override;
 
     virtual wxSize GetLabelSize(
-        wxDC& dc,
+        wxReadOnlyDC& dc,
         wxWindow* wnd,
         const wxAuiToolBarItem& item) override;
 
     virtual wxSize GetToolSize(
-        wxDC& dc,
+        wxReadOnlyDC& dc,
         wxWindow* wnd,
         const wxAuiToolBarItem& item) override;
 

--- a/include/wx/aui/tabart.h
+++ b/include/wx/aui/tabart.h
@@ -32,6 +32,7 @@ class wxAuiNotebookPage;
 class wxAuiNotebookPageArray;
 class wxWindow;
 class wxDC;
+class wxReadOnlyDC;
 
 
 // tab art class
@@ -85,7 +86,7 @@ public:
                          wxRect* outRect) = 0;
 
     virtual wxSize GetTabSize(
-                         wxDC& dc,
+                         wxReadOnlyDC& dc,
                          wxWindow* wnd,
                          const wxString& caption,
                          const wxBitmapBundle& bitmap,
@@ -174,7 +175,7 @@ public:
                  wxWindow* wnd) override;
 
     wxSize GetTabSize(
-                 wxDC& dc,
+                 wxReadOnlyDC& dc,
                  wxWindow* wnd,
                  const wxString& caption,
                  const wxBitmapBundle& bitmap,
@@ -277,7 +278,7 @@ public:
                  wxWindow* wnd) override;
 
     wxSize GetTabSize(
-                 wxDC& dc,
+                 wxReadOnlyDC& dc,
                  wxWindow* wnd,
                  const wxString& caption,
                  const wxBitmapBundle& bitmap,

--- a/include/wx/aui/tabartgtk.h
+++ b/include/wx/aui/tabartgtk.h
@@ -47,7 +47,7 @@ public:
                             const wxSize& required_bmp_size) override;
     int GetBorderWidth(wxWindow* wnd) override;
     int GetAdditionalBorderSpace(wxWindow* wnd) override;
-    virtual wxSize GetTabSize(wxDC& dc, wxWindow* wnd, const wxString& caption,
+    virtual wxSize GetTabSize(wxReadOnlyDC& dc, wxWindow* wnd, const wxString& caption,
                               const wxBitmapBundle& bitmap, bool active,
                               int close_button_state, int* x_extent) override;
 };

--- a/include/wx/aui/tabartmsw.h
+++ b/include/wx/aui/tabartmsw.h
@@ -57,7 +57,7 @@ public:
         wxWindow* wnd) override;
 
     wxSize GetTabSize(
-        wxDC& dc,
+        wxReadOnlyDC& dc,
         wxWindow* wnd,
         const wxString& caption,
         const wxBitmapBundle& bitmap,
@@ -82,7 +82,7 @@ private:
     wxSize m_tabSize;
     int m_maxTabHeight;
 
-    void InitSizes(wxWindow* wnd, wxDC& dc);
+    void InitSizes(wxWindow* wnd, wxReadOnlyDC& dc);
 
     bool IsThemed() const;
 };

--- a/include/wx/control.h
+++ b/include/wx/control.h
@@ -139,7 +139,7 @@ public:
     // ------------------------------
 
     // replaces parts of the given (multiline) string with an ellipsis if needed
-    static wxString Ellipsize(const wxString& label, const wxDC& dc,
+    static wxString Ellipsize(const wxString& label, const wxReadOnlyDC& dc,
                               wxEllipsizeMode mode, int maxWidth,
                               int flags = wxELLIPSIZE_FLAGS_DEFAULT);
 

--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -703,6 +703,12 @@ class WXDLLIMPEXP_CORE wxReadOnlyDC : public wxObject
 public:
     virtual ~wxReadOnlyDC() { delete m_pimpl; }
 
+    wxWindow *GetWindow() const
+        { return m_pimpl->GetWindow(); }
+
+    bool IsOk() const
+        { return m_pimpl && m_pimpl->IsOk(); }
+
     // query capabilities
 
     bool CanDrawBitmap() const
@@ -929,14 +935,8 @@ public:
     const wxDCImpl *GetImpl() const
         { return m_pimpl; }
 
-    wxWindow *GetWindow() const
-        { return m_pimpl->GetWindow(); }
-
     void *GetHandle() const
         { return m_pimpl->GetHandle(); }
-
-    bool IsOk() const
-        { return m_pimpl && m_pimpl->IsOk(); }
 
     // page and document
 

--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -697,27 +697,11 @@ private:
 };
 
 
-class WXDLLIMPEXP_CORE wxDC : public wxObject
+// This base class provides only functions that don't modify device contents.
+class WXDLLIMPEXP_CORE wxReadOnlyDC : public wxObject
 {
 public:
-    // copy attributes (font, colours and writing direction) from another DC
-    void CopyAttributes(const wxDC& dc);
-
-    virtual ~wxDC() { delete m_pimpl; }
-
-    wxDCImpl *GetImpl()
-        { return m_pimpl; }
-    const wxDCImpl *GetImpl() const
-        { return m_pimpl; }
-
-    wxWindow *GetWindow() const
-        { return m_pimpl->GetWindow(); }
-
-    void *GetHandle() const
-        { return m_pimpl->GetHandle(); }
-
-    bool IsOk() const
-        { return m_pimpl && m_pimpl->IsOk(); }
+    virtual ~wxReadOnlyDC() { delete m_pimpl; }
 
     // query capabilities
 
@@ -784,82 +768,12 @@ public:
     wxLayoutDirection GetLayoutDirection() const
         { return m_pimpl->GetLayoutDirection(); }
 
-    // page and document
-
-    bool StartDoc(const wxString& message)
-        { return m_pimpl->StartDoc(message); }
-    void EndDoc()
-        { m_pimpl->EndDoc(); }
-
-    void StartPage()
-        { m_pimpl->StartPage(); }
-    void EndPage()
-        { m_pimpl->EndPage(); }
-
-    // bounding box
-
-    void CalcBoundingBox(wxCoord x, wxCoord y)
-        { m_pimpl->CalcBoundingBox(x,y); }
-    void ResetBoundingBox()
-        { m_pimpl->ResetBoundingBox(); }
-
-    wxCoord MinX() const
-        { return m_pimpl->MinX(); }
-    wxCoord MaxX() const
-        { return m_pimpl->MaxX(); }
-    wxCoord MinY() const
-        { return m_pimpl->MinY(); }
-    wxCoord MaxY() const
-        { return m_pimpl->MaxY(); }
-
-    // setters and getters
+    // font
 
     void SetFont(const wxFont& font)
         { m_pimpl->SetFont( font ); }
     const wxFont&   GetFont() const
         { return m_pimpl->GetFont(); }
-
-    void SetPen(const wxPen& pen)
-        { m_pimpl->SetPen( pen ); }
-    const wxPen&    GetPen() const
-        { return m_pimpl->GetPen(); }
-
-    void SetBrush(const wxBrush& brush)
-        { m_pimpl->SetBrush( brush ); }
-    const wxBrush&  GetBrush() const
-        { return m_pimpl->GetBrush(); }
-
-    void SetBackground(const wxBrush& brush)
-        { m_pimpl->SetBackground( brush ); }
-    const wxBrush&  GetBackground() const
-        { return m_pimpl->GetBackground(); }
-
-    void SetBackgroundMode(int mode)
-        { m_pimpl->SetBackgroundMode( mode ); }
-    int GetBackgroundMode() const
-        { return m_pimpl->GetBackgroundMode(); }
-
-    void SetTextForeground(const wxColour& colour)
-        { m_pimpl->SetTextForeground(colour); }
-    const wxColour& GetTextForeground() const
-        { return m_pimpl->GetTextForeground(); }
-
-    void SetTextBackground(const wxColour& colour)
-        { m_pimpl->SetTextBackground(colour); }
-    const wxColour& GetTextBackground() const
-        { return m_pimpl->GetTextBackground(); }
-
-#if wxUSE_PALETTE
-    void SetPalette(const wxPalette& palette)
-        { m_pimpl->SetPalette(palette); }
-#endif // wxUSE_PALETTE
-
-    // logical functions
-
-    void SetLogicalFunction(wxRasterOperationMode function)
-        { m_pimpl->SetLogicalFunction(function); }
-    wxRasterOperationMode GetLogicalFunction() const
-        { return m_pimpl->GetLogicalFunction(); }
 
     // text measurement
 
@@ -907,55 +821,6 @@ public:
 
     bool GetPartialTextExtents(const wxString& text, wxArrayInt& widths) const
         { return m_pimpl->DoGetPartialTextExtents(text, widths); }
-
-    // clearing
-
-    void Clear()
-        { m_pimpl->Clear(); }
-
-    // clipping
-
-    void SetClippingRegion(wxCoord x, wxCoord y, wxCoord width, wxCoord height)
-        { m_pimpl->DoSetClippingRegion(x, y, width, height); }
-    void SetClippingRegion(const wxPoint& pt, const wxSize& sz)
-        { m_pimpl->DoSetClippingRegion(pt.x, pt.y, sz.x, sz.y); }
-    void SetClippingRegion(const wxRect& rect)
-        { m_pimpl->DoSetClippingRegion(rect.x, rect.y, rect.width, rect.height); }
-
-    // unlike the functions above, the coordinates of the region used in this
-    // one are in device coordinates, not the logical ones
-    void SetDeviceClippingRegion(const wxRegion& region)
-        { m_pimpl->DoSetDeviceClippingRegion(region); }
-
-    // this function is deprecated because its name is confusing: you may
-    // expect it to work with logical coordinates but, in fact, it does exactly
-    // the same thing as SetDeviceClippingRegion()
-    //
-    // please review the code using it and either replace it with calls to
-    // SetDeviceClippingRegion() or correct it if it was [wrongly] passing
-    // logical coordinates to this function
-    wxDEPRECATED_INLINE(void SetClippingRegion(const wxRegion& region),
-                        SetDeviceClippingRegion(region); )
-
-    void DestroyClippingRegion()
-        { m_pimpl->DestroyClippingRegion(); }
-
-    bool GetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoord *h) const
-    {
-        wxRect r;
-        const bool clipping = m_pimpl->DoGetClippingRect(r);
-        if ( x )
-            *x = r.x;
-        if ( y )
-            *y = r.y;
-        if ( w )
-            *w = r.width;
-        if ( h )
-            *h = r.height;
-        return clipping;
-    }
-    bool GetClippingBox(wxRect& rect) const
-        { return m_pimpl->DoGetClippingRect(rect); }
 
     // coordinates conversions and transforms
 
@@ -1042,6 +907,157 @@ public:
     void SetDeviceLocalOrigin( wxCoord x, wxCoord y )
         { m_pimpl->SetDeviceLocalOrigin( x, y ); }
 
+protected:
+    explicit wxReadOnlyDC(wxDCImpl *pimpl)
+        : m_pimpl(pimpl)
+    {
+    }
+
+    wxDCImpl * const m_pimpl;
+};
+
+// Full device context class, providing functions for drawing on the device in
+// addition to the base class functions only querying it.
+class WXDLLIMPEXP_CORE wxDC : public wxReadOnlyDC
+{
+public:
+    // copy attributes (font, colours and writing direction) from another DC
+    void CopyAttributes(const wxDC& dc);
+
+    wxDCImpl *GetImpl()
+        { return m_pimpl; }
+    const wxDCImpl *GetImpl() const
+        { return m_pimpl; }
+
+    wxWindow *GetWindow() const
+        { return m_pimpl->GetWindow(); }
+
+    void *GetHandle() const
+        { return m_pimpl->GetHandle(); }
+
+    bool IsOk() const
+        { return m_pimpl && m_pimpl->IsOk(); }
+
+    // page and document
+
+    bool StartDoc(const wxString& message)
+        { return m_pimpl->StartDoc(message); }
+    void EndDoc()
+        { m_pimpl->EndDoc(); }
+
+    void StartPage()
+        { m_pimpl->StartPage(); }
+    void EndPage()
+        { m_pimpl->EndPage(); }
+
+    // bounding box
+
+    void CalcBoundingBox(wxCoord x, wxCoord y)
+        { m_pimpl->CalcBoundingBox(x,y); }
+    void ResetBoundingBox()
+        { m_pimpl->ResetBoundingBox(); }
+
+    wxCoord MinX() const
+        { return m_pimpl->MinX(); }
+    wxCoord MaxX() const
+        { return m_pimpl->MaxX(); }
+    wxCoord MinY() const
+        { return m_pimpl->MinY(); }
+    wxCoord MaxY() const
+        { return m_pimpl->MaxY(); }
+
+    // setters and getters
+
+    void SetPen(const wxPen& pen)
+        { m_pimpl->SetPen( pen ); }
+    const wxPen&    GetPen() const
+        { return m_pimpl->GetPen(); }
+
+    void SetBrush(const wxBrush& brush)
+        { m_pimpl->SetBrush( brush ); }
+    const wxBrush&  GetBrush() const
+        { return m_pimpl->GetBrush(); }
+
+    void SetBackground(const wxBrush& brush)
+        { m_pimpl->SetBackground( brush ); }
+    const wxBrush&  GetBackground() const
+        { return m_pimpl->GetBackground(); }
+
+    void SetBackgroundMode(int mode)
+        { m_pimpl->SetBackgroundMode( mode ); }
+    int GetBackgroundMode() const
+        { return m_pimpl->GetBackgroundMode(); }
+
+    void SetTextForeground(const wxColour& colour)
+        { m_pimpl->SetTextForeground(colour); }
+    const wxColour& GetTextForeground() const
+        { return m_pimpl->GetTextForeground(); }
+
+    void SetTextBackground(const wxColour& colour)
+        { m_pimpl->SetTextBackground(colour); }
+    const wxColour& GetTextBackground() const
+        { return m_pimpl->GetTextBackground(); }
+
+#if wxUSE_PALETTE
+    void SetPalette(const wxPalette& palette)
+        { m_pimpl->SetPalette(palette); }
+#endif // wxUSE_PALETTE
+
+    // logical functions
+
+    void SetLogicalFunction(wxRasterOperationMode function)
+        { m_pimpl->SetLogicalFunction(function); }
+    wxRasterOperationMode GetLogicalFunction() const
+        { return m_pimpl->GetLogicalFunction(); }
+
+    // clearing
+
+    void Clear()
+        { m_pimpl->Clear(); }
+
+    // clipping
+
+    void SetClippingRegion(wxCoord x, wxCoord y, wxCoord width, wxCoord height)
+        { m_pimpl->DoSetClippingRegion(x, y, width, height); }
+    void SetClippingRegion(const wxPoint& pt, const wxSize& sz)
+        { m_pimpl->DoSetClippingRegion(pt.x, pt.y, sz.x, sz.y); }
+    void SetClippingRegion(const wxRect& rect)
+        { m_pimpl->DoSetClippingRegion(rect.x, rect.y, rect.width, rect.height); }
+
+    // unlike the functions above, the coordinates of the region used in this
+    // one are in device coordinates, not the logical ones
+    void SetDeviceClippingRegion(const wxRegion& region)
+        { m_pimpl->DoSetDeviceClippingRegion(region); }
+
+    // this function is deprecated because its name is confusing: you may
+    // expect it to work with logical coordinates but, in fact, it does exactly
+    // the same thing as SetDeviceClippingRegion()
+    //
+    // please review the code using it and either replace it with calls to
+    // SetDeviceClippingRegion() or correct it if it was [wrongly] passing
+    // logical coordinates to this function
+    wxDEPRECATED_INLINE(void SetClippingRegion(const wxRegion& region),
+                        SetDeviceClippingRegion(region); )
+
+    void DestroyClippingRegion()
+        { m_pimpl->DestroyClippingRegion(); }
+
+    bool GetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoord *h) const
+    {
+        wxRect r;
+        const bool clipping = m_pimpl->DoGetClippingRect(r);
+        if ( x )
+            *x = r.x;
+        if ( y )
+            *y = r.y;
+        if ( w )
+            *w = r.width;
+        if ( h )
+            *h = r.height;
+        return clipping;
+    }
+    bool GetClippingBox(wxRect& rect) const
+        { return m_pimpl->DoGetClippingRect(rect); }
 
     // -----------------------------------------------
     // the actual drawing API
@@ -1314,9 +1330,7 @@ public:
 
 protected:
     // ctor takes ownership of the pointer
-    wxDC(wxDCImpl *pimpl) : m_pimpl(pimpl) { }
-
-    wxDCImpl * const m_pimpl;
+    explicit wxDC(wxDCImpl *pimpl) : wxReadOnlyDC(pimpl) { }
 
     void SetWindow(wxWindow* w)
         { return m_pimpl->SetWindow(w); }

--- a/include/wx/dcclient.h
+++ b/include/wx/dcclient.h
@@ -61,4 +61,177 @@ private:
     wxDECLARE_ABSTRACT_CLASS(wxPaintDC);
 };
 
+//-----------------------------------------------------------------------------
+// wxInfoDC
+//-----------------------------------------------------------------------------
+
+// A very limited wxDC-like class which can be only used to query the device
+// context, but not to draw anything on it: it doesn't inherit from wxDC but
+// can be implicitly converted to wxReadOnlyDC and makes all of its functions
+// available.
+class WXDLLIMPEXP_CORE wxInfoDC
+{
+public:
+    explicit wxInfoDC(wxWindow* win) : m_dcClient(win) { }
+
+    // Implicit conversions to wxReadOnlyDC allow passing objects of this class
+    // to the functions taking this type.
+    operator wxReadOnlyDC&() { return m_dcClient; }
+    operator const wxReadOnlyDC&() const { return m_dcClient; }
+
+    wxReadOnlyDC* operator&() { return &m_dcClient; }
+    const wxReadOnlyDC* operator&() const { return &m_dcClient; }
+
+    // wxReadOnlyDC re-exposed here.
+    bool CanDrawBitmap() const { return m_dcClient.CanDrawBitmap(); }
+    bool CanGetTextExtent() const { return m_dcClient.CanGetTextExtent(); }
+
+    void GetSize(int *width, int *height) const { m_dcClient.GetSize(width, height); }
+    wxSize GetSize() const { return m_dcClient.GetSize(); }
+    void GetSizeMM(int* width, int* height) const { m_dcClient.GetSizeMM(width, height); }
+    wxSize GetSizeMM() const { return m_dcClient.GetSizeMM(); }
+
+    int GetDepth() const { return m_dcClient.GetDepth(); }
+    wxSize GetPPI() const { return m_dcClient.GetPPI(); }
+
+    int GetResolution() const { return m_dcClient.GetResolution(); }
+    double GetContentScaleFactor() const { return m_dcClient.GetContentScaleFactor(); }
+
+    wxSize FromDIP(const wxSize& sz) const { return m_dcClient.FromDIP(sz); }
+    wxPoint FromDIP(const wxPoint& pt) const { return m_dcClient.FromDIP(pt); }
+    int FromDIP(int d) const { return m_dcClient.FromDIP(d); }
+
+    wxSize ToDIP(const wxSize & sz) const { return m_dcClient.ToDIP(sz); }
+    wxPoint ToDIP(const wxPoint & pt) const { return m_dcClient.ToDIP(pt); }
+    int ToDIP(int d) const { return m_dcClient.ToDIP(d); }
+
+    void SetLayoutDirection(wxLayoutDirection dir)
+        { m_dcClient.SetLayoutDirection( dir ); }
+    wxLayoutDirection GetLayoutDirection() const
+        { return m_dcClient.GetLayoutDirection(); }
+
+    void SetFont(const wxFont& font) { m_dcClient.SetFont(font); }
+    const wxFont& GetFont() const { return m_dcClient.GetFont(); }
+
+    wxCoord GetCharHeight() const { return m_dcClient.GetCharHeight(); }
+    wxCoord GetCharWidth() const { return m_dcClient.GetCharWidth(); }
+
+    wxFontMetrics GetFontMetrics() const { return m_dcClient.GetFontMetrics(); }
+    void GetTextExtent(const wxString& string,
+                       wxCoord *x, wxCoord *y,
+                       wxCoord *descent = nullptr,
+                       wxCoord *externalLeading = nullptr,
+                       const wxFont *theFont = nullptr) const
+        { return m_dcClient.GetTextExtent(string, x, y, descent, externalLeading, theFont); }
+
+    wxSize GetTextExtent(const wxString& string) const
+    {
+        return m_dcClient.GetTextExtent(string);
+    }
+
+    void GetMultiLineTextExtent(const wxString& string,
+                                        wxCoord *width,
+                                        wxCoord *height,
+                                        wxCoord *heightLine = nullptr,
+                                        const wxFont *font = nullptr) const
+        { return m_dcClient.GetMultiLineTextExtent(string, width, height, heightLine, font); }
+
+    wxSize GetMultiLineTextExtent(const wxString& string) const
+    {
+        return m_dcClient.GetMultiLineTextExtent(string);
+    }
+
+    bool GetPartialTextExtents(const wxString& text, wxArrayInt& widths) const
+        { return m_dcClient.GetPartialTextExtents(text, widths); }
+
+    wxCoord DeviceToLogicalX(wxCoord x) const
+        { return m_dcClient.DeviceToLogicalX(x); }
+    wxCoord DeviceToLogicalY(wxCoord y) const
+        { return m_dcClient.DeviceToLogicalY(y); }
+    wxCoord DeviceToLogicalXRel(wxCoord x) const
+        { return m_dcClient.DeviceToLogicalXRel(x); }
+    wxCoord DeviceToLogicalYRel(wxCoord y) const
+        { return m_dcClient.DeviceToLogicalYRel(y); }
+    wxPoint DeviceToLogical(const wxPoint& pt) const
+        { return m_dcClient.DeviceToLogical(pt.x, pt.y); }
+    wxPoint DeviceToLogical(wxCoord x, wxCoord y) const
+        { return m_dcClient.DeviceToLogical(x, y); }
+    wxSize DeviceToLogicalRel(const wxSize& dim) const
+        { return m_dcClient.DeviceToLogicalRel(dim.x, dim.y); }
+    wxSize DeviceToLogicalRel(int x, int y) const
+        { return m_dcClient.DeviceToLogicalRel(x, y); }
+    wxCoord LogicalToDeviceX(wxCoord x) const
+        { return m_dcClient.LogicalToDeviceX(x); }
+    wxCoord LogicalToDeviceY(wxCoord y) const
+        { return m_dcClient.LogicalToDeviceY(y); }
+    wxCoord LogicalToDeviceXRel(wxCoord x) const
+        { return m_dcClient.LogicalToDeviceXRel(x); }
+    wxCoord LogicalToDeviceYRel(wxCoord y) const
+        { return m_dcClient.LogicalToDeviceYRel(y); }
+    wxPoint LogicalToDevice(const wxPoint& pt) const
+        { return m_dcClient.LogicalToDevice(pt.x, pt.y); }
+    wxPoint LogicalToDevice(wxCoord x, wxCoord y) const
+        { return m_dcClient.LogicalToDevice(x, y); }
+    wxSize LogicalToDeviceRel(const wxSize& dim) const
+        { return m_dcClient.LogicalToDeviceRel(dim.x, dim.y); }
+    wxSize LogicalToDeviceRel(int x, int y) const
+        { return m_dcClient.LogicalToDeviceRel(x, y); }
+
+    void SetMapMode(wxMappingMode mode)
+        { m_dcClient.SetMapMode(mode); }
+    wxMappingMode GetMapMode() const
+        { return m_dcClient.GetMapMode(); }
+
+    void SetUserScale(double x, double y)
+        { m_dcClient.SetUserScale(x,y); }
+    void GetUserScale(double *x, double *y) const
+        { m_dcClient.GetUserScale( x, y ); }
+
+    void SetLogicalScale(double x, double y)
+        { m_dcClient.SetLogicalScale( x, y ); }
+    void GetLogicalScale(double *x, double *y) const
+        { m_dcClient.GetLogicalScale( x, y ); }
+
+    void SetLogicalOrigin(wxCoord x, wxCoord y)
+        { m_dcClient.SetLogicalOrigin(x,y); }
+    void GetLogicalOrigin(wxCoord *x, wxCoord *y) const
+        { m_dcClient.GetLogicalOrigin(x, y); }
+    wxPoint GetLogicalOrigin() const
+        { return m_dcClient.GetLogicalOrigin(); }
+
+    void SetDeviceOrigin(wxCoord x, wxCoord y)
+        { m_dcClient.SetDeviceOrigin( x, y); }
+    void GetDeviceOrigin(wxCoord *x, wxCoord *y) const
+        { m_dcClient.GetDeviceOrigin(x, y); }
+    wxPoint GetDeviceOrigin() const
+        { return m_dcClient.GetDeviceOrigin(); }
+
+    void SetAxisOrientation(bool xLeftRight, bool yBottomUp)
+        { m_dcClient.SetAxisOrientation(xLeftRight, yBottomUp); }
+
+#if wxUSE_DC_TRANSFORM_MATRIX
+    bool CanUseTransformMatrix() const
+        { return m_dcClient.CanUseTransformMatrix(); }
+
+    bool SetTransformMatrix(const wxAffineMatrix2D &matrix)
+        { return m_dcClient.SetTransformMatrix(matrix); }
+
+    wxAffineMatrix2D GetTransformMatrix() const
+        { return m_dcClient.GetTransformMatrix(); }
+
+    void ResetTransformMatrix()
+        { m_dcClient.ResetTransformMatrix(); }
+#endif // wxUSE_DC_TRANSFORM_MATRIX
+
+    // mostly internal
+    void SetDeviceLocalOrigin( wxCoord x, wxCoord y )
+        { m_dcClient.SetDeviceLocalOrigin( x, y ); }
+private:
+    wxClientDC m_dcClient;
+};
+
+// Define this to indicate that wxInfoDC is available to allow application code
+// to fall back to using wxClientDC if it isn't.
+#define wxHAS_INFO_DC
+
 #endif // _WX_DCCLIENT_H_BASE_

--- a/include/wx/dcclient.h
+++ b/include/wx/dcclient.h
@@ -83,6 +83,9 @@ public:
     const wxReadOnlyDC* operator&() const { return &m_dcClient; }
 
     // wxReadOnlyDC re-exposed here.
+    wxWindow* GetWindow() const { return m_dcClient.GetWindow(); }
+    bool IsOk() const { return m_dcClient.IsOk(); }
+
     bool CanDrawBitmap() const { return m_dcClient.CanDrawBitmap(); }
     bool CanGetTextExtent() const { return m_dcClient.CanGetTextExtent(); }
 

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -45,6 +45,7 @@ class WXDLLIMPEXP_FWD_BASE wxEventFilter;
 #if wxUSE_GUI
     class WXDLLIMPEXP_FWD_CORE wxDC;
     class WXDLLIMPEXP_FWD_CORE wxMenu;
+    class WXDLLIMPEXP_FWD_CORE wxReadOnlyDC;
     class WXDLLIMPEXP_FWD_CORE wxWindow;
     class WXDLLIMPEXP_FWD_CORE wxWindowBase;
 #endif // wxUSE_GUI
@@ -1845,7 +1846,7 @@ public:
     int GetClickCount() const { return m_clickCount; }
 
     // Find the logical position of the event given the DC
-    wxPoint GetLogicalPosition(const wxDC& dc) const;
+    wxPoint GetLogicalPosition(const wxReadOnlyDC& dc) const;
 
     // Get wheel rotation, positive or negative indicates direction of
     // rotation.  Current devices all send an event when rotation is equal to

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -199,52 +199,76 @@ public:
                       int row, int col,
                       bool isSelected) = 0;
 
-    // get the preferred size of the cell for its contents
-    virtual wxSize GetBestSize(wxGrid& grid,
-                               wxGridCellAttr& attr,
-                               wxReadOnlyDC& dc,
-                               int row, int col) = 0;
+    // get the preferred size of the cell for its contents: this function must
+    // be overridden by all derived classes, it's not pure virtual only due to
+    // backwards-compatibility concerns.
+    virtual wxSize GetPreferredSize(wxGrid& grid,
+                                    wxGridCellAttr& attr,
+                                    wxReadOnlyDC& dc,
+                                    int row, int col);
 
     // Get the preferred height for a given width. Override this method if the
     // renderer computes height as function of its width, as is the case of the
     // standard wxGridCellAutoWrapStringRenderer, for example.
     // and vice versa
-    virtual int GetBestHeight(wxGrid& grid,
-                              wxGridCellAttr& attr,
-                              wxReadOnlyDC& dc,
-                              int row, int col,
-                              int WXUNUSED(width))
+    virtual int GetPreferredHeight(wxGrid& grid,
+                                   wxGridCellAttr& attr,
+                                   wxReadOnlyDC& dc,
+                                   int row, int col,
+                                   int WXUNUSED(width))
     {
-        return GetBestSize(grid, attr, dc, row, col).GetHeight();
+        return GetPreferredSize(grid, attr, dc, row, col).GetHeight();
     }
 
     // Get the preferred width for a given height, this is the symmetric
-    // version of GetBestHeight().
-    virtual int GetBestWidth(wxGrid& grid,
-                             wxGridCellAttr& attr,
-                             wxReadOnlyDC& dc,
-                             int row, int col,
-                             int WXUNUSED(height))
+    // version of GetPreferredHeight().
+    virtual int GetPreferredWidth(wxGrid& grid,
+                                  wxGridCellAttr& attr,
+                                  wxReadOnlyDC& dc,
+                                  int row, int col,
+                                  int WXUNUSED(height))
     {
-        return GetBestSize(grid, attr, dc, row, col).GetWidth();
+        return GetPreferredSize(grid, attr, dc, row, col).GetWidth();
     }
 
 
-    // Unlike GetBestSize(), this functions is optional: it is used when
+    // Unlike GetPreferredSize(), this functions is optional: it is used when
     // auto-sizing columns to determine the best width without iterating over
     // all cells in this column, if possible.
     //
     // If it isn't, return wxDefaultSize as the base class version does by
     // default.
-    virtual wxSize GetMaxBestSize(wxGrid& WXUNUSED(grid),
-                                  wxGridCellAttr& WXUNUSED(attr),
-                                  wxReadOnlyDC& WXUNUSED(dc))
+    virtual wxSize GetMaxSize(wxGrid& WXUNUSED(grid),
+                              wxGridCellAttr& WXUNUSED(attr),
+                              wxReadOnlyDC& WXUNUSED(dc))
     {
         return wxDefaultSize;
     }
 
     // create a new object which is the copy of this one
     virtual wxGridCellRenderer *Clone() const = 0;
+
+
+    // These functions still exist for compatibility and are the ones actually
+    // called by wxGrid, but new code should implement the new functions using
+    // "Preferred" in their names instead, to which these ones forward.
+    virtual wxSize GetBestSize(wxGrid& grid,
+                               wxGridCellAttr& attr,
+                               wxDC& dc,
+                               int row, int col);
+    virtual int GetBestHeight(wxGrid& grid,
+                              wxGridCellAttr& attr,
+                              wxDC& dc,
+                              int row, int col,
+                              int width);
+    virtual int GetBestWidth(wxGrid& grid,
+                             wxGridCellAttr& attr,
+                             wxDC& dc,
+                             int row, int col,
+                             int height);
+    virtual wxSize GetMaxBestSize(wxGrid& grid,
+                                  wxGridCellAttr& attr,
+                                  wxDC& dc);
 
 protected:
     // set the text colours before drawing

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -202,7 +202,7 @@ public:
     // get the preferred size of the cell for its contents
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxDC& dc,
+                               wxReadOnlyDC& dc,
                                int row, int col) = 0;
 
     // Get the preferred height for a given width. Override this method if the
@@ -211,7 +211,7 @@ public:
     // and vice versa
     virtual int GetBestHeight(wxGrid& grid,
                               wxGridCellAttr& attr,
-                              wxDC& dc,
+                              wxReadOnlyDC& dc,
                               int row, int col,
                               int WXUNUSED(width))
     {
@@ -222,7 +222,7 @@ public:
     // version of GetBestHeight().
     virtual int GetBestWidth(wxGrid& grid,
                              wxGridCellAttr& attr,
-                             wxDC& dc,
+                             wxReadOnlyDC& dc,
                              int row, int col,
                              int WXUNUSED(height))
     {
@@ -238,7 +238,7 @@ public:
     // default.
     virtual wxSize GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                   wxGridCellAttr& WXUNUSED(attr),
-                                  wxDC& WXUNUSED(dc))
+                                  wxReadOnlyDC& WXUNUSED(dc))
     {
         return wxDefaultSize;
     }
@@ -1718,7 +1718,7 @@ public:
     //
     void StringToLines( const wxString& value, wxArrayString& lines ) const;
 
-    void GetTextBoxSize( const wxDC& dc,
+    void GetTextBoxSize( const wxReadOnlyDC& dc,
                          const wxArrayString& lines,
                          long *width, long *height ) const;
 

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -43,7 +43,7 @@ public:
     // return the string extent
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxDC& dc,
+                               wxReadOnlyDC& dc,
                                int row, int col) override;
 
     virtual wxGridCellRenderer *Clone() const override
@@ -52,7 +52,7 @@ public:
 protected:
     // calc the string extent for given string/font
     wxSize DoGetBestSize(const wxGridCellAttr& attr,
-                         wxDC& dc,
+                         wxReadOnlyDC& dc,
                          const wxString& text);
 };
 
@@ -85,12 +85,12 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxDC& dc,
+                               wxReadOnlyDC& dc,
                                int row, int col) override;
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
-                                  wxDC& dc) override;
+                                  wxReadOnlyDC& dc) override;
 
     // Optional parameters for this renderer are "<min>,<max>".
     virtual void SetParameters(const wxString& params) override;
@@ -139,7 +139,7 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxDC& dc,
+                               wxReadOnlyDC& dc,
                                int row, int col) override;
 
     // parameters string format is "width[,precision[,format]]"
@@ -186,12 +186,12 @@ public:
     // return the checkmark size
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxDC& dc,
+                               wxReadOnlyDC& dc,
                                int row, int col) override;
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
-                                  wxDC& dc) override;
+                                  wxReadOnlyDC& dc) override;
 
     virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellBoolRenderer(*this); }
@@ -227,12 +227,12 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxDC& dc,
+                               wxReadOnlyDC& dc,
                                int row, int col) override;
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
-                                  wxDC& dc) override;
+                                  wxReadOnlyDC& dc) override;
 
     virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellDateRenderer(*this); }
@@ -288,7 +288,7 @@ public:
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
-                                  wxDC& dc) override;
+                                  wxReadOnlyDC& dc) override;
 
     // Parameters string is a comma-separated list of values.
     virtual void SetParameters(const wxString& params) override;
@@ -328,7 +328,7 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxDC& dc,
+                               wxReadOnlyDC& dc,
                                int row, int col) override;
 
     virtual wxGridCellRenderer *Clone() const override
@@ -361,18 +361,18 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxDC& dc,
+                               wxReadOnlyDC& dc,
                                int row, int col) override;
 
     virtual int GetBestHeight(wxGrid& grid,
                               wxGridCellAttr& attr,
-                              wxDC& dc,
+                              wxReadOnlyDC& dc,
                               int row, int col,
                               int width) override;
 
     virtual int GetBestWidth(wxGrid& grid,
                               wxGridCellAttr& attr,
-                              wxDC& dc,
+                              wxReadOnlyDC& dc,
                               int row, int col,
                               int height) override;
 
@@ -381,7 +381,7 @@ public:
 
 private:
     wxArrayString GetTextLines( wxGrid& grid,
-                                wxDC& dc,
+                                wxReadOnlyDC& dc,
                                 const wxGridCellAttr& attr,
                                 const wxRect& rect,
                                 int row, int col);
@@ -391,7 +391,7 @@ private:
     // Break a single logical line of text into several physical lines, all of
     // which are added to the lines array. The lines are broken at maxWidth and
     // the dc is used for measuring text extent only.
-    void BreakLine(wxDC& dc,
+    void BreakLine(wxReadOnlyDC& dc,
                    const wxString& logicalLine,
                    wxCoord maxWidth,
                    wxArrayString& lines);
@@ -401,7 +401,7 @@ private:
     // is returned in line output parameter.
     //
     // Returns the width of the last line.
-    wxCoord BreakWord(wxDC& dc,
+    wxCoord BreakWord(wxReadOnlyDC& dc,
                       const wxString& word,
                       wxCoord maxWidth,
                       wxArrayString& lines,

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -43,7 +43,7 @@ public:
     // return the string extent
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxReadOnlyDC& dc,
+                               wxDC& dc,
                                int row, int col) override;
 
     virtual wxGridCellRenderer *Clone() const override
@@ -85,12 +85,12 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxReadOnlyDC& dc,
+                               wxDC& dc,
                                int row, int col) override;
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
-                                  wxReadOnlyDC& dc) override;
+                                  wxDC& dc) override;
 
     // Optional parameters for this renderer are "<min>,<max>".
     virtual void SetParameters(const wxString& params) override;
@@ -139,7 +139,7 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxReadOnlyDC& dc,
+                               wxDC& dc,
                                int row, int col) override;
 
     // parameters string format is "width[,precision[,format]]"
@@ -186,12 +186,12 @@ public:
     // return the checkmark size
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxReadOnlyDC& dc,
+                               wxDC& dc,
                                int row, int col) override;
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
-                                  wxReadOnlyDC& dc) override;
+                                  wxDC& dc) override;
 
     virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellBoolRenderer(*this); }
@@ -227,12 +227,12 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxReadOnlyDC& dc,
+                               wxDC& dc,
                                int row, int col) override;
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
-                                  wxReadOnlyDC& dc) override;
+                                  wxDC& dc) override;
 
     virtual wxGridCellRenderer *Clone() const override
         { return new wxGridCellDateRenderer(*this); }
@@ -288,7 +288,7 @@ public:
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
-                                  wxReadOnlyDC& dc) override;
+                                  wxDC& dc) override;
 
     // Parameters string is a comma-separated list of values.
     virtual void SetParameters(const wxString& params) override;
@@ -328,7 +328,7 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxReadOnlyDC& dc,
+                               wxDC& dc,
                                int row, int col) override;
 
     virtual wxGridCellRenderer *Clone() const override
@@ -361,18 +361,18 @@ public:
 
     virtual wxSize GetBestSize(wxGrid& grid,
                                wxGridCellAttr& attr,
-                               wxReadOnlyDC& dc,
+                               wxDC& dc,
                                int row, int col) override;
 
     virtual int GetBestHeight(wxGrid& grid,
                               wxGridCellAttr& attr,
-                              wxReadOnlyDC& dc,
+                              wxDC& dc,
                               int row, int col,
                               int width) override;
 
     virtual int GetBestWidth(wxGrid& grid,
                               wxGridCellAttr& attr,
-                              wxReadOnlyDC& dc,
+                              wxDC& dc,
                               int row, int col,
                               int height) override;
 

--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -235,7 +235,7 @@ public:
     // case we determine our position/size ourselves
 
     // calculate the size of the line
-    void CalculateSize( wxDC *dc, int spacing );
+    void CalculateSize( wxReadOnlyDC *dc, int spacing );
 
     // remember the position this line appears at
     void SetPosition( int x, int y, int spacing );

--- a/include/wx/generic/private/markuptext.h
+++ b/include/wx/generic/private/markuptext.h
@@ -14,6 +14,7 @@
 #include "wx/gdicmn.h"
 
 class WXDLLIMPEXP_FWD_CORE wxDC;
+class WXDLLIMPEXP_FWD_CORE wxReadOnlyDC;
 
 class wxMarkupParserOutput;
 
@@ -36,7 +37,7 @@ public:
     // The font currently selected into the DC is used for measuring (notice
     // that it is changed by this function but normally -- i.e. if markup is
     // valid -- restored to its original value when it returns).
-    wxSize Measure(wxDC& dc, int *visibleHeight = nullptr) const;
+    wxSize Measure(wxReadOnlyDC& dc, int *visibleHeight = nullptr) const;
 
 protected:
     wxMarkupTextBase(const wxString& markup)

--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -329,7 +329,7 @@ protected:
     void PaintLevel( wxGenericTreeItem *item, wxDC& dc, int level, int &y );
     void PaintItem( wxGenericTreeItem *item, wxDC& dc);
 
-    void CalculateLevel( wxGenericTreeItem *item, wxDC &dc, int level, int &y );
+    void CalculateLevel( wxGenericTreeItem *item, wxReadOnlyDC &dc, int level, int &y );
     void CalculatePositions();
 
     void RefreshSubtree( wxGenericTreeItem *item );

--- a/include/wx/renderer.h
+++ b/include/wx/renderer.h
@@ -24,6 +24,7 @@
 #define _WX_RENDERER_H_
 
 class WXDLLIMPEXP_FWD_CORE wxDC;
+class WXDLLIMPEXP_FWD_CORE wxReadOnlyDC;
 class WXDLLIMPEXP_FWD_CORE wxWindow;
 
 #include "wx/gdicmn.h" // for wxPoint, wxSize
@@ -291,7 +292,7 @@ public:
                                     int flags = 0) = 0;
 
     // Returns the default size of a collapse button
-    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxDC& dc) = 0;
+    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxReadOnlyDC& dc) = 0;
 
     // draw rectangle indicating that an item in e.g. a list control
     // has been selected or focused
@@ -524,7 +525,7 @@ public:
                                     int flags = 0) override
         { m_rendererNative.DrawCollapseButton(win, dc, rect, flags); }
 
-    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxDC& dc) override
+    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxReadOnlyDC& dc) override
         { return m_rendererNative.GetCollapseButtonSize(win, dc); }
 
     virtual void DrawItemSelectionRect(wxWindow *win,

--- a/include/wx/ribbon/art.h
+++ b/include/wx/ribbon/art.h
@@ -22,6 +22,7 @@
 #include "wx/ribbon/bar.h"
 
 class WXDLLIMPEXP_FWD_CORE wxDC;
+class WXDLLIMPEXP_FWD_CORE wxReadOnlyDC;
 class WXDLLIMPEXP_FWD_CORE wxWindow;
 
 enum wxRibbonArtSetting
@@ -322,7 +323,7 @@ public:
                         const wxRect& rect) = 0;
 
     virtual void GetBarTabWidth(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         const wxString& label,
                         const wxBitmap& bitmap,
@@ -332,39 +333,39 @@ public:
                         int* minimum) = 0;
 
     virtual int GetTabCtrlHeight(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         const wxRibbonPageTabInfoArray& pages) = 0;
 
     virtual wxSize GetScrollButtonMinimumSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         long style) = 0;
 
     virtual wxSize GetPanelSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize client_size,
                         wxPoint* client_offset) = 0;
 
     virtual wxSize GetPanelClientSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
                         wxPoint* client_offset) = 0;
 
     virtual wxRect GetPanelExtButtonArea(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxRect rect) = 0;
 
     virtual wxSize GetGallerySize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonGallery* wnd,
                         wxSize client_size) = 0;
 
     virtual wxSize GetGalleryClientSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonGallery* wnd,
                         wxSize size,
                         wxPoint* client_offset,
@@ -373,13 +374,13 @@ public:
                         wxRect* extension_button) = 0;
 
     virtual wxRect GetPageBackgroundRedrawArea(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPage* wnd,
                         wxSize page_old_size,
                         wxSize page_new_size) = 0;
 
     virtual bool GetButtonBarButtonSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
@@ -392,18 +393,18 @@ public:
                         wxRect* dropdown_region) = 0;
 
     virtual wxCoord GetButtonBarButtonTextWidth(
-                        wxDC& dc, const wxString& label,
+                        wxReadOnlyDC& dc, const wxString& label,
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size) = 0;
 
     virtual wxSize GetMinimisedPanelMinimumSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize* desired_bitmap_size,
                         wxDirection* expanded_panel_direction) = 0;
 
     virtual wxSize GetToolSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         wxSize bitmap_size,
                         wxRibbonButtonKind kind,
@@ -440,7 +441,7 @@ public:
                          const wxColour& tertiary) override;
 
     int GetTabCtrlHeight(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         const wxRibbonPageTabInfoArray& pages) override;
 
@@ -536,7 +537,7 @@ public:
                         const wxRect& rect) override;
 
     void GetBarTabWidth(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         const wxString& label,
                         const wxBitmap& bitmap,
@@ -546,34 +547,34 @@ public:
                         int* minimum) override;
 
     wxSize GetScrollButtonMinimumSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         long style) override;
 
     wxSize GetPanelSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize client_size,
                         wxPoint* client_offset) override;
 
     wxSize GetPanelClientSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
                         wxPoint* client_offset) override;
 
     wxRect GetPanelExtButtonArea(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxRect rect) override;
 
     wxSize GetGallerySize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonGallery* wnd,
                         wxSize client_size) override;
 
     wxSize GetGalleryClientSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonGallery* wnd,
                         wxSize size,
                         wxPoint* client_offset,
@@ -582,13 +583,13 @@ public:
                         wxRect* extension_button) override;
 
     wxRect GetPageBackgroundRedrawArea(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPage* wnd,
                         wxSize page_old_size,
                         wxSize page_new_size) override;
 
     bool GetButtonBarButtonSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
@@ -601,18 +602,18 @@ public:
                         wxRect* dropdown_region) override;
 
     wxCoord GetButtonBarButtonTextWidth(
-                        wxDC& dc, const wxString& label,
+                        wxReadOnlyDC& dc, const wxString& label,
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size) override;
 
     wxSize GetMinimisedPanelMinimumSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize* desired_bitmap_size,
                         wxDirection* expanded_panel_direction) override;
 
     wxSize GetToolSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         wxSize bitmap_size,
                         wxRibbonButtonKind kind,
@@ -805,7 +806,7 @@ public:
     void SetFont(int id, const wxFont& font) override;
 
     wxSize GetScrollButtonMinimumSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         long style) override;
 
@@ -816,19 +817,19 @@ public:
                         long style) override;
 
     wxSize GetPanelSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize client_size,
                         wxPoint* client_offset) override;
 
     wxSize GetPanelClientSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
                         wxPoint* client_offset) override;
 
     wxRect GetPanelExtButtonArea(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxRect rect) override;
 
@@ -838,12 +839,12 @@ public:
                         const wxRect& rect) override;
 
     int GetTabCtrlHeight(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         const wxRibbonPageTabInfoArray& pages) override;
 
     void GetBarTabWidth(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         const wxString& label,
                         const wxBitmap& bitmap,

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -192,7 +192,7 @@ protected:
                      size_t first_btn, size_t* last_button,
                      wxRibbonButtonBarButtonState target_size);
     void FetchButtonSizeInfo(wxRibbonButtonBarButtonBase* button,
-        wxRibbonButtonBarButtonState size, wxDC& dc);
+        wxRibbonButtonBarButtonState size, wxReadOnlyDC& dc);
     virtual void UpdateWindowUI(long flags) override;
 
     wxArrayRibbonButtonBarLayout m_layouts;

--- a/include/wx/richtext/richtextbuffer.h
+++ b/include/wx/richtext/richtextbuffer.h
@@ -691,7 +691,7 @@ public:
     /**
         Constructor.
     */
-    wxTextAttrDimensionConverter(wxDC& dc, double scale = 1.0, const wxSize& parentSize = wxDefaultSize);
+    wxTextAttrDimensionConverter(wxReadOnlyDC& dc, double scale = 1.0, const wxSize& parentSize = wxDefaultSize);
     /**
         Constructor.
     */
@@ -2546,7 +2546,7 @@ public:
         and @a parentRect is the container that is used to determine a relative size
         or position (for example if a text box must be 50% of the parent text box).
     */
-    virtual bool Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) = 0;
+    virtual bool Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) = 0;
 
     /**
         Hit-testing: returns a flag indicating hit test details, plus
@@ -2565,12 +2565,12 @@ public:
         @return One of the ::wxRichTextHitTestFlags values.
     */
 
-    virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0);
+    virtual int HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0);
 
     /**
         Finds the absolute position and row height for the given character position.
     */
-    virtual bool FindPosition(wxDC& WXUNUSED(dc), wxRichTextDrawingContext& WXUNUSED(context), long WXUNUSED(index), wxPoint& WXUNUSED(pt), int* WXUNUSED(height), bool WXUNUSED(forceLineStart)) { return false; }
+    virtual bool FindPosition(wxReadOnlyDC& WXUNUSED(dc), wxRichTextDrawingContext& WXUNUSED(context), long WXUNUSED(index), wxPoint& WXUNUSED(pt), int* WXUNUSED(height), bool WXUNUSED(forceLineStart)) { return false; }
 
     /**
         Returns the best size, i.e. the ideal starting size for this object irrespective
@@ -2584,7 +2584,7 @@ public:
         is invalid for this object.
     */
 
-    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const  = 0;
+    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const  = 0;
 
     /**
         Do a split from @a pos, returning an object containing the second part, and setting
@@ -2898,7 +2898,7 @@ public:
         Calculates the available content space in the given rectangle, given the
         margins, border and padding specified in the object's attributes.
     */
-    virtual wxRect GetAvailableContentArea(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& outerRect) const;
+    virtual wxRect GetAvailableContentArea(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& outerRect) const;
 
     /**
         Lays out the object first with a given amount of space, and then if no width was specified in attr,
@@ -2908,7 +2908,7 @@ public:
         in a previous layout pass to @a availableParentSpace, but should have a width of 50% of @a availableContainerSpace.
         (If these two rects were the same, a 2nd pass could see the object getting too small.)
     */
-    virtual bool LayoutToBestSize(wxDC& dc, wxRichTextDrawingContext& context, wxRichTextBuffer* buffer,
+    virtual bool LayoutToBestSize(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, wxRichTextBuffer* buffer,
                     const wxRichTextAttr& parentAttr, const wxRichTextAttr& attr,
                     const wxRect& availableParentSpace, const wxRect& availableContainerSpace, int style);
 
@@ -3021,7 +3021,7 @@ public:
     /**
         Converts units in tenths of a millimetre to device units.
     */
-    int ConvertTenthsMMToPixels(wxDC& dc, int units) const;
+    int ConvertTenthsMMToPixels(wxReadOnlyDC& dc, int units) const;
 
     /**
         Converts units in tenths of a millimetre to device units.
@@ -3031,7 +3031,7 @@ public:
     /**
         Convert units in pixels to tenths of a millimetre.
     */
-    int ConvertPixelsToTenthsMM(wxDC& dc, int pixels) const;
+    int ConvertPixelsToTenthsMM(wxReadOnlyDC& dc, int pixels) const;
 
     /**
         Convert units in pixels to tenths of a millimetre.
@@ -3055,12 +3055,12 @@ public:
         Note that the outline doesn't affect the position of the rectangle, it's drawn in whatever space
         is available.
     */
-    static bool GetBoxRects(wxDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& attr, wxRect& marginRect, wxRect& borderRect, wxRect& contentRect, wxRect& paddingRect, wxRect& outlineRect);
+    static bool GetBoxRects(wxReadOnlyDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& attr, wxRect& marginRect, wxRect& borderRect, wxRect& contentRect, wxRect& paddingRect, wxRect& outlineRect);
 
     /**
         Returns the total margin for the object in pixels, taking into account margin, padding and border size.
     */
-    static bool GetTotalMargin(wxDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& attr, int& leftMargin, int& rightMargin,
+    static bool GetTotalMargin(wxReadOnlyDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& attr, int& leftMargin, int& rightMargin,
         int& topMargin, int& bottomMargin);
 
     /**
@@ -3069,7 +3069,7 @@ public:
         availableContainerSpace might be a parent that the cell has to compute its width relative to.
         E.g. a cell that's 50% of its parent.
     */
-    static wxRect AdjustAvailableSpace(wxDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& parentAttr, const wxRichTextAttr& childAttr,
+    static wxRect AdjustAvailableSpace(wxReadOnlyDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& parentAttr, const wxRichTextAttr& childAttr,
         const wxRect& availableParentSpace, const wxRect& availableContainerSpace);
 
 protected:
@@ -3119,9 +3119,9 @@ public:
 
 // Overridables
 
-    virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
+    virtual int HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
 
-    virtual bool FindPosition(wxDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart) override;
+    virtual bool FindPosition(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart) override;
 
     virtual void CalculateRange(long start, long& end) override;
 
@@ -3129,7 +3129,7 @@ public:
 
     virtual wxString GetTextForRange(const wxRichTextRange& range) const override;
 
-    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
+    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
 
     virtual void Dump(wxTextOutputStream& stream) override;
 
@@ -3240,13 +3240,13 @@ public:
 
 // Overridables
 
-    virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
+    virtual int HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
 
     virtual bool Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style) override;
 
-    virtual bool Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
+    virtual bool Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
 
-    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
+    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
 
     virtual bool DeleteRange(const wxRichTextRange& range) override;
 
@@ -3937,9 +3937,9 @@ public:
 
     virtual bool Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style) override;
 
-    virtual bool Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
+    virtual bool Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
 
-    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
+    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
 
     virtual wxString GetXMLNodeName() const override { return wxT("field"); }
 
@@ -4031,13 +4031,13 @@ public:
         and @a parentRect is the container that is used to determine a relative size
         or position (for example if a text box must be 50% of the parent text box).
     */
-    virtual bool Layout(wxRichTextField* obj, wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) = 0;
+    virtual bool Layout(wxRichTextField* obj, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) = 0;
 
     /**
         Returns the object size for the given range. Returns @false if the range
         is invalid for this object.
     */
-    virtual bool GetRangeSize(wxRichTextField* obj, const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const = 0;
+    virtual bool GetRangeSize(wxRichTextField* obj, const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const = 0;
 
     /**
         Returns @true if we can edit the object's properties via a GUI.
@@ -4199,18 +4199,18 @@ public:
         and @a parentRect is the container that is used to determine a relative size
         or position (for example if a text box must be 50% of the parent text box).
     */
-    virtual bool Layout(wxRichTextField* obj, wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
+    virtual bool Layout(wxRichTextField* obj, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
 
     /**
         Returns the object size for the given range. Returns @false if the range
         is invalid for this object.
     */
-    virtual bool GetRangeSize(wxRichTextField* obj, const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
+    virtual bool GetRangeSize(wxRichTextField* obj, const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
 
     /**
         Get the size of the field, given the label, font size, and so on.
     */
-    wxSize GetSize(wxRichTextField* obj, wxDC& dc, wxRichTextDrawingContext& context, int style) const;
+    wxSize GetSize(wxRichTextField* obj, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int style) const;
 
     /**
         Returns @true if the display type is wxRICHTEXT_FIELD_STYLE_COMPOSITE, @false otherwise.
@@ -4512,13 +4512,13 @@ public:
 
     virtual bool Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style) override;
 
-    virtual bool Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
+    virtual bool Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
 
-    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
+    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
 
-    virtual bool FindPosition(wxDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart) override;
+    virtual bool FindPosition(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart) override;
 
-    virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
+    virtual int HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
 
     virtual void CalculateRange(long start, long& end) override;
 
@@ -4550,7 +4550,7 @@ public:
     /**
         Applies paragraph styles such as centering to the wrapped lines.
     */
-    virtual void ApplyParagraphStyle(wxRichTextLine* line, const wxRichTextAttr& attr, const wxRect& rect, wxDC& dc);
+    virtual void ApplyParagraphStyle(wxRichTextLine* line, const wxRichTextAttr& attr, const wxRect& rect, wxReadOnlyDC& dc);
 
     /**
         Inserts text at the given position.
@@ -4583,7 +4583,7 @@ public:
         Finds a suitable wrap position. @a wrapPosition is the last position in the line to the left
         of the split.
     */
-    bool FindWrapPosition(const wxRichTextRange& range, wxDC& dc, wxRichTextDrawingContext& context, int availableSpace, long& wrapPosition, wxArrayInt* partialExtents);
+    bool FindWrapPosition(const wxRichTextRange& range, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int availableSpace, long& wrapPosition, wxArrayInt* partialExtents);
 
     /**
         Finds the object at the given position.
@@ -4639,7 +4639,7 @@ public:
     /**
         Lays out the floating objects.
     */
-    void LayoutFloat(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style, wxRichTextFloatCollector* floatCollector);
+    void LayoutFloat(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style, wxRichTextFloatCollector* floatCollector);
 
     /**
         Whether the paragraph is impacted by floating objects from above.
@@ -4696,11 +4696,11 @@ public:
 
     virtual bool Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style) override;
 
-    virtual bool Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
+    virtual bool Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
 
     virtual bool AdjustAttributes(wxRichTextAttr& attr, wxRichTextDrawingContext& context) override;
 
-    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
+    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
 
     virtual wxString GetTextForRange(const wxRichTextRange& range) const override;
 
@@ -4990,9 +4990,9 @@ public:
 
     virtual bool Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style) override;
 
-    virtual bool Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
+    virtual bool Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
 
-    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
+    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
 
     /**
         Returns the 'natural' size for this object - the image size.
@@ -5063,7 +5063,7 @@ public:
     /**
         Creates a cached image at the required size.
     */
-    virtual bool LoadImageCache(wxDC& dc, wxRichTextDrawingContext& context, wxSize& retImageSize, bool resetCache = false, const wxSize& parentSize = wxDefaultSize);
+    virtual bool LoadImageCache(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, wxSize& retImageSize, bool resetCache = false, const wxSize& parentSize = wxDefaultSize);
 
     /**
         Do the loading and scaling
@@ -5606,7 +5606,7 @@ public:
 
 // Implementation
 
-    virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
+    virtual int HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
 
     /**
         Copies the buffer.
@@ -5945,7 +5945,7 @@ public:
 
     virtual bool Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style) override;
 
-    virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
+    virtual int HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
 
     virtual bool AdjustAttributes(wxRichTextAttr& attr, wxRichTextDrawingContext& context) override;
 
@@ -6023,15 +6023,15 @@ public:
 
     virtual bool Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style) override;
 
-    virtual int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
+    virtual int HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags = 0) override;
 
     virtual bool AdjustAttributes(wxRichTextAttr& attr, wxRichTextDrawingContext& context) override;
 
     virtual wxString GetXMLNodeName() const override { return wxT("table"); }
 
-    virtual bool Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
+    virtual bool Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style) override;
 
-    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
+    virtual bool GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position = wxPoint(0,0), const wxSize& parentSize = wxDefaultSize, wxArrayInt* partialExtents = nullptr) const override;
 
     virtual bool DeleteRange(const wxRichTextRange& range) override;
 
@@ -6049,7 +6049,7 @@ public:
     virtual bool ExportXML(wxXmlNode* parent, wxRichTextXMLHandler* handler) override;
 #endif
 
-    virtual bool FindPosition(wxDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart) override;
+    virtual bool FindPosition(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart) override;
 
     virtual void CalculateRange(long start, long& end) override;
 
@@ -6985,7 +6985,7 @@ public:
     /**
         Measure the bullet.
     */
-    virtual bool MeasureBullet(wxRichTextParagraph* paragraph, wxDC& dc, const wxRichTextAttr& attr, wxSize& sz) = 0;
+    virtual bool MeasureBullet(wxRichTextParagraph* paragraph, wxReadOnlyDC& dc, const wxRichTextAttr& attr, wxSize& sz) = 0;
 };
 
 /**
@@ -7020,10 +7020,10 @@ public:
     virtual bool EnumerateStandardBulletNames(wxArrayString& bulletNames) override;
 
     // Measure the bullet.
-    virtual bool MeasureBullet(wxRichTextParagraph* paragraph, wxDC& dc, const wxRichTextAttr& attr, wxSize& sz) override;
+    virtual bool MeasureBullet(wxRichTextParagraph* paragraph, wxReadOnlyDC& dc, const wxRichTextAttr& attr, wxSize& sz) override;
 
     // Set a font which may depend on text effects.
-    static void SetFontForBullet(wxRichTextBuffer& buffer, wxDC& dc, const wxRichTextAttr& attr);
+    static void SetFontForBullet(wxRichTextBuffer& buffer, wxReadOnlyDC& dc, const wxRichTextAttr& attr);
 };
 
 /*!

--- a/include/wx/richtext/richtextctrl.h
+++ b/include/wx/richtext/richtextctrl.h
@@ -1420,7 +1420,7 @@ public:
     /**
         Implements layout. An application may override this to perform operations before or after layout.
     */
-    virtual void DoLayoutBuffer(wxRichTextBuffer& buffer, wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int flags);
+    virtual void DoLayoutBuffer(wxRichTextBuffer& buffer, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int flags);
 
     /**
         Move the caret to the given character position.

--- a/include/wx/richtext/richtextstyles.h
+++ b/include/wx/richtext/richtextstyles.h
@@ -532,7 +532,7 @@ public:
     void OnIdle(wxIdleEvent& event);
 
     /// Convert units in tends of a millimetre to device units
-    int ConvertTenthsMMToPixels(wxDC& dc, int units) const;
+    int ConvertTenthsMMToPixels(wxReadOnlyDC& dc, int units) const;
 
     /// Can we set the selection based on the editor caret position?
     /// Need to override this if being used in a combobox popup

--- a/include/wx/univ/textctrl.h
+++ b/include/wx/univ/textctrl.h
@@ -207,7 +207,7 @@ public:
     void ScrollText(wxTextCoord col);
 
     // adjust the DC for horz text control scrolling too
-    virtual void DoPrepareDC(wxDC& dc) override;
+    virtual void DoPrepareReadOnlyDC(wxReadOnlyDC& dc) override;
 
     // implementation only from now on
     // -------------------------------

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -58,6 +58,7 @@ class WXDLLIMPEXP_FWD_CORE wxControl;
 class WXDLLIMPEXP_FWD_CORE wxDC;
 class WXDLLIMPEXP_FWD_CORE wxDropTarget;
 class WXDLLIMPEXP_FWD_CORE wxLayoutConstraints;
+class WXDLLIMPEXP_FWD_CORE wxReadOnlyDC;
 class WXDLLIMPEXP_FWD_CORE wxSizer;
 class WXDLLIMPEXP_FWD_CORE wxTextEntry;
 class WXDLLIMPEXP_FWD_CORE wxToolTip;
@@ -1142,7 +1143,8 @@ public:
         // return true if window had been frozen and not unthawed yet
     bool IsFrozen() const { return m_freezeCount != 0; }
 
-        // adjust DC for drawing on this window
+        // adjust DC for measuring or drawing on this window
+    virtual void PrepareReadOnlyDC( wxReadOnlyDC & WXUNUSED(dc) ) { }
     virtual void PrepareDC( wxDC & WXUNUSED(dc) ) { }
 
         // enable or disable double buffering

--- a/interface/wx/dcclient.h
+++ b/interface/wx/dcclient.h
@@ -40,24 +40,10 @@ public:
 /**
     @class wxClientDC
 
-    wxClientDC is primarily useful for obtaining information about the window
-    from outside EVT_PAINT() handler.
+    Deprecated class for drawing on the client area of a window.
 
-    Typical use of this class is to obtain the extent of some text string in
-    order to allocate enough size for a window, e.g.
-    @code
-        // Create the initially empty label with the size big enough to show
-        // the given string.
-        wxClientDC dc(this);
-        wxStaticText* text = new wxStaticText
-            (
-                this, wxID_ANY, "",
-                wxPoint(),
-                dc.GetTextExtent("String of max length"),
-                wxST_NO_AUTORESIZE
-            );
-    }
-    @endcode
+    wxClientDC should not be used any longer, please use wxInfoDC instead for
+    obtaining information about the device context associated with a window.
 
     @note While wxClientDC may also be used for drawing on the client area of a
     window from outside an EVT_PAINT() handler in some ports, this does @em not
@@ -112,6 +98,11 @@ public:
 
 /**
     @class wxWindowDC
+
+    Deprecated class for drawing on the entire window.
+
+    Please don't use this class in the new code, as it doesn't work on modern
+    systems any longer and using it is not guaranteed to have any effect at all.
 
     A wxWindowDC must be constructed if an application wishes to paint on the
     whole area of a window (client and decorations). This should normally be

--- a/interface/wx/dcscreen.h
+++ b/interface/wx/dcscreen.h
@@ -8,6 +8,11 @@
 /**
     @class wxScreenDC
 
+    Deprecated class for drawing on the screen.
+
+    Please don't use this class in the new code, as it doesn't work on modern
+    systems any longer and using it is not guaranteed to have any effect at all.
+
     A wxScreenDC can be used to paint on the screen. This should normally be
     constructed as a temporary stack object; don't store a wxScreenDC object.
 

--- a/interface/wx/scrolwin.h
+++ b/interface/wx/scrolwin.h
@@ -81,8 +81,9 @@ enum wxScrollbarVisibility
     context (prepared by wxScrolled::DoPrepareDC()).
 
     If you don't wish to calculate your own scrolling, you must call
-    DoPrepareDC() when not drawing from within OnDraw(), to set the device
-    origin for the device context according to the current scroll position.
+    PrepareDC() or PrepareReadOnlyDC() when not drawing from within OnDraw(),
+    to set the device origin for the device context according to the current
+    scroll position.
 
     A wxScrolled will normally scroll itself and therefore its child windows
     as well. It might however be desired to scroll a different window than
@@ -266,40 +267,57 @@ public:
         Call this function to prepare the device context for drawing a scrolled
         image.
 
-        It sets the device origin according to the current scroll position.
+        It sets the device origin according to the current scroll position and
+        also changes the device scale according to the current scaling factor
+        set by SetScale().
+
         DoPrepareDC() is called automatically within the default @c wxEVT_PAINT
         event handler, so your OnDraw() override will be passed an already
         'pre-scrolled' device context. However, if you wish to draw from
         outside of OnDraw() (e.g. from your own @c wxEVT_PAINT handler), you
         must call this function yourself.
 
-        For example:
+        Note that this function can be used only with wxPaintDC, but not
+        wxInfoDC, while DoPrepareReadOnlyDC() can be used with either of these
+        classes.
+     */
+    void DoPrepareDC(wxDC& dc);
+
+    /**
+        Call this function to adjust any device context used with this window.
+
+        It sets the device origin according to the current scroll position and
+        also changes the device scale according to the current scaling factor
+        set by SetScale().
+
+        Unlike DoPrepareDC(), this function can be used with wxInfoDC, which
+        makes it useful when computing the coordinates of mouse events, for
+        example:
+
         @code
         void MyWindow::OnEvent(wxMouseEvent& event)
         {
-          wxClientDC dc(this);
-          DoPrepareDC(dc);
+          wxInfoDC dc(this);
+          DoPrepareReadOnlyDC(dc);
 
-          dc.SetPen(*wxBLACK_PEN);
-          float x, y;
-          event.Position(&x, &y);
-          if (xpos > -1 && ypos > -1 && event.Dragging())
+          if ( event.Dragging() )
           {
-            dc.DrawLine(xpos, ypos, x, y);
+            m_lastDragPosition = event.GetLogicalPosition(dc);
+            Refresh();
           }
-          xpos = x;
-          ypos = y;
         }
         @endcode
 
         Notice that the function sets the origin by moving it relatively to the
         current origin position, so you shouldn't change the origin before
-        calling DoPrepareDC() or, if you do, reset it to (0, 0) later. If you
-        call DoPrepareDC() immediately after device context creation, as in the
+        calling it or, if you do, reset it to (0, 0) later. If you call
+        this function immediately after device context creation, as in the
         example above, this problem doesn't arise, of course, so it is
         customary to do it like this.
+
+        @since 3.3.0
     */
-    void DoPrepareDC(wxDC& dc);
+    void DoPrepareReadOnlyDC(wxDC& dc);
 
     /**
         Enable or disable use of wxWindow::ScrollWindow() for scrolling.
@@ -434,12 +452,32 @@ public:
     virtual void OnDraw(wxDC& dc);
 
     /**
-        This function is for backwards compatibility only and simply calls
-        DoPrepareDC() now. Notice that it is not called by the default paint
-        event handle (DoPrepareDC() is), so overriding this method in your
-        derived class is useless.
+        This function is overridden to call DoPrepareDC().
+
+        It may be more convenient to call this function in the code which only
+        has wxWindow pointer, as this function is available in the base class
+        too, unlike DoPrepareDC().
+
+        Note that, if necessary, you should only override DoPrepareDC(), or
+        DoPrepareReadOnlyDC(), and not this function.
+
+        @see PrepareReadOnlyDC()
     */
-    void PrepareDC(wxDC& dc);
+    virtual void PrepareDC(wxDC& dc);
+
+    /**
+        This function is overridden to call DoPrepareReadOnlyDC().
+
+        It may be more convenient to call this function in the code which only
+        has wxWindow pointer, as this function is available in the base class
+        too, unlike DoPrepareReadOnlyDC().
+
+        Note that, if necessary, you should only override
+        DoPrepareReadOnlyDC(), and not this function.
+
+        @since 3.3.0
+    */
+    virtual void PrepareReadOnlyDC(wxReadOnlyDC& dc);
 
     /**
         Scrolls a window so the view start is at the given point.
@@ -547,7 +585,22 @@ public:
     int GetScrollPageSize(int orient) const;
     void SetScrollPageSize(int orient, int pageSize);
     int GetScrollLines( int orient ) const;
+
+    /**
+        Set the scaling factor for the window.
+
+        This method can be used to scale the window contents, provided that
+        DoPrepareDC() or DoPrepareReadOnlyDC() is called.
+
+        @param xs
+            The horizontal scaling factor.
+        @param ys
+            The vertical scaling factor.
+
+        @see GetScaleX(), GetScaleY()
+    */
     void SetScale(double xs, double ys);
+
     double GetScaleX() const;
     double GetScaleY() const;
 

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -31,6 +31,10 @@
 #include "wx/aui/auibar.h"
 #include "wx/aui/framemanager.h"
 
+#ifndef WX_PRECOMP
+    #include "wx/dcclient.h"
+#endif
+
 #ifdef __WXMAC__
 #include "wx/osx/private.h"
 #endif
@@ -542,7 +546,7 @@ void wxAuiGenericToolBarArt::DrawControlLabel(
 }
 
 wxSize wxAuiGenericToolBarArt::GetLabelSize(
-                                        wxDC& dc,
+                                        wxReadOnlyDC& dc,
                                         wxWindow* WXUNUSED(wnd),
                                         const wxAuiToolBarItem& item)
 {
@@ -565,7 +569,7 @@ wxSize wxAuiGenericToolBarArt::GetLabelSize(
 }
 
 wxSize wxAuiGenericToolBarArt::GetToolSize(
-                                        wxDC& dc,
+                                        wxReadOnlyDC& dc,
                                         wxWindow* wnd,
                                         const wxAuiToolBarItem& item)
 {
@@ -1883,7 +1887,7 @@ bool wxAuiToolBar::GetToolBarFits() const
 
 bool wxAuiToolBar::Realize()
 {
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     if (!dc.IsOk())
         return false;
 
@@ -1931,7 +1935,7 @@ bool wxAuiToolBar::Realize()
     return true;
 }
 
-wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, wxOrientation orientation)
+wxSize wxAuiToolBar::RealizeHelper(wxReadOnlyDC& dc, wxOrientation orientation)
 {
     // Remove old sizer before adding any controls in this tool bar, which are
     // elements of this sizer, to the new sizer below.
@@ -2134,6 +2138,13 @@ wxSize wxAuiToolBar::RealizeHelper(wxClientDC& dc, wxOrientation orientation)
     return m_sizer->GetMinSize();
 }
 
+bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
+{
+    RealizeHelper(static_cast<wxReadOnlyDC&>(dc),
+                  horizontal ? wxHORIZONTAL : wxVERTICAL);
+    return true;
+}
+
 int wxAuiToolBar::GetOverflowState() const
 {
     return m_overflowState;
@@ -2165,7 +2176,7 @@ wxRect wxAuiToolBar::GetOverflowRect() const
 
 wxSize wxAuiToolBar::GetLabelSize(const wxString& label)
 {
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
 
     int tx, ty;
     int textWidth = 0, textHeight = 0;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -716,7 +716,7 @@ void wxAuiTabContainer::Render(wxDC* raw_dc, wxWindow* wnd)
 }
 
 // Is the tab visible?
-bool wxAuiTabContainer::IsTabVisible(int tabPage, int tabOffset, wxDC* dc, wxWindow* wnd)
+bool wxAuiTabContainer::IsTabVisible(int tabPage, int tabOffset, wxReadOnlyDC* dc, wxWindow* wnd)
 {
     if (!dc || !dc->IsOk())
         return false;
@@ -833,7 +833,7 @@ bool wxAuiTabContainer::IsTabVisible(int tabPage, int tabOffset, wxDC* dc, wxWin
 // Make the tab visible if it wasn't already
 void wxAuiTabContainer::MakeTabVisible(int tabPage, wxWindow* win)
 {
-    wxClientDC dc(win);
+    wxInfoDC dc(win);
     if (!IsTabVisible(tabPage, GetTabOffset(), & dc, win))
     {
         int i;

--- a/src/aui/barartmsw.cpp
+++ b/src/aui/barartmsw.cpp
@@ -369,7 +369,7 @@ void wxAuiMSWToolBarArt::DrawOverflowButton(
 }
 
 wxSize wxAuiMSWToolBarArt::GetLabelSize(
-    wxDC& dc,
+    wxReadOnlyDC& dc,
     wxWindow* wnd,
     const wxAuiToolBarItem& item)
 {
@@ -377,7 +377,7 @@ wxSize wxAuiMSWToolBarArt::GetLabelSize(
 }
 
 wxSize wxAuiMSWToolBarArt::GetToolSize(
-    wxDC& dc,
+    wxReadOnlyDC& dc,
     wxWindow* wnd,
     const wxAuiToolBarItem& item)
 {

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -676,7 +676,7 @@ int wxAuiGenericTabArt::GetAdditionalBorderSpace(wxWindow* WXUNUSED(wnd))
     return 0;
 }
 
-wxSize wxAuiGenericTabArt::GetTabSize(wxDC& dc,
+wxSize wxAuiGenericTabArt::GetTabSize(wxReadOnlyDC& dc,
                                       wxWindow* wnd,
                                       const wxString& caption,
                                       const wxBitmapBundle& bitmap,
@@ -847,7 +847,7 @@ int wxAuiGenericTabArt::GetBestTabCtrlSize(wxWindow* wnd,
                                            const wxAuiNotebookPageArray& pages,
                                            const wxSize& requiredBmp_size)
 {
-    wxClientDC dc(wnd);
+    wxInfoDC dc(wnd);
     dc.SetFont(m_measuringFont);
 
     // sometimes a standard bitmap size needs to be enforced, especially
@@ -1222,7 +1222,7 @@ int wxAuiSimpleTabArt::GetAdditionalBorderSpace(wxWindow* WXUNUSED(wnd))
     return 0;
 }
 
-wxSize wxAuiSimpleTabArt::GetTabSize(wxDC& dc,
+wxSize wxAuiSimpleTabArt::GetTabSize(wxReadOnlyDC& dc,
                                      wxWindow* wnd,
                                      const wxString& caption,
                                      const wxBitmapBundle& WXUNUSED(bitmap),
@@ -1370,7 +1370,7 @@ int wxAuiSimpleTabArt::GetBestTabCtrlSize(wxWindow* wnd,
                                           const wxAuiNotebookPageArray& WXUNUSED(pages),
                                           const wxSize& WXUNUSED(requiredBmp_size))
 {
-    wxClientDC dc(wnd);
+    wxInfoDC dc(wnd);
     dc.SetFont(m_measuringFont);
     int x_ext = 0;
     wxSize s = GetTabSize(dc,

--- a/src/aui/tabartgtk.cpp
+++ b/src/aui/tabartgtk.cpp
@@ -488,7 +488,7 @@ int wxAuiGtkTabArt::GetAdditionalBorderSpace(wxWindow* wnd)
     return 2 * GetBorderWidth(wnd);
 }
 
-wxSize wxAuiGtkTabArt::GetTabSize(wxDC& dc,
+wxSize wxAuiGtkTabArt::GetTabSize(wxReadOnlyDC& dc,
                               wxWindow* wnd,
                               const wxString& caption,
                               const wxBitmapBundle& bitmap,

--- a/src/aui/tabartmsw.cpp
+++ b/src/aui/tabartmsw.cpp
@@ -261,7 +261,7 @@ int wxAuiMSWTabArt::GetAdditionalBorderSpace(wxWindow* wnd)
         return wxAuiGenericTabArt::GetAdditionalBorderSpace(wnd);
 }
 
-wxSize wxAuiMSWTabArt::GetTabSize(wxDC& dc,
+wxSize wxAuiMSWTabArt::GetTabSize(wxReadOnlyDC& dc,
     wxWindow* wnd,
     const wxString& caption,
     const wxBitmapBundle& bitmap,
@@ -428,7 +428,7 @@ int wxAuiMSWTabArt::GetBestTabCtrlSize(wxWindow* wnd,
     return wxAuiGenericTabArt::GetBestTabCtrlSize(wnd, pages, requiredBmp_size);
 }
 
-void wxAuiMSWTabArt::InitSizes(wxWindow* wnd, wxDC& WXUNUSED(dc))
+void wxAuiMSWTabArt::InitSizes(wxWindow* wnd, wxReadOnlyDC& WXUNUSED(dc))
 {
     // Borrow close button from tooltip (best fit on various backgrounds)
     wxUxThemeHandle hTooltipTheme(wnd, L"Tooltip");

--- a/src/common/ctrlcmn.cpp
+++ b/src/common/ctrlcmn.cpp
@@ -277,7 +277,7 @@ namespace
 
 struct EllipsizeCalculator
 {
-    EllipsizeCalculator(const wxString& s, const wxDC& dc,
+    EllipsizeCalculator(const wxString& s, const wxReadOnlyDC& dc,
                         int maxFinalWidthPx, int replacementWidthPx,
                         int flags)
         :
@@ -445,7 +445,7 @@ struct EllipsizeCalculator
 
     // inputs:
     wxString m_str;
-    const wxDC& m_dc;
+    const wxReadOnlyDC& m_dc;
     int m_maxFinalWidthPx;
     int m_replacementWidthPx;
     wxArrayInt m_charOffsetsPx;
@@ -453,7 +453,7 @@ struct EllipsizeCalculator
     bool m_isOk;
 };
 
-wxString DoEllipsizeSingleLine(const wxString& curLine, const wxDC& dc,
+wxString DoEllipsizeSingleLine(const wxString& curLine, const wxReadOnlyDC& dc,
                                wxEllipsizeMode mode, int maxFinalWidthPx,
                                int replacementWidthPx, int flags)
 {
@@ -571,7 +571,7 @@ wxString DoEllipsizeSingleLine(const wxString& curLine, const wxDC& dc,
 
 
 /* static */
-wxString wxControlBase::Ellipsize(const wxString& label, const wxDC& dc,
+wxString wxControlBase::Ellipsize(const wxString& label, const wxReadOnlyDC& dc,
                                   wxEllipsizeMode mode, int maxFinalWidth,
                                   int flags)
 {

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -732,7 +732,7 @@ int wxMouseEvent::GetButton() const
 }
 
 // Find the logical position of the event given the DC
-wxPoint wxMouseEvent::GetLogicalPosition(const wxDC& dc) const
+wxPoint wxMouseEvent::GetLogicalPosition(const wxReadOnlyDC& dc) const
 {
     wxPoint pt(dc.DeviceToLogicalX(m_x), dc.DeviceToLogicalY(m_y));
     return pt;

--- a/src/common/listctrlcmn.cpp
+++ b/src/common/listctrlcmn.cpp
@@ -184,7 +184,7 @@ wxSize wxListCtrlBase::DoGetBestClientSize() const
         return wxControl::DoGetBestClientSize();
 
     int totalWidth;
-    wxClientDC dc(const_cast<wxListCtrlBase*>(this));
+    wxInfoDC dc(const_cast<wxListCtrlBase*>(this));
 
     // In report mode, we use only the column headers, not items, to determine
     // the best width. The reason for this is that it's easier (we can't just

--- a/src/common/stattextcmn.cpp
+++ b/src/common/stattextcmn.cpp
@@ -101,7 +101,7 @@ wxCONSTRUCTOR_6( wxStaticText, wxWindow*, Parent, wxWindowID, Id, \
 
 void wxTextWrapper::Wrap(wxWindow *win, const wxString& text, int widthMax)
 {
-    const wxClientDC dc(win);
+    const wxInfoDC dc(win);
 
     const wxArrayString ls = wxSplit(text, '\n', '\0');
     for ( wxArrayString::const_iterator i = ls.begin(); i != ls.end(); ++i )
@@ -264,7 +264,7 @@ wxString wxStaticTextBase::Ellipsize(const wxString& label) const
         return label;
     }
 
-    wxClientDC dc(const_cast<wxStaticTextBase*>(this));
+    wxInfoDC dc(const_cast<wxStaticTextBase*>(this));
 
     wxEllipsizeMode mode;
     if ( HasFlag(wxST_ELLIPSIZE_START) )

--- a/src/generic/bannerwindow.cpp
+++ b/src/generic/bannerwindow.cpp
@@ -115,7 +115,7 @@ wxSize wxBannerWindow::DoGetBestClientSize() const
     }
     else
     {
-        wxClientDC dc(const_cast<wxBannerWindow *>(this));
+        wxInfoDC dc(const_cast<wxBannerWindow *>(this));
         const wxSize sizeText = dc.GetMultiLineTextExtent(m_message);
 
         dc.SetFont(GetTitleFont());

--- a/src/generic/buttonbar.cpp
+++ b/src/generic/buttonbar.cpp
@@ -144,7 +144,7 @@ bool wxButtonToolBar::Create(wxWindow *parent,
     // Calculate the label height if necessary
     if (GetWindowStyle() & wxTB_TEXT)
     {
-        wxClientDC dc(this);
+        wxInfoDC dc(this);
         dc.SetFont(font);
         int w, h;
         dc.GetTextExtent(wxT("X"), & w, & h);
@@ -408,7 +408,7 @@ void wxButtonToolBar::DoLayout()
 
                     if (!tool->GetShortHelp().empty())
                     {
-                        wxClientDC dc(this);
+                        wxInfoDC dc(this);
                         dc.SetFont(GetFont());
                         int tw, th;
                         dc.GetTextExtent(tool->GetShortHelp(), & tw, & th);

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -743,7 +743,7 @@ void wxGenericCalendarCtrl::DoGetSize(int *width, int *height) const
 
 void wxGenericCalendarCtrl::RecalcGeometry()
 {
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
 
     dc.SetFont(GetFont());
 

--- a/src/generic/collheaderctrlg.cpp
+++ b/src/generic/collheaderctrlg.cpp
@@ -81,7 +81,7 @@ wxSize wxGenericCollapsibleHeaderCtrl::DoGetBestClientSize() const
         self = const_cast<wxGenericCollapsibleHeaderCtrl*>(this);
 
     // The code here parallels that of OnPaint() -- except without drawing.
-    wxClientDC dc(self);
+    wxInfoDC dc(self);
 
     wxSize size = wxRendererNative::Get().GetCollapseButtonSize(self, dc);
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1294,7 +1294,7 @@ wxSize wxDataViewTextRenderer::GetSize() const
         if ( m_markupText )
         {
             wxDataViewCtrl* const view = GetView();
-            wxClientDC dc(view);
+            wxInfoDC dc(view);
             if ( GetAttr().HasFont() )
                 dc.SetFont(GetAttr().GetEffectiveFont(view->GetFont()));
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -280,6 +280,53 @@ wxGridCellWorker::~wxGridCellWorker()
 }
 
 // ----------------------------------------------------------------------------
+// wxGridCellRenderer
+// ----------------------------------------------------------------------------
+
+wxSize
+wxGridCellRenderer::GetPreferredSize(wxGrid& WXUNUSED(grid),
+                                     wxGridCellAttr& WXUNUSED(attr),
+                                     wxReadOnlyDC& WXUNUSED(dc),
+                                     int WXUNUSED(row), int WXUNUSED(col))
+{
+    wxFAIL_MSG("Must be overridden if GetBestSize() isn't.");
+    return wxSize();
+}
+
+wxSize wxGridCellRenderer::GetBestSize(wxGrid& grid,
+                                       wxGridCellAttr& attr,
+                                       wxDC& dc,
+                                       int row, int col)
+{
+    return GetPreferredSize(grid, attr, dc, row, col);
+}
+
+int wxGridCellRenderer::GetBestHeight(wxGrid& grid,
+                                      wxGridCellAttr& attr,
+                                      wxDC& dc,
+                                      int row, int col,
+                                      int WXUNUSED(width))
+{
+    return GetBestSize(grid, attr, dc, row, col).GetHeight();
+}
+
+int wxGridCellRenderer::GetBestWidth(wxGrid& grid,
+                                     wxGridCellAttr& attr,
+                                     wxDC& dc,
+                                     int row, int col,
+                                     int WXUNUSED(height))
+{
+    return GetBestSize(grid, attr, dc, row, col).GetWidth();
+}
+
+wxSize wxGridCellRenderer::GetMaxBestSize(wxGrid& grid,
+                                          wxGridCellAttr& attr,
+                                          wxDC& dc)
+{
+    return GetMaxSize(grid, attr, dc);
+}
+
+// ----------------------------------------------------------------------------
 // wxGridHeaderLabelsRenderer and related classes
 // ----------------------------------------------------------------------------
 
@@ -10701,7 +10748,10 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
             return;
     }
 
-    wxInfoDC dc(m_gridWin);
+    // We need to create wxClientDC here, and not wxInfoDC, as we have to pass
+    // a wxDC, and not just wxReadOnlyDC, to the virtual functions of
+    // wxGridCellRenderer that we call below.
+    wxClientDC dc(m_gridWin);
 
     AcceptCellEditControlIfShown();
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -7780,7 +7780,7 @@ void wxGrid::StringToLines( const wxString& value, wxArrayString& lines ) const
     }
 }
 
-void wxGrid::GetTextBoxSize( const wxDC& dc,
+void wxGrid::GetTextBoxSize( const wxReadOnlyDC& dc,
                              const wxArrayString& lines,
                              long *width, long *height ) const
 {
@@ -10376,7 +10376,7 @@ void wxGrid::SetRowSize( int row, int height )
     {
         long w, h;
         wxArrayString lines;
-        wxClientDC dc(m_rowLabelWin);
+        wxInfoDC dc(m_rowLabelWin);
         dc.SetFont(GetLabelFont());
         StringToLines(GetRowLabelValue( row ), lines);
         GetTextBoxSize( dc, lines, &w, &h );
@@ -10502,7 +10502,7 @@ void wxGrid::SetColSize( int col, int width )
         {
             long w, h;
             wxArrayString lines;
-            wxClientDC dc(m_colLabelWin);
+            wxInfoDC dc(m_colLabelWin);
             dc.SetFont(GetLabelFont());
             StringToLines(GetColLabelValue(col), lines);
             if ( GetColLabelTextOrientation() == wxHORIZONTAL )
@@ -10701,7 +10701,7 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
             return;
     }
 
-    wxClientDC dc(m_gridWin);
+    wxInfoDC dc(m_gridWin);
 
     AcceptCellEditControlIfShown();
 
@@ -10938,8 +10938,8 @@ wxCoord wxGrid::CalcColOrRowLabelAreaMinSize(wxGridDirection direction)
     // calculate size for the rows or columns?
     const bool calcRows = direction == wxGRID_ROW;
 
-    wxClientDC dc(calcRows ? GetGridRowLabelWindow()
-                           : GetGridColLabelWindow());
+    wxInfoDC dc(calcRows ? GetGridRowLabelWindow()
+                         : GetGridColLabelWindow());
     dc.SetFont(GetLabelFont());
 
     // which dimension should we take into account for calculations?

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -211,7 +211,7 @@ void wxGridCellDateRenderer::Draw(wxGrid& grid,
 
 wxSize wxGridCellDateRenderer::GetBestSize(wxGrid& grid,
                                            wxGridCellAttr& attr,
-                                           wxReadOnlyDC& dc,
+                                           wxDC& dc,
                                            int row, int col)
 {
     return DoGetBestSize(attr, dc, GetString(grid, row, col));
@@ -219,7 +219,7 @@ wxSize wxGridCellDateRenderer::GetBestSize(wxGrid& grid,
 
 wxSize wxGridCellDateRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                               wxGridCellAttr& attr,
-                                              wxReadOnlyDC& dc)
+                                              wxDC& dc)
 {
     wxSize size;
 
@@ -277,7 +277,7 @@ wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxGridCellChoiceRendere
 
 wxSize wxGridCellChoiceRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                                 wxGridCellAttr& attr,
-                                                wxReadOnlyDC& dc)
+                                                wxDC& dc)
 {
     wxSize size;
 
@@ -350,7 +350,7 @@ void wxGridCellEnumRenderer::Draw(wxGrid& grid,
 
 wxSize wxGridCellEnumRenderer::GetBestSize(wxGrid& grid,
                                             wxGridCellAttr& attr,
-                                            wxReadOnlyDC& dc,
+                                            wxDC& dc,
                                             int row, int col)
 {
     return DoGetBestSize(attr, dc, GetString(grid, row, col));
@@ -534,7 +534,7 @@ wxGridCellAutoWrapStringRenderer::BreakWord(wxReadOnlyDC& dc,
 wxSize
 wxGridCellAutoWrapStringRenderer::GetBestSize(wxGrid& grid,
                                               wxGridCellAttr& attr,
-                                              wxReadOnlyDC& dc,
+                                              wxDC& dc,
                                               int row, int col)
 {
     // We have to make a choice here and fix either width or height because we
@@ -552,7 +552,7 @@ static const int AUTOWRAP_Y_MARGIN = 4;
 int
 wxGridCellAutoWrapStringRenderer::GetBestHeight(wxGrid& grid,
                                                 wxGridCellAttr& attr,
-                                                wxReadOnlyDC& dc,
+                                                wxDC& dc,
                                                 int row, int col,
                                                 int width)
 {
@@ -567,7 +567,7 @@ wxGridCellAutoWrapStringRenderer::GetBestHeight(wxGrid& grid,
 int
 wxGridCellAutoWrapStringRenderer::GetBestWidth(wxGrid& grid,
                                                wxGridCellAttr& attr,
-                                               wxReadOnlyDC& dc,
+                                               wxDC& dc,
                                                int row, int col,
                                                int height)
 {
@@ -610,7 +610,7 @@ wxSize wxGridCellStringRenderer::DoGetBestSize(const wxGridCellAttr& attr,
 
 wxSize wxGridCellStringRenderer::GetBestSize(wxGrid& grid,
                                              wxGridCellAttr& attr,
-                                             wxReadOnlyDC& dc,
+                                             wxDC& dc,
                                              int row, int col)
 {
     return DoGetBestSize(attr, dc, grid.GetCellValue(row, col));
@@ -757,7 +757,7 @@ void wxGridCellNumberRenderer::Draw(wxGrid& grid,
 
 wxSize wxGridCellNumberRenderer::GetBestSize(wxGrid& grid,
                                              wxGridCellAttr& attr,
-                                             wxReadOnlyDC& dc,
+                                             wxDC& dc,
                                              int row, int col)
 {
     return DoGetBestSize(attr, dc, GetString(grid, row, col));
@@ -765,7 +765,7 @@ wxSize wxGridCellNumberRenderer::GetBestSize(wxGrid& grid,
 
 wxSize wxGridCellNumberRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                                 wxGridCellAttr& attr,
-                                                wxReadOnlyDC& dc)
+                                                wxDC& dc)
 {
     // In theory, it's possible that there is a value in min..max range which
     // is longer than both min and max, e.g. we could conceivably have "88" be
@@ -886,7 +886,7 @@ void wxGridCellFloatRenderer::Draw(wxGrid& grid,
 
 wxSize wxGridCellFloatRenderer::GetBestSize(wxGrid& grid,
                                             wxGridCellAttr& attr,
-                                            wxReadOnlyDC& dc,
+                                            wxDC& dc,
                                             int row, int col)
 {
     return DoGetBestSize(attr, dc, GetString(grid, row, col));
@@ -977,7 +977,7 @@ void wxGridCellFloatRenderer::SetParameters(const wxString& params)
 
 wxSize wxGridCellBoolRenderer::GetBestSize(wxGrid& grid,
                                            wxGridCellAttr& attr,
-                                           wxReadOnlyDC& dc,
+                                           wxDC& dc,
                                            int WXUNUSED(row),
                                            int WXUNUSED(col))
 {
@@ -986,7 +986,7 @@ wxSize wxGridCellBoolRenderer::GetBestSize(wxGrid& grid,
 
 wxSize wxGridCellBoolRenderer::GetMaxBestSize(wxGrid& grid,
                                               wxGridCellAttr& WXUNUSED(attr),
-                                              wxReadOnlyDC& WXUNUSED(dc))
+                                              wxDC& WXUNUSED(dc))
 {
     static wxPrivate::DpiDependentValue<wxSize> s_sizeCheckMark;
 

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -211,7 +211,7 @@ void wxGridCellDateRenderer::Draw(wxGrid& grid,
 
 wxSize wxGridCellDateRenderer::GetBestSize(wxGrid& grid,
                                            wxGridCellAttr& attr,
-                                           wxDC& dc,
+                                           wxReadOnlyDC& dc,
                                            int row, int col)
 {
     return DoGetBestSize(attr, dc, GetString(grid, row, col));
@@ -219,7 +219,7 @@ wxSize wxGridCellDateRenderer::GetBestSize(wxGrid& grid,
 
 wxSize wxGridCellDateRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                               wxGridCellAttr& attr,
-                                              wxDC& dc)
+                                              wxReadOnlyDC& dc)
 {
     wxSize size;
 
@@ -277,7 +277,7 @@ wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxGridCellChoiceRendere
 
 wxSize wxGridCellChoiceRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                                 wxGridCellAttr& attr,
-                                                wxDC& dc)
+                                                wxReadOnlyDC& dc)
 {
     wxSize size;
 
@@ -350,7 +350,7 @@ void wxGridCellEnumRenderer::Draw(wxGrid& grid,
 
 wxSize wxGridCellEnumRenderer::GetBestSize(wxGrid& grid,
                                             wxGridCellAttr& attr,
-                                            wxDC& dc,
+                                            wxReadOnlyDC& dc,
                                             int row, int col)
 {
     return DoGetBestSize(attr, dc, GetString(grid, row, col));
@@ -390,7 +390,7 @@ wxGridCellAutoWrapStringRenderer::Draw(wxGrid& grid,
 
 wxArrayString
 wxGridCellAutoWrapStringRenderer::GetTextLines(wxGrid& grid,
-                                               wxDC& dc,
+                                               wxReadOnlyDC& dc,
                                                const wxGridCellAttr& attr,
                                                const wxRect& rect,
                                                int row, int col)
@@ -429,7 +429,7 @@ wxGridCellAutoWrapStringRenderer::GetTextLines(wxGrid& grid,
 }
 
 void
-wxGridCellAutoWrapStringRenderer::BreakLine(wxDC& dc,
+wxGridCellAutoWrapStringRenderer::BreakLine(wxReadOnlyDC& dc,
                                             const wxString& logicalLine,
                                             wxCoord maxWidth,
                                             wxArrayString& lines)
@@ -482,7 +482,7 @@ wxGridCellAutoWrapStringRenderer::BreakLine(wxDC& dc,
 
 
 wxCoord
-wxGridCellAutoWrapStringRenderer::BreakWord(wxDC& dc,
+wxGridCellAutoWrapStringRenderer::BreakWord(wxReadOnlyDC& dc,
                                             const wxString& word,
                                             wxCoord maxWidth,
                                             wxArrayString& lines,
@@ -534,7 +534,7 @@ wxGridCellAutoWrapStringRenderer::BreakWord(wxDC& dc,
 wxSize
 wxGridCellAutoWrapStringRenderer::GetBestSize(wxGrid& grid,
                                               wxGridCellAttr& attr,
-                                              wxDC& dc,
+                                              wxReadOnlyDC& dc,
                                               int row, int col)
 {
     // We have to make a choice here and fix either width or height because we
@@ -552,7 +552,7 @@ static const int AUTOWRAP_Y_MARGIN = 4;
 int
 wxGridCellAutoWrapStringRenderer::GetBestHeight(wxGrid& grid,
                                                 wxGridCellAttr& attr,
-                                                wxDC& dc,
+                                                wxReadOnlyDC& dc,
                                                 int row, int col,
                                                 int width)
 {
@@ -567,7 +567,7 @@ wxGridCellAutoWrapStringRenderer::GetBestHeight(wxGrid& grid,
 int
 wxGridCellAutoWrapStringRenderer::GetBestWidth(wxGrid& grid,
                                                wxGridCellAttr& attr,
-                                               wxDC& dc,
+                                               wxReadOnlyDC& dc,
                                                int row, int col,
                                                int height)
 {
@@ -601,7 +601,7 @@ wxGridCellAutoWrapStringRenderer::GetBestWidth(wxGrid& grid,
 // ----------------------------------------------------------------------------
 
 wxSize wxGridCellStringRenderer::DoGetBestSize(const wxGridCellAttr& attr,
-                                               wxDC& dc,
+                                               wxReadOnlyDC& dc,
                                                const wxString& text)
 {
     dc.SetFont(attr.GetFont());
@@ -610,7 +610,7 @@ wxSize wxGridCellStringRenderer::DoGetBestSize(const wxGridCellAttr& attr,
 
 wxSize wxGridCellStringRenderer::GetBestSize(wxGrid& grid,
                                              wxGridCellAttr& attr,
-                                             wxDC& dc,
+                                             wxReadOnlyDC& dc,
                                              int row, int col)
 {
     return DoGetBestSize(attr, dc, grid.GetCellValue(row, col));
@@ -757,7 +757,7 @@ void wxGridCellNumberRenderer::Draw(wxGrid& grid,
 
 wxSize wxGridCellNumberRenderer::GetBestSize(wxGrid& grid,
                                              wxGridCellAttr& attr,
-                                             wxDC& dc,
+                                             wxReadOnlyDC& dc,
                                              int row, int col)
 {
     return DoGetBestSize(attr, dc, GetString(grid, row, col));
@@ -765,7 +765,7 @@ wxSize wxGridCellNumberRenderer::GetBestSize(wxGrid& grid,
 
 wxSize wxGridCellNumberRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                                 wxGridCellAttr& attr,
-                                                wxDC& dc)
+                                                wxReadOnlyDC& dc)
 {
     // In theory, it's possible that there is a value in min..max range which
     // is longer than both min and max, e.g. we could conceivably have "88" be
@@ -886,7 +886,7 @@ void wxGridCellFloatRenderer::Draw(wxGrid& grid,
 
 wxSize wxGridCellFloatRenderer::GetBestSize(wxGrid& grid,
                                             wxGridCellAttr& attr,
-                                            wxDC& dc,
+                                            wxReadOnlyDC& dc,
                                             int row, int col)
 {
     return DoGetBestSize(attr, dc, GetString(grid, row, col));
@@ -977,7 +977,7 @@ void wxGridCellFloatRenderer::SetParameters(const wxString& params)
 
 wxSize wxGridCellBoolRenderer::GetBestSize(wxGrid& grid,
                                            wxGridCellAttr& attr,
-                                           wxDC& dc,
+                                           wxReadOnlyDC& dc,
                                            int WXUNUSED(row),
                                            int WXUNUSED(col))
 {
@@ -986,7 +986,7 @@ wxSize wxGridCellBoolRenderer::GetBestSize(wxGrid& grid,
 
 wxSize wxGridCellBoolRenderer::GetMaxBestSize(wxGrid& grid,
                                               wxGridCellAttr& WXUNUSED(attr),
-                                              wxDC& WXUNUSED(dc))
+                                              wxReadOnlyDC& WXUNUSED(dc))
 {
     static wxPrivate::DpiDependentValue<wxSize> s_sizeCheckMark;
 

--- a/src/generic/hyperlinkg.cpp
+++ b/src/generic/hyperlinkg.cpp
@@ -125,7 +125,7 @@ void wxGenericHyperlinkCtrl::ConnectMenuHandlers()
 
 wxSize wxGenericHyperlinkCtrl::DoGetBestClientSize() const
 {
-    wxClientDC dc(const_cast<wxGenericHyperlinkCtrl*>(this));
+    wxInfoDC dc(const_cast<wxGenericHyperlinkCtrl*>(this));
     return dc.GetTextExtent(GetLabel());
 }
 

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -417,7 +417,7 @@ wxListLineData::wxListLineData( wxListMainWindow *owner )
     InitItems( GetMode() == wxLC_REPORT ? m_owner->GetColumnCount() : 1 );
 }
 
-void wxListLineData::CalculateSize( wxDC *dc, int spacing )
+void wxListLineData::CalculateSize( wxReadOnlyDC *dc, int spacing )
 {
     wxCHECK_RET( !m_items.empty(), wxT("no subitems at all??") );
 
@@ -1679,7 +1679,7 @@ wxCoord wxListMainWindow::GetLineHeight() const
     {
         wxListMainWindow *self = wxConstCast(this, wxListMainWindow);
 
-        wxClientDC dc( self );
+        wxInfoDC dc( self );
         dc.SetFont( GetFont() );
 
         wxCoord y;
@@ -3340,7 +3340,7 @@ int wxListMainWindow::GetItemSpacing( bool isSmall )
 int
 wxListMainWindow::ComputeMinHeaderWidth(const wxListHeaderData* column) const
 {
-    wxClientDC dc(const_cast<wxListMainWindow*>(this));
+    wxInfoDC dc(const_cast<wxListMainWindow*>(this));
 
     int width = dc.GetTextExtent(column->GetText()).x + AUTOSIZE_COL_MARGIN;
 
@@ -3982,7 +3982,7 @@ void wxListMainWindow::RecalculatePositions()
 {
     const int lineHeight = GetLineHeight();
 
-    wxClientDC dc( this );
+    wxInfoDC dc( this );
     dc.SetFont( GetFont() );
 
     const size_t count = GetItemCount();
@@ -4651,7 +4651,7 @@ long wxListMainWindow::InsertColumn( long col, const wxListItem &item )
 int wxListMainWindow::GetItemWidthWithImage(wxListItem * item)
 {
     int width = 0;
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
 
     dc.SetFont( GetFont() );
 

--- a/src/generic/markuptext.cpp
+++ b/src/generic/markuptext.cpp
@@ -52,7 +52,7 @@ public:
     // Initialize the base class with the font to use. As we don't care about
     // colours (which don't affect the text measurements), don't bother to
     // specify them at all.
-    wxMarkupParserMeasureOutput(wxDC& dc, int *visibleHeight)
+    wxMarkupParserMeasureOutput(wxReadOnlyDC& dc, int *visibleHeight)
         : wxMarkupParserAttrOutput(dc.GetFont(), wxColour(), wxColour()),
           m_dc(dc),
           m_visibleHeight(visibleHeight)
@@ -93,7 +93,7 @@ public:
     }
 
 private:
-    wxDC& m_dc;
+    wxReadOnlyDC& m_dc;
 
     // The values that we compute.
     wxSize m_size;
@@ -309,7 +309,7 @@ private:
 // wxMarkupText implementation
 // ============================================================================
 
-wxSize wxMarkupTextBase::Measure(wxDC& dc, int *visibleHeight) const
+wxSize wxMarkupTextBase::Measure(wxReadOnlyDC& dc, int *visibleHeight) const
 {
     wxMarkupParserMeasureOutput out(dc, visibleHeight);
     wxMarkupParser parser(out);

--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -732,7 +732,7 @@ void wxVListBoxComboPopup::CalcWidths()
         // I think using wxDC::GetTextExtent is faster than
         // wxWindow::GetTextExtent (assuming same dc is used
         // for all calls, as we do here).
-        wxClientDC dc(m_combo);
+        wxInfoDC dc(m_combo);
         if ( !m_useFont.IsOk() )
             m_useFont = m_combo->GetFont();
         dc.SetFont(m_useFont);

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -123,7 +123,7 @@ public:
         const wxRect& rect,
         int flags = 0) override;
 
-    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxDC& dc) override;
+    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxReadOnlyDC& dc) override;
 
     virtual void DrawItemSelectionRect(wxWindow *win,
                                        wxDC& dc,
@@ -801,7 +801,7 @@ wxRendererGeneric::DrawCollapseButton(wxWindow *win,
     dc.DrawPolygon(WXSIZEOF(pt), pt, rect.x, rect.y);
 }
 
-wxSize wxRendererGeneric::GetCollapseButtonSize(wxWindow *WXUNUSED(win), wxDC& WXUNUSED(dc))
+wxSize wxRendererGeneric::GetCollapseButtonSize(wxWindow *WXUNUSED(win), wxReadOnlyDC& WXUNUSED(dc))
 {
     return wxSize(18, 18);
 }

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -641,7 +641,7 @@ int wxScrollHelperBase::CalcScrollInc(wxScrollWinEvent& event)
     return nScrollInc;
 }
 
-void wxScrollHelperBase::DoPrepareDC(wxDC& dc)
+void wxScrollHelperBase::DoPrepareReadOnlyDC(wxReadOnlyDC& dc)
 {
     wxPoint pt = dc.GetDeviceOrigin();
 #if defined(__WXGTK__) && !defined(__WXGTK3__)
@@ -901,6 +901,11 @@ void wxAnyScrollHelperBase::HandleOnChar(wxKeyEvent& event)
         newEvent.SetOrientation(wxHORIZONTAL);
         m_win->ProcessWindowEvent(newEvent);
     }
+}
+
+void wxAnyScrollHelperBase::DoPrepareDC(wxDC& dc)
+{
+    DoPrepareReadOnlyDC(dc);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/generic/stattextg.cpp
+++ b/src/generic/stattextg.cpp
@@ -84,7 +84,7 @@ void wxGenericStaticText::OnPaint(wxPaintEvent& WXUNUSED(event))
 
 wxSize wxGenericStaticText::DoGetBestClientSize() const
 {
-    wxClientDC dc(wxConstCast(this, wxGenericStaticText));
+    wxInfoDC dc(wxConstCast(this, wxGenericStaticText));
 
 #if wxUSE_MARKUP
     if ( m_markupText )

--- a/src/generic/tipwin.cpp
+++ b/src/generic/tipwin.cpp
@@ -227,7 +227,7 @@ wxTipWindowView::wxTipWindowView(wxWindow *parent)
 
 void wxTipWindowView::Adjust(const wxString& text, wxCoord maxLength)
 {
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     dc.SetFont(GetFont());
 
     // calculate the length: we want each line be no longer than maxLength

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -220,7 +220,7 @@ public:
 
     // sets the items font for the specified DC if it uses any special font or
     // simply returns false otherwise
-    bool SetFont(wxGenericTreeCtrl *control, wxDC& dc) const
+    bool SetFont(wxGenericTreeCtrl *control, wxReadOnlyDC& dc) const
     {
         wxFont font;
 
@@ -250,7 +250,7 @@ public:
     // calculate and cache the item size using either the provided DC (which is
     // supposed to have wxGenericTreeCtrl::m_normalFont selected into it!) or a
     // wxClientDC on the control window
-    void CalculateSize(wxGenericTreeCtrl *control, wxDC& dc)
+    void CalculateSize(wxGenericTreeCtrl *control, wxReadOnlyDC& dc)
         { DoCalculateSize(control, dc, true /* dc uses normal font */); }
     void CalculateSize(wxGenericTreeCtrl *control);
 
@@ -320,7 +320,7 @@ private:
     // if dcUsesNormalFont is true, the current dc font must be the normal tree
     // control font
     void DoCalculateSize(wxGenericTreeCtrl *control,
-                         wxDC& dc,
+                         wxReadOnlyDC& dc,
                          bool dcUsesNormalFont);
 
     // since there can be very many of these, we save size by chosing
@@ -841,13 +841,13 @@ void wxGenericTreeItem::CalculateSize(wxGenericTreeCtrl* control)
     if ( m_width != 0 )
         return;
 
-    wxClientDC dc(control);
+    wxInfoDC dc(control);
     DoCalculateSize(control, dc, false /* normal font not used */);
 }
 
 void
 wxGenericTreeItem::DoCalculateSize(wxGenericTreeCtrl* control,
-                                   wxDC& dc,
+                                   wxReadOnlyDC& dc,
                                    bool dcUsesNormalFont)
 {
     if ( m_width != 0 ) // Size known, nothing to do
@@ -2398,7 +2398,7 @@ void wxGenericTreeCtrl::SortChildren(const wxTreeItemId& itemId)
 
 void wxGenericTreeCtrl::CalculateLineHeight()
 {
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     m_lineHeight = dc.GetCharHeight() + FromDIP(4);
 
     if ( HasImages() )
@@ -3981,7 +3981,7 @@ void wxGenericTreeCtrl::OnInternalIdle()
 
 void
 wxGenericTreeCtrl::CalculateLevel(wxGenericTreeItem *item,
-                                  wxDC &dc,
+                                  wxReadOnlyDC &dc,
                                   int level,
                                   int &y )
 {
@@ -4023,12 +4023,10 @@ void wxGenericTreeCtrl::CalculatePositions()
     if ( !m_anchor )
         return;
 
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     PrepareDC( dc );
 
     dc.SetFont( m_normalFont );
-
-    dc.SetPen( m_dottedPen );
 
     int y = 2;
     CalculateLevel( m_anchor, dc, 0, y ); // start recursion

--- a/src/gtk/minifram.cpp
+++ b/src/gtk/minifram.cpp
@@ -334,7 +334,7 @@ bool wxMiniFrame::Create( wxWindow *parent, wxWindowID id, const wxString &title
     m_miniTitle = 0;
     if (style & wxCAPTION)
     {
-        wxClientDC dc(this);
+        wxInfoDC dc(this);
         dc.SetFont(*wxSMALL_FONT);
         m_miniTitle = wxMax(dc.GetTextExtent("X").y, 16);
     }

--- a/src/html/htmlwin.cpp
+++ b/src/html/htmlwin.cpp
@@ -969,7 +969,6 @@ wxString wxHtmlWindow::DoSelectionToText(wxHtmlSelection *sel)
     if ( !sel )
         return wxEmptyString;
 
-    wxClientDC dc(this);
     wxString text;
 
     wxHtmlTerminalCellsInterator i(sel->GetFromCell(), sel->GetToCell());

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -531,7 +531,7 @@ wxSize wxMSWButton::GetFittingSize(wxWindow *win,
 
 wxSize wxMSWButton::ComputeBestFittingSize(wxControl *btn, int flags)
 {
-    wxClientDC dc(btn);
+    wxInfoDC dc(btn);
 
     wxSize sizeBtn;
     dc.GetMultiLineTextExtent(btn->GetLabelText(), &sizeBtn.x, &sizeBtn.y);
@@ -686,7 +686,7 @@ wxSize wxAnyButton::DoGetBestSize() const
 #if wxUSE_MARKUP
         if ( m_markupText )
         {
-            wxClientDC dc(self);
+            wxInfoDC dc(self);
             size = wxMSWButton::GetFittingSize(self,
                                                m_markupText->Measure(dc),
                                                flags);

--- a/src/msw/checkbox.cpp
+++ b/src/msw/checkbox.cpp
@@ -109,7 +109,7 @@ wxSize wxCheckBox::DoGetBestClientSize() const
 
     if ( s_checkSize.HasChanged(this) )
     {
-        wxClientDC dc(const_cast<wxCheckBox*>(this));
+        wxInfoDC dc(const_cast<wxCheckBox*>(this));
         dc.SetFont(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
 
         s_checkSize.SetAtNewDPI(dc.GetCharHeight());
@@ -121,7 +121,7 @@ wxSize wxCheckBox::DoGetBestClientSize() const
     int wCheckbox, hCheckbox;
     if ( !str.empty() )
     {
-        wxClientDC dc(const_cast<wxCheckBox *>(this));
+        wxInfoDC dc(const_cast<wxCheckBox *>(this));
         dc.SetFont(GetFont());
         dc.GetMultiLineTextExtent(GetLabelText(str), &wCheckbox, &hCheckbox);
         wCheckbox += checkSize + GetCharWidth();

--- a/src/msw/commandlinkbutton.cpp
+++ b/src/msw/commandlinkbutton.cpp
@@ -145,7 +145,7 @@ wxSize wxCommandLinkButton::DoGetBestSize() const
 
         wxCommandLinkButton *thisButton =
             const_cast<wxCommandLinkButton *>(this);
-        wxClientDC dc(thisButton);
+        wxInfoDC dc(thisButton);
 
         wxFont noteFont = dc.GetFont();
 

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -719,7 +719,7 @@ bool wxListBox::SetFont(const wxFont &font)
 
         // Non owner drawn list boxes update the item height on their own, but
         // we need to do it manually in the owner drawn case.
-        wxClientDC dc(this);
+        wxInfoDC dc(this);
         dc.SetFont(m_font);
         SendMessage(GetHwnd(), LB_SETITEMHEIGHT, 0,
                     dc.GetCharHeight() + 2 * LISTBOX_EXTRA_SPACE);

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -780,7 +780,7 @@ wxSize wxMenuItem::GetMenuTextExtent(const wxString& text) const
     // Note that we must have both a valid menu and a valid window by the time
     // we can be called -- and GetFontToUse() already assumes this, so there is
     // no need to check that they're both non-null here.
-    wxClientDC dc(GetMenu()->GetWindow());
+    wxInfoDC dc(GetMenu()->GetWindow());
 
     wxFont font;
     GetFontToUse(font);

--- a/src/msw/radiobut.cpp
+++ b/src/msw/radiobut.cpp
@@ -269,7 +269,7 @@ wxSize wxRadioButton::DoGetBestSize() const
 
     if ( s_radioSize.HasChanged(this) )
     {
-        wxClientDC dc(const_cast<wxRadioButton*>(this));
+        wxInfoDC dc(const_cast<wxRadioButton*>(this));
         dc.SetFont(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
 
         s_radioSize.SetAtNewDPI(dc.GetCharHeight());

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -245,7 +245,7 @@ public:
                                     const wxRect& rect,
                                     int flags = 0) override;
 
-    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxDC& dc) override;
+    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxReadOnlyDC& dc) override;
 
     virtual void DrawItemSelectionRect(wxWindow *win,
                                        wxDC& dc,
@@ -951,7 +951,7 @@ wxRendererXP::DrawCollapseButton(wxWindow *win,
     m_rendererNative.DrawCollapseButton(win, dc, rect, flags);
 }
 
-wxSize wxRendererXP::GetCollapseButtonSize(wxWindow *win, wxDC& dc)
+wxSize wxRendererXP::GetCollapseButtonSize(wxWindow *win, wxReadOnlyDC& dc)
 {
     wxUxThemeHandle hTheme(win, L"TASKDIALOG");
 

--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -88,7 +88,7 @@ WXDWORD wxStaticText::MSWGetStyle(long style, WXDWORD *exstyle) const
 
 wxSize wxStaticText::DoGetBestClientSize() const
 {
-    wxClientDC dc(const_cast<wxStaticText *>(this));
+    wxInfoDC dc(const_cast<wxStaticText *>(this));
 
     wxCoord widthTextMax, heightTextTotal;
     dc.GetMultiLineTextExtent(GetLabelText(), &widthTextMax, &heightTextTotal);

--- a/src/msw/statusbar.cpp
+++ b/src/msw/statusbar.cpp
@@ -235,7 +235,7 @@ void wxStatusBar::DoUpdateStatusText(int nField)
     if (!m_hWnd)
         return;
 
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
 
     // Get field style, if any
     int style;

--- a/src/osx/cocoa/combobox.mm
+++ b/src/osx/cocoa/combobox.mm
@@ -356,7 +356,7 @@ wxSize wxComboBox::DoGetBestSize() const
     int wLine;
     
     {
-        wxClientDC dc(const_cast<wxComboBox*>(this));
+        wxInfoDC dc(const_cast<wxComboBox*>(this));
         
         // Find the widest line
         for(unsigned int i = 0; i < GetCount(); i++)

--- a/src/osx/cocoa/renderer.mm
+++ b/src/osx/cocoa/renderer.mm
@@ -107,7 +107,7 @@ public:
                                     const wxRect& rect,
                                     int flags = 0) override;
 
-    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxDC& dc) override;
+    virtual wxSize GetCollapseButtonSize(wxWindow *win, wxReadOnlyDC& dc) override;
 
     virtual void DrawItemSelectionRect(wxWindow *win,
                                        wxDC& dc,
@@ -879,7 +879,7 @@ void wxRendererMac::DrawCollapseButton(wxWindow *win,
                        kThemeArrowButton, adornment);
 }
 
-wxSize wxRendererMac::GetCollapseButtonSize(wxWindow *WXUNUSED(win), wxDC& WXUNUSED(dc))
+wxSize wxRendererMac::GetCollapseButtonSize(wxWindow *WXUNUSED(win), wxReadOnlyDC& WXUNUSED(dc))
 {
     wxSize size;
     SInt32 width, height;

--- a/src/osx/listbox_osx.cpp
+++ b/src/osx/listbox_osx.cpp
@@ -254,7 +254,7 @@ wxSize wxListBox::DoGetBestSize() const
     int lbHeight;
 
     {
-        wxClientDC dc(const_cast<wxListBox*>(this));
+        wxInfoDC dc(const_cast<wxListBox*>(this));
         dc.SetFont(GetFont());
 
         // Find the widest line

--- a/src/ribbon/art_aui.cpp
+++ b/src/ribbon/art_aui.cpp
@@ -341,7 +341,7 @@ void wxRibbonAUIArtProvider::DrawTabCtrlBackground(
 }
 
 int wxRibbonAUIArtProvider::GetTabCtrlHeight(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* WXUNUSED(wnd),
                         const wxRibbonPageTabInfoArray& pages)
 {
@@ -520,7 +520,7 @@ void wxRibbonAUIArtProvider::DrawTab(wxDC& dc,
 }
 
 void wxRibbonAUIArtProvider::GetBarTabWidth(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* WXUNUSED(wnd),
                         const wxString& label,
                         const wxBitmap& bitmap,
@@ -592,7 +592,7 @@ void wxRibbonAUIArtProvider::DrawPageBackground(
 }
 
 wxSize wxRibbonAUIArtProvider::GetScrollButtonMinimumSize(
-                        wxDC& WXUNUSED(dc),
+                        wxReadOnlyDC& WXUNUSED(dc),
                         wxWindow* WXUNUSED(wnd),
                         long WXUNUSED(style))
 {
@@ -670,7 +670,7 @@ void wxRibbonAUIArtProvider::DrawScrollButton(
 }
 
 wxSize wxRibbonAUIArtProvider::GetPanelSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize client_size,
                         wxPoint* client_offset)
@@ -694,7 +694,7 @@ wxSize wxRibbonAUIArtProvider::GetPanelSize(
 }
 
 wxSize wxRibbonAUIArtProvider::GetPanelClientSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
                         wxPoint* client_offset)
@@ -719,7 +719,7 @@ wxSize wxRibbonAUIArtProvider::GetPanelClientSize(
     return size;
 }
 
-wxRect wxRibbonAUIArtProvider::GetPanelExtButtonArea(wxDC& dc,
+wxRect wxRibbonAUIArtProvider::GetPanelExtButtonArea(wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxRect rect)
 {

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -1991,7 +1991,7 @@ void wxRibbonMSWArtProvider::DrawPanelBackground(
         DrawPanelBorder(dc, true_rect, m_panel_hover_border_pen, m_panel_hover_border_gradient_pen);
 }
 
-wxRect wxRibbonMSWArtProvider::GetPanelExtButtonArea(wxDC& WXUNUSED(dc),
+wxRect wxRibbonMSWArtProvider::GetPanelExtButtonArea(wxReadOnlyDC& WXUNUSED(dc),
                         const wxRibbonPanel* WXUNUSED(wnd),
                         wxRect rect)
 {
@@ -2871,7 +2871,7 @@ void wxRibbonMSWArtProvider::DrawHelpButton(wxDC& dc,
 }
 
 void wxRibbonMSWArtProvider::GetBarTabWidth(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* WXUNUSED(wnd),
                         const wxString& label,
                         const wxBitmap& bitmap,
@@ -2919,7 +2919,7 @@ void wxRibbonMSWArtProvider::GetBarTabWidth(
 }
 
 int wxRibbonMSWArtProvider::GetTabCtrlHeight(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* WXUNUSED(wnd),
                         const wxRibbonPageTabInfoArray& pages)
 {
@@ -2955,7 +2955,7 @@ int wxRibbonMSWArtProvider::GetTabCtrlHeight(
 }
 
 wxSize wxRibbonMSWArtProvider::GetScrollButtonMinimumSize(
-                        wxDC& WXUNUSED(dc),
+                        wxReadOnlyDC& WXUNUSED(dc),
                         wxWindow* WXUNUSED(wnd),
                         long WXUNUSED(style))
 {
@@ -2963,7 +2963,7 @@ wxSize wxRibbonMSWArtProvider::GetScrollButtonMinimumSize(
 }
 
 wxSize wxRibbonMSWArtProvider::GetPanelSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize client_size,
                         wxPoint* client_offset)
@@ -2989,7 +2989,7 @@ wxSize wxRibbonMSWArtProvider::GetPanelSize(
 }
 
 wxSize wxRibbonMSWArtProvider::GetPanelClientSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize size,
                         wxPoint* client_offset)
@@ -3017,7 +3017,7 @@ wxSize wxRibbonMSWArtProvider::GetPanelClientSize(
 }
 
 wxSize wxRibbonMSWArtProvider::GetGallerySize(
-                        wxDC& WXUNUSED(dc),
+                        wxReadOnlyDC& WXUNUSED(dc),
                         const wxRibbonGallery* WXUNUSED(wnd),
                         wxSize client_size)
 {
@@ -3030,7 +3030,7 @@ wxSize wxRibbonMSWArtProvider::GetGallerySize(
 }
 
 wxSize wxRibbonMSWArtProvider::GetGalleryClientSize(
-                        wxDC& WXUNUSED(dc),
+                        wxReadOnlyDC& WXUNUSED(dc),
                         const wxRibbonGallery* WXUNUSED(wnd),
                         wxSize size,
                         wxPoint* client_offset,
@@ -3091,7 +3091,7 @@ wxSize wxRibbonMSWArtProvider::GetGalleryClientSize(
 }
 
 wxRect wxRibbonMSWArtProvider::GetPageBackgroundRedrawArea(
-                        wxDC& WXUNUSED(dc),
+                        wxReadOnlyDC& WXUNUSED(dc),
                         const wxRibbonPage* WXUNUSED(wnd),
                         wxSize page_old_size,
                         wxSize page_new_size)
@@ -3135,7 +3135,7 @@ wxRect wxRibbonMSWArtProvider::GetPageBackgroundRedrawArea(
 }
 
 bool wxRibbonMSWArtProvider::GetButtonBarButtonSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         wxWindow* wnd,
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
@@ -3261,7 +3261,7 @@ bool wxRibbonMSWArtProvider::GetButtonBarButtonSize(
 }
 
 wxCoord wxRibbonMSWArtProvider::GetButtonBarButtonTextWidth(
-                        wxDC& dc, const wxString& label,
+                        wxReadOnlyDC& dc, const wxString& label,
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size)
 {
@@ -3302,7 +3302,7 @@ wxCoord wxRibbonMSWArtProvider::GetButtonBarButtonTextWidth(
 }
 
 wxSize wxRibbonMSWArtProvider::GetMinimisedPanelMinimumSize(
-                        wxDC& dc,
+                        wxReadOnlyDC& dc,
                         const wxRibbonPanel* wnd,
                         wxSize* desired_bitmap_size,
                         wxDirection* expanded_panel_direction)
@@ -3341,7 +3341,7 @@ wxSize wxRibbonMSWArtProvider::GetMinimisedPanelMinimumSize(
 }
 
 wxSize wxRibbonMSWArtProvider::GetToolSize(
-                        wxDC& WXUNUSED(dc),
+                        wxReadOnlyDC& WXUNUSED(dc),
                         wxWindow* WXUNUSED(wnd),
                         wxSize bitmap_size,
                         wxRibbonButtonKind kind,

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -67,7 +67,7 @@ void wxRibbonBar::AddPage(wxRibbonPage *page)
     info.shown = true;
     // info.rect not set (intentional)
 
-    wxClientDC dcTemp(this);
+    wxInfoDC dcTemp(this);
     wxString label;
     if(m_flags & wxRIBBON_BAR_SHOW_PAGE_LABELS)
         label = page->GetLabel();
@@ -153,7 +153,7 @@ bool wxRibbonBar::Realize()
 {
     bool status = true;
 
-    wxClientDC dcTemp(this);
+    wxInfoDC dcTemp(this);
     int sep = m_art->GetMetric(wxRIBBON_ART_TAB_SEPARATION_SIZE);
     size_t numtabs = m_pages.GetCount();
     bool firstVisible = true;
@@ -561,7 +561,7 @@ void wxRibbonBar::RecalculateTabSizes()
             m_tab_scroll_buttons_shown = true;
         }
         {
-            wxClientDC temp_dc(this);
+            wxInfoDC temp_dc(this);
             int right_button_pos = GetClientSize().GetWidth() - m_tab_margin_right - m_tab_scroll_right_button_rect.GetWidth();
             if ( right_button_pos < m_tab_margin_left )
                 right_button_pos = m_tab_margin_left;
@@ -1143,7 +1143,7 @@ void wxRibbonBar::ScrollTabBar(int amount)
     if(show_right != (m_tab_scroll_right_button_rect.GetWidth() != 0) ||
         show_left != (m_tab_scroll_left_button_rect.GetWidth() != 0))
     {
-        wxClientDC temp_dc(this);
+        wxInfoDC temp_dc(this);
         if(show_left)
         {
             m_tab_scroll_left_button_rect.SetWidth(m_art->GetScrollButtonMinimumSize(temp_dc, this, wxRIBBON_SCROLL_BTN_LEFT | wxRIBBON_SCROLL_BTN_NORMAL | wxRIBBON_SCROLL_BTN_FOR_TABS).GetWidth());

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -439,7 +439,7 @@ wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
     base->min_size_class = wxRIBBON_BUTTONBAR_BUTTON_SMALL;
     base->max_size_class = wxRIBBON_BUTTONBAR_BUTTON_LARGE;
 
-    wxClientDC temp_dc(this);
+    wxInfoDC temp_dc(this);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
@@ -531,7 +531,7 @@ wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertHybridButton(
 }
 
 void wxRibbonButtonBar::FetchButtonSizeInfo(wxRibbonButtonBarButtonBase* button,
-        wxRibbonButtonBarButtonState size, wxDC& dc)
+        wxRibbonButtonBarButtonState size, wxReadOnlyDC& dc)
 {
     wxRibbonButtonBarButtonSizeInfo& info = button->sizes[size];
     if(m_art)
@@ -680,7 +680,7 @@ void wxRibbonButtonBar::SetButtonText(int button_id, const wxString& label)
         return;
     base->label = label;
 
-    wxClientDC temp_dc(this);
+    wxInfoDC temp_dc(this);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
@@ -697,7 +697,7 @@ void wxRibbonButtonBar::SetButtonTextMinWidth(int button_id,
     base->text_min_width[0] = 0;
     base->text_min_width[1] = min_width_medium;
     base->text_min_width[2] = min_width_large;
-    wxClientDC temp_dc(this);
+    wxInfoDC temp_dc(this);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, temp_dc);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_LARGE, temp_dc);
@@ -710,7 +710,7 @@ void wxRibbonButtonBar::SetButtonTextMinWidth(
     wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
     if(base == nullptr)
         return;
-    wxClientDC temp_dc(this);
+    wxInfoDC temp_dc(this);
     base->text_min_width[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM] =
         m_art->GetButtonBarButtonTextWidth(
         temp_dc, label, base->kind, wxRIBBON_BUTTONBAR_BUTTON_MEDIUM);
@@ -770,7 +770,7 @@ void wxRibbonButtonBar::SetArtProvider(wxRibbonArtProvider* art)
     if (!art)
         return;
 
-    wxClientDC temp_dc(this);
+    wxInfoDC temp_dc(this);
     size_t btn_count = m_buttons.Count();
     size_t btn_i;
     for(btn_i = 0; btn_i < btn_count; ++btn_i)

--- a/src/ribbon/panel.cpp
+++ b/src/ribbon/panel.cpp
@@ -352,7 +352,7 @@ wxSize wxRibbonPanel::GetBestSizeForParentSize(const wxSize& parentSize) const
         wxRibbonControl* control = wxDynamicCast(win, wxRibbonControl);
         if (control)
         {
-            wxClientDC temp_dc(const_cast<wxRibbonPanel*>(this));
+            wxInfoDC temp_dc(const_cast<wxRibbonPanel*>(this));
             wxSize clientParentSize = m_art->GetPanelClientSize(temp_dc, this, parentSize, nullptr);
             wxSize childSize = control->GetBestSizeForParentSize(clientParentSize);
             wxSize overallSize = m_art->GetPanelSize(temp_dc, this, childSize, nullptr);
@@ -374,7 +374,7 @@ wxSize wxRibbonPanel::DoGetNextSmallerSize(wxOrientation direction,
 
     if(m_art != nullptr)
     {
-        wxClientDC dc(const_cast<wxRibbonPanel*>(this));
+        wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
         wxSize child_relative = m_art->GetPanelClientSize(dc, this, relative_to, nullptr);
         wxSize smaller(-1, -1);
         bool minimise = false;
@@ -495,7 +495,7 @@ wxSize wxRibbonPanel::DoGetNextLargerSize(wxOrientation direction,
 
     if(m_art != nullptr)
     {
-        wxClientDC dc(const_cast<wxRibbonPanel*>(this));
+        wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
         wxSize child_relative = m_art->GetPanelClientSize(dc, this, relative_to, nullptr);
         wxSize larger(-1, -1);
 
@@ -595,14 +595,14 @@ wxSize wxRibbonPanel::GetMinNotMinimisedSize() const
     // Ask sizer if present
     if(GetSizer())
     {
-        wxClientDC dc(const_cast<wxRibbonPanel*>(this));
+        wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
         return m_art->GetPanelSize(dc, this, GetPanelSizerMinSize(), nullptr);
     }
     else if(GetChildren().GetCount() == 1)
     {
         // Common case of single child taking up the entire panel
         wxWindow* child = GetChildren().Item(0)->GetData();
-        wxClientDC dc(const_cast<wxRibbonPanel*>(this));
+        wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
         return m_art->GetPanelSize(dc, this, child->GetMinSize(), nullptr);
     }
 
@@ -623,7 +623,7 @@ wxSize wxRibbonPanel::GetPanelSizerMinSize() const
          return GetSizer()->CalcMin();
     }
     // else use previously calculated m_smallest_unminimised_size
-    wxClientDC dc(const_cast<wxRibbonPanel*>(this));
+    wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
     return m_art->GetPanelClientSize(dc,
                                     this,
                                     m_smallest_unminimised_size,
@@ -644,14 +644,14 @@ wxSize wxRibbonPanel::DoGetBestSize() const
     // Ask sizer if present
     if( GetSizer())
     {
-        wxClientDC dc(const_cast<wxRibbonPanel*>(this));
+        wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
         return m_art->GetPanelSize(dc, this, GetPanelSizerBestSize(), nullptr);
     }
     else if(GetChildren().GetCount() == 1)
     {
         // Common case of no sizer and single child taking up the entire panel
         wxWindow* child = GetChildren().Item(0)->GetData();
-        wxClientDC dc(const_cast<wxRibbonPanel*>(this));
+        wxInfoDC dc(const_cast<wxRibbonPanel*>(this));
         return m_art->GetPanelSize(dc, this, child->GetBestSize(), nullptr);
     }
 
@@ -695,7 +695,7 @@ bool wxRibbonPanel::Realize()
 
     if(m_art != nullptr)
     {
-        wxClientDC temp_dc(this);
+        wxInfoDC temp_dc(this);
 
         m_smallest_unminimised_size =
             m_art->GetPanelSize(temp_dc, this, minimum_children_size, nullptr);
@@ -757,7 +757,7 @@ bool wxRibbonPanel::Layout()
 
     // Get wxRibbonPanel client size
     wxPoint position;
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     wxSize size = m_art->GetPanelClientSize(dc, this, GetSize(), &position);
 
     // If there is a sizer, use it

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -105,7 +105,7 @@ public:
     void Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style);
 
     // HitTest the floats
-    int HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags);
+    int HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags);
 
     // Get floating object count
     int GetFloatingObjectCount() const { return m_left.GetCount() + m_right.GetCount(); }
@@ -129,7 +129,7 @@ public:
 
     static void DrawFloat(const wxRichTextFloatRectMapArray& array, wxDC& dc, wxRichTextDrawingContext& context, const wxRichTextRange& range, const wxRichTextSelection& selection, const wxRect& rect, int descent, int style);
 
-    static int HitTestFloat(const wxRichTextFloatRectMapArray& array, wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags);
+    static int HitTestFloat(const wxRichTextFloatRectMapArray& array, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags);
 
 private:
     wxRichTextFloatRectMapArray m_left;
@@ -434,7 +434,7 @@ void wxRichTextFloatCollector::Draw(wxDC& dc, wxRichTextDrawingContext& context,
         DrawFloat(m_right, dc, context, range, selection, rect, descent, style);
 }
 
-int wxRichTextFloatCollector::HitTestFloat(const wxRichTextFloatRectMapArray& array, wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int WXUNUSED(flags))
+int wxRichTextFloatCollector::HitTestFloat(const wxRichTextFloatRectMapArray& array, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int WXUNUSED(flags))
 {
     int i;
     if (array.GetCount() == 0)
@@ -471,7 +471,7 @@ int wxRichTextFloatCollector::HitTestFloat(const wxRichTextFloatRectMapArray& ar
     return wxRICHTEXT_HITTEST_NONE;
 }
 
-int wxRichTextFloatCollector::HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
+int wxRichTextFloatCollector::HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
 {
     int ret = HitTestFloat(m_left, dc, context, pt, textPosition, obj, contextObj, flags);
     if (ret == wxRICHTEXT_HITTEST_NONE)
@@ -482,7 +482,7 @@ int wxRichTextFloatCollector::HitTest(wxDC& dc, wxRichTextDrawingContext& contex
 }
 
 // Helpers for efficiency
-inline void wxCheckSetFont(wxDC& dc, const wxFont& font)
+inline void wxCheckSetFont(wxReadOnlyDC& dc, const wxFont& font)
 {
     dc.SetFont(font);
 }
@@ -603,7 +603,7 @@ int wxRichTextObject::GetBottomMargin() const
 
 // Calculate the available content space in the given rectangle, given the
 // margins, border and padding specified in the object's attributes.
-wxRect wxRichTextObject::GetAvailableContentArea(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& outerRect) const
+wxRect wxRichTextObject::GetAvailableContentArea(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& outerRect) const
 {
     wxRect marginRect, borderRect, contentRect, paddingRect, outlineRect;
     marginRect = outerRect;
@@ -629,7 +629,7 @@ void wxRichTextObject::Invalidate(const wxRichTextRange& invalidRange)
 }
 
 // Convert units in tenths of a millimetre to device units
-int wxRichTextObject::ConvertTenthsMMToPixels(wxDC& dc, int units) const
+int wxRichTextObject::ConvertTenthsMMToPixels(wxReadOnlyDC& dc, int units) const
 {
     // Unscale
     double scale = 1.0;
@@ -659,7 +659,7 @@ int wxRichTextObject::ConvertTenthsMMToPixels(int ppi, int units, double scale)
 }
 
 // Convert units in pixels to tenths of a millimetre
-int wxRichTextObject::ConvertPixelsToTenthsMM(wxDC& dc, int pixels) const
+int wxRichTextObject::ConvertPixelsToTenthsMM(wxReadOnlyDC& dc, int pixels) const
 {
     int p = pixels;
     double scale = 1.0;
@@ -1043,7 +1043,7 @@ bool wxRichTextObject::DrawBorder(wxDC& dc, wxRichTextBuffer* buffer, const wxRi
 //
 // | Margin | Border | Padding | CONTENT | Padding | Border | Margin |
 
-bool wxRichTextObject::GetBoxRects(wxDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& attr, wxRect& marginRect, wxRect& borderRect, wxRect& contentRect, wxRect& paddingRect, wxRect& outlineRect)
+bool wxRichTextObject::GetBoxRects(wxReadOnlyDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& attr, wxRect& marginRect, wxRect& borderRect, wxRect& contentRect, wxRect& paddingRect, wxRect& outlineRect)
 {
     int borderLeft = 0, borderRight = 0, borderTop = 0, borderBottom = 0;
     int outlineLeft = 0, outlineRight = 0, outlineTop = 0, outlineBottom = 0;
@@ -1128,7 +1128,7 @@ bool wxRichTextObject::GetBoxRects(wxDC& dc, wxRichTextBuffer* buffer, const wxR
 }
 
 // Get the total margin for the object in pixels, taking into account margin, padding and border size
-bool wxRichTextObject::GetTotalMargin(wxDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& attr, int& leftMargin, int& rightMargin,
+bool wxRichTextObject::GetTotalMargin(wxReadOnlyDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& attr, int& leftMargin, int& rightMargin,
         int& topMargin, int& bottomMargin)
 {
     // Assume boxRect is the area around the content
@@ -1149,7 +1149,7 @@ bool wxRichTextObject::GetTotalMargin(wxDC& dc, wxRichTextBuffer* buffer, const 
 // child attribute, e.g. 50% width of the parent, 400 pixels, x position 20% of the parent, etc.
 // availableContainerSpace might be a parent that the cell has to compute its width relative to.
 // E.g. a cell that's 50% of its parent.
-wxRect wxRichTextObject::AdjustAvailableSpace(wxDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& WXUNUSED(parentAttr), const wxRichTextAttr& childAttr, const wxRect& availableParentSpace, const wxRect& availableContainerSpace)
+wxRect wxRichTextObject::AdjustAvailableSpace(wxReadOnlyDC& dc, wxRichTextBuffer* buffer, const wxRichTextAttr& WXUNUSED(parentAttr), const wxRichTextAttr& childAttr, const wxRect& availableParentSpace, const wxRect& availableContainerSpace)
 {
     wxRect rect = availableParentSpace;
     double scale = 1.0;
@@ -1232,7 +1232,7 @@ wxPoint wxRichTextObject::GetAbsolutePosition() const
 
 // Hit-testing: returns a flag indicating hit test details, plus
 // information about position
-int wxRichTextObject::HitTest(wxDC& WXUNUSED(dc), wxRichTextDrawingContext& WXUNUSED(context), const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int WXUNUSED(flags))
+int wxRichTextObject::HitTest(wxReadOnlyDC& WXUNUSED(dc), wxRichTextDrawingContext& WXUNUSED(context), const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int WXUNUSED(flags))
 {
     if (!IsShown())
         return wxRICHTEXT_HITTEST_NONE;
@@ -1252,7 +1252,7 @@ int wxRichTextObject::HitTest(wxDC& WXUNUSED(dc), wxRichTextDrawingContext& WXUN
 
 // Lays out the object first with a given amount of space, and then if no width was specified in attr,
 // lays out the object again using the maximum ('best') size
-bool wxRichTextObject::LayoutToBestSize(wxDC& dc, wxRichTextDrawingContext& context, wxRichTextBuffer* buffer,
+bool wxRichTextObject::LayoutToBestSize(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, wxRichTextBuffer* buffer,
     const wxRichTextAttr& parentAttr, const wxRichTextAttr& attr,
     const wxRect& availableParentSpace, const wxRect& availableContainerSpace,
     int style)
@@ -1446,7 +1446,7 @@ void wxRichTextCompositeObject::Copy(const wxRichTextCompositeObject& obj)
 
 /// Hit-testing: returns a flag indicating hit test details, plus
 /// information about position
-int wxRichTextCompositeObject::HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
+int wxRichTextCompositeObject::HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
 {
     if (!IsShown())
         return wxRICHTEXT_HITTEST_NONE;
@@ -1477,7 +1477,7 @@ int wxRichTextCompositeObject::HitTest(wxDC& dc, wxRichTextDrawingContext& conte
 }
 
 /// Finds the absolute position and row height for the given character position
-bool wxRichTextCompositeObject::FindPosition(wxDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart)
+bool wxRichTextCompositeObject::FindPosition(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart)
 {
     wxRichTextObjectList::compatibility_iterator node = m_children.GetFirst();
     while (node)
@@ -1768,7 +1768,7 @@ void wxRichTextCompositeObject::Dump(wxTextOutputStream& stream)
 
 /// Get/set the object size for the given range. Returns false if the range
 /// is invalid for this object.
-bool wxRichTextCompositeObject::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
+bool wxRichTextCompositeObject::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
 {
     if (!range.IsWithin(GetRange()))
         return false;
@@ -2034,7 +2034,7 @@ void wxRichTextParagraphLayoutBox::UpdateRanges()
 }
 
 // HitTest
-int wxRichTextParagraphLayoutBox::HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
+int wxRichTextParagraphLayoutBox::HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
 {
     if (!IsShown())
         return wxRICHTEXT_HITTEST_NONE;
@@ -2136,7 +2136,7 @@ bool wxRichTextParagraphLayoutBox::Draw(wxDC& dc, wxRichTextDrawingContext& cont
 }
 
 /// Lay the item out
-bool wxRichTextParagraphLayoutBox::Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style)
+bool wxRichTextParagraphLayoutBox::Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style)
 {
     context.SetLayingOut(true);
 
@@ -2493,7 +2493,7 @@ bool wxRichTextParagraphLayoutBox::Layout(wxDC& dc, wxRichTextDrawingContext& co
 }
 
 /// Get/set the size for the given range.
-bool wxRichTextParagraphLayoutBox::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* WXUNUSED(partialExtents)) const
+bool wxRichTextParagraphLayoutBox::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* WXUNUSED(partialExtents)) const
 {
     wxSize sz;
 
@@ -4975,7 +4975,7 @@ static int wxRichTextGetRangeWidth(const wxRichTextParagraph& para, const wxRich
 }
 
 /// Lay the item out
-bool wxRichTextParagraph::Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style)
+bool wxRichTextParagraph::Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style)
 {
     // Deal with floating objects firstly before the normal layout
     wxRichTextBuffer* buffer = GetBuffer();
@@ -5578,7 +5578,7 @@ bool wxRichTextParagraph::Layout(wxDC& dc, wxRichTextDrawingContext& context, co
 
 /// Apply paragraph styles, such as centering, to wrapped lines
 /// TODO: take into account box attributes, possibly
-void wxRichTextParagraph::ApplyParagraphStyle(wxRichTextLine* line, const wxRichTextAttr& attr, const wxRect& rect, wxDC& WXUNUSED(dc))
+void wxRichTextParagraph::ApplyParagraphStyle(wxRichTextLine* line, const wxRichTextAttr& attr, const wxRect& rect, wxReadOnlyDC& WXUNUSED(dc))
 {
     if (!attr.HasAlignment())
         return;
@@ -5703,7 +5703,7 @@ void wxRichTextParagraph::ClearLines()
 
 /// Get/set the object size for the given range. Returns false if the range
 /// is invalid for this object.
-bool wxRichTextParagraph::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
+bool wxRichTextParagraph::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
 {
     if (!range.IsWithin(GetRange()))
         return false;
@@ -5940,7 +5940,7 @@ bool wxRichTextParagraph::GetRangeSize(const wxRichTextRange& range, wxSize& siz
 }
 
 /// Finds the absolute position and row height for the given character position
-bool wxRichTextParagraph::FindPosition(wxDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart)
+bool wxRichTextParagraph::FindPosition(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart)
 {
     if (index == -1)
     {
@@ -6037,7 +6037,7 @@ bool wxRichTextParagraph::FindPosition(wxDC& dc, wxRichTextDrawingContext& conte
 
 /// Hit-testing: returns a flag indicating hit test details, plus
 /// information about position
-int wxRichTextParagraph::HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
+int wxRichTextParagraph::HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
 {
     if (!IsShown())
         return wxRICHTEXT_HITTEST_NONE;
@@ -6353,7 +6353,7 @@ bool wxRichTextParagraph::GetContiguousPlainText(wxString& text, const wxRichTex
 }
 
 /// Find a suitable wrap position.
-bool wxRichTextParagraph::FindWrapPosition(const wxRichTextRange& range, wxDC& dc, wxRichTextDrawingContext& context, int availableSpace, long& wrapPosition, wxArrayInt* partialExtents)
+bool wxRichTextParagraph::FindWrapPosition(const wxRichTextRange& range, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int availableSpace, long& wrapPosition, wxArrayInt* partialExtents)
 {
     if (range.GetLength() <= 0)
         return false;
@@ -6632,7 +6632,7 @@ void wxRichTextParagraph::ClearDefaultTabs()
     sm_defaultTabs.Clear();
 }
 
-void wxRichTextParagraph::LayoutFloat(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style, wxRichTextFloatCollector* floatCollector)
+void wxRichTextParagraph::LayoutFloat(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style, wxRichTextFloatCollector* floatCollector)
 {
     wxTextAttrDimensionConverter converter(dc, GetBuffer() ? GetBuffer()->GetScale() : 1.0, parentRect.GetSize());
 
@@ -7165,7 +7165,7 @@ bool wxRichTextPlainText::DrawTabbedString(wxDC& dc, const wxRichTextAttr& attr,
 }
 
 /// Lay the item out
-bool wxRichTextPlainText::Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& WXUNUSED(rect), const wxRect& WXUNUSED(parentRect), int WXUNUSED(style))
+bool wxRichTextPlainText::Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& WXUNUSED(rect), const wxRect& WXUNUSED(parentRect), int WXUNUSED(style))
 {
     // Only lay out if we haven't already cached the size
     if (m_size.x == -1)
@@ -7203,7 +7203,7 @@ void wxRichTextPlainText::Copy(const wxRichTextPlainText& obj)
 
 /// Get/set the object size for the given range. Returns false if the range
 /// is invalid for this object.
-bool wxRichTextPlainText::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int WXUNUSED(flags), const wxPoint& position, const wxSize& WXUNUSED(parentSize), wxArrayInt* partialExtents) const
+bool wxRichTextPlainText::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int WXUNUSED(flags), const wxPoint& position, const wxSize& WXUNUSED(parentSize), wxArrayInt* partialExtents) const
 {
     if (!range.IsWithin(GetRange()))
         return false;
@@ -9132,7 +9132,7 @@ void wxRichTextBuffer::SetRenderer(wxRichTextRenderer* renderer)
 
 /// Hit-testing: returns a flag indicating hit test details, plus
 /// information about position
-int wxRichTextBuffer::HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
+int wxRichTextBuffer::HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
 {
     int ret = wxRichTextParagraphLayoutBox::HitTest(dc, context, pt, textPosition, obj, contextObj, flags);
     if (ret != wxRICHTEXT_HITTEST_NONE)
@@ -9271,7 +9271,7 @@ bool wxRichTextStdRenderer::DrawTextBullet(wxRichTextParagraph* paragraph, wxDC&
         return false;
 }
 
-void wxRichTextStdRenderer::SetFontForBullet(wxRichTextBuffer& buffer, wxDC& dc, const wxRichTextAttr& attr)
+void wxRichTextStdRenderer::SetFontForBullet(wxRichTextBuffer& buffer, wxReadOnlyDC& dc, const wxRichTextAttr& attr)
 {
     wxFont font;
     if ((attr.GetBulletStyle() & wxTEXT_ATTR_BULLET_STYLE_SYMBOL) && !attr.GetBulletFont().IsEmpty() && attr.HasFont())
@@ -9338,7 +9338,7 @@ bool wxRichTextStdRenderer::DrawBitmapBullet(wxRichTextParagraph* WXUNUSED(parag
 }
 
 // Measure the bullet.
-bool wxRichTextStdRenderer::MeasureBullet(wxRichTextParagraph* paragraph, wxDC& dc, const wxRichTextAttr& attr, wxSize& sz)
+bool wxRichTextStdRenderer::MeasureBullet(wxRichTextParagraph* paragraph, wxReadOnlyDC& dc, const wxRichTextAttr& attr, wxSize& sz)
 {
     SetFontForBullet(*(paragraph->GetBuffer()), dc, attr);
 
@@ -9465,7 +9465,7 @@ bool wxRichTextField::Draw(wxDC& dc, wxRichTextDrawingContext& context, const wx
     return defaultFieldType.Draw(this, dc, context, range, selection, rect, descent, style);
 }
 
-bool wxRichTextField::Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style)
+bool wxRichTextField::Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int style)
 {
     wxRichTextFieldType* fieldType = wxRichTextBuffer::FindFieldType(GetFieldType());
     if (fieldType && fieldType->Layout(this, dc, context, rect, parentRect, style))
@@ -9478,7 +9478,7 @@ bool wxRichTextField::Layout(wxDC& dc, wxRichTextDrawingContext& context, const 
     return defaultFieldType.Layout(this, dc, context, rect, parentRect, style);
 }
 
-bool wxRichTextField::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
+bool wxRichTextField::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
 {
     wxRichTextFieldType* fieldType = wxRichTextBuffer::FindFieldType(GetFieldType());
     if (fieldType)
@@ -9713,7 +9713,7 @@ bool wxRichTextFieldTypeStandard::Draw(wxRichTextField* obj, wxDC& dc, wxRichTex
     return true;
 }
 
-bool wxRichTextFieldTypeStandard::Layout(wxRichTextField* obj, wxDC& dc, wxRichTextDrawingContext& context, const wxRect& WXUNUSED(rect), const wxRect& WXUNUSED(parentRect), int style)
+bool wxRichTextFieldTypeStandard::Layout(wxRichTextField* obj, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& WXUNUSED(rect), const wxRect& WXUNUSED(parentRect), int style)
 {
     if (m_displayStyle == wxRICHTEXT_FIELD_STYLE_COMPOSITE)
         return false; // USe default composite layout
@@ -9725,7 +9725,7 @@ bool wxRichTextFieldTypeStandard::Layout(wxRichTextField* obj, wxDC& dc, wxRichT
     return true;
 }
 
-bool wxRichTextFieldTypeStandard::GetRangeSize(wxRichTextField* obj, const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
+bool wxRichTextFieldTypeStandard::GetRangeSize(wxRichTextField* obj, const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
 {
     if (IsTopLevel(obj))
         return obj->wxRichTextParagraphLayoutBox::GetRangeSize(range, size, descent, dc, context, flags, position, parentSize);
@@ -9746,7 +9746,7 @@ bool wxRichTextFieldTypeStandard::GetRangeSize(wxRichTextField* obj, const wxRic
     }
 }
 
-wxSize wxRichTextFieldTypeStandard::GetSize(wxRichTextField* WXUNUSED(obj), wxDC& dc, wxRichTextDrawingContext& WXUNUSED(context), int WXUNUSED(style)) const
+wxSize wxRichTextFieldTypeStandard::GetSize(wxRichTextField* WXUNUSED(obj), wxReadOnlyDC& dc, wxRichTextDrawingContext& WXUNUSED(context), int WXUNUSED(style)) const
 {
     int borderSize = 1;
     int w = 0, h = 0, maxDescent = 0;
@@ -9804,7 +9804,7 @@ bool wxRichTextCell::Draw(wxDC& dc, wxRichTextDrawingContext& context, const wxR
     return wxRichTextBox::Draw(dc, context, range, selection, rect, descent, style);
 }
 
-int wxRichTextCell::HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
+int wxRichTextCell::HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
 {
     int ret = wxRichTextParagraphLayoutBox::HitTest(dc, context, pt, textPosition, obj, contextObj, flags);
     if (ret != wxRICHTEXT_HITTEST_NONE)
@@ -10190,7 +10190,7 @@ int GetRowspanDisplacement(const wxRichTextTable* table, int row, int col, int p
 
     // Helper function for Layout() that expands any cell with rowspan > 1
 static
-void ExpandCellsWithRowspan(const wxRichTextTable* table, int paddingY, int& bottomY, wxDC& dc, wxRichTextDrawingContext& context, const wxRect& availableSpace, int style)
+void ExpandCellsWithRowspan(const wxRichTextTable* table, int paddingY, int& bottomY, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& availableSpace, int style)
 {
     // This is called when the table's cell layout is otherwise complete.
     // For any cell with rowspan > 1, expand downwards into the row(s) below.
@@ -10301,7 +10301,7 @@ void ExpandCellsWithRowspan(const wxRichTextTable* table, int paddingY, int& bot
 // layout to a particular size, or it could be the total space available in the
 // parent. rect is the overall size, so we must subtract margins and padding.
 // to get the actual available space.
-bool wxRichTextTable::Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& WXUNUSED(parentRect), int style)
+bool wxRichTextTable::Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& WXUNUSED(parentRect), int style)
 {
     SetPosition(rect.GetPosition());
 
@@ -10984,7 +10984,7 @@ bool wxRichTextTable::AdjustAttributes(wxRichTextAttr& attr, wxRichTextDrawingCo
 }
 
 // Finds the absolute position and row height for the given character position
-bool wxRichTextTable::FindPosition(wxDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart)
+bool wxRichTextTable::FindPosition(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, long index, wxPoint& pt, int* height, bool forceLineStart)
 {
     wxRichTextCell* child = GetCell(index+1);
     if (child)
@@ -11069,7 +11069,7 @@ void wxRichTextTable::CalculateRange(long start, long& end)
 }
 
 // Gets the range size.
-bool wxRichTextTable::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
+bool wxRichTextTable::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& descent, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int flags, const wxPoint& position, const wxSize& parentSize, wxArrayInt* partialExtents) const
 {
     return wxRichTextBox::GetRangeSize(range, size, descent, dc, context, flags, position, parentSize, partialExtents);
 }
@@ -11297,7 +11297,7 @@ wxPosition wxRichTextTable::GetFocusedCell() const
     return position;
 }
 
-int wxRichTextTable::HitTest(wxDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
+int wxRichTextTable::HitTest(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxPoint& pt, long& textPosition, wxRichTextObject** obj, wxRichTextObject** contextObj, int flags)
 {
     for (int row = 0; row < GetRowCount(); ++row)
     {
@@ -12514,7 +12514,7 @@ void wxRichTextImage::Init()
 }
 
 /// Create a cached image at the required size
-bool wxRichTextImage::LoadImageCache(wxDC& dc, wxRichTextDrawingContext& context, wxSize& retImageSize, bool resetCache, const wxSize& parentSize)
+bool wxRichTextImage::LoadImageCache(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, wxSize& retImageSize, bool resetCache, const wxSize& parentSize)
 {
     if (!m_imageBlock.IsOk())
     {
@@ -12819,7 +12819,7 @@ bool wxRichTextImage::Draw(wxDC& dc, wxRichTextDrawingContext& context, const wx
 }
 
 /// Lay the item out
-bool wxRichTextImage::Layout(wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int WXUNUSED(style))
+bool wxRichTextImage::Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int WXUNUSED(style))
 {
     wxSize imageSize;
     if (!LoadImageCache(dc, context, imageSize, false, parentRect.GetSize()))
@@ -12845,7 +12845,7 @@ bool wxRichTextImage::Layout(wxDC& dc, wxRichTextDrawingContext& context, const 
 
 /// Get/set the object size for the given range. Returns false if the range
 /// is invalid for this object.
-bool wxRichTextImage::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& WXUNUSED(descent), wxDC& dc, wxRichTextDrawingContext& context, int WXUNUSED(flags), const wxPoint& WXUNUSED(position), const wxSize& parentSize, wxArrayInt* partialExtents) const
+bool wxRichTextImage::GetRangeSize(const wxRichTextRange& range, wxSize& size, int& WXUNUSED(descent), wxReadOnlyDC& dc, wxRichTextDrawingContext& context, int WXUNUSED(flags), const wxPoint& WXUNUSED(position), const wxSize& parentSize, wxArrayInt* partialExtents) const
 {
     if (!range.IsWithin(GetRange()))
         return false;
@@ -14343,7 +14343,7 @@ void wxTextAttrDimension::CollectCommonAttributes(const wxTextAttrDimension& att
     }
 }
 
-wxTextAttrDimensionConverter::wxTextAttrDimensionConverter(wxDC& dc, double scale, const wxSize& parentSize)
+wxTextAttrDimensionConverter::wxTextAttrDimensionConverter(wxReadOnlyDC& dc, double scale, const wxSize& parentSize)
     : m_parentSize(parentSize)
 {
     m_ppi = dc.GetPPI().x; m_scale = scale;

--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -605,7 +605,7 @@ void wxRichTextCtrl::OnLeftClick(wxMouseEvent& event)
 {
     SetFocus();
 
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     PrepareDC(dc);
     dc.SetFont(GetFont());
 
@@ -684,7 +684,7 @@ void wxRichTextCtrl::OnLeftUp(wxMouseEvent& event)
             ReleaseMouse();
 
         // See if we clicked on a URL
-        wxClientDC dc(this);
+        wxInfoDC dc(this);
         PrepareDC(dc);
         dc.SetFont(GetFont());
 
@@ -885,7 +885,7 @@ void wxRichTextCtrl::OnMoveMouse(wxMouseEvent& event)
     }
 #endif // wxUSE_DRAG_AND_DROP
 
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     PrepareDC(dc);
     dc.SetFont(GetFont());
 
@@ -1023,7 +1023,7 @@ void wxRichTextCtrl::OnRightClick(wxMouseEvent& event)
 {
     SetFocus();
 
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     PrepareDC(dc);
     dc.SetFont(GetFont());
 
@@ -1073,7 +1073,7 @@ void wxRichTextCtrl::OnLeftDClick(wxMouseEvent& event)
         // Instead, select or deselect the object.
         if (wxRichTextBuffer::GetFloatingLayoutMode())
         {
-            wxClientDC dc(this);
+            wxInfoDC dc(this);
             PrepareDC(dc);
             dc.SetFont(GetFont());
 
@@ -1840,7 +1840,7 @@ bool wxRichTextCtrl::ScrollIntoView(long position, int keyCode)
     int leftMargin, rightMargin, topMargin, bottomMargin;
 
     {
-        wxClientDC dc(this);
+        wxInfoDC dc(this);
         wxRichTextObject::GetTotalMargin(dc, & GetBuffer(), GetBuffer().GetAttributes(), leftMargin, rightMargin,
             topMargin, bottomMargin);
     }
@@ -2113,7 +2113,7 @@ bool wxRichTextCtrl::MoveRight(int noPositions, int flags)
         pt.y += 2;
 
         long newPos = 0;
-        wxClientDC dc(this);
+        wxInfoDC dc(this);
         PrepareDC(dc);
         dc.SetFont(GetFont());
 
@@ -2310,7 +2310,7 @@ bool wxRichTextCtrl::MoveDown(int noLines, int flags)
     }
 
     long newPos = 0;
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     PrepareDC(dc);
     dc.SetFont(GetFont());
 
@@ -3216,7 +3216,7 @@ wxTextCtrlHitTestResult
 wxRichTextCtrl::HitTest(const wxPoint& pt,
                         long * pos) const
 {
-    wxClientDC dc(const_cast<wxRichTextCtrl*>(this));
+    wxInfoDC dc(const_cast<wxRichTextCtrl*>(this));
     const_cast<wxRichTextCtrl*>(this)->PrepareDC(dc);
 
     // Buffer uses logical position (relative to start of buffer)
@@ -3241,7 +3241,7 @@ wxRichTextCtrl::HitTest(const wxPoint& pt,
 wxRichTextParagraphLayoutBox*
 wxRichTextCtrl::FindContainerAtPoint(const wxPoint& pt, long& position, int& hit, wxRichTextObject* hitObj, int flags/* = 0*/)
 {
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     PrepareDC(dc);
     dc.SetFont(GetFont());
 
@@ -3899,7 +3899,7 @@ void wxRichTextCtrl::OnContextMenu(wxContextMenuEvent& event)
 // Returns the number of property commands added.
 int wxRichTextCtrl::PrepareContextMenu(wxMenu* menu, const wxPoint& pt, bool addPropertyCommands)
 {
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     PrepareDC(dc);
     dc.SetFont(GetFont());
 
@@ -4194,7 +4194,7 @@ void wxRichTextCtrl::PositionCaret(wxRichTextParagraphLayoutBox* container)
 /// Get the caret height and position for the given character position
 bool wxRichTextCtrl::GetCaretPositionForIndex(long position, wxRect& rect, wxRichTextParagraphLayoutBox* container)
 {
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     PrepareDC(dc);
     dc.SetUserScale(GetScale(), GetScale());
     dc.SetFont(GetFont());
@@ -4283,7 +4283,7 @@ bool wxRichTextCtrl::LayoutContent(bool onlyVisibleRect)
             availableSpace.SetPosition(GetUnscaledPoint(GetLogicalPoint(wxPoint(0, 0))));
         }
 
-        wxClientDC dc(this);
+        wxInfoDC dc(this);
 
         PrepareDC(dc);
         dc.SetFont(GetFont());
@@ -4307,7 +4307,7 @@ bool wxRichTextCtrl::LayoutContent(bool onlyVisibleRect)
     return true;
 }
 
-void wxRichTextCtrl::DoLayoutBuffer(wxRichTextBuffer& buffer, wxDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int flags)
+void wxRichTextCtrl::DoLayoutBuffer(wxRichTextBuffer& buffer, wxReadOnlyDC& dc, wxRichTextDrawingContext& context, const wxRect& rect, const wxRect& parentRect, int flags)
 {
     buffer.Layout(dc, context, rect, parentRect, flags);
 }
@@ -5269,7 +5269,7 @@ bool wxRichTextCtrl::ProcessDelayedImageLoading(const wxRect& screenRect, wxRich
                             marginRect = imageObj->GetRect(); // outer rectangle, will calculate contentRect
                             if (marginRect.GetSize() != wxDefaultSize)
                             {
-                                wxClientDC dc(this);
+                                wxInfoDC dc(this);
                                 wxRichTextAttr attr(imageObj->GetAttributes());
                                 imageObj->AdjustAttributes(attr, context);
                                 imageObj->GetBoxRects(dc, & GetBuffer(), attr, marginRect, borderRect, contentRect, paddingRect, outlineRect);

--- a/src/richtext/richtextstyles.cpp
+++ b/src/richtext/richtextstyles.cpp
@@ -752,7 +752,7 @@ wxString wxRichTextStyleListBox::CreateHTML(wxRichTextStyleDefinition* def) cons
 
     if (attr.GetLeftIndent() > 0)
     {
-        wxClientDC dc(const_cast<wxRichTextStyleListBox*>(this));
+        wxInfoDC dc(const_cast<wxRichTextStyleListBox*>(this));
 
         str << wxT("<td width=") << wxMin(50, (ConvertTenthsMMToPixels(dc, attr.GetLeftIndent())/2)) << wxT("></td>");
     }
@@ -892,7 +892,7 @@ wxString wxRichTextStyleListBox::CreateHTML(wxRichTextStyleDefinition* def) cons
 }
 
 // Convert units in tends of a millimetre to device units
-int wxRichTextStyleListBox::ConvertTenthsMMToPixels(wxDC& dc, int units) const
+int wxRichTextStyleListBox::ConvertTenthsMMToPixels(wxReadOnlyDC& dc, int units) const
 {
     int ppi = dc.GetPPI().x;
 

--- a/src/univ/anybutton.cpp
+++ b/src/univ/anybutton.cpp
@@ -92,7 +92,7 @@ wxInputHandler *wxAnyButton::GetStdInputHandler(wxInputHandler *handlerDef)
 
 wxSize wxAnyButton::DoGetBestClientSize() const
 {
-    wxClientDC dc(wxConstCast(this, wxAnyButton));
+    wxInfoDC dc(wxConstCast(this, wxAnyButton));
     wxCoord width, height;
     dc.GetMultiLineTextExtent(GetLabel(), &width, &height);
 

--- a/src/univ/checkbox.cpp
+++ b/src/univ/checkbox.cpp
@@ -179,7 +179,7 @@ wxSize wxCheckBox::GetBitmapSize() const
 
 wxSize wxCheckBox::DoGetBestClientSize() const
 {
-    wxClientDC dc(wxConstCast(this, wxCheckBox));
+    wxInfoDC dc(wxConstCast(this, wxCheckBox));
     dc.SetFont(GetFont());
     wxCoord width, height;
     dc.GetMultiLineTextExtent(GetLabel(), &width, &height);

--- a/src/univ/menu.cpp
+++ b/src/univ/menu.cpp
@@ -94,7 +94,7 @@ private:
     void CalcWidth(wxMenuBar *menubar)
     {
         wxSize size;
-        wxClientDC dc(menubar);
+        wxInfoDC dc(menubar);
         dc.SetFont(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
         dc.GetTextExtent(m_label, &size.x, &size.y);
 
@@ -2025,7 +2025,7 @@ wxSize wxMenuBar::DoGetBestClientSize() const
     wxSize size;
     if ( GetMenuCount() > 0 )
     {
-        wxClientDC dc(wxConstCast(this, wxMenuBar));
+        wxInfoDC dc(wxConstCast(this, wxMenuBar));
         dc.SetFont(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
         dc.GetTextExtent(GetMenuLabel(0), &size.x, &size.y);
 

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -2869,9 +2869,9 @@ wxTextCtrlHitTestResult wxTextCtrl::HitTestLine(const wxString& line,
 
     int col;
     wxTextCtrl *self = wxConstCast(this, wxTextCtrl);
-    wxClientDC dc(self);
+    wxInfoDC dc(self);
     dc.SetFont(GetFont());
-    self->DoPrepareDC(dc);
+    self->DoPrepareReadOnlyDC(dc);
 
     wxCoord width;
     dc.GetTextExtent(line, &width, nullptr);
@@ -3474,7 +3474,7 @@ void wxTextCtrl::CalcScrolledPosition(int x, int y, int *xx, int *yy) const
     }
 }
 
-void wxTextCtrl::DoPrepareDC(wxDC& dc)
+void wxTextCtrl::DoPrepareReadOnlyDC(wxReadOnlyDC& dc)
 {
     // for single line controls we only have to deal with SData().m_ofsHorz and it's
     // useless to call base class version as they don't use normal scrolling
@@ -3486,7 +3486,7 @@ void wxTextCtrl::DoPrepareDC(wxDC& dc)
     }
     else
     {
-        wxScrollHelper::DoPrepareDC(dc);
+        wxScrollHelper::DoPrepareReadOnlyDC(dc);
     }
 }
 
@@ -3549,7 +3549,7 @@ wxCoord wxTextCtrl::GetMaxWidth() const
         // OPT: should we remember the widths of all the lines?
 
         wxTextCtrl *self = wxConstCast(this, wxTextCtrl);
-        wxClientDC dc(self);
+        wxInfoDC dc(self);
         dc.SetFont(GetFont());
 
         self->MData().m_widthMax = 0;

--- a/src/univ/themes/gtk.cpp
+++ b/src/univ/themes/gtk.cpp
@@ -1733,7 +1733,7 @@ wxMenuGeometryInfo *wxGTKRenderer::GetMenuGeometry(wxWindow *win,
                                                    const wxMenu& menu) const
 {
     // prepare the dc: for now we draw all the items with the system font
-    wxClientDC dc(win);
+    wxInfoDC dc(win);
     dc.SetFont(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
 
     // the height of a normal item

--- a/src/univ/themes/win32.cpp
+++ b/src/univ/themes/win32.cpp
@@ -2481,7 +2481,7 @@ wxMenuGeometryInfo *wxWin32Renderer::GetMenuGeometry(wxWindow *win,
                                                      const wxMenu& menu) const
 {
     // prepare the dc: for now we draw all the items with the system font
-    wxClientDC dc(win);
+    wxInfoDC dc(win);
     dc.SetFont(wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT));
 
     // the height of a normal item

--- a/src/x11/textctrl.cpp
+++ b/src/x11/textctrl.cpp
@@ -233,7 +233,7 @@ bool wxTextCtrl::Create( wxWindow *parent,
     else
         m_sourceFont = GetFont();
 
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     dc.SetFont( m_sourceFont );
     m_lineHeight = dc.GetCharHeight();
     m_charWidth = dc.GetCharWidth();
@@ -859,7 +859,7 @@ bool wxTextCtrl::SetFont(const wxFont& font)
 
     m_sourceFont = font;
 
-    wxClientDC dc(this);
+    wxInfoDC dc(this);
     dc.SetFont( m_sourceFont );
     m_lineHeight = dc.GetCharHeight();
     m_charWidth = dc.GetCharWidth();


### PR DESCRIPTION
This is incomplete as there is no documentation yet, but most of the changes have been done: there is now a new `wxInfoDC` class (see #12486) which can be used when you only need to get information about the DC and so replaces all "valid" uses of `wxClientDC`, with the remaining ones known to be broken unless explicitly guarded by `wxClientDC::CanBeUsedForDrawing()` as in wxAUI code.

One thing which is not great is that we still have to use `wxClientDC` with `wxDCOverlay`, I'd like to change/improve the API here too, but I don't know how yet.

But for now please let me know if you have any ideas/suggestions/criticisms about `wxInfoDC` itself. The rationale for doing it in this way is in the first commit message.