### PR TITLE
Correct shared library prefix for CYGWIN

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -260,6 +260,8 @@ function(wx_set_target_properties target_name)
     set(lib_prefix "lib")
     if(MSVC OR (WIN32 AND wxBUILD_SHARED))
         set(lib_prefix)
+    elseif (CYGWIN AND wxBUILD_SHARED)
+        set(lib_prefix "cyg")
     endif()
 
     # static (and import) library names


### PR DESCRIPTION
Under CYGWIN, shared libraries using POSIX layer must have "cyg" instead of "lib" as prefix.
For example, correct library name must be `cygwx_baseu-3.2-0.dll` instead of `libwx_baseu-3.2-0.dll`.

EDIT:
The fix has been made only to a CMake script because autotools already generate correct file names for shared libraries.