### PR TITLE
Fixes for checkboxes in `wxPropGrid` in high DPI

### DIFF
--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -1482,7 +1482,15 @@ static void DrawSimpleCheckBox(wxWindow* win, wxDC& dc, const wxRect& rect, wxSi
 #endif
     }
 
-    wxRendererNative::Get().DrawCheckBox(win, dc, rect, cbFlags);
+    // Ignore the specified height because the native renderer only draws
+    // checkboxes correctly when using its own preferred size in high DPI.
+    wxRendererNative::Get().DrawCheckBox
+    (
+        win,
+        dc,
+        wxRect(wxRendererNative::Get().GetCheckBoxSize(win)).CenterIn(rect),
+        cbFlags
+    );
 #else
     wxUnusedVar(win);
 

--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -1564,11 +1564,7 @@ public:
     void SetBoxHeight(int height)
     {
         m_boxHeight = height;
-        // Box rectangle
-        wxRect rect(GetClientSize());
-        rect.y += 1;
-        rect.width += 1;
-        m_boxRect = GetBoxRect(rect, m_boxHeight);
+        m_boxRect = GetBoxRect(GetClientSize(), m_boxHeight);
     }
 
     static wxRect GetBoxRect(const wxRect& r, int box_h)

--- a/src/propgrid/property.cpp
+++ b/src/propgrid/property.cpp
@@ -86,7 +86,7 @@ void wxPGCellRenderer::DrawEditorValue( wxDC& dc, const wxRect& rect,
     {
         wxRect rect2(rect);
         rect2.Offset(xOffset, yOffset);
-        rect2.height -= yOffset;
+        rect2.height -= yOffset * 2;
         editor->DrawValue( dc, rect2, property, text );
     }
     else


### PR DESCRIPTION
This partially reuses and partially replaces #24671 and fixes the same #24650 and #24651 as it did.