### PR TITLE
grid.h: add missing <memory>

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <unordered_map>
 #include <unordered_set>
+#include <memory>
 
 // ----------------------------------------------------------------------------
 // constants


### PR DESCRIPTION
At least gcc-14 needs this.