### PR TITLE
allow using wxCHK_UNDETERMINED with wxUpdateUIEvent

### DIFF
--- a/include/wx/checkbox.h
+++ b/include/wx/checkbox.h
@@ -103,13 +103,27 @@ public:
     // background colour of the checkbox itself under the other platforms.
     virtual void SetTransparentPartColour(const wxColour& WXUNUSED(col)) { }
 
+    // do the window-specific processing before processing the update event
+    // (mainly for deciding whether wxUpdateUIEvent::Is3State() is set)
+    virtual void DoPrepareUpdateWindowUI(wxUpdateUIEvent& event) const override
+        { event.Allow3rdState(Is3State()); }
+
     // wxCheckBox-specific processing after processing the update event
     virtual void DoUpdateWindowUI(wxUpdateUIEvent& event) override
     {
         wxControl::DoUpdateWindowUI(event);
 
         if ( event.GetSetChecked() )
-            SetValue(event.GetChecked());
+        {
+            if ( Is3State() )
+            {
+                Set3StateValue(event.Get3StateValue());
+            }
+            else
+            {
+                SetValue(event.GetChecked());
+            }
+        }
     }
 
 protected:

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -2926,7 +2926,7 @@ public:
     wxUpdateUIEvent(wxWindowID commandId = 0)
         : wxCommandEvent(wxEVT_UPDATE_UI, commandId)
     {
-        m_checked =
+        m_3checked = wxCHK_UNCHECKED;
         m_enabled =
         m_shown =
         m_setEnabled =
@@ -2934,10 +2934,11 @@ public:
         m_setText =
         m_setChecked = false;
         m_isCheckable = true;
+        m_is3State = false;
     }
     wxUpdateUIEvent(const wxUpdateUIEvent& event)
         : wxCommandEvent(event),
-          m_checked(event.m_checked),
+          m_3checked(event.m_3checked),
           m_enabled(event.m_enabled),
           m_shown(event.m_shown),
           m_setEnabled(event.m_setEnabled),
@@ -2945,10 +2946,12 @@ public:
           m_setText(event.m_setText),
           m_setChecked(event.m_setChecked),
           m_isCheckable(event.m_isCheckable),
+          m_is3State(event.m_is3State),
           m_text(event.m_text)
     { }
 
-    bool GetChecked() const { return m_checked; }
+    bool GetChecked() const { return Get3StateValue() != wxCHK_UNCHECKED; }
+    wxCheckBoxState Get3StateValue() const { return m_3checked; }
     bool GetEnabled() const { return m_enabled; }
     bool GetShown() const { return m_shown; }
     wxString GetText() const { return m_text; }
@@ -2957,14 +2960,18 @@ public:
     bool GetSetEnabled() const { return m_setEnabled; }
     bool GetSetShown() const { return m_setShown; }
 
-    void Check(bool check) { m_checked = check; m_setChecked = true; }
+    void Check(bool check) { Set3StateValue(check ? wxCHK_CHECKED : wxCHK_UNCHECKED); }
+    void Set3StateValue(wxCheckBoxState check);
     void Enable(bool enable) { m_enabled = enable; m_setEnabled = true; }
     void Show(bool show) { m_shown = show; m_setShown = true; }
     void SetText(const wxString& text) { m_text = text; m_setText = true; }
 
     // A flag saying if the item can be checked. True by default.
     bool IsCheckable() const { return m_isCheckable; }
-    void DisallowCheck() { m_isCheckable = false; }
+    void DisallowCheck();
+    // A flag saying if the item can be wxCHK_UNDETERMINED. False by default.
+    bool Is3State() const { return m_is3State; }
+    void Allow3rdState(bool b = true);
 
     // Sets the interval between updates in milliseconds.
     // Set to -1 to disable updates, or to 0 to update as frequently as possible.
@@ -2991,7 +2998,7 @@ public:
     virtual wxEvent *Clone() const override { return new wxUpdateUIEvent(*this); }
 
 protected:
-    bool          m_checked;
+    wxCheckBoxState m_3checked;
     bool          m_enabled;
     bool          m_shown;
     bool          m_setEnabled;
@@ -2999,6 +3006,7 @@ protected:
     bool          m_setText;
     bool          m_setChecked;
     bool          m_isCheckable;
+    bool          m_is3State;
     wxString      m_text;
 #if wxUSE_LONGLONG
     static wxLongLong       sm_lastUpdate;

--- a/include/wx/tglbtn.h
+++ b/include/wx/tglbtn.h
@@ -54,6 +54,7 @@ public:
 
         wxUpdateUIEvent event( GetId() );
         event.SetEventObject(this);
+        DoPrepareUpdateWindowUI(event);
 
         if (GetEventHandler()->ProcessEvent(event) )
         {

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -1341,6 +1341,11 @@ public:
     // send wxUpdateUIEvents to this window, and children if recurse is true
     virtual void UpdateWindowUI(long flags = wxUPDATE_UI_NONE);
 
+    // do the window-specific processing before processing the update event
+    // (mainly for deciding whether wxUpdateUIEvent::Is3State() is set)
+    virtual void DoPrepareUpdateWindowUI(wxUpdateUIEvent& event) const
+        { event.Allow3rdState(false); }
+
     // do the window-specific processing after processing the update event
     virtual void DoUpdateWindowUI(wxUpdateUIEvent& event) ;
 

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -2428,6 +2428,13 @@ public:
     void Check(bool check);
 
     /**
+        For wxCheckBox with wxCHK_3STATE:  Set the UI element state.
+
+        @since 3.3.0
+    */
+    void Set3StateValue(wxCheckBoxState check);
+
+    /**
         Enable or disable the UI element.
     */
     void Enable(bool enable);
@@ -2436,6 +2443,13 @@ public:
         Returns @true if the UI element should be checked.
     */
     bool GetChecked() const;
+
+    /**
+        Return the state a wxCheckBox with wxCHK_3STATE should display
+
+        @since 3.3.0
+    */
+    wxCheckBoxState Get3StateValue() const;
 
     /**
         Returns @true if the UI element should be enabled.
@@ -2463,6 +2477,28 @@ public:
     bool IsCheckable() const;
 
     /**
+        Returns @true if the UI element supports wxCheckboxState.
+
+        For the event handlers that can be used for multiple items, not all of
+        which support wxCheckboxState, this method can be useful to determine whether
+        to call Set3StateValue() on the event object or not, i.e. the main use case for
+        this method is:
+        @code
+        void MyWindow::OnUpdateUI(wxUpdateUIEvent& event)
+        {
+            ....
+            if ( event.Is3State() )
+                event.Set3StateValue(...some condition...);
+            else if ( event.IsCheckable() )
+                event.Check(...some condition...);
+        }
+        @endcode
+
+        @since 3.3.0
+    */
+    bool Is3State() const;
+
+    /**
         Static function returning a value specifying how wxWidgets will send update
         events: to all windows, or only to those which specify that they will process
         the events.
@@ -2472,7 +2508,7 @@ public:
     static wxUpdateUIMode GetMode();
 
     /**
-        Returns @true if the application has called Check().
+        Returns @true if the application has called Check() or SetSet3StateValue().
         For wxWidgets internal use only.
     */
     bool GetSetChecked() const;

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -4099,6 +4099,22 @@ public:
     */
     virtual void UpdateWindowUI(long flags = wxUPDATE_UI_NONE);
 
+    /**
+        When UpdateWindowUI() runs, it creates instances of
+        wxUpdateUIEvent.  Those instances may vary depending on the
+        window that the wxUpdateUIEvent will control.  For example, a
+        wxCheckBox with wxCHK_3STATE should enable
+        wxUpdateUIEvent::Is3State(), but most other windows should not.
+        This function can be overridden to perform the
+        window-specific initializations, such as enabling setting the
+        checkable state.
+
+        @see wxUpdateUIEvent, UpdateWindowUI()
+
+        @since 3.3.0
+    */
+    virtual void DoPrepareUpdateWindowUI(wxUpdateUIEvent& event) const;
+
     ///@}
 
 

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -32,6 +32,7 @@
 #include "wx/msgdlg.h"
 #include "wx/textdlg.h"
 #include "wx/stattext.h"
+#include "wx/checkbox.h"
 
 #include "wx/aui/aui.h"
 #include "../sample.xpm"
@@ -103,6 +104,8 @@ class MyFrame : public wxFrame
         ID_NotebookAlignBottom,
         ID_NotebookNewTab,
         ID_NotebookDeleteTab,
+        ID_3CHECK,
+        ID_UI_2CHECK_UPDATED,
 
         ID_SampleItem,
 
@@ -167,6 +170,8 @@ private:
     void OnNotebookDeleteTab(wxCommandEvent& evt);
 
     void OnPaneClose(wxAuiManagerEvent& evt);
+
+    void OnCheckboxUpdateUI(wxUpdateUIEvent& evt);
 
 private:
 
@@ -660,6 +665,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_AUINOTEBOOK_PAGE_CLOSE(wxID_ANY, MyFrame::OnNotebookPageClose)
     EVT_AUINOTEBOOK_PAGE_CLOSED(wxID_ANY, MyFrame::OnNotebookPageClosed)
     EVT_AUINOTEBOOK_PAGE_CHANGING(wxID_ANY, MyFrame::OnNotebookPageChanging)
+    EVT_UPDATE_UI(ID_UI_2CHECK_UPDATED, MyFrame::OnCheckboxUpdateUI)
 wxEND_EVENT_TABLE()
 
 
@@ -790,9 +796,14 @@ MyFrame::MyFrame(wxWindow* parent,
     append_items.Add(item);
 
 
+    // If using wxUPDATE_UI_PROCESS_ALL (the default),
+    // some of the problems handling controls in toolbar
+    // are masked by the calls to wxCheckBox::UpdateWindowUI()
+    wxUpdateUIEvent::SetMode(wxUPDATE_UI_PROCESS_SPECIFIED);
     // create some toolbars
     wxAuiToolBar* tb1 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW);
+    tb1->SetExtraStyle(tb1->GetExtraStyle() | wxWS_EX_PROCESS_UI_UPDATES);
     tb1->AddTool(ID_SampleItem+1, "Test", wxArtProvider::GetBitmapBundle(wxART_ERROR));
     tb1->AddSeparator();
     tb1->AddTool(ID_SampleItem+2, "Test", wxArtProvider::GetBitmapBundle(wxART_QUESTION));
@@ -805,6 +816,7 @@ MyFrame::MyFrame(wxWindow* parent,
 
     wxAuiToolBar* tb2 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW | wxAUI_TB_HORIZONTAL);
+    tb2->SetExtraStyle(tb2->GetExtraStyle() | wxWS_EX_PROCESS_UI_UPDATES);
 
     wxBitmapBundle tb2_bmp1 = wxArtProvider::GetBitmapBundle(wxART_QUESTION, wxART_OTHER, wxSize(16,16));
     tb2->AddTool(ID_SampleItem+6, "Disabled", tb2_bmp1);
@@ -826,6 +838,7 @@ MyFrame::MyFrame(wxWindow* parent,
 
     wxAuiToolBar* tb3 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW);
+    tb3->SetExtraStyle(tb3->GetExtraStyle() | wxWS_EX_PROCESS_UI_UPDATES);
     wxBitmapBundle tb3_bmp1 = wxArtProvider::GetBitmapBundle(wxART_FOLDER, wxART_OTHER, wxSize(16,16));
     tb3->AddTool(ID_SampleItem+16, "Check 1", tb3_bmp1, "Check 1", wxITEM_CHECK);
     tb3->AddTool(ID_SampleItem+17, "Check 2", tb3_bmp1, "Check 2", wxITEM_CHECK);
@@ -848,6 +861,7 @@ MyFrame::MyFrame(wxWindow* parent,
                                          wxAUI_TB_OVERFLOW |
                                          wxAUI_TB_TEXT |
                                          wxAUI_TB_HORZ_TEXT);
+    tb4->SetExtraStyle(tb4->GetExtraStyle() | wxWS_EX_PROCESS_UI_UPDATES);
     wxBitmapBundle tb4_bmp1 = wxArtProvider::GetBitmapBundle(wxART_NORMAL_FILE, wxART_OTHER, wxSize(16,16));
     tb4->AddTool(ID_DropDownToolbarItem, "Item 1", tb4_bmp1);
     tb4->AddTool(ID_SampleItem+23, "Item 2", tb4_bmp1);
@@ -867,11 +881,27 @@ MyFrame::MyFrame(wxWindow* parent,
     choice->AppendString("Good choice");
     choice->AppendString("Better choice");
     tb4->AddControl(choice);
+#if wxUSE_CHECKBOX
+    wxCheckBox* checkbox1 = new wxCheckBox(tb4, ID_3CHECK,
+                                                "Checkbox",
+                                                wxDefaultPosition, wxDefaultSize,
+                                                wxCHK_3STATE | wxCHK_ALLOW_3RD_STATE_FOR_USER);
+    checkbox1->SetMinSize(checkbox1->GetSizeFromText(checkbox1->GetLabelText()));
+    tb4->AddControl(checkbox1);
+    wxCheckBox* checkbox2 = new wxCheckBox(tb4, ID_UI_2CHECK_UPDATED,
+                                                "Checkbox UI Updated",
+                                                wxDefaultPosition, wxDefaultSize,
+                                                wxCHK_2STATE);
+    checkbox2->SetMinSize(checkbox2->GetSizeFromText(checkbox2->GetLabelText()));
+    checkbox2->Disable();
+    tb4->AddControl(checkbox2);
+#endif
     tb4->Realize();
 
 
     wxAuiToolBar* tb5 = new wxAuiToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                          wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW | wxAUI_TB_VERTICAL);
+    tb5->SetExtraStyle(tb5->GetExtraStyle() | wxWS_EX_PROCESS_UI_UPDATES);
     tb5->AddTool(ID_SampleItem+30, "Test", wxArtProvider::GetBitmapBundle(wxART_ERROR));
     tb5->AddSeparator();
     tb5->AddTool(ID_SampleItem+31, "Test", wxArtProvider::GetBitmapBundle(wxART_QUESTION));
@@ -1355,6 +1385,26 @@ void MyFrame::OnPaneClose(wxAuiManagerEvent& evt)
         if (res != wxYES)
             evt.Veto();
     }
+}
+
+// copy state from user-controllable checkbox to disabled checkbox
+void MyFrame::OnCheckboxUpdateUI(wxUpdateUIEvent& evt)
+{
+#if wxUSE_CHECKBOX
+    wxASSERT(evt.IsCheckable());
+    wxWindow* tb4 = m_mgr.GetPane("tb4").window;
+    wxWindow* wnd = tb4->FindWindow(ID_3CHECK);
+    wxCheckBox* src = wxCheckCast<wxCheckBox>(wnd);
+    if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+    {
+        evt.Show(true);
+        evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+    }
+    else
+    {
+        evt.Show(false);
+    }
+#endif
 }
 
 void MyFrame::OnCreatePerspective(wxCommandEvent& WXUNUSED(event))

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -106,6 +106,7 @@ class MyFrame : public wxFrame
         ID_NotebookDeleteTab,
         ID_3CHECK,
         ID_UI_2CHECK_UPDATED,
+        ID_UI_3CHECK_UPDATED,
 
         ID_SampleItem,
 
@@ -666,6 +667,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_AUINOTEBOOK_PAGE_CLOSED(wxID_ANY, MyFrame::OnNotebookPageClosed)
     EVT_AUINOTEBOOK_PAGE_CHANGING(wxID_ANY, MyFrame::OnNotebookPageChanging)
     EVT_UPDATE_UI(ID_UI_2CHECK_UPDATED, MyFrame::OnCheckboxUpdateUI)
+    EVT_UPDATE_UI(ID_UI_3CHECK_UPDATED, MyFrame::OnCheckboxUpdateUI)
 wxEND_EVENT_TABLE()
 
 
@@ -889,12 +891,19 @@ MyFrame::MyFrame(wxWindow* parent,
     checkbox1->SetMinSize(checkbox1->GetSizeFromText(checkbox1->GetLabelText()));
     tb4->AddControl(checkbox1);
     wxCheckBox* checkbox2 = new wxCheckBox(tb4, ID_UI_2CHECK_UPDATED,
-                                                "Checkbox UI Updated",
+                                                "2Checkbox UI Updated",
                                                 wxDefaultPosition, wxDefaultSize,
                                                 wxCHK_2STATE);
     checkbox2->SetMinSize(checkbox2->GetSizeFromText(checkbox2->GetLabelText()));
     checkbox2->Disable();
     tb4->AddControl(checkbox2);
+    wxCheckBox* checkbox3 = new wxCheckBox(tb4, ID_UI_3CHECK_UPDATED,
+                                                "3Checkbox UI Updated",
+                                                wxDefaultPosition, wxDefaultSize,
+                                                wxCHK_3STATE);
+    checkbox3->SetMinSize(checkbox3->GetSizeFromText(checkbox3->GetLabelText()));
+    checkbox3->Disable();
+    tb4->AddControl(checkbox3);
 #endif
     tb4->Realize();
 
@@ -1395,14 +1404,21 @@ void MyFrame::OnCheckboxUpdateUI(wxUpdateUIEvent& evt)
     wxWindow* tb4 = m_mgr.GetPane("tb4").window;
     wxWindow* wnd = tb4->FindWindow(ID_3CHECK);
     wxCheckBox* src = wxCheckCast<wxCheckBox>(wnd);
-    if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+    if (!evt.Is3State())
     {
-        evt.Show(true);
-        evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+        if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+        {
+            evt.Show(true);
+            evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+        }
+        else
+        {
+            evt.Show(false);
+        }
     }
     else
     {
-        evt.Show(false);
+        evt.Set3StateValue(src->Get3StateValue());
     }
 #endif
 }

--- a/samples/ribbon/ribbondemo.cpp
+++ b/samples/ribbon/ribbondemo.cpp
@@ -83,6 +83,7 @@ public:
         ID_UI_CHANGE_TEXT_UPDATED,
         ID_3CHECK,
         ID_UI_2CHECK_UPDATED,
+        ID_UI_3CHECK_UPDATED,
         ID_REMOVE_PAGE,
         ID_HIDE_PAGES,
         ID_SHOW_PAGES,
@@ -209,6 +210,7 @@ EVT_UPDATE_UI(ID_UI_ENABLE_UPDATED, MyFrame::OnEnableUpdateUI)
 EVT_RIBBONBUTTONBAR_CLICKED(ID_CHECK, MyFrame::OnCheck)
 EVT_UPDATE_UI(ID_UI_CHECK_UPDATED, MyFrame::OnCheckUpdateUI)
 EVT_UPDATE_UI(ID_UI_2CHECK_UPDATED, MyFrame::OnCheckboxUpdateUI)
+EVT_UPDATE_UI(ID_UI_3CHECK_UPDATED, MyFrame::OnCheckboxUpdateUI)
 EVT_RIBBONBUTTONBAR_CLICKED(ID_CHANGE_TEXT1, MyFrame::OnChangeText1)
 EVT_RIBBONBUTTONBAR_CLICKED(ID_CHANGE_TEXT2, MyFrame::OnChangeText2)
 EVT_UPDATE_UI(ID_UI_CHANGE_TEXT_UPDATED, MyFrame::OnChangeTextUpdateUI)
@@ -462,6 +464,13 @@ MyFrame::MyFrame()
         checkbox2->SetMinSize(checkbox2->GetSizeFromText(checkbox2->GetLabelText()));
         checkbox2->Disable();
         sizer->Add(checkbox2, 0, wxALL | wxEXPAND);
+        wxCheckBox* checkbox3 = new wxCheckBox(panel, ID_UI_3CHECK_UPDATED,
+                                                    "3Checkbox UI Updated",
+                                                    wxDefaultPosition, wxDefaultSize,
+                                                    wxCHK_3STATE);
+        checkbox3->SetMinSize(checkbox3->GetSizeFromText(checkbox3->GetLabelText()));
+        checkbox3->Disable();
+        sizer->Add(checkbox3, 0, wxALL | wxEXPAND);
 #endif
 
         //Also set the general disabled text colour:
@@ -770,14 +779,21 @@ void MyFrame::OnCheckboxUpdateUI(wxUpdateUIEvent& evt)
     wxWindow* parent = cb->GetParent();
     wxWindow* wnd = parent->FindWindow(ID_3CHECK);
     wxCheckBox* src = wxCheckCast<wxCheckBox>(wnd);
-    if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+    if (!evt.Is3State())
     {
-        evt.Show(true);
-        evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+        if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+        {
+            evt.Show(true);
+            evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+        }
+        else
+        {
+            evt.Show(false);
+        }
     }
     else
     {
-        evt.Show(false);
+        evt.Set3StateValue(src->Get3StateValue());
     }
 #endif
 }

--- a/samples/ribbon/ribbondemo.cpp
+++ b/samples/ribbon/ribbondemo.cpp
@@ -26,6 +26,7 @@
 #include "wx/combobox.h"
 #include "wx/tglbtn.h"
 #include "wx/wrapsizer.h"
+#include "wx/checkbox.h"
 
 // -- application --
 
@@ -80,6 +81,8 @@ public:
         ID_CHANGE_TEXT1,
         ID_CHANGE_TEXT2,
         ID_UI_CHANGE_TEXT_UPDATED,
+        ID_3CHECK,
+        ID_UI_2CHECK_UPDATED,
         ID_REMOVE_PAGE,
         ID_HIDE_PAGES,
         ID_SHOW_PAGES,
@@ -95,6 +98,7 @@ public:
 
     void OnEnableUpdateUI(wxUpdateUIEvent& evt);
     void OnCheckUpdateUI(wxUpdateUIEvent& evt);
+    void OnCheckboxUpdateUI(wxUpdateUIEvent& evt);
     void OnChangeTextUpdateUI(wxUpdateUIEvent& evt);
     void OnCheck(wxRibbonButtonBarEvent& evt);
     void OnEnable(wxRibbonButtonBarEvent& evt);
@@ -204,6 +208,7 @@ EVT_RIBBONBUTTONBAR_CLICKED(ID_UI_ENABLE_UPDATED, MyFrame::OnEnableUpdated)
 EVT_UPDATE_UI(ID_UI_ENABLE_UPDATED, MyFrame::OnEnableUpdateUI)
 EVT_RIBBONBUTTONBAR_CLICKED(ID_CHECK, MyFrame::OnCheck)
 EVT_UPDATE_UI(ID_UI_CHECK_UPDATED, MyFrame::OnCheckUpdateUI)
+EVT_UPDATE_UI(ID_UI_2CHECK_UPDATED, MyFrame::OnCheckboxUpdateUI)
 EVT_RIBBONBUTTONBAR_CLICKED(ID_CHANGE_TEXT1, MyFrame::OnChangeText1)
 EVT_RIBBONBUTTONBAR_CLICKED(ID_CHANGE_TEXT2, MyFrame::OnChangeText2)
 EVT_UPDATE_UI(ID_UI_CHANGE_TEXT_UPDATED, MyFrame::OnChangeTextUpdateUI)
@@ -437,6 +442,27 @@ MyFrame::MyFrame()
         bar->AddButton(ID_CHANGE_TEXT1, "One", ribbon_xpm);
         bar->AddButton(ID_CHANGE_TEXT2, "Two", ribbon_xpm);
         bar->AddButton(ID_UI_CHANGE_TEXT_UPDATED, "Zero", ribbon_xpm);
+
+#if wxUSE_CHECKBOX
+        panel = new wxRibbonPanel(page, wxID_ANY, "3State",
+                                                    wxNullBitmap, wxDefaultPosition, wxDefaultSize,
+                                                    wxRIBBON_PANEL_DEFAULT_STYLE);
+        wxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+        panel->SetSizer(sizer);
+        wxCheckBox* checkbox1 = new wxCheckBox(panel, ID_3CHECK,
+                                                    "Checkbox",
+                                                    wxDefaultPosition, wxDefaultSize,
+                                                    wxCHK_3STATE | wxCHK_ALLOW_3RD_STATE_FOR_USER);
+        checkbox1->SetMinSize(checkbox1->GetSizeFromText(checkbox1->GetLabelText()));
+        sizer->Add(checkbox1, 0, wxALL | wxEXPAND);
+        wxCheckBox* checkbox2 = new wxCheckBox(panel, ID_UI_2CHECK_UPDATED,
+                                                    "2Checkbox UI Updated",
+                                                    wxDefaultPosition, wxDefaultSize,
+                                                    wxCHK_2STATE);
+        checkbox2->SetMinSize(checkbox2->GetSizeFromText(checkbox2->GetLabelText()));
+        checkbox2->Disable();
+        sizer->Add(checkbox2, 0, wxALL | wxEXPAND);
+#endif
 
         //Also set the general disabled text colour:
         wxRibbonArtProvider* artProvider = m_ribbon->GetArtProvider();
@@ -734,6 +760,26 @@ void MyFrame::OnEnableUpdateUI(wxUpdateUIEvent& evt)
 void MyFrame::OnCheckUpdateUI(wxUpdateUIEvent& evt)
 {
     evt.Check(m_bChecked);
+}
+
+void MyFrame::OnCheckboxUpdateUI(wxUpdateUIEvent& evt)
+{
+#if wxUSE_CHECKBOX
+    wxASSERT(evt.IsCheckable());
+    wxCheckBox* cb = wxDynamicCast(evt.GetEventObject(), wxCheckBox);
+    wxWindow* parent = cb->GetParent();
+    wxWindow* wnd = parent->FindWindow(ID_3CHECK);
+    wxCheckBox* src = wxCheckCast<wxCheckBox>(wnd);
+    if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+    {
+        evt.Show(true);
+        evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+    }
+    else
+    {
+        evt.Show(false);
+    }
+#endif
 }
 
 void MyFrame::OnChangeTextUpdateUI(wxUpdateUIEvent& evt)

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -30,6 +30,7 @@
 #include "wx/filedlg.h"
 #include "wx/colordlg.h"
 #include "wx/srchctrl.h"
+#include "wx/checkbox.h"
 
 // If this is 1, the sample will test an extra toolbar identical to the
 // main one, but not managed by the frame. This can test subtle differences
@@ -155,6 +156,8 @@ public:
     void OnUpdateToggleRadioBtn(wxUpdateUIEvent& event)
         { event.Enable( m_tbar != nullptr ); }
 
+    void OnCheckboxUpdateUI(wxUpdateUIEvent& evt);
+
 private:
     void DoEnablePrint();
     void DoDeletePrint();
@@ -244,7 +247,9 @@ enum
     IDM_TOOLBAR_TOGGLERADIOBTN2,
     IDM_TOOLBAR_TOGGLERADIOBTN3,
 
-    ID_COMBO = 1000
+    ID_COMBO = 1000,
+    ID_3CHECK,
+    ID_UI_2CHECK_UPDATED,
 };
 
 // ----------------------------------------------------------------------------
@@ -306,6 +311,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
                         MyFrame::OnUpdateToggleRadioBtn)
     EVT_UPDATE_UI(IDM_TOOLBAR_TOGGLE_HORIZONTAL_TEXT,
                   MyFrame::OnUpdateToggleHorzText)
+    EVT_UPDATE_UI(ID_UI_2CHECK_UPDATED,
+                  MyFrame::OnCheckboxUpdateUI)
 wxEND_EVENT_TABLE()
 
 // ============================================================================
@@ -390,6 +397,12 @@ void MyFrame::RecreateToolbar()
 
 void MyFrame::PopulateToolbar(wxToolBarBase* toolBar)
 {
+    // If using wxUPDATE_UI_PROCESS_ALL (the default),
+    // some of the problems handling controls in toolbar
+    // are masked by the calls to wxCheckBox::UpdateWindowUI()
+    wxUpdateUIEvent::SetMode(wxUPDATE_UI_PROCESS_SPECIFIED);
+    toolBar->SetExtraStyle(toolBar->GetExtraStyle() | wxWS_EX_PROCESS_UI_UPDATES);
+
     // Set up toolbar
     enum
     {
@@ -470,6 +483,22 @@ void MyFrame::PopulateToolbar(wxToolBarBase* toolBar)
         combo->Append("in a");
         combo->Append("toolbar");
         toolBar->AddControl(combo, "Combo Label");
+
+#if wxUSE_CHECKBOX
+        wxCheckBox* checkbox1 = new wxCheckBox(toolBar, ID_3CHECK,
+                                                    "",
+                                                    wxDefaultPosition, wxDefaultSize,
+                                                    wxCHK_3STATE | wxCHK_ALLOW_3RD_STATE_FOR_USER);
+        checkbox1->SetMinSize(checkbox1->GetSizeFromText(checkbox1->GetLabelText()));
+        toolBar->AddControl(checkbox1, "Checkbox");
+        wxCheckBox* checkbox2 = new wxCheckBox(toolBar, ID_UI_2CHECK_UPDATED,
+                                                    "",
+                                                    wxDefaultPosition, wxDefaultSize,
+                                                    wxCHK_2STATE);
+        checkbox2->SetMinSize(checkbox2->GetSizeFromText(checkbox2->GetLabelText()));
+        checkbox2->Disable();
+        toolBar->AddControl(checkbox2, "Checkbox2 UI Updated");
+#endif
     }
 #endif // USE_CONTROLS_IN_TOOLBAR
 
@@ -999,6 +1028,26 @@ void MyFrame::OnUpdateToggleHorzText(wxUpdateUIEvent& event)
     event.Enable( tbar &&
                     tbar->HasFlag(wxTB_TEXT) &&
                         !tbar->HasFlag(wxTB_NOICONS) );
+}
+
+// copy state from user-controllable checkbox to disabled checkbox
+void MyFrame::OnCheckboxUpdateUI(wxUpdateUIEvent& evt)
+{
+#if wxUSE_CHECKBOX
+    wxASSERT(evt.IsCheckable());
+    wxToolBar* tbar = GetToolBar();
+    wxWindow* wnd = tbar->FindWindow(ID_3CHECK);
+    wxCheckBox* src = wxCheckCast<wxCheckBox>(wnd);
+    if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+    {
+        evt.Show(true);
+        evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+    }
+    else
+    {
+        evt.Show(false);
+    }
+#endif
 }
 
 void MyFrame::OnChangeToolTip(wxCommandEvent& WXUNUSED(event))

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -250,6 +250,7 @@ enum
     ID_COMBO = 1000,
     ID_3CHECK,
     ID_UI_2CHECK_UPDATED,
+    ID_UI_3CHECK_UPDATED,
 };
 
 // ----------------------------------------------------------------------------
@@ -312,6 +313,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_UPDATE_UI(IDM_TOOLBAR_TOGGLE_HORIZONTAL_TEXT,
                   MyFrame::OnUpdateToggleHorzText)
     EVT_UPDATE_UI(ID_UI_2CHECK_UPDATED,
+                  MyFrame::OnCheckboxUpdateUI)
+    EVT_UPDATE_UI(ID_UI_3CHECK_UPDATED,
                   MyFrame::OnCheckboxUpdateUI)
 wxEND_EVENT_TABLE()
 
@@ -497,7 +500,14 @@ void MyFrame::PopulateToolbar(wxToolBarBase* toolBar)
                                                     wxCHK_2STATE);
         checkbox2->SetMinSize(checkbox2->GetSizeFromText(checkbox2->GetLabelText()));
         checkbox2->Disable();
-        toolBar->AddControl(checkbox2, "Checkbox2 UI Updated");
+        toolBar->AddControl(checkbox2, "2Checkbox UI Updated");
+        wxCheckBox* checkbox3 = new wxCheckBox(toolBar, ID_UI_3CHECK_UPDATED,
+                                                    "",
+                                                    wxDefaultPosition, wxDefaultSize,
+                                                    wxCHK_3STATE);
+        checkbox3->SetMinSize(checkbox3->GetSizeFromText(checkbox3->GetLabelText()));
+        checkbox3->Disable();
+        toolBar->AddControl(checkbox3, "3Checkbox UI Updated");
 #endif
     }
 #endif // USE_CONTROLS_IN_TOOLBAR
@@ -1038,14 +1048,21 @@ void MyFrame::OnCheckboxUpdateUI(wxUpdateUIEvent& evt)
     wxToolBar* tbar = GetToolBar();
     wxWindow* wnd = tbar->FindWindow(ID_3CHECK);
     wxCheckBox* src = wxCheckCast<wxCheckBox>(wnd);
-    if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+    if (!evt.Is3State())
     {
-        evt.Show(true);
-        evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+        if (src->Get3StateValue() != wxCHK_UNDETERMINED)
+        {
+            evt.Show(true);
+            evt.Check(src->Get3StateValue() != wxCHK_UNCHECKED);
+        }
+        else
+        {
+            evt.Show(false);
+        }
     }
     else
     {
-        evt.Show(false);
+        evt.Set3StateValue(src->Get3StateValue());
     }
 #endif
 }

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2212,60 +2212,67 @@ void wxAuiToolBar::DoIdleUpdate()
         if (item.m_toolId == -1)
             continue;
 
-        wxUpdateUIEvent evt(item.m_toolId);
-        evt.SetEventObject(this);
-
-        if ( !item.CanBeToggled() )
-            evt.DisallowCheck();
-
-        if (handler->ProcessEvent(evt))
+        if (item.GetKind() != wxITEM_CONTROL)
         {
-            if (evt.GetSetEnabled())
-            {
-                bool is_enabled;
-                if (item.m_window)
-                    is_enabled = item.m_window->IsThisEnabled();
-                else
-                    is_enabled = (item.m_state & wxAUI_BUTTON_STATE_DISABLED) ? false : true;
+            wxUpdateUIEvent evt(item.m_toolId);
+            evt.SetEventObject(this);
 
-                bool new_enabled = evt.GetEnabled();
-                if (new_enabled != is_enabled)
+            if ( !item.CanBeToggled() )
+                evt.DisallowCheck();
+
+            if (handler->ProcessEvent(evt))
+            {
+                if (evt.GetSetEnabled())
                 {
+                    bool is_enabled;
                     if (item.m_window)
-                    {
-                        item.m_window->Enable(new_enabled);
-                    }
+                        is_enabled = item.m_window->IsThisEnabled();
                     else
+                        is_enabled = (item.m_state & wxAUI_BUTTON_STATE_DISABLED) ? false : true;
+
+                    bool new_enabled = evt.GetEnabled();
+                    if (new_enabled != is_enabled)
                     {
-                        if (new_enabled)
-                            item.m_state &= ~wxAUI_BUTTON_STATE_DISABLED;
+                        if (item.m_window)
+                        {
+                            item.m_window->Enable(new_enabled);
+                        }
                         else
-                            item.m_state |= wxAUI_BUTTON_STATE_DISABLED;
+                        {
+                            if (new_enabled)
+                                item.m_state &= ~wxAUI_BUTTON_STATE_DISABLED;
+                            else
+                                item.m_state |= wxAUI_BUTTON_STATE_DISABLED;
+                        }
+                        need_refresh = true;
                     }
-                    need_refresh = true;
                 }
-            }
 
-            if (evt.GetSetChecked())
-            {
-                // make sure we aren't checking an item that can't be
-                if (item.m_kind != wxITEM_CHECK && item.m_kind != wxITEM_RADIO)
-                    continue;
-
-                bool is_checked = (item.m_state & wxAUI_BUTTON_STATE_CHECKED) ? true : false;
-                bool new_checked = evt.GetChecked();
-
-                if (new_checked != is_checked)
+                if (evt.GetSetChecked())
                 {
-                    if (new_checked)
-                        item.m_state |= wxAUI_BUTTON_STATE_CHECKED;
-                    else
-                        item.m_state &= ~wxAUI_BUTTON_STATE_CHECKED;
+                    // make sure we aren't checking an item that can't be
+                    if (item.m_kind != wxITEM_CHECK && item.m_kind != wxITEM_RADIO)
+                        continue;
 
-                    need_refresh = true;
+                    bool is_checked = (item.m_state & wxAUI_BUTTON_STATE_CHECKED) ? true : false;
+                    bool new_checked = evt.GetChecked();
+
+                    if (new_checked != is_checked)
+                    {
+                        if (new_checked)
+                            item.m_state |= wxAUI_BUTTON_STATE_CHECKED;
+                        else
+                            item.m_state &= ~wxAUI_BUTTON_STATE_CHECKED;
+
+                        need_refresh = true;
+                    }
                 }
-            }
 
+            }
+        }
+        else
+        {
+            item.GetWindow()->UpdateWindowUI();
         }
     }
 

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -464,6 +464,28 @@ long wxUpdateUIEvent::sm_updateInterval = 0;
 
 wxUpdateUIMode wxUpdateUIEvent::sm_updateMode = wxUPDATE_UI_PROCESS_ALL;
 
+void wxUpdateUIEvent::Set3StateValue(wxCheckBoxState check)
+{
+    wxASSERT_MSG(IsCheckable(), "Shouldn't be called if non-checkable");
+    wxASSERT_MSG(Is3State() || check != wxCHK_UNDETERMINED, "Is3State() not enabled");
+
+    m_3checked = check;
+    m_setChecked = true;
+}
+
+void wxUpdateUIEvent::DisallowCheck()
+{
+    wxASSERT_MSG(!GetSetChecked(), "SetCheck() or Set3StateValue() has already been called");
+
+    m_isCheckable = false;
+}
+
+void wxUpdateUIEvent::Allow3rdState(bool b /*= true*/)
+{
+    wxASSERT_MSG(b || Get3StateValue() != wxCHK_UNDETERMINED, "wxCHK_UNDETERMINED already set");
+    m_is3State = b;
+}
+
 // Can we update?
 bool wxUpdateUIEvent::CanUpdate(wxWindowBase *win)
 {

--- a/src/common/tbarbase.cpp
+++ b/src/common/tbarbase.cpp
@@ -789,24 +789,31 @@ void wxToolBarBase::UpdateWindowUI(long flags)
         if ( tool->IsSeparator() )
             continue;
 
-        int toolid = tool->GetId();
-
-        wxUpdateUIEvent event(toolid);
-        event.SetEventObject(this);
-
-        if ( !tool->CanBeToggled() )
-            event.DisallowCheck();
-
-        if ( evtHandler->ProcessEvent(event) )
+        if ( !tool->IsControl() )
         {
-            if ( event.GetSetEnabled() )
-                EnableTool(toolid, event.GetEnabled());
-            if ( event.GetSetChecked() )
-                ToggleTool(toolid, event.GetChecked());
+            int toolid = tool->GetId();
+
+            wxUpdateUIEvent event(toolid);
+            event.SetEventObject(this);
+
+            if ( !tool->CanBeToggled() )
+                event.DisallowCheck();
+
+            if ( evtHandler->ProcessEvent(event) )
+            {
+                if ( event.GetSetEnabled() )
+                    EnableTool(toolid, event.GetEnabled());
+                if ( event.GetSetChecked() )
+                    ToggleTool(toolid, event.GetChecked());
 #if 0
-            if ( event.GetSetText() )
-                // Set tooltip?
+                if ( event.GetSetText() )
+                    // Set tooltip?
 #endif // 0
+            }
+        }
+        else
+        {
+            tool->GetControl()->UpdateWindowUI(flags);
         }
     }
 }

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -2725,6 +2725,7 @@ void wxWindowBase::UpdateWindowUI(long flags)
 {
     wxUpdateUIEvent event(GetId());
     event.SetEventObject(this);
+    DoPrepareUpdateWindowUI(event);
 
     if ( GetEventHandler()->ProcessEvent(event) )
     {


### PR DESCRIPTION
Note that the diffs here are better viewed with --ignore-space-change.

I have added use of the new `wxUpdateUIEvent::Set3StateValue()` to the toolbar, ribbon, and aui samples.  I'm not convinced all three samples need to demonstrate this feature, so if you want to trim the samples, feel free to do so.