### PR TITLE
Always keep narrow command line arguments in wxInitData

### DIFF
--- a/include/wx/private/init.h
+++ b/include/wx/private/init.h
@@ -59,9 +59,11 @@ public:
     wchar_t** argvMSW = nullptr;
 #endif // __WINDOWS__
 
-    // wxMSW traditionally doesn't use narrow command line arguments, but the
-    // other ports do need them, even under Windows, so we keep them here.
-#ifndef __WXMSW__
+    // At least wxGTK needs narrow command line arguments too and even thought
+    // other ports under Windows typically don't need them (e.g. wxMSW itself
+    // doesn't), we have to have them, as this header is toolkit-independent,
+    // and so can't differ between wxMSW and wxGTK.
+
     // Initializes argvA using argc and argv. This means that argc and argv
     // MUST be initialized before calling this function.
     void InitArgvA();
@@ -69,7 +71,6 @@ public:
     // This pointer may or not need to be freed, as indicated by ownsArgvA flag.
     char** argvA = nullptr;
     bool ownsArgvA = false;
-#endif // !__WXMSW__
 
     wxDECLARE_NO_COPY_CLASS(wxInitData);
 };

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -153,9 +153,10 @@ void wxInitData::Initialize(int argcIn, char **argvIn)
 {
     wxASSERT_MSG( !argc && !argv, "initializing twice?" );
 
-#ifndef __WXMSW__
+    // We assume that the command line arguments are static and remain valid
+    // until the end of the program, so we don't make a copy of them here.
     argvA = argvIn;
-#endif
+    ownsArgvA = false;
 
     argv = new wchar_t *[argcIn + 1];
 
@@ -183,8 +184,6 @@ void wxInitData::Initialize(int argcIn, char **argvIn)
     argv[wargc] = nullptr;
 }
 
-#ifndef __WXMSW__
-
 void wxInitData::InitArgvA()
 {
     // We need to convert from wide arguments back to the narrow ones.
@@ -200,8 +199,6 @@ void wxInitData::InitArgvA()
         argvA[i] = wxConvWhateverWorks.cWC2MB(argv[i]).release();
     }
 }
-
-#endif // !__WXMSW__
 
 #ifdef __WINDOWS__
 
@@ -221,9 +218,7 @@ void wxInitData::MSWInitialize()
     // point is used.
     argv = argvMSW;
 
-#ifndef __WXMSW__
     InitArgvA();
-#endif // !__WXMSW__
 }
 
 #endif // __WINDOWS__
@@ -252,9 +247,7 @@ void wxInitData::InitIfNecessary(int argcIn, wchar_t** argvIn)
         argv[i] = wxCRT_StrdupW(argvIn[i]);
     }
 
-#ifndef __WXMSW__
     InitArgvA();
-#endif // !__WXMSW__
 
 #ifdef __WINDOWS__
     // Not used in this case and shouldn't be passed to LocalFree().
@@ -282,7 +275,6 @@ void wxInitData::Free()
 
     if ( argc )
     {
-#ifndef __WXMSW__
         if ( ownsArgvA )
         {
             for ( int i = 0; i < argc; i++ )
@@ -292,7 +284,6 @@ void wxInitData::Free()
 
             wxDELETEA(argvA);
         }
-#endif // !__WXMSW__
 
         argc = 0;
     }


### PR DESCRIPTION
Even if wxMSW doesn't need them, wxGTK can be also used under Windows and it does need them, so always store them in wxInitData as, being a wxBase class, it can't depend on the GUI toolkit.

Closes #24694.