### PR TITLE
Disallow overriding wxBitmap::Create() outside of wxWidgets

### DIFF
--- a/include/wx/dfb/bitmap.h
+++ b/include/wx/dfb/bitmap.h
@@ -39,8 +39,8 @@ public:
 #endif
 
     bool Create(const wxIDirectFBSurfacePtr& surface);
-    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);
-    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH)
+    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) final;
+    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH) final
         { return Create(sz.GetWidth(), sz.GetHeight(), depth); }
     bool Create(int width, int height, const wxDC& WXUNUSED(dc))
         { return Create(width,height); }

--- a/include/wx/gtk/bitmap.h
+++ b/include/wx/gtk/bitmap.h
@@ -80,8 +80,8 @@ public:
     wxBitmap(GdkPixbuf* pixbuf, int depth = 0);
     explicit wxBitmap(const wxCursor& cursor);
 
-    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) override;
-    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH) override
+    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) final;
+    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH) final
         { return Create(sz.GetWidth(), sz.GetHeight(), depth); }
 #ifdef __WXGTK3__
     bool Create(int width, int height, const wxDC& dc);

--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -140,12 +140,12 @@ public:
     bool ConvertToDIB();
 #endif
 
-    virtual bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);
-    virtual bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH)
+    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);
+    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH)
         { return Create(sz.GetWidth(), sz.GetHeight(), depth); }
 
-    virtual bool Create(int width, int height, const wxDC& dc);
-    virtual bool Create(const void* data, wxBitmapType type, int width, int height, int depth = 1);
+    bool Create(int width, int height, const wxDC& dc);
+    bool Create(const void* data, wxBitmapType type, int width, int height, int depth = 1);
 
     bool CreateWithDIPSize(const wxSize& sz,
                            double scale,

--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -128,11 +128,11 @@ public:
     // get the given part of bitmap
     wxBitmap GetSubBitmap( const wxRect& rect ) const override;
 
-    virtual bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) override;
-    virtual bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH) override
+    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) final;
+    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH) final
         { return Create(sz.GetWidth(), sz.GetHeight(), depth); }
 
-    virtual bool Create(const void* data, wxBitmapType type, int width, int height, int depth = 1);
+    bool Create(const void* data, wxBitmapType type, int width, int height, int depth = 1);
     bool Create( CGImageRef image, double scale = 1.0 );
     bool Create( WXImage image );
     bool Create( CGContextRef bitmapcontext);
@@ -140,7 +140,6 @@ public:
     // Create a bitmap compatible with the given DC, inheriting its magnification factor
     bool Create(int width, int height, const wxDC& dc);
 
-    // virtual bool Create( WXHICON icon) ;
     virtual bool LoadFile(const wxString& name, wxBitmapType type = wxBITMAP_DEFAULT_TYPE) override;
     virtual bool SaveFile(const wxString& name, wxBitmapType type, const wxPalette *cmap = nullptr) const override;
 

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -34,9 +34,9 @@ public:
 
     static void InitStandardHandlers();
 
-    virtual bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) override;
-    virtual bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH) override;
-    virtual bool Create(int width, int height, const wxDC& dc);
+    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) final;
+    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH) final;
+    bool Create(int width, int height, const wxDC& dc);
 
     virtual void SetScaleFactor(double scale);
     virtual double GetScaleFactor() const;

--- a/include/wx/x11/bitmap.h
+++ b/include/wx/x11/bitmap.h
@@ -65,8 +65,8 @@ public:
 
     static void InitStandardHandlers();
 
-    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);
-    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH)
+    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH) final;
+    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH) final
         { return Create(sz.GetWidth(), sz.GetHeight(), depth); }
     bool Create(int width, int height, const wxDC& WXUNUSED(dc))
         { return Create(width,height); }

--- a/interface/wx/bitmap.h
+++ b/interface/wx/bitmap.h
@@ -69,8 +69,8 @@ public:
 
         @return @true if the call succeeded, @false otherwise (the default).
     */
-    virtual bool Create(wxBitmap* bitmap, const void* data, wxBitmapType type,
-                        int width, int height, int depth = 1);
+    bool Create(wxBitmap* bitmap, const void* data, wxBitmapType type,
+                int width, int height, int depth = 1);
 
     /**
         Gets the file extension associated with this handler.
@@ -455,12 +455,12 @@ public:
 
         @return @true if the creation was successful.
     */
-    virtual bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);
+    bool Create(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);
 
     /**
         @overload
     */
-    virtual bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH);
+    bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH);
 
     /**
         Create a bitmap compatible with the given DC, inheriting its magnification factor
@@ -593,7 +593,7 @@ public:
 
         This overload depends on the @a type of data.
 
-    virtual bool Create(const void* data, int type, int width,
+    bool Create(const void* data, int type, int width,
                         int height, int depth = -1);
 
         NOTE: leave this undoc for the same reason of the relative ctor.


### PR DESCRIPTION
This doesn't really make much sense, this function is only virtual in the first place to force wxBitmap (in all ports except for wxMSW) to implement wxBitmapBase pure virtual functions, but it's implemented only by wxWidgets itself and shouldn't be overridden again, so declare it as final in all the ports overriding it and make it non-virtual in wxMSW.

Also, none of the other Create() functions in wxWindow-derived classes is virtual, so this improves consistency as well.

Finally, this avoids clang-analyzer-optin.cplusplus.VirtualCall warning from clang-tidy due to calling a virtual function from wxBitmap ctor, which is the right thing to do only because we really want to call wxBitmap's own version and not anything defined in a derived class.