### PR TITLE
Implement maximum length on the multiline text control under GTK

### DIFF
--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -59,7 +59,7 @@ public:
     virtual void GetSelection(long* from, long* to) const override;
 
     virtual void Remove(long from, long to) override;
-
+    virtual void SetMaxLength(unsigned long length) override;
     virtual void MarkDirty() override;
     virtual void DiscardEdits() override;
 
@@ -165,6 +165,7 @@ public:
 
     void GTKOnTextChanged() override;
     void GTKAfterLayout();
+    bool IsMaxLengthAllowed() const { return m_maxLengthAllowed; }
 
 protected:
     // overridden wxWindow virtual methods
@@ -199,7 +200,7 @@ protected:
     void GTKSetActivatesDefault();
     void GTKSetWrapMode();
     void GTKSetJustification();
-
+    
 private:
     void Init();
 
@@ -237,7 +238,7 @@ private:
     // Our text buffer. Convenient, and holds the buffer while using
     // a dummy one when frozen
     GtkTextBuffer *m_buffer;
-
+    bool m_maxLengthAllowed = false;
     GtkTextMark* m_showPositionDefer;
     GSList* m_anonymousMarkList;
     unsigned m_afterLayoutId;

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -200,7 +200,7 @@ protected:
     void GTKSetActivatesDefault();
     void GTKSetWrapMode();
     void GTKSetJustification();
-    
+
 private:
     void Init();
 

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -59,6 +59,7 @@ public:
     virtual void GetSelection(long* from, long* to) const override;
 
     virtual void Remove(long from, long to) override;
+
     virtual void SetMaxLength(unsigned long length) override;
     virtual void MarkDirty() override;
     virtual void DiscardEdits() override;
@@ -238,6 +239,7 @@ private:
     // Our text buffer. Convenient, and holds the buffer while using
     // a dummy one when frozen
     GtkTextBuffer *m_buffer;
+
     bool m_maxLengthAllowed = false;
     GtkTextMark* m_showPositionDefer;
     GSList* m_anonymousMarkList;

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -166,7 +166,6 @@ public:
 
     void GTKOnTextChanged() override;
     void GTKAfterLayout();
-    bool IsMaxLengthAllowed() const { return m_maxLengthAllowed; }
 
 protected:
     // overridden wxWindow virtual methods
@@ -240,7 +239,6 @@ private:
     // a dummy one when frozen
     GtkTextBuffer *m_buffer;
 
-    bool m_maxLengthAllowed = false;
     GtkTextMark* m_showPositionDefer;
     GSList* m_anonymousMarkList;
     unsigned m_afterLayoutId;

--- a/include/wx/gtk/textentry.h
+++ b/include/wx/gtk/textentry.h
@@ -64,6 +64,7 @@ public:
     bool GTKIsUpperCase() const { return m_isUpperCase; }
 
     int GTKGetMaxLength() const { return m_maxlen; }
+
     // Called from "changed" signal handler (or, possibly, slightly later, when
     // coalescing several "changed" signals into a single event) for GtkEntry.
     //

--- a/include/wx/gtk/textentry.h
+++ b/include/wx/gtk/textentry.h
@@ -62,6 +62,7 @@ public:
     void SendMaxLenEvent();
     bool GTKEntryOnInsertText(const char* text);
     bool GTKIsUpperCase() const { return m_isUpperCase; }
+
     int GTKGetMaxLength() const { return m_maxlen; }
     // Called from "changed" signal handler (or, possibly, slightly later, when
     // coalescing several "changed" signals into a single event) for GtkEntry.
@@ -99,6 +100,7 @@ protected:
     // Call this from the overridden wxWindow::GTKIMFilterKeypress() to use
     // GtkEntry IM context.
     int GTKEntryIMFilterKeypress(GdkEventKey* event) const;
+
     int m_maxlen = 0;
     // If GTKEntryIMFilterKeypress() is not called (as multiline wxTextCtrl
     // uses its own IM), call this method instead to still notify wxTextEntry

--- a/include/wx/gtk/textentry.h
+++ b/include/wx/gtk/textentry.h
@@ -62,7 +62,7 @@ public:
     void SendMaxLenEvent();
     bool GTKEntryOnInsertText(const char* text);
     bool GTKIsUpperCase() const { return m_isUpperCase; }
-
+    int GTKGetMaxLength() const { return m_maxlen; }
     // Called from "changed" signal handler (or, possibly, slightly later, when
     // coalescing several "changed" signals into a single event) for GtkEntry.
     //
@@ -99,7 +99,7 @@ protected:
     // Call this from the overridden wxWindow::GTKIMFilterKeypress() to use
     // GtkEntry IM context.
     int GTKEntryIMFilterKeypress(GdkEventKey* event) const;
-
+    int m_maxlen = 0;
     // If GTKEntryIMFilterKeypress() is not called (as multiline wxTextCtrl
     // uses its own IM), call this method instead to still notify wxTextEntry
     // about the key press events in the given widget.

--- a/interface/wx/textentry.h
+++ b/interface/wx/textentry.h
@@ -410,8 +410,6 @@ public:
         event is sent to notify the program about it (giving it the possibility
         to show an explanatory message, for example) and the extra input is discarded.
 
-        @note this function may only be used with single line text controls under wxGTK
-        and wxQt ports.
     */
     virtual void SetMaxLength(unsigned long len);
 
@@ -482,7 +480,7 @@ public:
             @c wxTE_PASSWORD style.
 
         @remarks Hints can be used for single line text controls under all
-            platforms, but only MSW and GTK+ 2 support them for multi-line text
+            platforms, but only MSW and GTK+ support them for multi-line text
             controls, they are ignored for them under the other platforms.
 
         @since 2.9.0

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -140,7 +140,7 @@ public:
     MyTextCtrl    *m_tab;
     MyTextCtrl    *m_readonly;
     MyTextCtrl    *m_limited;
-
+    MyTextCtrl    *m_limitedMultiline;
     MyTextCtrl    *m_multitext;
     MyTextCtrl    *m_horizontal;
 
@@ -1176,6 +1176,9 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_limited->SetMaxLength(8);
     wxSize size2 = m_limited->GetSizeFromTextSize(m_limited->GetTextExtent("WWWWWWWW"));
     m_limited->SetSizeHints(size2, size2);
+    m_limitedMultiline = new MyTextCtrl( this, wxID_ANY, "", wxPoint( 10, 110 ), wxDefaultSize, wxTE_MULTILINE );
+    m_limitedMultiline->SetHint( "Max 20 characters" );
+    m_limitedMultiline->SetMaxLength( 20 );
 
     wxTextCtrl* upperOnly = new MyTextCtrl(this, wxID_ANY, "Only upper case",
                                            wxDefaultPosition, wxDefaultSize);
@@ -1313,6 +1316,7 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     column1->Add( m_password, 0, wxALL | wxEXPAND, 10 );
     column1->Add( m_readonly, 0, wxALL, 10 );
     column1->Add( m_limited, 0, wxALL, 10 );
+    column1->Add( m_limitedMultiline, 0, wxALL, 10 );
     column1->Add( upperOnly, 0, wxALL, 10 );
     column1->Add( m_horizontal, 1, wxALL | wxEXPAND, 10 );
 

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -141,6 +141,7 @@ public:
     MyTextCtrl    *m_readonly;
     MyTextCtrl    *m_limited;
     MyTextCtrl    *m_limitedMultiline;
+
     MyTextCtrl    *m_multitext;
     MyTextCtrl    *m_horizontal;
 

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1568,6 +1568,10 @@ void wxTextCtrl::GTKOnTextChanged()
     if ( IgnoreTextUpdate() )
         return;
 
+    auto count = gtk_text_buffer_get_char_count( m_buffer );
+    if( m_maxlen > 0 && count >= m_maxlen && IsMaxLengthAllowed() )
+        return;
+
     if ( MarkDirtyOnChange() )
         MarkDirty();
 

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -2272,7 +2272,7 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
         GtkRequisition req;
         gtk_widget_get_preferred_size(m_widget, &req, nullptr);
         tsize.IncTo(wxSize(req.width, req.height));
-}
+    }
 
     // We should always use at least the specified height if it's valid.
     if ( ylen > tsize.y )

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1264,14 +1264,14 @@ void wxTextCtrl::WriteText( const wxString &text )
 {
     wxCHECK_RET( m_text != nullptr, wxT("invalid text ctrl") );
 
-    auto oldFlag = m_maxLengthAllowed;
+    auto oldMaxLengthAllowed = m_maxLengthAllowed;
     m_maxLengthAllowed = false;
     if ( text.empty() )
     {
         // We don't need to actually do anything, but we still need to generate
         // an event expected from this call.
         SendTextUpdatedEvent(this);
-        m_maxLengthAllowed = oldFlag;
+        m_maxLengthAllowed = oldMaxLengthAllowed;
         return;
     }
 
@@ -1292,7 +1292,7 @@ void wxTextCtrl::WriteText( const wxString &text )
     if ( !IsMultiLine() )
     {
         wxTextEntry::WriteText(text);
-        m_maxLengthAllowed = oldFlag;
+        m_maxLengthAllowed = oldMaxLengthAllowed;
         return;
     }
 
@@ -1334,7 +1334,7 @@ void wxTextCtrl::WriteText( const wxString &text )
         m_afterLayoutId =
             g_idle_add_full(GTK_TEXT_VIEW_PRIORITY_VALIDATE + 1, afterLayout, this, nullptr);
     }
-    m_maxLengthAllowed = oldFlag;
+    m_maxLengthAllowed = oldMaxLengthAllowed;
 }
 
 wxString wxTextCtrl::GetLineText( long lineNo ) const
@@ -2267,10 +2267,6 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
     //multiline
     else
     {
-        // add space for vertical scrollbar
-        if ( m_scrollBar[1] && !(m_windowStyle & wxTE_NO_VSCROLL) )
-            tsize.IncBy(GTKGetPreferredSize(GTK_WIDGET(m_scrollBar[1])).x + 3, 0);
-
         // height
         if ( ylen <= 0 )
         {
@@ -2280,11 +2276,6 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
                 tsize.IncBy(0, GTKGetPreferredSize(GTK_WIDGET(m_scrollBar[0])).y + 3);
         }
 
-        if ( !HasFlag(wxBORDER_NONE) )
-        {
-            // hardcode borders, margins, etc
-            tsize.IncBy(5, 4);
-        }
     }
 
     // We should always use at least the specified height if it's valid.

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -2269,14 +2269,12 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
     {
         // height
         if ( ylen <= 0 )
-        {
             tsize.y = 1 + cHeight * wxMax(wxMin(GetNumberOfLines(), 10), 2);
-            // add space for horizontal scrollbar
-            if ( m_scrollBar[0] && (m_windowStyle & wxHSCROLL) )
-                tsize.IncBy(0, GTKGetPreferredSize(GTK_WIDGET(m_scrollBar[0])).y + 3);
-        }
 
-    }
+        GtkRequisition req;
+        gtk_widget_get_preferred_size(m_widget, &req, nullptr);
+        tsize.IncTo(wxSize(req.width, req.height));
+}
 
     // We should always use at least the specified height if it's valid.
     if ( ylen > tsize.y )

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -707,7 +707,7 @@ void wxTextCtrl::Init()
 {
     m_dontMarkDirty =
     m_modified = false;
-    
+
     m_countUpdatesToIgnore = 0;
 
     SetUpdateFont(false);

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -574,10 +574,6 @@ au_insert_text_callback(GtkTextBuffer *buffer,
         // reason, ("Run Last") it won't work in GTKOnInsertText() as it called from
         // the handler that does not connected after
         gtk_text_buffer_delete( buffer, &offset, end );
-#if GTK_CHECK_VERSION( 3, 2, 0 )
-        if( wx_is_at_least_gtk3(2) )
-            gtk_text_iter_assign( end, &offset );
-#endif
         wxCommandEvent event( wxEVT_TEXT_MAXLEN, win->GetId() );
         event.SetEventObject( win );
         event.SetString( win->GetValue() );

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <ctype.h>
+
 #include <string.h>
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/gtk3-compat.h"
@@ -706,6 +707,7 @@ void wxTextCtrl::Init()
 {
     m_dontMarkDirty =
     m_modified = false;
+    
     m_countUpdatesToIgnore = 0;
 
     SetUpdateFont(false);
@@ -897,7 +899,7 @@ bool wxTextCtrl::Create( wxWindow *parent,
             g_signal_connect (m_buffer, "apply_tag",
                               G_CALLBACK (au_apply_tag_callback), nullptr);
 
-            // Check for URLs in the initial string sed to Create
+            // Check for URLs in the initial string passed to Create
             gtk_text_buffer_get_start_iter(m_buffer, &start);
             gtk_text_buffer_get_end_iter(m_buffer, &end);
             au_check_range(&start, &end);
@@ -1292,8 +1294,6 @@ void wxTextCtrl::WriteText( const wxString &text )
         m_maxLengthAllowed = old;
         return;
     }
-    auto temp = text;
-    const wxScopedCharBuffer buffer(temp.utf8_str());
 
     // First remove the selection if there is one
     gtk_text_buffer_delete_selection(m_buffer, false, true);
@@ -1305,7 +1305,7 @@ void wxTextCtrl::WriteText( const wxString &text )
 
     const bool insertIsEnd = gtk_text_iter_is_end(&iter) != 0;
 
-    gtk_text_buffer_insert( m_buffer, &iter, buffer, buffer.length() );
+    gtk_text_buffer_insert( m_buffer, &iter, text, text.length() );
 
     GtkAdjustment* adj = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW(m_widget));
 
@@ -1804,13 +1804,7 @@ void wxTextCtrl::Paste()
 {
     wxCHECK_RET( m_text != nullptr, wxT("invalid text ctrl") );
 
-    if ( IsMultiLine() )
-    {
-        g_signal_emit_by_name (m_text, "paste-clipboard");
-        auto value = GetValue();
-    }
-    else
-        wxTextEntry::Paste();
+    wxTextEntry::Paste();
 }
 
 // If the return values from and to are the same, there is no

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1568,6 +1568,9 @@ void wxTextCtrl::GTKOnTextChanged()
     if( IsMultiLine() )
     {
         auto count = gtk_text_buffer_get_char_count( m_buffer );
+        // We are ignoring the change for the equality in order to have proper event generation
+        // otherwise the event generation is not consistent - we get text changed and then the maxlen
+        // events. This is not correct
         if( m_maxlen > 0 && count >= m_maxlen )
             return;
     }

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -561,23 +561,26 @@ au_insert_text_callback(GtkTextBuffer *buffer,
                                    &start, end);
     }
     const auto maxlen = win->GTKGetMaxLength();
-    auto count = gtk_text_buffer_get_char_count( buffer );
-    if ( maxlen > 0 && count > maxlen )
+    if( maxlen > 0 )
     {
-        GtkTextIter offset;
-        int trim_len = count - maxlen;
-        gtk_text_buffer_get_iter_at_offset( buffer, &offset, gtk_text_iter_get_offset( end ) - trim_len );
-        // This function is connected using g_signal_connect_after() call, therefore
-        // direct buffer modification is required.
-        // Using g_signal_connect() doesn't work as the text is still being entered
-        // probably because the signal is documented as "Run Last". For exactly same
-        // reason, ("Run Last") it won't work in GTKOnInsertText() as it called from
-        // the handler that does not connected after
-        gtk_text_buffer_delete( buffer, &offset, end );
-        wxCommandEvent event( wxEVT_TEXT_MAXLEN, win->GetId() );
-        event.SetEventObject( win );
-        event.SetString( win->GetValue() );
-        win->HandleWindowEvent( event );
+        auto count = gtk_text_buffer_get_char_count( buffer );
+        if ( count > maxlen )
+        {
+            GtkTextIter offset;
+            int trim_len = count - maxlen;
+            gtk_text_buffer_get_iter_at_offset( buffer, &offset, gtk_text_iter_get_offset( end ) - trim_len );
+            // This function is connected using g_signal_connect_after() call, therefore
+            // direct buffer modification is required.
+            // Using g_signal_connect() doesn't work as the text is still being entered
+            // probably because the signal is documented as "Run Last". For exactly same
+            // reason, ("Run Last") it won't work in GTKOnInsertText() as it called from
+            // the handler that does not connected after
+            gtk_text_buffer_delete( buffer, &offset, end );
+            wxCommandEvent event( wxEVT_TEXT_MAXLEN, win->GetId() );
+            event.SetEventObject( win );
+            event.SetString( win->GetValue() );
+            win->HandleWindowEvent( event );
+        }
     }
 
     if ( !len || !(win->GetWindowStyleFlag() & wxTE_AUTO_URL) )

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -576,6 +576,7 @@ au_insert_text_callback(GtkTextBuffer *buffer,
             // reason, ("Run Last") it won't work in GTKOnInsertText() as it called from
             // the handler that does not connected after
             gtk_text_buffer_delete( buffer, &offset, end );
+            win->IgnoreNextTextUpdate();
             wxCommandEvent event( wxEVT_TEXT_MAXLEN, win->GetId() );
             event.SetEventObject( win );
             event.SetString( win->GetValue() );
@@ -1564,17 +1565,6 @@ void wxTextCtrl::GTKOnTextChanged()
 {
     if ( IgnoreTextUpdate() )
         return;
-
-    if( IsMultiLine() )
-    {
-        auto count = gtk_text_buffer_get_char_count( m_buffer );
-        // We are ignoring the change for the equality in order to have proper event generation
-        // otherwise the event generation is not consistent - we get text changed and then the maxlen
-        // events. This is not correct
-        if( m_maxlen > 0 && count >= m_maxlen )
-            return;
-    }
-
     if ( MarkDirtyOnChange() )
         MarkDirty();
 

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1803,8 +1803,10 @@ void wxTextCtrl::Copy()
 void wxTextCtrl::Paste()
 {
     wxCHECK_RET( m_text != nullptr, wxT("invalid text ctrl") );
-
-    wxTextEntry::Paste();
+    if( IsMultiLine() )
+        g_signal_emit_by_name (m_text, "paste-clipboard");
+    else
+        wxTextEntry::Paste();
 }
 
 // If the return values from and to are the same, there is no

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -665,7 +665,7 @@ void TextCtrlTestCase::LongText()
 {
     // This test is only possible under MSW as in the other ports
     // SetMaxLength() can't be used with multi line text controls.
-#ifdef __WXMSW__
+#if defined( __WXMSW__ ) || defined( __WXGTK__ )
     delete m_text;
     CreateText(wxTE_MULTILINE|wxTE_DONTWRAP);
 


### PR DESCRIPTION
This is a second attempt.

It is simpler and less code.

Please review