### PR TITLE
Fix library naming when cross compiling for Windows using CMake

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -14,7 +14,7 @@ include(CMakePrintHelpers)
 
 # Use the MSVC/makefile naming convention, or the configure naming convention,
 # this is the same check as used in FindwxWidgets.
-if(WIN32 AND NOT CYGWIN AND NOT MSYS)
+if(WIN32 AND NOT CYGWIN AND NOT MSYS AND NOT CMAKE_CROSSCOMPILING)
     set(WIN32_MSVC_NAMING 1)
 else()
     set(WIN32_MSVC_NAMING 0)


### PR DESCRIPTION
I ran into an issue while cross compiling wxWidgets on Linux for Windows using CMake. When using a cross compilation toolchain, the CMake variable `WIN32` will evaluate to true and so will `CMAKE_CROSSCOMPILING`. This means wxWidgets is built using the `WIN32_MSVC_NAMING`, even though it is built on Linux.

<https://github.com/wxWidgets/wxWidgets/blob/9e1b62779757a83acd75304e7c3defb40bd6a99a/build/cmake/functions.cmake#L15-L21>

In addition, the [FindwxWidgets.cmake](https://github.com/Kitware/CMake/blob/1debc1f2bc34ede149e110af77d07cd403175908/Modules/FindwxWidgets.cmake#L264-L268) file, provided in the CMake installation checks for `CMAKE_CROSSCOMPILING` to set the `wxWidgets_FIND_STYLE`. I therefore end up with CMake trying to use the Unix find-style (through wx-config) to locate a Windows-style wxWidgets build, which fails.

This issue is fixed by simply adding the check for `NOT CMAKE_CROSSCOMPILING` when determining the naming in the functions.cmake file.