### PR TITLE
Add synchronous `wxWebRequest`

### DIFF
--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -101,12 +101,12 @@ private:
 
     wxWebSessionWinHTTP& m_sessionImpl;
     wxString m_url;
-    HINTERNET m_connect;
-    HINTERNET m_request;
+    HINTERNET m_connect = nullptr;
+    HINTERNET m_request = nullptr;
     wxObjectDataPtr<wxWebResponseWinHTTP> m_response;
     wxObjectDataPtr<wxWebAuthChallengeWinHTTP> m_authChallenge;
     wxMemoryBuffer m_dataWriteBuffer;
-    wxFileOffset m_dataWritten;
+    wxFileOffset m_dataWritten = 0;
 
     void SendRequest();
 
@@ -154,7 +154,7 @@ public:
     }
 
 private:
-    HINTERNET m_handle;
+    HINTERNET m_handle = nullptr;
 
     bool Open();
 

--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -36,8 +36,6 @@ public:
 
     bool ReadData();
 
-    bool ReportAvailableData(DWORD dataLen);
-
 private:
     HINTERNET m_requestHandle;
     wxFileOffset m_contentLength;

--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -142,6 +142,8 @@ private:
 
     wxNODISCARD Result CreateResponse();
 
+    wxNODISCARD Result InitAuthIfNeeded();
+
     // Return error result with the error message built from the name of the
     // operation and WinHTTP error code.
     wxNODISCARD Result Fail(const wxString& operation, DWORD errorCode);

--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -51,6 +51,8 @@ public:
 
     bool Init();
 
+    wxWebRequest::Result DoSetCredentials(const wxWebCredentials& cred);
+
     void SetCredentials(const wxWebCredentials& cred) override;
 
 private:
@@ -125,6 +127,12 @@ private:
     wxObjectDataPtr<wxWebAuthChallengeWinHTTP> m_authChallenge;
     wxMemoryBuffer m_dataWriteBuffer;
     wxFileOffset m_dataWritten = 0;
+
+    // Store authentication information from the URL, if any, as well as a flag
+    // which is reset after the first attempt to use it, so that we don't try
+    // to do it an infinite loop.
+    wxWebCredentials m_credentialsFromURL;
+    bool m_tryCredentialsFromURL = false;
 
     wxNODISCARD Result SendRequest();
 

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -19,9 +19,6 @@
 
 using wxWebRequestHeaderMap = std::unordered_map<wxString, wxString>;
 
-// Default buffer size when a fixed-size buffer must be used.
-const int wxWEBREQUEST_BUFFER_SIZE = 64 * 1024;
-
 // Trace mask used for the messages in wxWebRequest code.
 #define wxTRACE_WEBREQUEST "webrequest"
 
@@ -241,7 +238,6 @@ public:
 
 protected:
     wxWebRequestImpl& m_request;
-    size_t m_readSize;
 
     explicit wxWebResponseImpl(wxWebRequestImpl& request);
 

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -76,7 +76,7 @@ public:
     wxWebRequest::Storage GetStorage() const { return m_storage; }
 
     // This method is called to execute the request in a synchronous way.
-    virtual Result Execute() { return Result::Error("Not implemented"); }
+    virtual Result Execute() = 0;
 
     // This method is called to start execution of an asynchronous request.
     //
@@ -271,7 +271,7 @@ class wxWebSessionFactory
 {
 public:
     virtual wxWebSessionImpl* Create() = 0;
-    virtual wxWebSessionImpl* CreateSync() { return nullptr; }
+    virtual wxWebSessionImpl* CreateSync() = 0;
 
     virtual bool Initialize() { return true; }
 
@@ -308,7 +308,7 @@ public:
                   int id) = 0;
 
     virtual wxWebRequestImplPtr
-    CreateRequestSync(wxWebSessionSync& session, const wxString& url) { return wxWebRequestImplPtr{}; }
+    CreateRequestSync(wxWebSessionSync& session, const wxString& url) = 0;
 
     virtual wxVersionInfo GetLibraryVersionInfo() = 0;
 
@@ -326,7 +326,7 @@ public:
     virtual bool EnablePersistentStorage(bool WXUNUSED(enable)) { return false; }
 
 protected:
-    explicit wxWebSessionImpl(Mode mode = Mode::Async);
+    explicit wxWebSessionImpl(Mode mode);
 
     bool IsAsync() const { return m_mode == Mode::Async; }
 

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -109,11 +109,11 @@ public:
 
 protected:
     wxString m_method;
-    wxWebRequest::Storage m_storage;
+    wxWebRequest::Storage m_storage = wxWebRequest::Storage_Memory;
     wxWebRequestHeaderMap m_headers;
-    wxFileOffset m_dataSize;
+    wxFileOffset m_dataSize = 0;
     std::unique_ptr<wxInputStream> m_dataStream;
-    bool m_peerVerifyDisabled;
+    bool m_peerVerifyDisabled = false;
 
     wxWebRequestImpl(wxWebSession& session,
                      wxWebSessionImpl& sessionImpl,
@@ -141,12 +141,12 @@ private:
     wxWebSession& m_session;
     wxEvtHandler* const m_handler;
     const int m_id;
-    wxWebRequest::State m_state;
-    wxFileOffset m_bytesReceived;
+    wxWebRequest::State m_state = wxWebRequest::State_Idle;
+    wxFileOffset m_bytesReceived = 0;
     wxCharBuffer m_dataText;
 
     // Initially false, set to true after the first call to Cancel().
-    bool m_cancelled;
+    bool m_cancelled = false;
 
     wxDECLARE_NO_COPY_CLASS(wxWebRequestImpl);
 };

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -76,7 +76,7 @@ public:
     wxWebRequest::Storage GetStorage() const { return m_storage; }
 
     // This method is called to execute the request in a synchronous way.
-    virtual Result Execute() = 0;
+    virtual Result Execute() { return Result::Error("Not implemented"); }
 
     // This method is called to start execution of an asynchronous request.
     //
@@ -271,7 +271,7 @@ class wxWebSessionFactory
 {
 public:
     virtual wxWebSessionImpl* Create() = 0;
-    virtual wxWebSessionImpl* CreateSync() = 0;
+    virtual wxWebSessionImpl* CreateSync() { return nullptr; }
 
     virtual bool Initialize() { return true; }
 
@@ -308,7 +308,7 @@ public:
                   int id) = 0;
 
     virtual wxWebRequestImplPtr
-    CreateRequestSync(wxWebSessionSync& session, const wxString& url) = 0;
+    CreateRequestSync(wxWebSessionSync& session, const wxString& url) { return wxWebRequestImplPtr{}; }
 
     virtual wxVersionInfo GetLibraryVersionInfo() = 0;
 
@@ -326,7 +326,7 @@ public:
     virtual bool EnablePersistentStorage(bool WXUNUSED(enable)) { return false; }
 
 protected:
-    explicit wxWebSessionImpl(Mode mode);
+    explicit wxWebSessionImpl(Mode mode = Mode::Async);
 
     bool IsAsync() const { return m_mode == Mode::Async; }
 

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -124,9 +124,16 @@ protected:
 
     bool WasCancelled() const { return m_cancelled; }
 
+    // Get wxWebRequest::State and, optionally, error message corresponding to
+    // the given response (response must be valid here).
+    static Result GetResultFromHTTPStatus(const wxWebResponseImplPtr& response);
+
     // Call SetState() with either State_Failed or State_Completed appropriate
     // for the response status.
-    void SetFinalStateFromStatus();
+    void SetFinalStateFromStatus()
+    {
+        HandleResult(GetResultFromHTTPStatus(GetResponse()));
+    }
 
     // Unconditionally call SetState() with the parameters corresponding to the
     // given result.

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -139,6 +139,10 @@ protected:
 
     bool WasCancelled() const { return m_cancelled; }
 
+    // Get the HTTP method to use: this will be m_method if it's non-empty,
+    // POST is we have any data to send, and GET otherwise.
+    wxString GetHTTPMethod() const;
+
     // Get wxWebRequest::State and, optionally, error message corresponding to
     // the given response (response must be valid here).
     static Result GetResultFromHTTPStatus(const wxWebResponseImplPtr& response);

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -55,6 +55,8 @@ private:
 class wxWebRequestImpl : public wxRefCounterMT
 {
 public:
+    using Result = wxWebRequest::Result;
+
     virtual ~wxWebRequestImpl() = default;
 
     void SetHeader(const wxString& name, const wxString& value)
@@ -125,6 +127,26 @@ protected:
     // Call SetState() with either State_Failed or State_Completed appropriate
     // for the response status.
     void SetFinalStateFromStatus();
+
+    // Unconditionally call SetState() with the parameters corresponding to the
+    // given result.
+    void HandleResult(const Result& result)
+    {
+        SetState(result.state, result.error);
+    }
+
+    // Call SetState() if the result is an error (State_Failed) and return
+    // false in this case, otherwise just return true.
+    bool CheckResult(const Result& result)
+    {
+        if ( !result )
+        {
+            HandleResult(result);
+            return false;
+        }
+
+        return true;
+    }
 
 private:
     // Called from public Cancel() at most once per object.

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -113,9 +113,9 @@ public:
 
     virtual wxWebRequestHandle GetNativeHandle() const = 0;
 
-    void DisablePeerVerify(bool disable) { m_peerVerifyDisabled = disable; }
+    void MakeInsecure(int flags) { m_securityFlags = flags; }
 
-    bool IsPeerVerifyDisabled() const { return m_peerVerifyDisabled; }
+    int GetSecurityFlags() const { return m_securityFlags; }
 
     void SetState(wxWebRequest::State state, const wxString& failMsg = wxString());
 
@@ -129,7 +129,7 @@ protected:
     wxWebRequestHeaderMap m_headers;
     wxFileOffset m_dataSize = 0;
     std::unique_ptr<wxInputStream> m_dataStream;
-    bool m_peerVerifyDisabled = false;
+    int m_securityFlags = 0;
 
     // Ctor for async requests.
     wxWebRequestImpl(wxWebSession& session,

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -210,6 +210,8 @@ public:
     // opened.
     wxNODISCARD wxWebRequest::Result InitFileStorage();
 
+    void ReportDataReceived(size_t sizeReceived);
+
 protected:
     wxWebRequestImpl& m_request;
     size_t m_readSize;
@@ -217,8 +219,6 @@ protected:
     explicit wxWebResponseImpl(wxWebRequestImpl& request);
 
     void* GetDataBuffer(size_t sizeNeeded);
-
-    void ReportDataReceived(size_t sizeReceived);
 
     // This function can optionally be called to preallocate the read buffer,
     // if the total amount of data to be downloaded is known in advance.

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -204,15 +204,17 @@ public:
 
     virtual wxString GetDataFile() const;
 
+    // Open data file if necessary, i.e. if using wxWebRequest::Storage_File.
+    //
+    // Returns result with State_Failed if the file is needed but couldn't be
+    // opened.
+    wxNODISCARD wxWebRequest::Result InitFileStorage();
+
 protected:
     wxWebRequestImpl& m_request;
     size_t m_readSize;
 
     explicit wxWebResponseImpl(wxWebRequestImpl& request);
-
-    // Called from derived class ctor to finish initialization which can't be
-    // performed in ctor itself as it needs to use pure virtual method.
-    void Init();
 
     void* GetDataBuffer(size_t sizeNeeded);
 

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -141,6 +141,8 @@ protected:
 
     // Get the HTTP method to use: this will be m_method if it's non-empty,
     // POST is we have any data to send, and GET otherwise.
+    //
+    // Returned string is always in upper case.
     wxString GetHTTPMethod() const;
 
     // Get wxWebRequest::State and, optionally, error message corresponding to

--- a/include/wx/private/webrequest_curl.h
+++ b/include/wx/private/webrequest_curl.h
@@ -25,6 +25,7 @@
 class wxWebRequestCURL;
 class wxWebResponseCURL;
 class wxWebSessionCURL;
+class wxWebSessionSyncCURL;
 class SocketPoller;
 
 class wxWebAuthChallengeCURL : public wxWebAuthChallengeImpl
@@ -44,13 +45,21 @@ private:
 class wxWebRequestCURL : public wxWebRequestImpl
 {
 public:
+    // Ctor for async requests: creates a new libcurl handle and owns it.
     wxWebRequestCURL(wxWebSession& session,
                      wxWebSessionCURL& sessionImpl,
                      wxEvtHandler* handler,
                      const wxString& url,
                      int id);
 
+    // Ctor for sync requests: uses the libcurl handle from the session and
+    // doesn't own it.
+    wxWebRequestCURL(wxWebSessionSyncCURL& sessionImpl,
+                     const wxString& url);
+
     ~wxWebRequestCURL();
+
+    wxWebRequest::Result Execute() override;
 
     void Start() override;
 
@@ -81,15 +90,27 @@ public:
     size_t CURLOnRead(char* buffer, size_t size);
 
 private:
+    // Common initialization for sync and async requests performed when the
+    // request is created.
+    void DoStartPrepare(const wxString& url);
+
+    // This function is again common for sync and async requests, but is called
+    // right before starting, or executing, the request.
+    //
+    // If it returns result with State_Failed, the request should be aborted.
+    wxWebRequest::Result DoFinishPrepare();
+
     // Convert the status of the completed request to our result structure and,
     // if necessary, initialize m_authChallenge.
     wxWebRequest::Result DoHandleCompletion();
 
     void DoCancel() override;
 
-    wxWebSessionCURL& m_sessionImpl;
+    // This is only used for async requests.
+    wxWebSessionCURL* const m_sessionCURL;
 
-    CURL* m_handle = nullptr;
+    // This pointer is only owned by this object when using async requests.
+    CURL* const m_handle;
     char m_errorBuffer[CURL_ERROR_SIZE];
     struct curl_slist *m_headerList = nullptr;
     wxObjectDataPtr<wxWebResponseCURL> m_response;
@@ -131,7 +152,59 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxWebResponseCURL);
 };
 
-class wxWebSessionCURL : public wxWebSessionImpl, public wxEvtHandler
+// Common base class for synchronous and asynchronous sessions.
+class wxWebSessionBaseCURL : public wxWebSessionImpl
+{
+public:
+    explicit wxWebSessionBaseCURL(Mode mode);
+    ~wxWebSessionBaseCURL();
+
+    wxVersionInfo GetLibraryVersionInfo() override;
+
+    static bool CurlRuntimeAtLeastVersion(unsigned int, unsigned int,
+                                          unsigned int);
+
+protected:
+    static int ms_activeSessions;
+    static unsigned int ms_runtimeVersion;
+};
+
+// Sync session implementation uses libcurl "easy" API.
+class wxWebSessionSyncCURL : public wxWebSessionBaseCURL
+{
+public:
+    wxWebSessionSyncCURL();
+    ~wxWebSessionSyncCURL();
+
+    wxWebRequestImplPtr
+    CreateRequest(wxWebSession& WXUNUSED(session),
+                  wxEvtHandler* WXUNUSED(handler),
+                  const wxString& WXUNUSED(url),
+                  int WXUNUSED(id)) override
+    {
+        wxFAIL_MSG("This method should not be called for synchronous sessions");
+
+        return wxWebRequestImplPtr{};
+    }
+
+    wxWebRequestImplPtr
+    CreateRequestSync(wxWebSessionSync& session, const wxString& url) override;
+
+    wxWebSessionHandle GetNativeHandle() const override
+    {
+        return (wxWebSessionHandle)m_handle;
+    }
+
+    CURL* GetHandle() const { return m_handle; }
+
+private:
+    CURL* m_handle = nullptr;
+
+    wxDECLARE_NO_COPY_CLASS(wxWebSessionSyncCURL);
+};
+
+// Async session implementation uses libcurl "multi" API.
+class wxWebSessionCURL : public wxWebSessionBaseCURL, public wxEvtHandler
 {
 public:
     wxWebSessionCURL();
@@ -144,7 +217,14 @@ public:
                   const wxString& url,
                   int id = wxID_ANY) override;
 
-    wxVersionInfo GetLibraryVersionInfo() override;
+    wxWebRequestImplPtr
+    CreateRequestSync(wxWebSessionSync& WXUNUSED(session),
+                      const wxString& WXUNUSED(url)) override
+    {
+        wxFAIL_MSG("This method should not be called for asynchronous sessions");
+
+        return wxWebRequestImplPtr{};
+    }
 
     wxWebSessionHandle GetNativeHandle() const override
     {
@@ -156,9 +236,6 @@ public:
     void CancelRequest(wxWebRequestCURL* request);
 
     void RequestHasTerminated(wxWebRequestCURL* request);
-
-    static bool CurlRuntimeAtLeastVersion(unsigned int, unsigned int,
-                                          unsigned int);
 
 private:
     static int TimerCallback(CURLM*, long, void*);
@@ -184,9 +261,6 @@ private:
     wxTimer m_timeoutTimer;
     CURLM* m_handle = nullptr;
 
-    static int ms_activeSessions;
-    static unsigned int ms_runtimeVersion;
-
     wxDECLARE_NO_COPY_CLASS(wxWebSessionCURL);
 };
 
@@ -194,7 +268,14 @@ class wxWebSessionFactoryCURL : public wxWebSessionFactory
 {
 public:
     wxWebSessionImpl* Create() override
-    { return new wxWebSessionCURL(); }
+    {
+        return new wxWebSessionCURL();
+    }
+
+    wxWebSessionImpl* CreateSync() override
+    {
+        return new wxWebSessionSyncCURL();
+    }
 };
 
 #endif // wxUSE_WEBREQUEST_CURL

--- a/include/wx/private/webrequest_curl.h
+++ b/include/wx/private/webrequest_curl.h
@@ -92,8 +92,6 @@ private:
     wxObjectDataPtr<wxWebAuthChallengeCURL> m_authChallenge;
     wxFileOffset m_bytesSent;
 
-    void DestroyHeaderList();
-
     wxDECLARE_NO_COPY_CLASS(wxWebRequestCURL);
 };
 

--- a/include/wx/private/webrequest_curl.h
+++ b/include/wx/private/webrequest_curl.h
@@ -81,6 +81,10 @@ public:
     size_t CURLOnRead(char* buffer, size_t size);
 
 private:
+    // Convert the status of the completed request to our result structure and,
+    // if necessary, initialize m_authChallenge.
+    wxWebRequest::Result DoHandleCompletion();
+
     void DoCancel() override;
 
     wxWebSessionCURL& m_sessionImpl;

--- a/include/wx/private/webrequest_curl.h
+++ b/include/wx/private/webrequest_curl.h
@@ -85,9 +85,9 @@ private:
 
     wxWebSessionCURL& m_sessionImpl;
 
-    CURL* m_handle;
+    CURL* m_handle = nullptr;
     char m_errorBuffer[CURL_ERROR_SIZE];
-    struct curl_slist *m_headerList;
+    struct curl_slist *m_headerList = nullptr;
     wxObjectDataPtr<wxWebResponseCURL> m_response;
     wxObjectDataPtr<wxWebAuthChallengeCURL> m_authChallenge;
     wxFileOffset m_bytesSent;
@@ -176,9 +176,9 @@ private:
     TransferSet m_activeTransfers;
     CurlSocketMap m_activeSockets;
 
-    SocketPoller* m_socketPoller;
+    SocketPoller* m_socketPoller = nullptr;
     wxTimer m_timeoutTimer;
-    CURLM* m_handle;
+    CURLM* m_handle = nullptr;
 
     static int ms_activeSessions;
     static unsigned int ms_runtimeVersion;

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -211,29 +211,21 @@ extern WXDLLIMPEXP_DATA_NET(const char) wxWebSessionBackendWinHTTP[];
 extern WXDLLIMPEXP_DATA_NET(const char) wxWebSessionBackendURLSession[];
 extern WXDLLIMPEXP_DATA_NET(const char) wxWebSessionBackendCURL[];
 
-class WXDLLIMPEXP_NET wxWebSession
+// Common base class for synchronous and asynchronous web sessions.
+class WXDLLIMPEXP_NET wxWebSessionBase
 {
 public:
     // Default ctor creates an invalid session object, only IsOpened() can be
     // called on it.
-    wxWebSession();
+    wxWebSessionBase();
 
-    wxWebSession(const wxWebSession& other);
-    wxWebSession& operator=(const wxWebSession& other);
-    ~wxWebSession();
-
-    // Objects of this class can't be created directly, use the following
-    // factory functions to get access to them.
-    static wxWebSession& GetDefault();
-
-    static wxWebSession New(const wxString& backend = wxString());
+    wxWebSessionBase(const wxWebSessionBase& other);
+    wxWebSessionBase& operator=(const wxWebSessionBase& other);
+    ~wxWebSessionBase();
 
     // Can be used to check if the given backend is available without actually
     // creating a session using it.
     static bool IsBackendAvailable(const wxString& backend);
-
-    wxWebRequest
-    CreateRequest(wxEvtHandler* handler, const wxString& url, int id = wxID_ANY);
 
     wxVersionInfo GetLibraryVersionInfo();
 
@@ -256,9 +248,42 @@ private:
 
     static void InitFactoryMap();
 
-    explicit wxWebSession(const wxWebSessionImplPtr& impl);
+protected:
+    // This function handles empty backend string correctly, i.e. returns the
+    // default backend in this case.
+    //
+    // The returned pointer should not be deleted by the caller.
+    //
+    // If the specified backend is not found, returns a null pointer.
+    static wxWebSessionFactory* FindFactory(const wxString& backend);
+
+    explicit wxWebSessionBase(const wxWebSessionImplPtr& impl);
 
     wxWebSessionImplPtr m_impl;
+};
+
+class WXDLLIMPEXP_NET wxWebSession : public wxWebSessionBase
+{
+public:
+    wxWebSession() = default;
+
+    wxWebSession(const wxWebSession& other) = default;
+    wxWebSession& operator=(const wxWebSession& other) = default;
+
+    // Objects of this class can't be created directly, use the following
+    // factory functions to get access to them.
+    static wxWebSession& GetDefault();
+
+    static wxWebSession New(const wxString& backend = wxString());
+
+    wxWebRequest
+    CreateRequest(wxEvtHandler* handler, const wxString& url, int id = wxID_ANY);
+
+private:
+    explicit wxWebSession(const wxWebSessionImplPtr& impl)
+        : wxWebSessionBase(impl)
+    {
+    }
 };
 
 class WXDLLIMPEXP_NET wxWebRequestEvent : public wxEvent

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -80,7 +80,7 @@ public:
 
 private:
     // Ctor is used by wxWebRequest only.
-    friend class wxWebRequestBase;
+    friend class wxWebRequest;
     explicit wxWebAuthChallenge(const wxWebAuthChallengeImplPtr& impl);
 
     wxWebAuthChallengeImplPtr m_impl;
@@ -206,8 +206,6 @@ public:
 
     wxWebResponse GetResponse() const;
 
-    wxWebAuthChallenge GetAuthChallenge() const;
-
     wxFileOffset GetBytesSent() const;
 
     wxFileOffset GetBytesExpectedToSend() const;
@@ -242,6 +240,8 @@ public:
     void Start();
 
     void Cancel();
+
+    wxWebAuthChallenge GetAuthChallenge() const;
 
     int GetId() const;
 

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -80,7 +80,7 @@ public:
 
 private:
     // Ctor is used by wxWebRequest only.
-    friend class wxWebRequest;
+    friend class wxWebRequestBase;
     explicit wxWebAuthChallenge(const wxWebAuthChallengeImplPtr& impl);
 
     wxWebAuthChallengeImplPtr m_impl;
@@ -121,7 +121,7 @@ public:
 protected:
     // Ctor is used by wxWebRequest and implementation classes to create public
     // objects from the existing implementation pointers.
-    friend class wxWebRequest;
+    friend class wxWebRequestBase;
     friend class wxWebRequestImpl;
     friend class wxWebResponseImpl;
     explicit wxWebResponse(const wxWebResponseImplPtr& impl);
@@ -129,7 +129,7 @@ protected:
     wxWebResponseImplPtr m_impl;
 };
 
-class WXDLLIMPEXP_NET wxWebRequest
+class WXDLLIMPEXP_NET wxWebRequestBase
 {
 public:
     enum State
@@ -149,11 +149,6 @@ public:
         Storage_None
     };
 
-    wxWebRequest();
-    wxWebRequest(const wxWebRequest& other);
-    wxWebRequest& operator=(const wxWebRequest& other);
-    ~wxWebRequest();
-
     bool IsOk() const { return m_impl.get() != nullptr; }
 
     void SetHeader(const wxString& name, const wxString& value);
@@ -168,19 +163,9 @@ public:
 
     Storage GetStorage() const;
 
-    void Start();
-
-    void Cancel();
-
     wxWebResponse GetResponse() const;
 
     wxWebAuthChallenge GetAuthChallenge() const;
-
-    int GetId() const;
-
-    wxWebSession& GetSession() const;
-
-    State GetState() const;
 
     wxFileOffset GetBytesSent() const;
 
@@ -196,15 +181,43 @@ public:
 
     bool IsPeerVerifyDisabled() const;
 
+protected:
+    wxWebRequestBase();
+    explicit wxWebRequestBase(const wxWebRequestImplPtr& impl);
+    wxWebRequestBase(const wxWebRequestBase& other);
+    wxWebRequestBase& operator=(const wxWebRequestBase& other);
+    ~wxWebRequestBase();
+
+    wxWebRequestImplPtr m_impl;
+};
+
+class WXDLLIMPEXP_NET wxWebRequest : public wxWebRequestBase
+{
+public:
+    wxWebRequest() = default;
+    wxWebRequest(const wxWebRequest& other) = default;
+    wxWebRequest& operator=(const wxWebRequest& other) = default;
+
+    void Start();
+
+    void Cancel();
+
+    int GetId() const;
+
+    wxWebSession& GetSession() const;
+
+    State GetState() const;
+
 private:
     // Ctor is used by wxWebSession and implementation classes to create
     // wxWebRequest objects from the existing implementation pointers.
     friend class wxWebSession;
     friend class wxWebRequestImpl;
     friend class wxWebResponseImpl;
-    explicit wxWebRequest(const wxWebRequestImplPtr& impl);
-
-    wxWebRequestImplPtr m_impl;
+    explicit wxWebRequest(const wxWebRequestImplPtr& impl)
+        : wxWebRequestBase(impl)
+    {
+    }
 };
 
 extern WXDLLIMPEXP_DATA_NET(const char) wxWebSessionBackendWinHTTP[];

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -216,9 +216,25 @@ public:
 
     wxWebRequestHandle GetNativeHandle() const;
 
-    void DisablePeerVerify(bool disable = true);
+    enum
+    {
+        Ignore_Certificate = 1,
+        Ignore_Host = 2,
+        Ignore_All = Ignore_Certificate | Ignore_Host
+    };
 
-    bool IsPeerVerifyDisabled() const;
+    void MakeInsecure(int flags = Ignore_All);
+    int GetSecurityFlags() const;
+
+    void DisablePeerVerify(bool disable = true)
+    {
+        MakeInsecure(disable ? Ignore_Certificate : 0);
+    }
+
+    bool IsPeerVerifyDisabled() const
+    {
+        return (GetSecurityFlags() & Ignore_Certificate) != 0;
+    }
 
 protected:
     wxWebRequestBase();

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -149,6 +149,47 @@ public:
         Storage_None
     };
 
+    struct Result
+    {
+        static Result Ok(State state = State_Active)
+        {
+            Result result;
+            result.state = state;
+            return result;
+        }
+
+        static Result Cancelled()
+        {
+            Result result;
+            result.state = State_Cancelled;
+            return result;
+        }
+
+        static Result Error(const wxString& error)
+        {
+            Result result;
+            result.state = State_Failed;
+            result.error = error;
+            return result;
+        }
+
+        static Result Unauthorized(const wxString& error)
+        {
+            Result result;
+            result.state = State_Unauthorized;
+            result.error = error;
+            return result;
+        }
+
+        bool operator!() const
+        {
+            return state == State_Failed;
+        }
+
+        State state = State_Idle;
+        wxString error;
+    };
+
     bool IsOk() const { return m_impl.get() != nullptr; }
 
     void SetHeader(const wxString& name, const wxString& value);

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -261,6 +261,27 @@ private:
     }
 };
 
+class WXDLLIMPEXP_NET wxWebRequestSync : public wxWebRequestBase
+{
+public:
+    wxWebRequestSync() = default;
+    wxWebRequestSync(const wxWebRequestSync& other) = default;
+    wxWebRequestSync& operator=(const wxWebRequestSync& other) = default;
+
+    // Possible return values for the state here are State_Completed,
+    // State_Failed and State_Unauthorized.
+    Result Execute() const;
+
+private:
+    friend class wxWebSessionSync;
+
+    explicit wxWebRequestSync(const wxWebRequestImplPtr& impl)
+        : wxWebRequestBase(impl)
+    {
+    }
+};
+
+
 extern WXDLLIMPEXP_DATA_NET(const char) wxWebSessionBackendWinHTTP[];
 extern WXDLLIMPEXP_DATA_NET(const char) wxWebSessionBackendURLSession[];
 extern WXDLLIMPEXP_DATA_NET(const char) wxWebSessionBackendCURL[];
@@ -316,6 +337,8 @@ protected:
     wxWebSessionImplPtr m_impl;
 };
 
+// Web session class for using asynchronous web requests, suitable for use in
+// the main thread of GUI applications.
 class WXDLLIMPEXP_NET wxWebSession : public wxWebSessionBase
 {
 public:
@@ -335,6 +358,31 @@ public:
 
 private:
     explicit wxWebSession(const wxWebSessionImplPtr& impl)
+        : wxWebSessionBase(impl)
+    {
+    }
+};
+
+// Web session class for using synchronous web requests, suitable for use in
+// background worker threads.
+class WXDLLIMPEXP_NET wxWebSessionSync : public wxWebSessionBase
+{
+public:
+    wxWebSessionSync() = default;
+
+    wxWebSessionSync(const wxWebSessionSync& other) = default;
+    wxWebSessionSync& operator=(const wxWebSessionSync& other) = default;
+
+    // Objects of this class can't be created directly, use the following
+    // factory functions to get access to them.
+    static wxWebSessionSync& GetDefault();
+
+    static wxWebSessionSync New(const wxString& backend = wxString());
+
+    wxWebRequestSync CreateRequest(const wxString& url);
+
+private:
+    explicit wxWebSessionSync(const wxWebSessionImplPtr& impl)
         : wxWebSessionBase(impl)
     {
     }

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -416,18 +416,66 @@ public:
     void SetStorage(Storage storage);
 
     /**
+        Flags for disabling security features.
+
+        @since 3.3.0
+     */
+    enum
+    {
+        /**
+            Disable SSL certificate verification.
+
+            This can be used to accept self-signed or expired certificates.
+         */
+        Ignore_Certificate = 1,
+
+        /**
+            Disable host name verification.
+
+            This can be used to accept a valid certificate for a different host
+            than the one it was issued for.
+         */
+        Ignore_Host = 2,
+
+        /**
+            Disable all security checks for maximum insecurity.
+         */
+        Ignore_All = Ignore_Certificate | Ignore_Host
+    };
+
+    /**
+        Make connection insecure by disabling security checks.
+
+        Don't use this function unless absolutely necessary as disabling the
+        security checks makes the communication insecure by allowing
+        man-in-the-middle attacks.
+
+        By default, all security checks are enabled. Passing 0 as @a flags
+        (re-)enables all security checks and makes the connection secure again.
+
+        Please note that under macOS this function always disables all the
+        security checks if any of them is disabled, i.e. it is not possible to
+        skip just the certificate or just the host name verification.
+
+        @since 3.3.0
+     */
+    void MakeInsecure(int flags = Ignore_All);
+
+    /**
         Disable SSL certificate verification.
 
         This can be used to connect to self signed servers or other invalid
         SSL connections. Disabling verification makes the communication
         insecure.
+
+        @see MakeInsecure()
     */
     void DisablePeerVerify(bool disable = true);
 
     /**
         Return @true if SSL certificate verification has been disabled.
 
-        @see DisablePeerVerify()
+        @see DisablePeerVerify(), GetSecurityFlags()
     */
     bool IsPeerVerifyDisabled() const;
     ///@}
@@ -781,6 +829,50 @@ public:
     void SetStorage(Storage storage);
 
     /**
+        Flags for disabling security features.
+
+        @since 3.3.0
+     */
+    enum
+    {
+        /**
+            Disable SSL certificate verification.
+
+            This can be used to accept self-signed or expired certificates.
+         */
+        Ignore_Certificate = 1,
+
+        /**
+            Disable host name verification.
+
+            This can be used to accept a valid certificate for a different host
+            than the one it was issued for.
+         */
+        Ignore_Host = 2,
+
+        /**
+            Disable all security checks for maximum insecurity.
+         */
+        Ignore_All = Ignore_Certificate | Ignore_Host
+    };
+
+    /**
+        Make connection insecure by disabling security checks.
+
+        Don't use this function unless absolutely necessary as disabling the
+        security checks makes the communication insecure by allowing
+        man-in-the-middle attacks.
+
+        By default, all security checks are enabled. Passing 0 as @a flags
+        (re-)enables all security checks and makes the connection secure again.
+
+        Please notice that this function currently has no effect under macOS.
+
+        @since 3.3.0
+     */
+    void MakeInsecure(int flags = Ignore_All);
+
+    /**
         Disable SSL certificate verification.
 
         This can be used to connect to self signed servers or other invalid
@@ -788,13 +880,15 @@ public:
         insecure.
 
         Please notice that this function currently has no effect under macOS.
+
+        @see MakeInsecure()
     */
     void DisablePeerVerify(bool disable = true);
 
     /**
         Return @true if SSL certificate verification has been disabled.
 
-        @see DisablePeerVerify()
+        @see DisablePeerVerify(), GetSecurityFlags()
     */
     bool IsPeerVerifyDisabled() const;
     ///@}

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -499,18 +499,8 @@ public:
     }
     @endcode
 
-    To handle authentication, check for State_Unauthorized state too and set
-    credentials in this case, e.g.:
-    @code
-    if ( result.state == wxWebRequestSync::State_Unauthorized )
-    {
-        request.GetAuthChallenge().SetCredentials("me", wxSecretValue("let me in"));
-
-        // Unlike with the asynchronous requests, Execute() must be called
-        // again manually.
-        result = request.Execute();
-    }
-    @endcode
+    To handle authentication with this class the username and password must be
+    specified in the URL itself and wxWebAuthChallenge is not used with it.
 
     @see wxWebRequest
 
@@ -528,11 +518,9 @@ public:
         State_Idle,
 
         /**
-            The request is currently unauthorized.
+            The request is unauthorized.
 
-            Calling GetAuthChallenge() returns a challenge object with further
-            details and calling SetCredentials() on this object and Execute()
-            again will retry the request using these credentials.
+            Use an URL with the username and password to access this resource.
         */
         State_Unauthorized,
 
@@ -683,12 +671,6 @@ public:
         returns @c false.
     */
     wxWebResponse GetResponse() const;
-
-    /**
-        Returns the current authentication challenge object while the request
-        is in @c State_Unauthorized.
-    */
-    wxWebAuthChallenge GetAuthChallenge() const;
 
     /** @name Request options
         Methods that set options before starting the request

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -786,6 +786,8 @@ public:
         This can be used to connect to self signed servers or other invalid
         SSL connections. Disabling verification makes the communication
         insecure.
+
+        Please notice that this function currently has no effect under macOS.
     */
     void DisablePeerVerify(bool disable = true);
 

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -20,8 +20,11 @@
     wxWebSession::CreateRequest().
 
     The requests are handled asynchronously and event handlers are used to
-    communicate the request status. The response data may be stored in
-    memory, to a file or processed directly, see SetStorage() for details.
+    communicate the request status. See wxWebRequestSync for a class that can
+    be used to perform synchronous requests.
+
+    The response data may be stored in memory, to a file or processed directly,
+    see SetStorage() for details.
 
     Example usage in an event handler function of some window (i.e. @c this in
     the example below is a wxWindow pointer):
@@ -473,6 +476,354 @@ public:
 };
 
 /**
+    @class wxWebRequestSync
+
+    This class allows to perform synchronous HTTP requests using the operating
+    components as implementation.
+
+    Please note that this class must not be used from the main thread of GUI
+    applications, only use it from worker threads.
+
+    Example of use:
+    @code
+    auto request = wxWebSessionSync::GetDefault().CreateRequest("https://www.wxwidgets.org");
+    auto result = request.Execute();
+    if ( !result )
+    {
+        wxLogError("Request failed: %s", result.error);
+    }
+    else
+    {
+        // Do something with the response data, e.g. show it in a text control:
+        text->SetValue(request.GetResponse().AsString());
+    }
+    @endcode
+
+    To handle authentication, check for State_Unauthorized state too and set
+    credentials in this case, e.g.:
+    @code
+    if ( result.state == wxWebRequestSync::State_Unauthorized )
+    {
+        request.GetAuthChallenge().SetCredentials("me", wxSecretValue("let me in"));
+
+        // Unlike with the asynchronous requests, Execute() must be called
+        // again manually.
+        result = request.Execute();
+    }
+    @endcode
+
+    @see wxWebRequest
+
+    @since 3.3.0
+ */
+class wxWebRequestSync
+{
+public:
+    /**
+        Possible request states returned in the state field of Result.
+    */
+    enum State
+    {
+        /// This state is not used with synchronous requests.
+        State_Idle,
+
+        /**
+            The request is currently unauthorized.
+
+            Calling GetAuthChallenge() returns a challenge object with further
+            details and calling SetCredentials() on this object and Execute()
+            again will retry the request using these credentials.
+        */
+        State_Unauthorized,
+
+        /// This state is not used with synchronous requests.
+        State_Active,
+
+        /**
+            The request completed successfully and all data has been received.
+
+            The HTTP status code returned by wxWebResponse::GetStatus() will be
+            in 100-399 range, and typically 200.
+         */
+        State_Completed,
+
+        /**
+            The request failed.
+
+            This can happen either because the request couldn't be performed at
+            all (e.g. a connection error) or if the server returned an HTTP
+            error. In the former case wxWebResponse::GetStatus() returns 0,
+            while in the latter it returns a value in 400-599 range.
+         */
+        State_Failed,
+
+        /// This state is not used with synchronous requests.
+        State_Cancelled
+    };
+
+    /**
+        Result of a synchronous operation.
+     */
+    struct Result
+    {
+        /**
+            The state of the request.
+
+            This field can only take State_Completed, State_Failed or
+            State_Unauthorized values for the synchronous requests.
+         */
+        State state;
+
+        /**
+            The error message in case of a failure.
+
+            This field can also be non-empty for State_Unauthorized state.
+         */
+        wxString error;
+
+        /**
+            Returns true if the request failed.
+
+            Example of use:
+
+            @code
+            const auto result = request.Execute();
+            if ( !result )
+            {
+                wxLogError("Request failed: %s", result.error);
+                return;
+            }
+            @endcode
+
+            Note that State_Unauthorized is not considered a failure and needs
+            to be checked separately.
+         */
+        bool operator!() const;
+    };
+
+    /**
+        Possible storage types. Set by SetStorage().
+    */
+    enum Storage
+    {
+        /**
+            All data is collected in memory until the request is complete.
+
+            It can be later retrieved using wxWebResponse::AsString() or
+            wxWebResponse::GetStream().
+         */
+        Storage_Memory,
+
+        /**
+            The data is written to a file on disk as it is received.
+
+            This file can be later read from using wxWebResponse::GetStream()
+            or otherwise processed using wxWebRequestEvent::GetDataFile().
+         */
+        Storage_File,
+
+        /**
+            The data is not stored by the request.
+
+            This storage method is not useful for the synchronous requests as
+            data is simply lost when it is used, however it is still supported
+            just in case the received data is really not needed.
+        */
+        Storage_None
+    };
+
+    /**
+        Default constructor creates an invalid object.
+
+        Initialize it by assigning wxWebSessionSync::CreateRequest() to it
+        before using it.
+
+        @see IsOk()
+    */
+    wxWebRequestSync();
+
+    /**
+        Check if the object is valid.
+
+        If the object is invalid, it must be assigned a valid request before
+        any other methods can be used (with the exception of GetNativeHandle()).
+    */
+    bool IsOk() const;
+
+    /**
+        Return the native handle corresponding to this request object.
+
+        @c wxWebRequestHandle is an opaque type containing a value of the
+        following type according to the backend being used:
+
+        - For WinHTTP backend, this is @c HINTERNET request handle.
+        - For CURL backend, this is a @c CURL struct pointer.
+        - For macOS backend, this is @c NSURLSessionTask object pointer.
+
+        Note that this function returns a valid value only after the request is
+        executed successfully using Execute().
+
+        @see wxWebSession::GetNativeHandle()
+     */
+    wxWebRequestHandle GetNativeHandle() const;
+
+    /**
+        Synchronously execute the request.
+
+        This function blocks for potentially long time and so must not be used
+        from the main thread.
+     */
+    Result Execute() const;
+
+    /**
+        Returns a response object after a successful request.
+
+        Before sending a request or after a failed request this will return
+        an invalid response object, i.e. such that wxWebResponse::IsOk()
+        returns @c false.
+    */
+    wxWebResponse GetResponse() const;
+
+    /**
+        Returns the current authentication challenge object while the request
+        is in @c State_Unauthorized.
+    */
+    wxWebAuthChallenge GetAuthChallenge() const;
+
+    /** @name Request options
+        Methods that set options before starting the request
+    */
+    ///@{
+    /**
+        Sets a request header which will be sent to the server by this request.
+
+        The header will be added if it hasn't been set before or replaced
+        otherwise.
+
+        @param name
+            Name of the header
+        @param value
+            String value of the header. An empty string will remove the header.
+    */
+    void SetHeader(const wxString& name, const wxString& value);
+
+    /**
+        Set <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html">common</a>
+        or expanded HTTP method.
+
+        The default method is GET unless request data is provided in which
+        case POST is the default.
+
+        @param method
+            HTTP method name, e.g. "GET".
+    */
+    void SetMethod(const wxString& method);
+
+    /**
+        Set the text to be posted to the server.
+
+        After a successful call to this method, the request will use HTTP @c
+        POST instead of the default @c GET when it's executed.
+
+        @param text
+            The text data to post.
+        @param contentType
+            The value of HTTP "Content-Type" header, e.g. "text/html;
+            charset=UTF-8".
+        @param conv
+            Conversion used when sending the text to the server
+    */
+    void SetData(const wxString& text, const wxString& contentType,
+        const wxMBConv& conv = wxConvUTF8);
+
+    /**
+        Set the binary data to be posted to the server.
+
+        The next request will be a HTTP @c POST instead of the default HTTP
+        @c GET and the given @a dataStream will be posted as the body of
+        this request.
+
+        Example of use:
+        @code
+        std::unique_ptr<wxInputStream> stream(new wxFileInputStream("some_file.dat"));
+        if ( !stream->IsOk() ) {
+            // Handle error (due to e.g. file not found) here.
+            ...
+            return;
+        }
+        request.SetData(stream.release(), "application/octet-stream")
+        @endcode
+
+        @param dataStream
+            The data in this stream will be posted as the request body. The
+            pointer may be @NULL, which will result in sending 0 bytes of data,
+            but if not empty, should be valid, i.e. wxInputStream::IsOk() must
+            return @true. This object takes ownership of the passed in pointer
+            and will delete it, i.e. the pointer must be heap-allocated.
+        @param contentType
+            The value of HTTP "Content-Type" header, e.g.
+            "application/octet-stream".
+        @param dataSize
+            Amount of data which is sent to the server. If set to
+            @c wxInvalidOffset all stream data is sent.
+
+        @return @false if @a dataStream is not-empty but invalid or if @a
+            dataSize is not specified and the attempt to determine stream size
+            failed; @true in all the other cases.
+    */
+    bool SetData(wxInputStream* dataStream,
+        const wxString& contentType, wxFileOffset dataSize = wxInvalidOffset);
+
+    /**
+        Sets how response data will be stored.
+
+        The default storage method @c Storage_Memory collects all response data
+        in memory until the request is completed. This is fine for most usage
+        scenarios like API calls, loading images, etc. For larger downloads or
+        if the response data will be used permanently @c Storage_File instructs
+        the request to write the response to a temporary file. This temporary
+        file may then be read or moved after the request is complete. The file
+        will be downloaded to the system temp directory as returned by
+        wxStandardPaths::GetTempDir(). To specify a different directory use
+        wxWebSession::SetTempDir().
+
+        Sometimes response data needs to be processed while its downloaded from
+        the server. For example if the response is in a format that can be
+        parsed piece by piece like XML, JSON or an archive format like ZIP.
+        In these cases storing the data in memory or a file before being able
+        to process it might not be ideal and @c Storage_None should be set.
+        With this storage method the data is only available during the
+        @c wxEVT_WEBREQUEST_DATA event calls as soon as it's received from the
+        server.
+    */
+    void SetStorage(Storage storage);
+
+    /**
+        Disable SSL certificate verification.
+
+        This can be used to connect to self signed servers or other invalid
+        SSL connections. Disabling verification makes the communication
+        insecure.
+    */
+    void DisablePeerVerify(bool disable = true);
+
+    /**
+        Return @true if SSL certificate verification has been disabled.
+
+        @see DisablePeerVerify()
+    */
+    bool IsPeerVerifyDisabled() const;
+    ///@}
+
+    /**
+        Returns the total number of bytes received from the server.
+
+        This value is available after calling Execute().
+     */
+    wxFileOffset GetBytesReceived() const;
+};
+
+/**
     Authentication challenge information available via
     wxWebRequest::GetAuthChallenge().
 
@@ -551,7 +902,7 @@ public:
     @library{wxnet}
     @category{net}
 
-    @see wxWebRequest
+    @see wxWebRequest, wxWebRequestSync
 */
 class wxWebResponse
 {
@@ -559,8 +910,8 @@ public:
     /**
         Default constructor creates an invalid object.
 
-        Initialize it by assigning wxWebRequest::GetResponse() to it before
-        using it.
+        Initialize it by assigning wxWebRequest::GetResponse() or
+        wxWebRequestSync::GetResponse() to it before using it.
 
         @see IsOk()
     */
@@ -672,7 +1023,7 @@ public:
     @library{wxnet}
     @category{net}
 
-    @see wxWebRequest
+    @see wxWebRequest, wxWebSessionSync
 */
 class wxWebSession
 {
@@ -821,6 +1172,157 @@ public:
      */
     bool EnablePersistentStorage(bool enable);
 };
+
+/**
+    @class wxWebSessionSync
+
+    Session allows creating wxWebRequestSync objects used for the synchronous
+    HTTP requests.
+
+    This class is similar to wxWebSession but is used for synchronous requests
+    only. Please see wxWebSession description for more details.
+
+    @since 3.3.0
+
+    @library{wxnet}
+    @category{net}
+
+    @see wxWebRequestSync
+*/
+class wxWebSessionSync
+{
+public:
+    /**
+        Create a new synchronous request for the specified URL.
+
+        @param url
+            The URL of the HTTP resource for this request
+        @return
+            The new request object, use wxWebRequestSync::IsOk() to check if
+            its creation has succeeded.
+    */
+    wxWebRequestSync CreateRequest(const wxString& url);
+
+    /**
+        Retrieve the version information about the implementation library used
+        by this session.
+    */
+    virtual wxVersionInfo GetLibraryVersionInfo();
+
+    /**
+        Sets a request header in every wxWebRequestSync created from this
+        session after is has been set.
+
+        A good example for a session-wide request header is the @c User-Agent
+        header.
+
+        Calling this function with the same header name again replaces the
+        previously used value.
+
+        @param name Name of the header
+        @param value String value of the header
+    */
+    void AddCommonHeader(const wxString& name, const wxString& value);
+
+    /**
+        Override the default temporary directory that may be used by the
+        session implementation, when required.
+    */
+    void SetTempDir(const wxString& dir);
+
+    /**
+        Returns the current temporary directory.
+
+        @see SetTempDir()
+    */
+    wxString GetTempDir() const;
+
+    /**
+        Returns the default session
+    */
+    static wxWebSessionSync& GetDefault();
+
+    /**
+        Creates a new wxWebSessionSync object.
+
+        @a backend may be specified explicitly by using of the predefined @c
+        wxWebSessionBackendWinHTTP, @c wxWebSessionBackendURLSession or @c
+        wxWebSessionBackendCURL constants to select the corresponding backend
+        or left empty to select the default backend. The default depends on
+        the current platform: WinHTTP-based implementation is used under MSW,
+        NSURLSession-based one under macOS and libcurl-based otherwise.
+
+        Further, if @c WXWEBREQUEST_BACKEND environment variable is defined, it
+        overrides the default backend selection, allowing to force the use of
+        libcurl-based implementation by default under MSW or macOS platforms,
+        for example.
+
+        Use IsOpened() to check if the session creation succeeded.
+
+        @param backend
+            The backend web session implementation to use or empty to use the
+            default implementation as described above.
+
+        @return
+            The created wxWebSessionSync
+    */
+    static wxWebSessionSync New(const wxString& backend = wxString());
+
+    /**
+        Allows to check if the specified backend is available at runtime.
+
+        Usually the default backend should always be available, but e.g. macOS
+        before 10.9 does not have the @c NSURLSession implementation available.
+    */
+    static bool IsBackendAvailable(const wxString& backend);
+
+    /**
+        Return the native handle corresponding to this session object.
+
+        @c wxWebSessionHandle is an opaque type containing a value of the
+        following type according to the backend being used:
+
+        - For WinHTTP backend, this is @c HINTERNET session handle.
+        - For CURL backend, this is a @c CURLM struct pointer.
+        - For macOS backend, this is @c NSURLSession object pointer.
+
+        @see wxWebRequest::GetNativeHandle()
+     */
+    wxWebSessionHandle GetNativeHandle() const;
+
+    /**
+        Return @true if the session was successfully opened and can be used.
+    */
+    bool IsOpened() const;
+
+    /**
+        Close the session.
+
+        This frees any resources associated with the session and puts it in an
+        invalid state. Another session object can be assigned to it later to
+        allow using this object again.
+     */
+    void Close();
+
+    /**
+        Allows to enable persistent storage for the session.
+
+        Persistent storage is disabled by default, but this function can be
+        called to enable it before the first request is created. Note that it
+        can't be called any more after creating the first request in this
+        session.
+
+        When persistent storage is enabled, the session will store cookies and
+        other data between sessions.
+
+        @return @true if the backend supports to modify this setting. @false if
+            the setting is not supported by the backend.
+
+        @note This is only implemented in the macOS backend.
+     */
+    bool EnablePersistentStorage(bool enable);
+};
+
 
 /**
     @class wxWebRequestEvent

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -101,7 +101,7 @@ void wxWebRequestImpl::Cancel()
 wxString wxWebRequestImpl::GetHTTPMethod() const
 {
     if ( !m_method.empty() )
-        return m_method;
+        return m_method.Upper();
 
     return m_dataSize ? wxASCII_STR("POST") : wxASCII_STR("GET");
 }

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -383,29 +383,18 @@ void wxWebRequestImpl::ProcessStateEvent(wxWebRequest::State state, const wxStri
 // wxWebRequest
 //
 
-wxWebRequest::wxWebRequest()
-{
-}
+wxWebRequest::wxWebRequest() = default;
 
 wxWebRequest::wxWebRequest(const wxWebRequestImplPtr& impl)
     : m_impl(impl)
 {
 }
 
-wxWebRequest::wxWebRequest(const wxWebRequest& other)
-    : m_impl(other.m_impl)
-{
-}
+wxWebRequest::wxWebRequest(const wxWebRequest& other) = default;
 
-wxWebRequest& wxWebRequest::operator=(const wxWebRequest& other)
-{
-    m_impl = other.m_impl;
-    return *this;
-}
+wxWebRequest& wxWebRequest::operator=(const wxWebRequest& other) = default;
 
-wxWebRequest::~wxWebRequest()
-{
-}
+wxWebRequest::~wxWebRequest() = default;
 
 void wxWebRequest::SetHeader(const wxString& name, const wxString& value)
 {
@@ -560,29 +549,19 @@ bool wxWebRequest::IsPeerVerifyDisabled() const
 // wxWebAuthChallenge
 //
 
-wxWebAuthChallenge::wxWebAuthChallenge()
-{
-}
+wxWebAuthChallenge::wxWebAuthChallenge() = default;
 
 wxWebAuthChallenge::wxWebAuthChallenge(const wxWebAuthChallengeImplPtr& impl)
     : m_impl(impl)
 {
 }
 
-wxWebAuthChallenge::wxWebAuthChallenge(const wxWebAuthChallenge& other)
-    : m_impl(other.m_impl)
-{
-}
+wxWebAuthChallenge::wxWebAuthChallenge(const wxWebAuthChallenge& other) = default;
 
-wxWebAuthChallenge& wxWebAuthChallenge::operator=(const wxWebAuthChallenge& other)
-{
-    m_impl = other.m_impl;
-    return *this;
-}
+wxWebAuthChallenge&
+wxWebAuthChallenge::operator=(const wxWebAuthChallenge& other) = default;
 
-wxWebAuthChallenge::~wxWebAuthChallenge()
-{
-}
+wxWebAuthChallenge::~wxWebAuthChallenge() = default;
 
 wxWebAuthChallenge::Source wxWebAuthChallenge::GetSource() const
 {
@@ -782,29 +761,18 @@ void wxWebResponseImpl::Finalize()
 // wxWebResponse
 //
 
-wxWebResponse::wxWebResponse()
-{
-}
+wxWebResponse::wxWebResponse() = default;
 
 wxWebResponse::wxWebResponse(const wxWebResponseImplPtr& impl)
     : m_impl(impl)
 {
 }
 
-wxWebResponse::wxWebResponse(const wxWebResponse& other)
-    : m_impl(other.m_impl)
-{
-}
+wxWebResponse::wxWebResponse(const wxWebResponse& other) = default;
 
-wxWebResponse& wxWebResponse::operator=(const wxWebResponse& other)
-{
-    m_impl = other.m_impl;
-    return *this;
-}
+wxWebResponse& wxWebResponse::operator=(const wxWebResponse& other) = default;
 
-wxWebResponse::~wxWebResponse()
-{
-}
+wxWebResponse::~wxWebResponse() = default;
 
 wxFileOffset wxWebResponse::GetContentLength() const
 {
@@ -916,29 +884,18 @@ wxString wxWebSessionImpl::GetTempDir() const
 // wxWebSession
 //
 
-wxWebSession::wxWebSession()
-{
-}
+wxWebSession::wxWebSession() = default;
 
 wxWebSession::wxWebSession(const wxWebSessionImplPtr& impl)
     : m_impl(impl)
 {
 }
 
-wxWebSession::wxWebSession(const wxWebSession& other)
-    : m_impl(other.m_impl)
-{
-}
+wxWebSession::wxWebSession(const wxWebSession& other) = default;
 
-wxWebSession& wxWebSession::operator=(const wxWebSession& other)
-{
-    m_impl = other.m_impl;
-    return *this;
-}
+wxWebSession& wxWebSession::operator=(const wxWebSession& other) = default;
 
-wxWebSession::~wxWebSession()
-{
-}
+wxWebSession::~wxWebSession() = default;
 
 // static
 wxWebSession& wxWebSession::GetDefault()

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -98,6 +98,14 @@ void wxWebRequestImpl::Cancel()
     DoCancel();
 }
 
+wxString wxWebRequestImpl::GetHTTPMethod() const
+{
+    if ( !m_method.empty() )
+        return m_method;
+
+    return m_dataSize ? wxASCII_STR("POST") : wxASCII_STR("GET");
+}
+
 // static
 wxWebRequestSync::Result
 wxWebRequestImpl::GetResultFromHTTPStatus(const wxWebResponseImplPtr& resp)

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -551,14 +551,14 @@ wxWebRequestHandle wxWebRequestBase::GetNativeHandle() const
     return m_impl ? m_impl->GetNativeHandle() : nullptr;
 }
 
-void wxWebRequestBase::DisablePeerVerify(bool disable)
+void wxWebRequestBase::MakeInsecure(int flags)
 {
-    m_impl->DisablePeerVerify(disable);
+    m_impl->MakeInsecure(flags);
 }
 
-bool wxWebRequestBase::IsPeerVerifyDisabled() const
+int wxWebRequestBase::GetSecurityFlags() const
 {
-    return m_impl->IsPeerVerifyDisabled();
+    return m_impl->GetSecurityFlags();
 }
 
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -490,7 +490,7 @@ wxWebResponse wxWebRequestBase::GetResponse() const
     return wxWebResponse(m_impl->GetResponse());
 }
 
-wxWebAuthChallenge wxWebRequestBase::GetAuthChallenge() const
+wxWebAuthChallenge wxWebRequest::GetAuthChallenge() const
 {
     wxCHECK_IMPL( wxWebAuthChallenge() );
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -64,16 +64,10 @@ wxWebRequestImpl::wxWebRequestImpl(wxWebSession& session,
                                    wxWebSessionImpl& sessionImpl,
                                    wxEvtHandler* handler,
                                    int id)
-    : m_storage(wxWebRequest::Storage_Memory),
-      m_headers(sessionImpl.GetHeaders()),
-      m_dataSize(0),
-      m_peerVerifyDisabled(false),
+    : m_headers(sessionImpl.GetHeaders()),
       m_session(session),
       m_handler(handler),
-      m_id(id),
-      m_state(wxWebRequest::State_Idle),
-      m_bytesReceived(0),
-      m_cancelled(false)
+      m_id(id)
 {
 }
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -377,34 +377,38 @@ void wxWebRequestImpl::ProcessStateEvent(wxWebRequest::State state, const wxStri
 // wxWebRequest
 //
 
-wxWebRequest::wxWebRequest() = default;
+wxWebRequestBase::wxWebRequestBase() = default;
 
-wxWebRequest::wxWebRequest(const wxWebRequestImplPtr& impl)
+wxWebRequestBase::wxWebRequestBase(const wxWebRequestImplPtr& impl)
     : m_impl(impl)
 {
 }
 
-wxWebRequest::wxWebRequest(const wxWebRequest& other) = default;
+wxWebRequestBase::wxWebRequestBase(const wxWebRequestBase& other) = default;
 
-wxWebRequest& wxWebRequest::operator=(const wxWebRequest& other) = default;
+wxWebRequestBase&
+wxWebRequestBase::operator=(const wxWebRequestBase& other) = default;
 
-wxWebRequest::~wxWebRequest() = default;
+wxWebRequestBase::~wxWebRequestBase() = default;
 
-void wxWebRequest::SetHeader(const wxString& name, const wxString& value)
+void wxWebRequestBase::SetHeader(const wxString& name, const wxString& value)
 {
     wxCHECK_IMPL_VOID();
 
     m_impl->SetHeader(name, value);
 }
 
-void wxWebRequest::SetMethod(const wxString& method)
+void wxWebRequestBase::SetMethod(const wxString& method)
 {
     wxCHECK_IMPL_VOID();
 
     m_impl->SetMethod(method);
 }
 
-void wxWebRequest::SetData(const wxString& text, const wxString& contentType, const wxMBConv& conv)
+void
+wxWebRequestBase::SetData(const wxString& text,
+                          const wxString& contentType,
+                          const wxMBConv& conv)
 {
     wxCHECK_IMPL_VOID();
 
@@ -412,9 +416,9 @@ void wxWebRequest::SetData(const wxString& text, const wxString& contentType, co
 }
 
 bool
-wxWebRequest::SetData(wxInputStream* dataStream,
-                      const wxString& contentType,
-                      wxFileOffset dataSize)
+wxWebRequestBase::SetData(wxInputStream* dataStream,
+                          const wxString& contentType,
+                          wxFileOffset dataSize)
 {
     // Ensure that the stream is destroyed even we return below.
     std::unique_ptr<wxInputStream> streamPtr(dataStream);
@@ -424,14 +428,14 @@ wxWebRequest::SetData(wxInputStream* dataStream,
     return m_impl->SetData(streamPtr, contentType, dataSize);
 }
 
-void wxWebRequest::SetStorage(Storage storage)
+void wxWebRequestBase::SetStorage(Storage storage)
 {
     wxCHECK_IMPL_VOID();
 
     m_impl->SetStorage(storage);
 }
 
-wxWebRequest::Storage wxWebRequest::GetStorage() const
+wxWebRequestBase::Storage wxWebRequestBase::GetStorage() const
 {
     wxCHECK_IMPL( Storage_None );
 
@@ -458,14 +462,14 @@ void wxWebRequest::Cancel()
     m_impl->Cancel();
 }
 
-wxWebResponse wxWebRequest::GetResponse() const
+wxWebResponse wxWebRequestBase::GetResponse() const
 {
     wxCHECK_IMPL( wxWebResponse() );
 
     return wxWebResponse(m_impl->GetResponse());
 }
 
-wxWebAuthChallenge wxWebRequest::GetAuthChallenge() const
+wxWebAuthChallenge wxWebRequestBase::GetAuthChallenge() const
 {
     wxCHECK_IMPL( wxWebAuthChallenge() );
 
@@ -493,45 +497,45 @@ wxWebRequest::State wxWebRequest::GetState() const
     return m_impl->GetState();
 }
 
-wxFileOffset wxWebRequest::GetBytesSent() const
+wxFileOffset wxWebRequestBase::GetBytesSent() const
 {
     wxCHECK_IMPL( wxInvalidOffset );
 
     return m_impl->GetBytesSent();
 }
 
-wxFileOffset wxWebRequest::GetBytesExpectedToSend() const
+wxFileOffset wxWebRequestBase::GetBytesExpectedToSend() const
 {
     wxCHECK_IMPL( wxInvalidOffset );
 
     return m_impl->GetBytesExpectedToSend();
 }
 
-wxFileOffset wxWebRequest::GetBytesReceived() const
+wxFileOffset wxWebRequestBase::GetBytesReceived() const
 {
     wxCHECK_IMPL( wxInvalidOffset );
 
     return m_impl->GetBytesReceived();
 }
 
-wxFileOffset wxWebRequest::GetBytesExpectedToReceive() const
+wxFileOffset wxWebRequestBase::GetBytesExpectedToReceive() const
 {
     wxCHECK_IMPL( wxInvalidOffset );
 
     return m_impl->GetBytesExpectedToReceive();
 }
 
-wxWebRequestHandle wxWebRequest::GetNativeHandle() const
+wxWebRequestHandle wxWebRequestBase::GetNativeHandle() const
 {
     return m_impl ? m_impl->GetNativeHandle() : nullptr;
 }
 
-void wxWebRequest::DisablePeerVerify(bool disable)
+void wxWebRequestBase::DisablePeerVerify(bool disable)
 {
     m_impl->DisablePeerVerify(disable);
 }
 
-bool wxWebRequest::IsPeerVerifyDisabled() const
+bool wxWebRequestBase::IsPeerVerifyDisabled() const
 {
     return m_impl->IsPeerVerifyDisabled();
 }

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -602,8 +602,7 @@ wxWebAuthChallenge::SetCredentials(const wxWebCredentials& cred)
 //
 
 wxWebResponseImpl::wxWebResponseImpl(wxWebRequestImpl& request) :
-    m_request(request),
-    m_readSize(wxWEBREQUEST_BUFFER_SIZE)
+    m_request(request)
 {
 }
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -1119,6 +1119,8 @@ wxWebSessionHandle wxWebSessionBase::GetNativeHandle() const
 
 bool wxWebSessionBase::EnablePersistentStorage(bool enable)
 {
+    wxCHECK_IMPL( false );
+
     return m_impl->EnablePersistentStorage(enable);
 }
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -384,10 +384,10 @@ wxWebRequestBase::wxWebRequestBase(const wxWebRequestImplPtr& impl)
 {
 }
 
-wxWebRequestBase::wxWebRequestBase(const wxWebRequestBase& other) = default;
+wxWebRequestBase::wxWebRequestBase(const wxWebRequestBase&) = default;
 
 wxWebRequestBase&
-wxWebRequestBase::operator=(const wxWebRequestBase& other) = default;
+wxWebRequestBase::operator=(const wxWebRequestBase&) = default;
 
 wxWebRequestBase::~wxWebRequestBase() = default;
 
@@ -554,10 +554,10 @@ wxWebAuthChallenge::wxWebAuthChallenge(const wxWebAuthChallengeImplPtr& impl)
 {
 }
 
-wxWebAuthChallenge::wxWebAuthChallenge(const wxWebAuthChallenge& other) = default;
+wxWebAuthChallenge::wxWebAuthChallenge(const wxWebAuthChallenge&) = default;
 
 wxWebAuthChallenge&
-wxWebAuthChallenge::operator=(const wxWebAuthChallenge& other) = default;
+wxWebAuthChallenge::operator=(const wxWebAuthChallenge&) = default;
 
 wxWebAuthChallenge::~wxWebAuthChallenge() = default;
 
@@ -786,9 +786,9 @@ wxWebResponse::wxWebResponse(const wxWebResponseImplPtr& impl)
 {
 }
 
-wxWebResponse::wxWebResponse(const wxWebResponse& other) = default;
+wxWebResponse::wxWebResponse(const wxWebResponse&) = default;
 
-wxWebResponse& wxWebResponse::operator=(const wxWebResponse& other) = default;
+wxWebResponse& wxWebResponse::operator=(const wxWebResponse&) = default;
 
 wxWebResponse::~wxWebResponse() = default;
 
@@ -909,10 +909,10 @@ wxWebSessionBase::wxWebSessionBase(const wxWebSessionImplPtr& impl)
 {
 }
 
-wxWebSessionBase::wxWebSessionBase(const wxWebSessionBase& other) = default;
+wxWebSessionBase::wxWebSessionBase(const wxWebSessionBase&) = default;
 
 wxWebSessionBase&
-wxWebSessionBase::operator=(const wxWebSessionBase& other) = default;
+wxWebSessionBase::operator=(const wxWebSessionBase&) = default;
 
 wxWebSessionBase::~wxWebSessionBase() = default;
 

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -315,26 +315,26 @@ wxWebRequest::Result wxWebRequestCURL::DoFinishPrepare()
 
     const wxString method = GetHTTPMethod();
 
-    if ( method.CmpNoCase("GET") == 0 )
+    if ( method == "GET" )
     {
         // Nothing to do, libcurl defaults to GET. We could explicitly set
         // CURLOPT_HTTPGET option to 1, but this would be useless, as we always
         // reset the handle after making a request anyhow and curl_easy_reset()
         // already resets the method to GET.
     }
-    else if ( method.CmpNoCase("POST") == 0 )
+    else if ( method == "POST" )
     {
         curl_easy_setopt(m_handle, CURLOPT_POSTFIELDSIZE_LARGE,
             static_cast<curl_off_t>(m_dataSize));
         curl_easy_setopt(m_handle, CURLOPT_POST, 1L);
     }
-    else if ( method.CmpNoCase("PUT") == 0 )
+    else if ( method == "PUT" )
     {
         curl_easy_setopt(m_handle, CURLOPT_UPLOAD, 1L);
         curl_easy_setopt(m_handle, CURLOPT_INFILESIZE_LARGE,
             static_cast<curl_off_t>(m_dataSize));
     }
-    else if ( method.CmpNoCase("HEAD") == 0 )
+    else if ( method == "HEAD" )
     {
         curl_easy_setopt(m_handle, CURLOPT_NOBODY, 1L);
     }

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -355,8 +355,11 @@ wxWebRequest::Result wxWebRequestCURL::DoFinishPrepare()
     }
     curl_easy_setopt(m_handle, CURLOPT_HTTPHEADER, m_headerList);
 
-    if ( IsPeerVerifyDisabled() )
+    const int securityFlags = GetSecurityFlags();
+    if ( securityFlags & wxWebRequest::Ignore_Certificate )
         curl_easy_setopt(m_handle, CURLOPT_SSL_VERIFYPEER, 0);
+    if ( securityFlags & wxWebRequest::Ignore_Host )
+        curl_easy_setopt(m_handle, CURLOPT_SSL_VERIFYHOST, 0);
 
     return Result::Ok();
 }

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -411,9 +411,14 @@ wxWebRequest::Result wxWebRequestCURL::DoHandleCompletion()
     if ( !m_response || m_response->GetStatus() == 0 )
         return Result::Error(GetError());
 
-    const auto result = GetResultFromHTTPStatus(m_response);
+    return GetResultFromHTTPStatus(m_response);
+}
 
-    if ( result.state == wxWebRequest::State_Unauthorized )
+void wxWebRequestCURL::HandleCompletion()
+{
+    HandleResult(DoHandleCompletion());
+
+    if ( GetState() == wxWebRequest::State_Unauthorized )
     {
         m_authChallenge.reset(
             new wxWebAuthChallengeCURL(
@@ -424,13 +429,6 @@ wxWebRequest::Result wxWebRequestCURL::DoHandleCompletion()
             )
         );
     }
-
-    return result;
-}
-
-void wxWebRequestCURL::HandleCompletion()
-{
-    HandleResult(DoHandleCompletion());
 }
 
 wxString wxWebRequestCURL::GetError() const

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -283,7 +283,9 @@ wxWebRequestCURL::wxWebRequestCURL(wxWebSession & session,
 
 wxWebRequestCURL::~wxWebRequestCURL()
 {
-    DestroyHeaderList();
+    if ( m_headerList )
+        curl_slist_free_all(m_headerList);
+
     m_sessionImpl.RequestHasTerminated(this);
 }
 
@@ -395,15 +397,6 @@ size_t wxWebRequestCURL::CURLOnRead(char* buffer, size_t size)
     }
     else
         return 0;
-}
-
-void wxWebRequestCURL::DestroyHeaderList()
-{
-    if ( m_headerList )
-    {
-        curl_slist_free_all(m_headerList);
-        m_headerList = nullptr;
-    }
 }
 
 wxFileOffset wxWebRequestCURL::GetBytesSent() const

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -885,7 +885,7 @@ SocketPollerImpl* SocketPollerImpl::Create(wxEvtHandler* hndlr)
 int wxWebSessionCURL::ms_activeSessions = 0;
 unsigned int wxWebSessionCURL::ms_runtimeVersion = 0;
 
-wxWebSessionCURL::wxWebSessionCURL() :
+wxWebSessionCURL::wxWebSessionCURL()
 {
     // Initialize CURL globally if no sessions are active
     if ( ms_activeSessions == 0 )

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -122,8 +122,6 @@ wxWebResponseCURL::wxWebResponseCURL(wxWebRequestCURL& request) :
 
     // Have curl call the progress callback.
     curl_easy_setopt(GetHandle(), CURLOPT_NOPROGRESS, 0L);
-
-    Init();
 }
 
 size_t wxWebResponseCURL::CURLOnWrite(void* buffer, size_t size)
@@ -290,6 +288,9 @@ wxWebRequestCURL::~wxWebRequestCURL()
 void wxWebRequestCURL::Start()
 {
     m_response.reset(new wxWebResponseCURL(*this));
+
+    if ( !CheckResult(m_response->InitFileStorage()) )
+        return;
 
     if ( m_dataSize )
     {

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -235,8 +235,6 @@ wxWebRequestCURL::wxWebRequestCURL(wxWebSession & session,
     wxWebRequestImpl(session, sessionImpl, handler, id),
     m_sessionImpl(sessionImpl)
 {
-    m_headerList = nullptr;
-
     m_handle = curl_easy_init();
     if ( !m_handle )
     {
@@ -888,7 +886,6 @@ int wxWebSessionCURL::ms_activeSessions = 0;
 unsigned int wxWebSessionCURL::ms_runtimeVersion = 0;
 
 wxWebSessionCURL::wxWebSessionCURL() :
-    m_handle(nullptr)
 {
     // Initialize CURL globally if no sessions are active
     if ( ms_activeSessions == 0 )

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -494,12 +494,7 @@ void wxWebAuthChallengeCURL::SetCredentials(const wxWebCredentials& cred)
         (GetSource() == wxWebAuthChallenge::Source_Proxy) ? CURLOPT_PROXYUSERPWD : CURLOPT_USERPWD,
         authStr.utf8_str().data());
 
-    // Asynchronous requests must be resumed automatically, as control flow
-    // doesn't get back to the program and if we didn't this, nothing at all
-    // would happen next, but for the synchronous ones we count on the
-    // application code to just call Execute() again.
-    if ( m_request.IsAsync() )
-        m_request.StartRequest();
+    m_request.StartRequest();
 }
 
 //

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -342,9 +342,8 @@ void wxWebRequestWinHTTP::CreateResponse()
     }
 
     m_response.reset(new wxWebResponseWinHTTP(*this));
-    // wxWebResponseWinHTTP ctor could have changed the state if its
-    // initialization failed, so check for this.
-    if ( GetState() == wxWebRequest::State_Failed )
+
+    if ( !CheckResult(m_response->InitFileStorage()) )
         return;
 
     int status = m_response->GetStatus();
@@ -527,8 +526,6 @@ wxWebResponseWinHTTP::wxWebResponseWinHTTP(wxWebRequestWinHTTP& request):
 
     wxLogTrace(wxTRACE_WEBREQUEST, "Request %p: receiving %llu bytes",
                &request, m_contentLength);
-
-    Init();
 }
 
 wxString wxWebResponseWinHTTP::GetURL() const

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -692,10 +692,19 @@ wxWebResponseWinHTTP::wxWebResponseWinHTTP(wxWebRequestWinHTTP& request):
         wxWinHTTPQueryHeaderString(m_requestHandle, WINHTTP_QUERY_CONTENT_LENGTH);
     if ( contentLengthStr.empty() ||
             !contentLengthStr.ToLongLong(&m_contentLength) )
+    {
         m_contentLength = -1;
 
-    wxLogTrace(wxTRACE_WEBREQUEST, "Request %p: receiving %llu bytes",
-               &request, m_contentLength);
+        wxLogTrace(wxTRACE_WEBREQUEST,
+                   "Request %p: receiving response without content length",
+                   &request);
+    }
+    else
+    {
+        wxLogTrace(wxTRACE_WEBREQUEST,
+                   "Request %p: receiving %llu bytes",
+                   &request, m_contentLength);
+    }
 }
 
 wxString wxWebResponseWinHTTP::GetURL() const

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -25,6 +25,9 @@
     #include "wx/translation.h"
 #endif
 
+// Buffer size used for writing/reading data to/from the network.
+constexpr int wxWEBREQUEST_BUFFER_SIZE = 64 * 1024;
+
 // Helper class used to dynamically load the required symbols from winhttp.dll
 class wxWinHTTP
 {
@@ -740,8 +743,8 @@ bool wxWebResponseWinHTTP::ReadData(DWORD* bytesRead)
     return wxWinHTTP::WinHttpReadData
              (
                 m_requestHandle,
-                GetDataBuffer(m_readSize),
-                m_readSize,
+                GetDataBuffer(wxWEBREQUEST_BUFFER_SIZE),
+                wxWEBREQUEST_BUFFER_SIZE,
                 bytesRead    // [out] bytes read, must be null in async mode
              ) == TRUE;
 }

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -529,13 +529,7 @@ wxWebRequest::Result wxWebRequestWinHTTP::Execute()
 
 wxWebRequest::Result wxWebRequestWinHTTP::DoPrepareRequest()
 {
-    wxString method;
-    if ( !m_method.empty() )
-        method = m_method;
-    else if ( m_dataSize )
-        method = "POST";
-    else
-        method = "GET";
+    const wxString method = GetHTTPMethod();
 
     wxLogTrace(wxTRACE_WEBREQUEST, "Request %p: start \"%s %s\"",
                this, method, m_url);

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -600,14 +600,18 @@ wxWebRequest::Result wxWebRequestWinHTTP::DoPrepareRequest()
         return FailWithLastError("Opening request");
     }
 
-    if ( IsPeerVerifyDisabled() )
+    if ( int flags = GetSecurityFlags() )
     {
-        wxWinHTTPSetOption(m_request, WINHTTP_OPTION_SECURITY_FLAGS,
-            SECURITY_FLAG_IGNORE_CERT_CN_INVALID |
-            SECURITY_FLAG_IGNORE_CERT_DATE_INVALID |
-            SECURITY_FLAG_IGNORE_UNKNOWN_CA |
-            SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE
-        );
+        DWORD optValue = 0;
+
+        if ( flags & wxWebRequest::Ignore_Certificate )
+            optValue |= SECURITY_FLAG_IGNORE_CERT_DATE_INVALID |
+                        SECURITY_FLAG_IGNORE_UNKNOWN_CA |
+                        SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE;
+        if ( flags & wxWebRequest::Ignore_Host )
+            optValue |= SECURITY_FLAG_IGNORE_CERT_CN_INVALID;
+
+        wxWinHTTPSetOption(m_request, WINHTTP_OPTION_SECURITY_FLAGS, optValue);
     }
 
     return Result::Ok();

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -267,8 +267,8 @@ wxWebRequestWinHTTP::HandleCallback(DWORD dwInternetStatus,
         case WINHTTP_CALLBACK_STATUS_READ_COMPLETE:
             if ( dwStatusInformationLength > 0 )
             {
-                if ( !m_response->ReportAvailableData(dwStatusInformationLength)
-                        && !WasCancelled() )
+                m_response->ReportDataReceived(dwStatusInformationLength);
+                if ( !m_response->ReadData() && !WasCancelled() )
                     SetFailedWithLastError("Reading data");
             }
             else
@@ -575,12 +575,6 @@ bool wxWebResponseWinHTTP::ReadData()
                 m_readSize,
                 nullptr    // [out] bytes read, must be null in async mode
              ) == TRUE;
-}
-
-bool wxWebResponseWinHTTP::ReportAvailableData(DWORD dataLen)
-{
-    ReportDataReceived(dataLen);
-    return ReadData();
 }
 
 //

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -400,10 +400,11 @@ wxWebRequest::Result wxWebRequestWinHTTP::CreateResponse()
 
     m_response.reset(new wxWebResponseWinHTTP(*this));
 
-    const auto result = m_response->InitFileStorage();
-    if ( !result )
-        return result;
+    return m_response->InitFileStorage();
+}
 
+wxWebRequest::Result wxWebRequestWinHTTP::InitAuthIfNeeded()
+{
     int status = m_response->GetStatus();
     if ( status == HTTP_STATUS_DENIED || status == HTTP_STATUS_PROXY_AUTH_REQ )
     {
@@ -519,12 +520,7 @@ wxWebRequest::Result wxWebRequestWinHTTP::Execute()
         m_response->ReportDataReceived(bytesRead);
     }
 
-    // If we need to authenticate, we already have the appropriate result
-    // returned by CreateResponse().
-    if ( result.state == wxWebRequest::State_Unauthorized )
-        return result;
-
-    // Otherwise we're done.
+    // We're done.
     return GetResultFromHTTPStatus(m_response);
 }
 

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -419,10 +419,14 @@ wxWebRequest::Result wxWebRequestWinHTTP::InitAuthIfNeeded()
                 *this
             ));
 
-        if ( m_authChallenge->Init() )
-            return Result::Unauthorized(m_response->GetStatusText());
-        else
+        if ( !m_authChallenge->Init() )
             return FailWithLastError("Initializing authentication challenge");
+
+        wxLogTrace(wxTRACE_WEBREQUEST,
+                   "Request %p: authentication required (%s)",
+                   this, m_response->GetStatusText());
+
+        return Result::Unauthorized(m_response->GetStatusText());
     }
 
     return Result::Ok();

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -237,10 +237,7 @@ wxWebRequestWinHTTP::wxWebRequestWinHTTP(wxWebSession& session,
                                          int id):
     wxWebRequestImpl(session, sessionImpl, handler, id),
     m_sessionImpl(sessionImpl),
-    m_url(url),
-    m_connect(nullptr),
-    m_request(nullptr),
-    m_dataWritten(0)
+    m_url(url)
 {
 }
 
@@ -662,8 +659,7 @@ wxWebAuthChallengeWinHTTP::SetCredentials(const wxWebCredentials& cred)
 // wxWebSessionWinHTTP
 //
 
-wxWebSessionWinHTTP::wxWebSessionWinHTTP():
-    m_handle(nullptr)
+wxWebSessionWinHTTP::wxWebSessionWinHTTP()
 {
 }
 

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -260,10 +260,8 @@ wxWebRequestWinHTTP::HandleCallback(DWORD dwInternetStatus,
     switch ( dwInternetStatus )
     {
         case WINHTTP_CALLBACK_STATUS_SENDREQUEST_COMPLETE:
-            if ( m_dataSize )
-                WriteData();
-            else
-                CreateResponse();
+            // If there is no data to write, this will call CreateResponse().
+            WriteData();
             break;
 
         case WINHTTP_CALLBACK_STATUS_READ_COMPLETE:

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -138,7 +138,10 @@
     }
     else if ( authMethod == NSURLAuthenticationMethodServerTrust )
     {
-        if (request->IsPeerVerifyDisabled())
+        // We don't have any way to check if the certificate is valid and the
+        // host name is not or vice versa, so just skip all the checks if we're
+        // configured to skip any of them.
+        if (request->GetSecurityFlags() != 0)
             completionHandler(NSURLSessionAuthChallengeUseCredential,
                               [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     }

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -387,8 +387,7 @@ void wxWebAuthChallengeURLSession::SetCredentials(const wxWebCredentials& cred)
 
     [m_cred retain];
 
-    if ( m_request.IsAsync() )
-        m_request.Start();
+    m_request.Start();
 }
 
 

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -290,23 +290,7 @@ wxWebRequest::Result wxWebRequestURLSession::Execute()
     if ( taskResult.data )
         m_response->HandleData(taskResult.data);
 
-    result = GetResultAfterCompletion(taskResult.error);
-
-    if ( result.state == wxWebRequest::State_Unauthorized )
-    {
-        // We don't seem to have access to any information about the
-        // authentication challenge, so just do what we can.
-        m_authChallenge.reset(
-            new wxWebAuthChallengeURLSession(
-                m_response->GetStatus() == 407
-                    ? wxWebAuthChallenge::Source_Proxy
-                    : wxWebAuthChallenge::Source_Server,
-                    *this
-            )
-        );
-    }
-
-    return result;
+    return GetResultAfterCompletion(taskResult.error);
 }
 
 void wxWebRequestURLSession::Start()

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -505,11 +505,8 @@ wxVersionInfo wxWebSessionURLSession::GetLibraryVersionInfo()
 
 bool wxWebSessionURLSession::EnablePersistentStorage(bool enable)
 {
-    if (m_session)
-    {
-        wxFAIL_MSG("Persistent storage can only be enabled before the first request is made.");
-        return false;
-    }
+    wxCHECK_MSG( !(enable && m_session), false,
+                 "Persistent storage can only be enabled before the first request is made" );
 
     m_persistentStorageEnabled = enable;
     return true;

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -222,6 +222,9 @@ void wxWebRequestURLSession::Start()
 
     m_response.reset(new wxWebResponseURLSession(*this, m_task));
 
+    if ( !CheckResult(m_response->InitFileStorage()) )
+        return;
+
     SetState(wxWebRequest::State_Active);
     [m_task resume];
 }
@@ -306,8 +309,6 @@ wxWebResponseURLSession::wxWebResponseURLSession(wxWebRequestURLSession& request
     wxWebResponseImpl(request)
 {
     m_task = [task retain];
-
-    Init();
 }
 
 wxWebResponseURLSession::~wxWebResponseURLSession()

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -181,9 +181,7 @@ wxWebRequestURLSession::~wxWebRequestURLSession()
 wxWebRequest::Result
 wxWebRequestURLSession::DoPrepare(void (^completionHandler)(NSData*, NSURLResponse*, NSError*))
 {
-    wxString method = m_method;
-    if ( method.empty() )
-        method = m_dataSize ? wxASCII_STR("POST") : wxASCII_STR("GET");
+    const wxString method = GetHTTPMethod();
 
     NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:
                                 [NSURL URLWithString:wxCFStringRef(m_url).AsNSString()]];

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -990,6 +990,7 @@ TEST_CASE_METHOD(RequestFixture,
     request.Start();
     RunLoopWithTimeout();
 
+    INFO("Error: \"" << errorDescription << "\"");
     CHECK( request.GetState() == wxWebRequest::State_Completed );
 
     DumpResponse(request.GetResponse());
@@ -1001,7 +1002,10 @@ TEST_CASE_METHOD(SyncRequestFixture,
 {
     InitManualRequest();
 
-    CHECK( Execute() );
+    if ( !Execute() )
+    {
+        FAIL_CHECK("Error: \"" << error << "\"");
+    }
 
     DumpResponse(request.GetResponse());
 }

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -569,8 +569,13 @@ TEST_CASE_METHOD(RequestFixture,
         return;
 
     Create("/delete");
+    request.SetData(R"({"bloordyblop": 17})", "application/json");
     request.SetMethod("DELETE");
     Run();
+
+    const wxString& response = request.GetResponse().AsString();
+    CHECK_THAT( response.utf8_string(),
+                Catch::Contains(R"("bloordyblop": 17)") );
 }
 
 TEST_CASE_METHOD(RequestFixture,
@@ -992,9 +997,13 @@ TEST_CASE_METHOD(SyncRequestFixture,
         return;
 
     Create("/delete");
+    request.SetData(R"({"bloordyblop": 17})", "application/json");
     request.SetMethod("DELETE");
     REQUIRE( Execute() );
+
     CHECK( response.GetStatus() == 200 );
+    CHECK_THAT( response.AsString().utf8_string(),
+                Catch::Contains(R"("bloordyblop": 17)") );
 }
 
 TEST_CASE_METHOD(SyncRequestFixture,

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -253,6 +253,12 @@ public:
 // default buffer size works correctly.
 constexpr int DOWNLOAD_BYTES = 99999;
 
+// Substring used to check that we got the expected response after
+// authenticating successfully. It is so weird because httpbin and go-httpbin
+// use different strings for this: one uses "authenticated" while the other
+// ones uses "authorized", so we use a substring common to both of them.
+constexpr char AUTHORIZED_SUBSTRING[] = R"(ed": true)";
+
 TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Get::Bytes", "[net][webrequest][get]")
 {
@@ -480,7 +486,7 @@ TEST_CASE_METHOD(RequestFixture,
         const auto& response = request.GetResponse();
         CHECK( response.GetStatus() == 200 );
         CHECK_THAT( response.AsString().utf8_string(),
-                    Catch::Contains(R"("authorized": true)") );
+                    Catch::Contains(AUTHORIZED_SUBSTRING) );
     }
 
     SECTION("Bad password")
@@ -511,7 +517,7 @@ TEST_CASE_METHOD(RequestFixture,
         const auto& response = request.GetResponse();
         CHECK( response.GetStatus() == 200 );
         CHECK_THAT( response.AsString().utf8_string(),
-                    Catch::Contains(R"("authorized": true)") );
+                    Catch::Contains(AUTHORIZED_SUBSTRING) );
     }
 
     SECTION("Bad password")
@@ -537,7 +543,7 @@ TEST_CASE_METHOD(RequestFixture,
     const auto& response = request.GetResponse();
     CHECK( response.GetStatus() == 200 );
     CHECK_THAT( response.AsString().utf8_string(),
-                Catch::Contains(R"("authorized": true)") );
+                Catch::Contains(AUTHORIZED_SUBSTRING) );
 }
 
 TEST_CASE_METHOD(RequestFixture,
@@ -554,7 +560,7 @@ TEST_CASE_METHOD(RequestFixture,
     const auto& response = request.GetResponse();
     CHECK( response.GetStatus() == 200 );
     CHECK_THAT( response.AsString().utf8_string(),
-                Catch::Contains(R"("authorized": true)") );
+                Catch::Contains(AUTHORIZED_SUBSTRING) );
 }
 
 TEST_CASE_METHOD(RequestFixture,
@@ -885,7 +891,7 @@ TEST_CASE_METHOD(SyncRequestFixture,
         CHECK( state == wxWebRequest::State_Completed );
 
         CHECK_THAT( response.AsString().utf8_string(),
-                    Catch::Contains(R"("authorized": true)") );
+                    Catch::Contains(AUTHORIZED_SUBSTRING) );
     }
 
     SECTION("Bad password")
@@ -919,7 +925,7 @@ TEST_CASE_METHOD(SyncRequestFixture,
         CHECK( state == wxWebRequest::State_Completed );
 
         CHECK_THAT( response.AsString().utf8_string(),
-                    Catch::Contains(R"("authorized": true)") );
+                    Catch::Contains(AUTHORIZED_SUBSTRING) );
     }
 
     SECTION("Bad password")

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -228,6 +228,8 @@ public:
     void CreateAbs(const wxString& url) override
     {
         request = wxWebSession::GetDefault().CreateRequest(this, url);
+        REQUIRE( request.IsOk() );
+
         Bind(wxEVT_WEBREQUEST_STATE, &RequestFixture::OnRequestState, this);
         Bind(wxEVT_WEBREQUEST_DATA, &RequestFixture::OnData, this);
     }
@@ -728,6 +730,7 @@ public:
     void CreateAbs(const wxString& url) override
     {
         request = wxWebSessionSync::GetDefault().CreateRequest(url);
+        REQUIRE( request.IsOk() );
     }
 
     wxWebRequestBase& GetRequest() override

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -225,17 +225,21 @@ public:
     wxString errorDescription;
 };
 
+// Download more than 64KiB bytes to test that downloading more than the
+// default buffer size works correctly.
+constexpr int DOWNLOAD_BYTES = 99999;
+
 TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Get::Bytes", "[net][webrequest][get]")
 {
     if ( !InitBaseURL() )
         return;
 
-    Create("/bytes/65536");
+    Create(wxString::Format("/bytes/%d", DOWNLOAD_BYTES));
     Run();
-    CHECK( request.GetResponse().GetContentLength() == 65536 );
-    CHECK( request.GetBytesExpectedToReceive() == 65536 );
-    CHECK( request.GetBytesReceived() == 65536 );
+    CHECK( request.GetResponse().GetContentLength() == DOWNLOAD_BYTES );
+    CHECK( request.GetBytesExpectedToReceive() == DOWNLOAD_BYTES );
+    CHECK( request.GetBytesReceived() == DOWNLOAD_BYTES );
 }
 
 TEST_CASE_METHOD(RequestFixture,
@@ -593,10 +597,10 @@ TEST_CASE_METHOD(SyncRequestFixture,
     if ( !InitBaseURL() )
         return;
 
-    REQUIRE( Execute(wxString::Format("/bytes/%d", 65536)) );
+    REQUIRE( Execute(wxString::Format("/bytes/%d", DOWNLOAD_BYTES)) );
 
     CHECK( response.GetStatus() == 200 );
-    CHECK( response.GetContentLength() == 65536 );
+    CHECK( response.GetContentLength() == DOWNLOAD_BYTES );
 }
 
 TEST_CASE_METHOD(SyncRequestFixture,

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -563,6 +563,17 @@ TEST_CASE_METHOD(RequestFixture,
 }
 
 TEST_CASE_METHOD(RequestFixture,
+                 "WebRequest::Delete", "[net][webrequest]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    Create("/delete");
+    request.SetMethod("DELETE");
+    Run();
+}
+
+TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Auth::Basic", "[net][webrequest][auth]")
 {
     if ( !InitBaseURL() )
@@ -970,6 +981,18 @@ TEST_CASE_METHOD(SyncRequestFixture,
 
     request.SetData(is.release(), "image/png");
     request.SetMethod("PUT");
+    REQUIRE( Execute() );
+    CHECK( response.GetStatus() == 200 );
+}
+
+TEST_CASE_METHOD(SyncRequestFixture,
+                 "WebRequest::Sync::Delete", "[net][webrequest][sync]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    Create("/delete");
+    request.SetMethod("DELETE");
     REQUIRE( Execute() );
     CHECK( response.GetStatus() == 200 );
 }

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -451,8 +451,12 @@ TEST_CASE_METHOD(RequestFixture,
     {
         UseCredentials("wxtest", "wxwidgets");
         RunLoopWithTimeout();
-        CHECK( request.GetResponse().GetStatus() == 200 );
         CHECK( request.GetState() == wxWebRequest::State_Completed );
+
+        const auto& response = request.GetResponse();
+        CHECK( response.GetStatus() == 200 );
+        CHECK_THAT( response.AsString().utf8_string(),
+                    Catch::Contains(R"("authorized": true)") );
     }
 
     SECTION("Bad password")
@@ -478,8 +482,12 @@ TEST_CASE_METHOD(RequestFixture,
     {
         UseCredentials("wxtest", "wxwidgets");
         RunLoopWithTimeout();
-        CHECK( request.GetResponse().GetStatus() == 200 );
         CHECK( request.GetState() == wxWebRequest::State_Completed );
+
+        const auto& response = request.GetResponse();
+        CHECK( response.GetStatus() == 200 );
+        CHECK_THAT( response.AsString().utf8_string(),
+                    Catch::Contains(R"("authorized": true)") );
     }
 
     SECTION("Bad password")
@@ -816,6 +824,9 @@ TEST_CASE_METHOD(SyncRequestFixture,
         CHECK( Execute() );
         CHECK( response.GetStatus() == 200 );
         CHECK( state == wxWebRequest::State_Completed );
+
+        CHECK_THAT( response.AsString().utf8_string(),
+                    Catch::Contains(R"("authorized": true)") );
     }
 
     SECTION("Bad password")
@@ -846,6 +857,9 @@ TEST_CASE_METHOD(SyncRequestFixture,
         CHECK( Execute() );
         CHECK( response.GetStatus() == 200 );
         CHECK( state == wxWebRequest::State_Completed );
+
+        CHECK_THAT( response.AsString().utf8_string(),
+                    Catch::Contains(R"("authorized": true)") );
     }
 
     SECTION("Bad password")

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -1153,4 +1153,11 @@ TEST_CASE("WebRequestUtils", "[net][webrequest]")
     CHECK( params["boundary"] == "MIME_boundary_01234567" );
 }
 
+// This is not a real test, run it to see the version of the library used.
+TEST_CASE("WebRequest::Version", "[.]")
+{
+    const auto& info = wxWebSession::GetDefault().GetLibraryVersionInfo();
+    WARN("Using " << info.GetName() << " backend (" << info.ToString() << ")");
+}
+
 #endif // wxUSE_WEBREQUEST

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -122,6 +122,21 @@ protected:
         REQUIRE( response.compare(pos, strlen(expectedValue), expectedValue) == 0 );
     }
 
+    // Special helper for "manual" tests taking the URL from the environment.
+    void InitManualRequest()
+    {
+        // Allow getting 8-bit strings from the environment correctly.
+        setlocale(LC_ALL, "");
+
+        wxString url;
+        if ( !wxGetEnv("WX_TEST_WEBREQUEST_URL", &url) )
+        {
+            FAIL("Specify WX_TEST_WEBREQUEST_URL");
+        }
+
+        CreateAbs(url);
+    }
+
 private:
     wxString baseURL;
 };
@@ -970,16 +985,8 @@ static void DumpResponse(const wxWebResponse& response)
 TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Manual", "[.]")
 {
-    // Allow getting 8-bit strings from the environment correctly.
-    setlocale(LC_ALL, "");
+    InitManualRequest();
 
-    wxString url;
-    if ( !wxGetEnv("WX_TEST_WEBREQUEST_URL", &url) )
-    {
-        FAIL("Specify WX_TEST_WEBREQUEST_URL");
-    }
-
-    CreateAbs(url);
     request.Start();
     RunLoopWithTimeout();
 
@@ -992,16 +999,7 @@ TEST_CASE_METHOD(RequestFixture,
 TEST_CASE_METHOD(SyncRequestFixture,
                  "WebRequest::Sync::Manual", "[.]")
 {
-    // Allow getting 8-bit strings from the environment correctly.
-    setlocale(LC_ALL, "");
-
-    wxString url;
-    if ( !wxGetEnv("WX_TEST_WEBREQUEST_URL", &url) )
-    {
-        FAIL("Specify WX_TEST_WEBREQUEST_URL");
-    }
-
-    CreateAbs(url);
+    InitManualRequest();
 
     CHECK( Execute() );
 

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -500,6 +500,40 @@ TEST_CASE_METHOD(RequestFixture,
 }
 
 TEST_CASE_METHOD(RequestFixture,
+                 "WebRequest::Auth::BasicInURL", "[net][webrequest][auth]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    CreateWithAuth("/basic-auth/wxtest/wxwidgets", "wxtest", "wxwidgets");
+    Run();
+
+    CHECK( request.GetState() == wxWebRequest::State_Completed );
+
+    const auto& response = request.GetResponse();
+    CHECK( response.GetStatus() == 200 );
+    CHECK_THAT( response.AsString().utf8_string(),
+                Catch::Contains(R"("authorized": true)") );
+}
+
+TEST_CASE_METHOD(RequestFixture,
+                 "WebRequest::Auth::DigestInURL", "[net][webrequest][auth]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    CreateWithAuth("/digest-auth/auth/wxtest/wxwidgets", "wxtest", "wxwidgets");
+    Run();
+
+    CHECK( request.GetState() == wxWebRequest::State_Completed );
+
+    const auto& response = request.GetResponse();
+    CHECK( response.GetStatus() == 200 );
+    CHECK_THAT( response.AsString().utf8_string(),
+                Catch::Contains(R"("authorized": true)") );
+}
+
+TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Cancel", "[net][webrequest]")
 {
     if ( !InitBaseURL() )

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -909,6 +909,17 @@ TEST_CASE_METHOD(SyncRequestFixture,
     if ( !InitBaseURL() )
         return;
 
+    const auto& versionInfo = wxWebSession::GetDefault().GetLibraryVersionInfo();
+    if ( versionInfo.GetName() == "libcurl" && !versionInfo.AtLeast(7, 60) )
+    {
+        // This test fails under Ubuntu 18.04 which uses libcurl 7.58 with GnuTLS.
+        // It's not clear whether it does it because libcurl is too old or
+        // because of using GnuTLS instead of OpenSSL used elsewhere, but for
+        // now just skip it.
+        WARN("Skipping Digest auth test because it's known to fail with old libcurl");
+        return;
+    }
+
     SECTION("No password")
     {
         Create("/digest-auth/auth/wxtest/wxwidgets");

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -36,6 +36,11 @@
 // test entirely.
 static const char* WX_TEST_WEBREQUEST_URL_DEFAULT = "https://nghttp2.org/httpbin";
 
+// Note: WX_TEST_WEBREQUEST_URL_SELF_SIGNED is another environment variable
+// used by this test to test SSL connections to a self-signed server. It can be
+// set to https://self-signed.badssl.com/ or any other self-signed server to
+// enable the corresponding tests.
+
 class RequestFixture : public wxTimer
 {
 public:


### PR DESCRIPTION
This is ready for merging as is, but I'm probably going to fix a few other minor things in this branch yet. Still, any comments about the API and testing would be already very appreciated.

In addition to the main topic, there are a couple of other changes here:

- Allow more flexibility when disabling TLS checks.

TODO:

- [x] WinHTTP backend
- [x] `NSURLSession` backend (although the current implementation is suboptimal).
- [x] Documentation