### PR TITLE
Add wxTextCtrl::SearchText() for MSW

### DIFF
--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -44,6 +44,7 @@ public:
     virtual wxString GetRTFValue() const override;
     virtual void SetRTFValue(const wxString& val) override;
     virtual bool IsRTFSupported() override { return IsRich(); }
+    virtual wxTextSearchResult SearchText(const wxTextSearch& search) const override;
 #endif // wxUSE_RICHEDIT
 
     virtual bool IsEmpty() const;

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -630,7 +630,7 @@ struct wxTextSearch
         return *this;
     }
 
-    wxTextSearch& MatchCase(const bool matchCase = true)
+    wxTextSearch& MatchCase(bool matchCase = true)
     {
         m_matchCase = matchCase;
         return *this;

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -642,7 +642,7 @@ struct wxTextSearch
         return *this;
     }
 
-    wxTextSearch& Direction(const Direction direction)
+    wxTextSearch& Direction(const wxTextSearch::Direction direction)
     {
         m_direction = direction;
         return *this;
@@ -658,7 +658,7 @@ struct wxTextSearch
     long                  m_startingPosition = -1;
     bool                  m_matchCase = false;
     bool                  m_wholeWord = false;
-    Direction m_direction = Direction::Down;
+    wxTextSearch::Direction m_direction = wxTextSearch::Direction::Down;
 };
 
 // results from a search operation

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -669,7 +669,7 @@ struct wxTextSearchResult
     explicit wxTextSearchResult(long startPos, long endPos) :
         m_start(startPos), m_end(endPos) {}
     wxTextSearchResult() : m_start(wxNOT_FOUND), m_end(wxNOT_FOUND) {}
-
+wxTextSearchResult() = default;
     long m_start = wxNOT_FOUND;
     long m_end = wxNOT_FOUND;
 };

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -656,7 +656,7 @@ struct wxTextSearch
 
     wxString              m_searchValue;
     long                  m_startingPosition = -1;
-    bool                  m_matchCase = true;
+    bool                  m_matchCase = false;
     bool                  m_wholeWord = false;
     wxTextSearchDirection m_direction = wxTextSearchDirection::Down;
 };

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -668,6 +668,7 @@ struct wxTextSearchResult
     explicit operator bool() const { return m_start != wxNOT_FOUND; }
     explicit wxTextSearchResult(long startPos, long endPos) :
         m_start(startPos), m_end(endPos) {}
+    wxTextSearchResult() : m_start(wxNOT_FOUND), m_end(wxNOT_FOUND) {}
 
     long m_start = wxNOT_FOUND;
     long m_end = wxNOT_FOUND;

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -622,7 +622,7 @@ enum class wxTextSearchDirection
 // --------------
 struct wxTextSearch
 {
-    wxTextSearch(const wxString& text) : m_searchValue(text) {}
+    explicit wxTextSearch(const wxString& text = wxString{}) : m_searchValue(text) {}
 
     wxTextSearch& SearchValue(const wxString& value)
     {

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -642,7 +642,7 @@ struct wxTextSearch
         return *this;
     }
 
-    wxTextSearch& Direction(const wxTextSearch::Direction direction)
+    wxTextSearch& SearchDirection(const Direction direction)
     {
         m_direction = direction;
         return *this;
@@ -658,7 +658,7 @@ struct wxTextSearch
     long                  m_startingPosition = -1;
     bool                  m_matchCase = false;
     bool                  m_wholeWord = false;
-    wxTextSearch::Direction m_direction = wxTextSearch::Direction::Down;
+    Direction m_direction = Direction::Down;
 };
 
 // results from a search operation

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -609,6 +609,69 @@ private:
 };
 
 // ----------------------------------------------------------------------------
+// Search features for wxTextCtrl
+// ----------------------------------------------------------------------------
+
+enum class wxTextSearchDirection
+{
+    Down,
+    Up
+};
+
+// search options
+// --------------
+struct wxTextSearch
+{
+    wxTextSearch(const wxString& text) : m_searchValue(text) {}
+
+    wxTextSearch& SearchValue(const wxString& value)
+    {
+        m_searchValue = value;
+        return *this;
+    }
+
+    wxTextSearch& MatchCase(const bool matchCase = true)
+    {
+        m_matchCase = matchCase;
+        return *this;
+    }
+
+    wxTextSearch& MatchWholeWord(const bool matchWholeWord = true)
+    {
+        m_wholeWord = matchWholeWord;
+        return *this;
+    }
+
+    wxTextSearch& Direction(const wxTextSearchDirection direction)
+    {
+        m_direction = direction;
+        return *this;
+    }
+
+    wxTextSearch& Start(const long startPosition)
+    {
+        m_startingPosition = startPosition;
+        return *this;
+    }
+
+    wxString              m_searchValue;
+    long                  m_startingPosition = -1;
+    bool                  m_matchCase = true;
+    bool                  m_wholeWord = false;
+    wxTextSearchDirection m_direction = wxTextSearchDirection::Down;
+};
+
+// results from a search operation
+// -------------------------------
+struct wxTextSearchResult
+{
+    explicit operator bool() const { return m_start != wxNOT_FOUND; }
+
+    long m_start = wxNOT_FOUND;
+    long m_end = wxNOT_FOUND;
+};
+
+// ----------------------------------------------------------------------------
 // wxTextAreaBase: multiline text control specific methods
 // ----------------------------------------------------------------------------
 
@@ -697,6 +760,15 @@ public:
     // true, the port must override these functions to really implement them.
     virtual wxString GetRTFValue() const;
     virtual void SetRTFValue(const wxString& val);
+
+    // Searches for text.
+    // Base class implementations simply asserts,
+    // the port must override these functions to really implement them.
+    virtual wxTextSearchResult SearchText(const wxTextSearch& WXUNUSED(search)) const
+    {
+        wxFAIL_MSG("Text search not implemented for the current platform.");
+        return wxTextSearchResult();
+    }
 
 protected:
     // implementation of loading/saving

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -668,8 +668,8 @@ struct wxTextSearchResult
     explicit operator bool() const { return m_start != wxNOT_FOUND; }
     explicit wxTextSearchResult(long startPos, long endPos) :
         m_start(startPos), m_end(endPos) {}
-    wxTextSearchResult() : m_start(wxNOT_FOUND), m_end(wxNOT_FOUND) {}
-wxTextSearchResult() = default;
+    wxTextSearchResult() = default;
+
     long m_start = wxNOT_FOUND;
     long m_end = wxNOT_FOUND;
 };

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -666,6 +666,8 @@ struct wxTextSearch
 struct wxTextSearchResult
 {
     explicit operator bool() const { return m_start != wxNOT_FOUND; }
+    explicit wxTextSearchResult(long startPos, long endPos) :
+        m_start(startPos), m_end(endPos) {}
 
     long m_start = wxNOT_FOUND;
     long m_end = wxNOT_FOUND;

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -612,17 +612,17 @@ private:
 // Search features for wxTextCtrl
 // ----------------------------------------------------------------------------
 
-enum class wxTextSearchDirection
-{
-    Down,
-    Up
-};
-
 // search options
 // --------------
 struct wxTextSearch
 {
     explicit wxTextSearch(const wxString& text = wxString{}) : m_searchValue(text) {}
+
+    enum class Direction
+    {
+        Down,
+        Up
+    };
 
     wxTextSearch& SearchValue(const wxString& value)
     {
@@ -642,7 +642,7 @@ struct wxTextSearch
         return *this;
     }
 
-    wxTextSearch& Direction(const wxTextSearchDirection direction)
+    wxTextSearch& Direction(const Direction direction)
     {
         m_direction = direction;
         return *this;
@@ -658,7 +658,7 @@ struct wxTextSearch
     long                  m_startingPosition = -1;
     bool                  m_matchCase = false;
     bool                  m_wholeWord = false;
-    wxTextSearchDirection m_direction = wxTextSearchDirection::Down;
+    Direction m_direction = Direction::Down;
 };
 
 // results from a search operation

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1137,7 +1137,7 @@ public:
     @code
     wxTextSearchResult result =
         textctrl->SearchText(wxTextSearch(L"Institutional Research").
-            Direction(wxTextSearch::Direction::Down).
+            SearchDirection(wxTextSearch::Direction::Down).
             MatchCase().
             MatchWholeWord());
     @endcode
@@ -1152,7 +1152,7 @@ struct wxTextSearch
     wxTextSearch(const wxString& text) : m_searchValue(text) {}
 
     /**
-        One of the following values can be passed to wxTextSearch::Direction() to
+        One of the following values can be passed to wxTextSearch::SearchDirection() to
         control direction when searching a wxTextCtrl.
 
         @since 3.3.0
@@ -1199,7 +1199,7 @@ struct wxTextSearch
 
        By default, search will go downward.
      */
-    wxTextSearch& Direction(const wxTextSearch::Direction direction)
+    wxTextSearch& SearchDirection(const wxTextSearch::Direction direction)
     {
         m_direction = direction;
         return *this;

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1174,6 +1174,8 @@ struct wxTextSearch
 
     /**
        Whether the search should match case (i.e., be case sensitive).
+
+       By default, this is @c false; search will be case insensitive.
      */
     wxTextSearch& MatchCase(const bool matchCase = true)
     {
@@ -1183,6 +1185,8 @@ struct wxTextSearch
 
     /**
        Whether the search should match the whole word.
+
+       By default, this is @c false; searching will not match by whole word.
      */
     wxTextSearch& MatchWholeWord(const bool matchWholeWord = true)
     {
@@ -1192,6 +1196,8 @@ struct wxTextSearch
 
     /**
        Whether the search should go up or down in the text control.
+
+       By default, search will go downward.
      */
     wxTextSearch& Direction(const wxTextSearchDirection direction)
     {

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1813,7 +1813,7 @@ public:
 
         @onlyfor{wxmsw}
     */
-    wxTextSearchResult SearchText(const wxTextSearch& search) const
+    wxTextSearchResult SearchText(const wxTextSearch& search) const;
 
     /**
         Finds the position of the character at the specified point.

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1129,6 +1129,106 @@ public:
 };
 
 /**
+    One of the following values can be passed to wxTextSearch::Direction() to
+    control direction when searching a wxTextCtrl.
+
+    @since 3.3.0
+*/
+enum class wxTextSearchDirection
+{
+    Down,
+    Up
+};
+
+/**
+    Search options for wxTextCtrl::SearchText().
+
+    This is a builder class, where property functions can be
+    called during construction. For example:
+
+    @code
+    wxTextSearchResult result =
+        textctrl->SearchText(wxTextSearch(L"Institutional Research").
+            Direction(wxTextSearchDirection::Down).
+            MatchCase().
+            MatchWholeWord());
+    @endcode
+
+    @since 3.3.0
+*/
+struct wxTextSearch
+{
+    /**
+       The string to search for.
+     */
+    wxTextSearch(const wxString& text) : m_searchValue(text) {}
+
+    /**
+       The string to search for.
+     */
+    wxTextSearch& SearchValue(const wxString& value)
+    {
+        m_searchValue = value;
+        return *this;
+    }
+
+    /**
+       Whether the search should match case (i.e., be case sensitive).
+     */
+    wxTextSearch& MatchCase(const bool matchCase = true)
+    {
+        m_matchCase = matchCase;
+        return *this;
+    }
+
+    /**
+       Whether the search should match the whole word.
+     */
+    wxTextSearch& MatchWholeWord(const bool matchWholeWord = true)
+    {
+        m_wholeWord = matchWholeWord;
+        return *this;
+    }
+
+    /**
+       Whether the search should go up or down in the text control.
+     */
+    wxTextSearch& Direction(const wxTextSearchDirection direction)
+    {
+        m_direction = direction;
+        return *this;
+    }
+
+    /**
+       Where the search should start from. By default, if searching down,
+       then the search will start at 0. If searching up, then will start
+       at the end of control.
+     */
+    wxTextSearch& Start(const long startPosition)
+    {
+        m_startingPosition = startPosition;
+        return *this;
+    }
+
+    wxString              m_searchValue;
+    long                  m_startingPosition = -1;
+    bool                  m_matchCase = true;
+    bool                  m_wholeWord = false;
+    wxTextSearchDirection m_direction = wxTextSearchDirection::Down;
+};
+
+/** Result from wxTextCtrl::SearchText(), specifying the range of the found text.
+    Range values will be @c wxNOT_FOUND if a match was not found.
+
+    @since 3.3.0
+*/
+struct wxTextSearchResult
+{
+    long m_start = wxNOT_FOUND;
+    long m_end = wxNOT_FOUND;
+};
+
+/**
     @class wxTextProofOptions
 
     This class provides a convenient means of passing multiple parameters to
@@ -1700,6 +1800,20 @@ public:
         @see GetRTFValue()
     */
     void SetRTFValue(const wxString& val);
+
+    /**
+        Searches for a string in the control, using the provided search options.
+
+        The range of the match will be returned as a wxTextSearchResult, which will
+        contain -1 values if no match was found.
+
+        This is currently only implemented under wxMSW.
+
+        @since 3.3.0
+
+        @onlyfor{wxmsw}
+    */
+    wxTextSearchResult SearchText(const wxTextSearch& search) const
 
     /**
         Finds the position of the character at the specified point.

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1129,18 +1129,6 @@ public:
 };
 
 /**
-    One of the following values can be passed to wxTextSearch::Direction() to
-    control direction when searching a wxTextCtrl.
-
-    @since 3.3.0
-*/
-enum class wxTextSearchDirection
-{
-    Down,
-    Up
-};
-
-/**
     Search options for wxTextCtrl::SearchText().
 
     This is a builder class, where property functions can be
@@ -1149,7 +1137,7 @@ enum class wxTextSearchDirection
     @code
     wxTextSearchResult result =
         textctrl->SearchText(wxTextSearch(L"Institutional Research").
-            Direction(wxTextSearchDirection::Down).
+            Direction(wxTextSearch::Direction::Down).
             MatchCase().
             MatchWholeWord());
     @endcode
@@ -1162,6 +1150,18 @@ struct wxTextSearch
        The string to search for.
      */
     wxTextSearch(const wxString& text) : m_searchValue(text) {}
+
+    /**
+        One of the following values can be passed to wxTextSearch::Direction() to
+        control direction when searching a wxTextCtrl.
+
+        @since 3.3.0
+    */
+    enum class Direction
+    {
+        Down,
+        Up
+    };
 
     /**
        The string to search for.
@@ -1199,7 +1199,7 @@ struct wxTextSearch
 
        By default, search will go downward.
      */
-    wxTextSearch& Direction(const wxTextSearchDirection direction)
+    wxTextSearch& Direction(const wxTextSearch::Direction direction)
     {
         m_direction = direction;
         return *this;
@@ -1220,7 +1220,7 @@ struct wxTextSearch
     long                  m_startingPosition = -1;
     bool                  m_matchCase = true;
     bool                  m_wholeWord = false;
-    wxTextSearchDirection m_direction = wxTextSearchDirection::Down;
+    Direction m_direction = Direction::Down;
 };
 
 /** Result from wxTextCtrl::SearchText(), specifying the range of the found text.

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1202,9 +1202,15 @@ wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
 {
     // set up the flags
     WPARAM flags = 0;
-    if (search.m_direction == wxTextSearchDirection::Down)
+    switch ( search.m_direction )
     {
-        flags |= FR_DOWN;
+        case wxTextSearchDirection::Down:
+            flags |= FR_DOWN;
+            break;
+            
+        case wxTextSearchDirection::Up:
+            // Nothing to do this is (surprisingly) the default.
+            break;
     }
     if (search.m_wholeWord)
     {

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1207,7 +1207,7 @@ wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
         case wxTextSearchDirection::Down:
             flags |= FR_DOWN;
             break;
-            
+
         case wxTextSearchDirection::Up:
             // Nothing to do this is (surprisingly) the default.
             break;

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1234,11 +1234,6 @@ wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
     }
     else
     {
-        // if at the beginning of the window, then we can't search up
-        if (findText.chrg.cpMin == 0)
-        {
-            return wxTextSearchResult();
-        }
         // will search from the start of the selection and upward
         // to the start of the text
         findText.chrg.cpMax = 0;

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1198,6 +1198,56 @@ void wxTextCtrl::SetRTFValue(const wxString& val)
     SetInsertionPoint(0);
 }
 
+wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
+{
+    // set up the flags
+    WPARAM flags = 0;
+    if (search.m_direction == wxTextSearchDirection::Down)
+    {
+        flags |= FR_DOWN;
+    }
+    if (search.m_wholeWord)
+    {
+        flags |= FR_WHOLEWORD;
+    }
+    if (search.m_matchCase)
+    {
+        flags |= FR_MATCHCASE;
+    }
+
+    FINDTEXTEX findText;
+    findText.chrg.cpMin = (search.m_startingPosition != -1) ?
+        // user-provided start
+        search.m_startingPosition :
+        // if going down, then start from 0; otherwise, start from end
+        (search.m_direction == wxTextSearchDirection::Down) ? 0 : GetLastPosition();
+    if (search.m_direction == wxTextSearchDirection::Down)
+    {
+        // go to the end of the text
+        findText.chrg.cpMax = -1;
+    }
+    else
+    {
+        // if at the beginning of the window, then we can't search up
+        if (findText.chrg.cpMin == 0)
+        {
+            return wxTextSearchResult();
+        }
+        // will search from the start of the selection and upward
+        // to the start of the text
+        findText.chrg.cpMax = 0;
+    }
+
+    findText.lpstrText = search.m_searchValue.wc_str();
+
+    if (SendMessage(GetHwnd(), EM_FINDTEXTEXW, flags, (LPARAM)&findText) == -1)
+    {
+        return wxTextSearchResult();
+    }
+
+    return wxTextSearchResult{ findText.chrgText.cpMin, findText.chrgText.cpMax };
+}
+
 #endif // wxUSE_RICHEDIT
 
 void wxTextCtrl::WriteText(const wxString& value)

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1204,11 +1204,11 @@ wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
     WPARAM flags = 0;
     switch ( search.m_direction )
     {
-        case wxTextSearchDirection::Down:
+        case wxTextSearch::Direction::Down:
             flags |= FR_DOWN;
             break;
 
-        case wxTextSearchDirection::Up:
+        case wxTextSearch::Direction::Up:
             // Nothing to do this is (surprisingly) the default.
             break;
     }
@@ -1226,8 +1226,8 @@ wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
         // user-provided start
         search.m_startingPosition :
         // if going down, then start from 0; otherwise, start from end
-        (search.m_direction == wxTextSearchDirection::Down) ? 0 : GetLastPosition();
-    if (search.m_direction == wxTextSearchDirection::Down)
+        (search.m_direction == wxTextSearch::Direction::Down) ? 0 : GetLastPosition();
+    if (search.m_direction == wxTextSearch::Direction::Down)
     {
         // go to the end of the text
         findText.chrg.cpMax = -1;

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1516,6 +1516,12 @@ And there is a mispeled word)");
     results = text->SearchText(wxTextSearch(L"window").Direction(wxTextSearchDirection::Down).MatchCase());
     CHECK_FALSE(results); // case is different
 
+    // ignore case
+    results = text->SearchText(wxTextSearch(L"window").Direction(wxTextSearchDirection::Down).MatchCase(false));
+    CHECK(results);
+    CHECK(results.m_start == 38);
+    CHECK(results.m_end == 44);
+
     results = text->SearchText(wxTextSearch(L"Window").Direction(wxTextSearchDirection::Down).MatchCase());
     CHECK(results);
     CHECK(results.m_start == 38);

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1510,83 +1510,83 @@ And this should be in blue and the text you type should be in blue as well.
 And there is a mispeled word)");
 
     text->SetSelection(0, 0);
-    auto results = text->SearchText(wxTextSearch(L"IMnotHERE!").Direction(wxTextSearch::Direction::Down));
+    auto results = text->SearchText(wxTextSearch(L"IMnotHERE!").SearchDirection(wxTextSearch::Direction::Down));
     CHECK_FALSE(results);
 
-    results = text->SearchText(wxTextSearch(L"window").Direction(wxTextSearch::Direction::Down).MatchCase());
+    results = text->SearchText(wxTextSearch(L"window").SearchDirection(wxTextSearch::Direction::Down).MatchCase());
     CHECK_FALSE(results); // case is different
 
     // ignore case
-    results = text->SearchText(wxTextSearch(L"window").Direction(wxTextSearch::Direction::Down).MatchCase(false));
+    results = text->SearchText(wxTextSearch(L"window").SearchDirection(wxTextSearch::Direction::Down).MatchCase(false));
     CHECK(results);
     CHECK(results.m_start == 38);
     CHECK(results.m_end == 44);
 
-    results = text->SearchText(wxTextSearch(L"Window").Direction(wxTextSearch::Direction::Down).MatchCase());
+    results = text->SearchText(wxTextSearch(L"Window").SearchDirection(wxTextSearch::Direction::Down).MatchCase());
     CHECK(results);
     CHECK(results.m_start == 38);
     CHECK(results.m_end == 44);
 
-    results = text->SearchText(wxTextSearch(L"Window").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"Window").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK_FALSE(results); // whole word fails
 
-    results = text->SearchText(wxTextSearch(L"Windows").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"Windows").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 38);
     CHECK(results.m_end == 45);
 
 
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 62);
     CHECK(results.m_end == 66);
 
     // will find the same match
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start));
+    results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start));
     CHECK(results);
     CHECK(results.m_start == 62);
     CHECK(results.m_end == 66);
 
     // goes to next match
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
+    results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
     CHECK(results);
     CHECK(results.m_start == 67);
     CHECK(results.m_end == 71);
 
     // no more matches going down
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
+    results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
     CHECK_FALSE(results);
 
     // go up from the end
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 67);
     CHECK(results.m_end == 71);
 
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord().Start(results.m_start));
+    results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord().Start(results.m_start));
     CHECK(results);
     CHECK(results.m_start == 62);
     CHECK(results.m_end == 66);
 
     // no more going up
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord().Start(results.m_start));
+    results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord().Start(results.m_start));
     CHECK_FALSE(results);
 
     // phrase
-    results = text->SearchText(wxTextSearch(L"Next 10 characters").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"Next 10 characters").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 233);
     CHECK(results.m_end == 251);
 
     // Edge cases
     // last word
-    results = text->SearchText(wxTextSearch(L"word").Direction(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"word").SearchDirection(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 494);
     CHECK(results.m_end == 498);
 
     // first word
-    results = text->SearchText(wxTextSearch(L"Allows").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"Allows").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 0);
     CHECK(results.m_end == 6);

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1573,7 +1573,7 @@ And there is a mispeled word)");
     CHECK(results.m_end == 251);
 
     // Edge cases
-    // last word 
+    // last word
     results = text->SearchText(wxTextSearch(L"word").Direction(wxTextSearchDirection::Up).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 494);

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1510,83 +1510,83 @@ And this should be in blue and the text you type should be in blue as well.
 And there is a mispeled word)");
 
     text->SetSelection(0, 0);
-    auto results = text->SearchText(wxTextSearch(L"IMnotHERE!").Direction(wxTextSearchDirection::Down));
+    auto results = text->SearchText(wxTextSearch(L"IMnotHERE!").Direction(wxTextSearch::Direction::Down));
     CHECK_FALSE(results);
 
-    results = text->SearchText(wxTextSearch(L"window").Direction(wxTextSearchDirection::Down).MatchCase());
+    results = text->SearchText(wxTextSearch(L"window").Direction(wxTextSearch::Direction::Down).MatchCase());
     CHECK_FALSE(results); // case is different
 
     // ignore case
-    results = text->SearchText(wxTextSearch(L"window").Direction(wxTextSearchDirection::Down).MatchCase(false));
+    results = text->SearchText(wxTextSearch(L"window").Direction(wxTextSearch::Direction::Down).MatchCase(false));
     CHECK(results);
     CHECK(results.m_start == 38);
     CHECK(results.m_end == 44);
 
-    results = text->SearchText(wxTextSearch(L"Window").Direction(wxTextSearchDirection::Down).MatchCase());
+    results = text->SearchText(wxTextSearch(L"Window").Direction(wxTextSearch::Direction::Down).MatchCase());
     CHECK(results);
     CHECK(results.m_start == 38);
     CHECK(results.m_end == 44);
 
-    results = text->SearchText(wxTextSearch(L"Window").Direction(wxTextSearchDirection::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"Window").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK_FALSE(results); // whole word fails
 
-    results = text->SearchText(wxTextSearch(L"Windows").Direction(wxTextSearchDirection::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"Windows").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 38);
     CHECK(results.m_end == 45);
 
 
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearchDirection::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 62);
     CHECK(results.m_end == 66);
 
     // will find the same match
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearchDirection::Down).MatchCase().MatchWholeWord().Start(results.m_start));
+    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start));
     CHECK(results);
     CHECK(results.m_start == 62);
     CHECK(results.m_end == 66);
 
     // goes to next match
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearchDirection::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
+    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
     CHECK(results);
     CHECK(results.m_start == 67);
     CHECK(results.m_end == 71);
 
     // no more matches going down
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearchDirection::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
+    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
     CHECK_FALSE(results);
 
     // go up from the end
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearchDirection::Up).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 67);
     CHECK(results.m_end == 71);
 
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearchDirection::Up).MatchCase().MatchWholeWord().Start(results.m_start));
+    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord().Start(results.m_start));
     CHECK(results);
     CHECK(results.m_start == 62);
     CHECK(results.m_end == 66);
 
     // no more going up
-    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearchDirection::Up).MatchCase().MatchWholeWord().Start(results.m_start));
+    results = text->SearchText(wxTextSearch(L"very").Direction(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord().Start(results.m_start));
     CHECK_FALSE(results);
 
     // phrase
-    results = text->SearchText(wxTextSearch(L"Next 10 characters").Direction(wxTextSearchDirection::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"Next 10 characters").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 233);
     CHECK(results.m_end == 251);
 
     // Edge cases
     // last word
-    results = text->SearchText(wxTextSearch(L"word").Direction(wxTextSearchDirection::Up).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"word").Direction(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 494);
     CHECK(results.m_end == 498);
 
     // first word
-    results = text->SearchText(wxTextSearch(L"Allows").Direction(wxTextSearchDirection::Down).MatchCase().MatchWholeWord());
+    results = text->SearchText(wxTextSearch(L"Allows").Direction(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord());
     CHECK(results);
     CHECK(results.m_start == 0);
     CHECK(results.m_end == 6);


### PR DESCRIPTION
Supports case matching, whole-word matching, and search direction options.

The defaults are to **not** match by case or whole word.

Implements #23853

If this API looks agreeable, I can work on PRs for macOS and GTK later.