### PR TITLE
Generic DVC: wxDataViewChoiceByIndexRenderer's 'SetValue' and 'Create…

### DIFF
--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1997,7 +1997,7 @@ wxDataViewChoiceByIndexRenderer::wxDataViewChoiceByIndexRenderer( const wxArrayS
 
 wxWindow* wxDataViewChoiceByIndexRenderer::CreateEditorCtrl( wxWindow *parent, wxRect labelRect, const wxVariant &value )
 {
-    wxVariant string_value = GetChoice( value.GetLong() );
+    wxVariant string_value = value.GetLong() == wxNOT_FOUND ? "" : GetChoice( value.GetLong() );
 
     return wxDataViewChoiceRenderer::CreateEditorCtrl( parent, labelRect, string_value );
 }
@@ -2014,7 +2014,7 @@ bool wxDataViewChoiceByIndexRenderer::GetValueFromEditorCtrl( wxWindow* editor, 
 
 bool wxDataViewChoiceByIndexRenderer::SetValue( const wxVariant &value )
 {
-    wxVariant string_value = GetChoice( value.GetLong() );
+    wxVariant string_value = value.GetLong() == wxNOT_FOUND ? "" : GetChoice( value.GetLong() );
     return wxDataViewChoiceRenderer::SetValue( string_value );
 }
 


### PR DESCRIPTION
…EditorCtrl' with wxNOT_FOUND value in arguments fix. Caused segfault, but should be empty wxChoice instead.