### PR TITLE
Do not malloc zero bytes in wxInputStream::AllocSpaceWBack

### DIFF
--- a/src/common/stream.cpp
+++ b/src/common/stream.cpp
@@ -745,6 +745,10 @@ char *wxInputStream::AllocSpaceWBack(size_t needed_size)
     // get number of bytes left from previous wback buffer
     size_t toget = m_wbacksize - m_wbackcur;
 
+    // do not allocate 0 bytes, it is suspicious
+    if (needed_size + toget == 0)
+        return nullptr;
+
     // allocate a buffer large enough to hold prev + new data
     char *temp_b = (char *)malloc(needed_size + toget);
 


### PR DESCRIPTION
Running the tests, specifically TestExecute, under ElectricFence reveals that a malloc(0) call is made in wxInputStream::AllocSpaceWBack.

While legal, allocating zero bytes is unusual. Any memory pointed must not be read or written.

It is likely better to return nullptr in cases when a buffer of zero bytes was requested.