### PR TITLE
Add `wxOverlayDC`

### DIFF
--- a/include/wx/generic/private/drawresize.h
+++ b/include/wx/generic/private/drawresize.h
@@ -24,9 +24,8 @@ inline wxBitmap wxPaneCreateStippleBitmap()
 inline void
 wxDrawOverlayResizeHint(wxWindow* win, wxOverlay& overlay, const wxRect& rect)
 {
-    wxClientDC dc{win};
-    wxDCOverlay overlaydc(overlay, &dc);
-    overlaydc.Clear();
+    wxOverlayDC dc(overlay, win);
+    dc.Clear();
 
     wxBitmap stipple = wxPaneCreateStippleBitmap();
     wxBrush brush(stipple);

--- a/include/wx/overlay.h
+++ b/include/wx/overlay.h
@@ -12,12 +12,12 @@
 
 #include "wx/defs.h"
 
+#include "wx/dcclient.h"
+
 // ----------------------------------------------------------------------------
 // creates an overlay over an existing window, allowing for manipulations like
 // rubberbanding etc.
 // ----------------------------------------------------------------------------
-
-class WXDLLIMPEXP_FWD_CORE wxDC;
 
 class WXDLLIMPEXP_CORE wxOverlay
 {
@@ -85,6 +85,33 @@ private:
 
 
     wxDECLARE_NO_COPY_CLASS(wxDCOverlay);
+};
+
+// Convenient class combining wxClientDC with wxDCOverlay.
+class wxOverlayDC : public wxClientDC
+{
+public:
+    wxOverlayDC(wxOverlay& overlay, wxWindow* win)
+        : wxClientDC(win),
+          m_dcOverlay(overlay, this)
+    {
+    }
+
+    wxOverlayDC(wxOverlay& overlay, wxWindow* win, const wxRect& rect)
+        : wxClientDC(win),
+          m_dcOverlay(overlay, this, rect.x, rect.y, rect.width, rect.height)
+    {
+    }
+
+    void Clear()
+    {
+        m_dcOverlay.Clear();
+    }
+
+private:
+    wxDCOverlay m_dcOverlay;
+
+    wxDECLARE_NO_COPY_CLASS(wxOverlayDC);
 };
 
 #endif // _WX_OVERLAY_H_

--- a/include/wx/overlay.h
+++ b/include/wx/overlay.h
@@ -14,8 +14,7 @@
 
 // ----------------------------------------------------------------------------
 // creates an overlay over an existing window, allowing for manipulations like
-// rubberbanding etc. This API is not stable yet, not to be used outside wx
-// internal code
+// rubberbanding etc.
 // ----------------------------------------------------------------------------
 
 class WXDLLIMPEXP_FWD_CORE wxDC;

--- a/interface/wx/overlay.h
+++ b/interface/wx/overlay.h
@@ -9,8 +9,20 @@
    @class wxOverlay
 
    Creates an overlay over an existing window, allowing for manipulations like
-   rubberbanding, etc.  On wxOSX the overlay is implemented with native
-   platform APIs, on the other platforms it is simulated using wxMemoryDC.
+   rubber-banding, etc.
+
+   Overlay is implemented internally as a native window shown on top of the
+   window it is used with and it is more efficient to keep the wxOverlay object
+   around instead of recreating it every time it's needed, i.e. typically you
+   would have a member variable of type wxOverlay in your window class.
+
+   The overlay is initialized automatically when it is used but has to be
+   cleared manually, using its Reset() function, when its contents shouldn't be
+   shown any longer.
+
+   Use of this class is shown in the @ref page_samples_drawing where pressing
+   the left mouse button and dragging the mouse creates a rubber band effect
+   using wxOverlay.
 
    @library{wxcore}
 

--- a/interface/wx/overlay.h
+++ b/interface/wx/overlay.h
@@ -16,9 +16,9 @@
    around instead of recreating it every time it's needed, i.e. typically you
    would have a member variable of type wxOverlay in your window class.
 
-   The overlay is initialized automatically when it is used but has to be
-   cleared manually, using its Reset() function, when its contents shouldn't be
-   shown any longer.
+   The overlay is initialized automatically when it is used by wxDCOverlay or
+   wxOverlayDC but has to be cleared manually, using its Reset() function, when
+   its contents shouldn't be shown any longer.
 
    Use of this class is shown in the @ref page_samples_drawing where pressing
    the left mouse button and dragging the mouse creates a rubber band effect
@@ -26,7 +26,7 @@
 
    @library{wxcore}
 
-   @see wxDCOverlay, wxDC
+   @see wxDCOverlay, wxOverlayDC
  */
 class wxOverlay
 {
@@ -67,9 +67,12 @@ public:
 
    Connects an overlay with a drawing DC.
 
+   Note that when using wxDCOverlay with wxClientDC, which is the most common
+   case, using wxOverlayDC class is simpler and so is recommended.
+
    @library{wxcore}
 
-   @see wxOverlay, wxDC
+   @see wxOverlay, wxDC, wxOverlayDC
 
  */
 class wxDCOverlay
@@ -95,4 +98,46 @@ public:
        Clears the layer, restoring the state at the last init.
     */
     void Clear();
+};
+
+/**
+   @class wxOverlayDC
+
+   A device context allowing to draw on an overlay associated with a window.
+
+   Assuming `MyWindow` as a wxWindow-derived object with `wxOverlay m_overlay`
+   as a member variable, this class could be used in the following way:
+
+   @code
+   void MyWindow::OnDrawSomethingTemporary()
+   {
+       wxOverlayDC dc(m_overlay, this);
+       dc.Clear(); // Usually required, unless the entire DC is filled.
+
+       // Use wxDC functions as usual.
+       dc.DrawText("Hello, world!", 10, 10);
+   }
+
+   void MyWindow::OnClearTemporaryDrawing()
+   {
+       m_overlay.Reset();
+   }
+   @endcode
+
+   Note that while wxOverlayDC currently actually inherits from wxClientDC,
+   this is an implementation detail and shouldn't be relied upon, it is only
+   guaranteed to derive from wxDC as documented here.
+
+   @library{wxcore}
+
+   @see wxOverlay, wxDCOverlay, wxDC
+
+   @since 3.3.0
+ */
+class wxOverlayDC : public wxDC
+{
+public:
+    wxOverlayDC(wxOverlay& overlay, wxWindow* win);
+
+    wxOverlayDC(wxOverlay& overlay, wxWindow* win, const wxRect& rect);
 };

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -2161,11 +2161,10 @@ void MyCanvas::OnMouseMove(wxMouseEvent &event)
         m_currentpoint = wxPoint( xx , yy ) ;
         wxRect newrect ( m_anchorpoint , m_currentpoint ) ;
 
-        wxClientDC dc( this ) ;
-        PrepareDC( dc ) ;
+        wxOverlayDC dc(m_overlay, this);
+        PrepareDC(dc);
 
-        wxDCOverlay overlaydc( m_overlay, &dc );
-        overlaydc.Clear();
+        dc.Clear();
 #ifdef __WXMAC__
         dc.SetPen( *wxGREY_PEN );
         dc.SetBrush( wxColour( 192,192,192,64 ) );
@@ -2197,10 +2196,9 @@ bool MyCanvas::StopRubberBanding()
         return false;
 
     {
-        wxClientDC dc( this );
-        PrepareDC( dc );
-        wxDCOverlay overlaydc( m_overlay, &dc );
-        overlaydc.Clear();
+        wxOverlayDC dc(m_overlay, this);
+        PrepareDC(dc);
+        dc.Clear();
     }
     m_overlay.Reset();
     m_rubberBand = false;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -2986,9 +2986,8 @@ void wxAuiManager::OnHintFadeTimer(wxTimerEvent& WXUNUSED(event))
 
 void wxAuiManager::ShowHint(const wxRect& rect)
 {
-    wxClientDC dc(m_frame);
-    wxDCOverlay overlaydc(m_overlay, &dc);
-    overlaydc.Clear();
+    wxOverlayDC dc(m_overlay, m_frame);
+    dc.Clear();
 
     wxDCClipper clip(dc, rect);
 

--- a/src/generic/headerctrlg.cpp
+++ b/src/generic/headerctrlg.cpp
@@ -269,10 +269,8 @@ bool wxHeaderCtrl::IsReordering() const
 
 void wxHeaderCtrl::ClearMarkers()
 {
-    wxClientDC dc(this);
-
-    wxDCOverlay dcover(m_overlay, &dc);
-    dcover.Clear();
+    wxOverlayDC dc(m_overlay, this);
+    dc.Clear();
 }
 
 void wxHeaderCtrl::EndDragging()
@@ -372,10 +370,8 @@ void wxHeaderCtrl::EndResizing(int xPhysical)
 
 void wxHeaderCtrl::UpdateReorderingMarker(int xPhysical)
 {
-    wxClientDC dc(this);
-
-    wxDCOverlay dcover(m_overlay, &dc);
-    dcover.Clear();
+    wxOverlayDC dc(m_overlay, this);
+    dc.Clear();
 
     dc.SetPen(*wxBLUE);
     dc.SetBrush(*wxTRANSPARENT_BRUSH);


### PR DESCRIPTION
This simplifies using `wxOverlay` without much loss of generality in practice because we can't use neither `wxWindowDC` nor `wxScreenDC` (which are the only other classes with which `wxDCOverlay` can be used) portably.

Naming is a bit confusing, but I think the real problem is with `wxDCOverlay` (which we can't change) and `wxOverlayDC` looks like a natural name for this one, so I think we should keep it.

Please let me know if I'm missing something here — I might, because if I don't, then I don't understand why hadn't we done it like this a long time ago.

cc @AliKet, @paulcor, @csomor