### PR TITLE
Remove concerning warranty comments from library READMEs

### DIFF
--- a/docs/ios/readme.txt
+++ b/docs/ios/readme.txt
@@ -8,9 +8,10 @@ Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. These can
 be found at https://www.wxwidgets.org/support/mailing-lists/
 
-wxWidgets doesn't come with any guarantee whatsoever. It
-might crash your harddisk or destroy your monitor. It doesn't
-claim to be suitable for any special or general purpose.
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
+General Public Licence for more details.
 
   Regards,
 

--- a/docs/ios/readme.txt
+++ b/docs/ios/readme.txt
@@ -8,11 +8,6 @@ Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. These can
 be found at https://www.wxwidgets.org/support/mailing-lists/
 
-This library is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
-General Public Licence for more details.
-
   Regards,
 
     The wxWidgets Team

--- a/docs/osx/readme.txt
+++ b/docs/osx/readme.txt
@@ -13,11 +13,6 @@ on how to subscribe is available from the wxWidgets.org homepage.
 Questions/Problems related directly to the mac port can be reported
 at https://github.com/wxWidgets/wxWidgets/issues/new.
 
-This library is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
-General Public Licence for more details.
-
 Regards,
 
 Stefan Csomor

--- a/docs/osx/readme.txt
+++ b/docs/osx/readme.txt
@@ -13,9 +13,10 @@ on how to subscribe is available from the wxWidgets.org homepage.
 Questions/Problems related directly to the mac port can be reported
 at https://github.com/wxWidgets/wxWidgets/issues/new.
 
-wxWidgets/Mac doesn't come with any guarantee whatsoever. It
-might crash your harddisk or destroy your monitor. It doesn't
-claim to be suitable for any special or general purpose.
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
+General Public Licence for more details.
 
 Regards,
 

--- a/docs/qt/readme.txt
+++ b/docs/qt/readme.txt
@@ -41,11 +41,6 @@ Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. These can
 be found at https://www.wxwidgets.org/support/mailing-lists/
 
-This library is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
-General Public Licence for more details.
-
   Regards,
 
     The wxWidgets Team

--- a/docs/qt/readme.txt
+++ b/docs/qt/readme.txt
@@ -41,9 +41,10 @@ Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. These can
 be found at https://www.wxwidgets.org/support/mailing-lists/
 
-wxWidgets doesn't come with any guarantee whatsoever. It
-might crash your harddisk or destroy your monitor. It doesn't
-claim to be suitable for any special or general purpose.
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
+General Public Licence for more details.
 
   Regards,
 

--- a/docs/wine/readme.txt
+++ b/docs/wine/readme.txt
@@ -16,9 +16,3 @@ DISTRIBUTION YOU USE AND WHAT ERROR WAS REPORTED.
 Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. Information
 on how to subscribe is available from my homepage.
-
-This library is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
-General Public Licence for more details.
-

--- a/docs/wine/readme.txt
+++ b/docs/wine/readme.txt
@@ -17,7 +17,8 @@ Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. Information
 on how to subscribe is available from my homepage.
 
-wxWidgets/Wine doesn't come with any guarantee whatsoever. It might
-crash your harddisk or destroy your monitor. It doesn't claim to be
-suitable for any special or general purpose.
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
+General Public Licence for more details.
 

--- a/docs/x11/readme.txt
+++ b/docs/x11/readme.txt
@@ -41,11 +41,6 @@ Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. Information
 on how to subscribe is available from www.wxwidgets.org.
 
-This library is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
-General Public Licence for more details.
-
 Status
 ======
 

--- a/docs/x11/readme.txt
+++ b/docs/x11/readme.txt
@@ -41,9 +41,10 @@ Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. Information
 on how to subscribe is available from www.wxwidgets.org.
 
-wxWidgets/X11 doesn't come with any guarantee whatsoever. It might
-crash your hard disk or destroy your monitor. It doesn't claim to be
-suitable for any special or general purpose.
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
+General Public Licence for more details.
 
 Status
 ======


### PR DESCRIPTION
I assume this was meant for humor, but comments about wxWidgets crashing your harddrive or destroying your monitor a bit unprofessional (IMO).