### PR TITLE
textfiletest: fix skip condition

### DIFF
--- a/tests/textfile/textfiletest.cpp
+++ b/tests/textfile/textfiletest.cpp
@@ -342,7 +342,7 @@ TEST_CASE("wxTextFile::Special", "[textfile][linux][special-file]")
 
     SECTION("/sys")
     {
-        if ( wxFile::Exists("/sys/power/state") )
+        if ( !wxFile::Exists("/sys/power/state") )
         {
             WARN("/sys/power/state doesn't exist, skipping test");
             return;


### PR DESCRIPTION
... so that condition and skip message match.

As a side effect, it also prevents a test failure if /sys/power/state doesn't exist.