### PR TITLE
Docs fixes for wxTreeCtrl and wxGrid

### DIFF
--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -6035,11 +6035,21 @@ public:
     */
     void SetRowAttr(int row, wxGridCellAttr* attr);
 
-
+    /**
+        Returns an array of row labels within the given region.
+    */
     wxArrayInt CalcRowLabelsExposed( const wxRegion& reg,
                                      wxGridWindow *gridWindow = nullptr) const;
+
+    /**
+        Returns an array of column labels within the given region.
+    */
     wxArrayInt CalcColLabelsExposed( const wxRegion& reg,
                                      wxGridWindow *gridWindow = nullptr) const;
+
+    /**
+        Returns an array of (visible) cells within the given region.
+    */
     wxGridCellCoordsArray CalcCellsExposed( const wxRegion& reg,
                                             wxGridWindow *gridWindow = nullptr) const;
 

--- a/interface/wx/treectrl.h
+++ b/interface/wx/treectrl.h
@@ -177,17 +177,6 @@
 
     See also @ref overview_windowstyles.
 
-    @b Win32 @b notes:
-
-    wxTreeCtrl class uses the standard common treeview control under Win32
-    implemented in the system library comctl32.dll. Some versions of this
-    library are known to have bugs with handling the tree control colours: the
-    usual symptom is that the expanded items leave black (or otherwise
-    incorrectly coloured) background behind them, especially for the controls
-    using non-default background colour. The recommended solution is to upgrade
-    the comctl32.dll to a newer version: see
-    http://www.microsoft.com/downloads/details.aspx?familyid=cb2cf3a2-8025-4e8f-8511-9b476a8d35d2
-
     @library{wxcore}
     @category{ctrl}
     @appearance{treectrl}


### PR DESCRIPTION
Regarding the `wxGrid` commit: I know next to nothing about the class but it looks as if these methods should not be called from outside `wxGrid` (even if they are public). So perhaps the better solution would be to remove them from the docs: `PrepareDCFor()` method following the three in the actual header is not documented either.

If accepted, should be backported to 3.2 (assuming the `wxTreeCtrl` note does not apply to Windows XP).