### PR TITLE
Appearance fixes for wxMSW in dark mode

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -289,6 +289,14 @@ public:
     // Setup background and foreground colours correctly
     virtual void SetupColours();
 
+    virtual wxVisualAttributes GetDefaultAttributes() const override
+    {
+        return GetClassDefaultAttributes(GetWindowVariant());
+    }
+
+    static wxVisualAttributes
+    GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
+
     // ------------------------------------------------------------------------
     // helpers for message handlers: these perform the same function as the
     // message crackers from <windowsx.h> - they unpack WPARAM and LPARAM into

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -239,19 +239,14 @@ wxBorder wxControl::GetDefaultBorder() const
 }
 
 /* static */ wxVisualAttributes
-wxControl::GetClassDefaultAttributes(wxWindowVariant WXUNUSED(variant))
+wxControl::GetClassDefaultAttributes(wxWindowVariant variant)
 {
-    wxVisualAttributes attrs;
-
-    // old school (i.e. not "common") controls use the standard dialog font
-    // by default
-    attrs.font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+    wxVisualAttributes attrs = wxWindow::GetClassDefaultAttributes(variant);
 
     // most, or at least many, of the controls use the same colours as the
     // buttons -- others will have to override this (and possibly simply call
     // GetCompositeControlsDefaultAttributes() from their versions)
     attrs.colFg = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT);
-    attrs.colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);
 
     return attrs;
 }

--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -164,7 +164,7 @@ wxStaticText::MSWHandleMessage(WXLRESULT *result,
     {
         case WM_PAINT:
             // We only customize drawing of disabled labels in dark mode.
-            if ( IsThisEnabled() || !wxMSWDarkMode::IsActive() )
+            if ( ::IsWindowEnabled(GetHwnd()) || !wxMSWDarkMode::IsActive() )
                 break;
 
             // For them, the default "greying out" of the text for the disabled

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1673,6 +1673,20 @@ void wxWindowMSW::SetupColours()
         SetBackgroundColour(GetParent()->GetBackgroundColour());
 }
 
+/* static */ wxVisualAttributes
+wxWindowMSW::GetClassDefaultAttributes(wxWindowVariant variant)
+{
+    wxVisualAttributes attrs = wxWindowBase::GetClassDefaultAttributes(variant);
+
+    // For weird historical reasons, the default background colour for windows
+    // does _not_ use wxSYS_COLOUR_WINDOW but wxSYS_COLOUR_BTNFACE, however
+    // this colour is not appropriate in the dark mode, so override it there.
+    if ( wxMSWDarkMode::IsActive() )
+        attrs.colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+
+    return attrs;
+}
+
 bool wxWindowMSW::IsMouseInWindow() const
 {
     // get the mouse position


### PR DESCRIPTION
The first two commits fix the wrong background being used for the `wxPanel` children (see #24663), while the latter fixes appearance of disabled `wxStaticText` once again (and hopefully for the last time...).