### PR TITLE
Fix macOS and GTK broken links in platform docs

### DIFF
--- a/docs/doxygen/mainpages/platdetails.h
+++ b/docs/doxygen/mainpages/platdetails.h
@@ -132,12 +132,7 @@ In such case (or when you want to e.g. write a port-specific patch) it can be
 necessary to use the underlying toolkit API directly:
 
 - wxMSW port uses Win32 API: see MSDN docs at https://docs.microsoft.com/en-us/windows/win32/controls/window-controls
-- wxGTK port uses GTK and other lower-level libraries; see
-  - GTK docs at https://developer.gnome.org/gtk/
-  - GDK docs at https://library.gnome.org/devel/gdk/
-  - GLib docs at https://library.gnome.org/devel/glib/
-  - GObject docs at https://library.gnome.org/devel/gobject/
-  - Pango docs at https://library.gnome.org/devel/pango/
-- wxOSX port uses the Cocoa API: see Cocoa docs at https://developer.apple.com/cocoa
+- wxGTK port uses GTK and other lower-level libraries; see https://docs.gtk.org/
+- wxOSX port uses the Cocoa API: see Cocoa docs at https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CocoaFundamentals/WhatIsCocoa/WhatIsCocoa.html
 
 */


### PR DESCRIPTION
Cocoa link was broken, replaced with the latest overview topic on Apple developer.

Some GTK links were broken, others were getting redirected. I replaced all of them with the main GTK link, which includes links to everything else like Pango and GDK. This way, only one link needs to be maintained, but still provides everything.