### PR TITLE
Allow customizing exit code in case of `OnInit()` failure

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -27,6 +27,10 @@ Changes in behaviour not resulting in compilation errors
 - wxMSW doesn't support versions of Microsoft Windows before Windows 7. If you
   need Windows XP or Vista support, please use wxWidgets 3.2.
 
+- Default exit code in case of fatal error is now consistently 255, including
+  when using MSVC for which it was 127 previously. Use wxApp::SetErrorExitCode()
+  and wxApp::SetFatalErrorExitCode() to change this to old value if needed.
+
 - wxGLCanvas doesn't use multi-sampling by default any longer, please use
   wxGLAttributes::Samplers(1).SampleBuffers(4) explicitly if you need to keep
   using the same attributes that were previously used by default.

--- a/docs/doxygen/overviews/app.h
+++ b/docs/doxygen/overviews/app.h
@@ -11,13 +11,14 @@
 
 @tableofcontents
 
-A wxWidgets application does not have a @e main procedure; the equivalent is
-the wxApp::OnInit member defined for a class derived from wxApp.
+A wxWidgets application does not have a @e main function; the equivalent, i.e.
+the entry point where the execution of the program begins, is the
+wxApp::OnInit() member function defined in a class derived from wxApp (this
+class is typically specified using wxIMPLEMENT_APP() macro).
 
-@e OnInit will usually create a top window as a bare minimum. Unlike in earlier
-versions of wxWidgets, OnInit does not return a frame. Instead it returns a
-boolean value which indicates whether processing should continue (@true) or not
-(@false).
+@e OnInit usually creates the main application window and returns @true.
+If it returns @false, the application will exit immediately, without starting
+to run.
 
 Note that the program's command line arguments, represented by @e argc and
 @e argv, are available from within wxApp member functions.
@@ -38,7 +39,7 @@ An example of defining an application follows:
 class DerivedApp : public wxApp
 {
 public:
-    virtual bool OnInit();
+    virtual bool OnInit() override;
 };
 
 wxIMPLEMENT_APP(DerivedApp);

--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -136,12 +136,14 @@ public:
     virtual void Exit();
 
     // Allows to set a custom process exit code if a fatal error happens.
-    // This code is -1 by default, but can be changed if necessary.
+    // This code is 255 by default, but can be changed if necessary, notably
+    // set to -1 (which still maps to 255 under most systems, but to 127 when
+    // using MSVC) if compatibility with the previous wx versions is important.
     static void SetFatalErrorExitCode(int code) { ms_fatalErrorExitCode = code; }
     static int GetFatalErrorExitCode() { return ms_fatalErrorExitCode; }
 
     // Allows to set a custom process exit code if OnInit() returns false.
-    // By default, this exit code is -1, as for the fatal errors.
+    // By default, this exit code is 255, as for the fatal errors.
     virtual void SetErrorExitCode(int code) { m_exitCode = code; }
     int GetErrorExitCode() const { return m_exitCode; }
 

--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -135,7 +135,13 @@ public:
     // Called from wxExit() function, should terminate the application a.s.a.p.
     virtual void Exit();
 
+    // Allows to set a custom process exit code if a fatal error happens.
+    // This code is -1 by default, but can be changed if necessary.
+    static void SetFatalErrorExitCode(int code) { ms_fatalErrorExitCode = code; }
+    static int GetFatalErrorExitCode() { return ms_fatalErrorExitCode; }
+
     // Allows to set a custom process exit code if OnInit() returns false.
+    // By default, this exit code is -1, as for the fatal errors.
     virtual void SetErrorExitCode(int code) { m_exitCode = code; }
     int GetErrorExitCode() const { return m_exitCode; }
 
@@ -542,8 +548,12 @@ private:
     // set it
     bool m_fullyConstructed = false;
 
+    // Exit code to use if a fatal error occurs when the application object
+    // doesn't exist yet or is already destroyed.
+    static int ms_fatalErrorExitCode;
+
     // Exit code to use if OnInit() returns false.
-    int m_exitCode = -1;
+    int m_exitCode = ms_fatalErrorExitCode;
 
 
     friend class WXDLLIMPEXP_FWD_BASE wxEvtHandler;

--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -135,6 +135,10 @@ public:
     // Called from wxExit() function, should terminate the application a.s.a.p.
     virtual void Exit();
 
+    // Allows to set a custom process exit code if OnInit() returns false.
+    virtual void SetErrorExitCode(int code) { m_exitCode = code; }
+    int GetErrorExitCode() const { return m_exitCode; }
+
 
     // application info: name, description, vendor
     // -------------------------------------------
@@ -537,6 +541,10 @@ private:
     // flag set to true at the end of wxApp ctor, call WXAppConstructed() to
     // set it
     bool m_fullyConstructed = false;
+
+    // Exit code to use if OnInit() returns false.
+    int m_exitCode = -1;
+
 
     friend class WXDLLIMPEXP_FWD_BASE wxEvtHandler;
 

--- a/include/wx/msw/seh.h
+++ b/include/wx/msw/seh.h
@@ -17,9 +17,6 @@
     // it calls wxApp::OnFatalException() if wxTheApp object exists
     WXDLLIMPEXP_BASE unsigned long wxGlobalSEHandler(EXCEPTION_POINTERS *pExcPtrs);
 
-    // helper macro for wxSEH_HANDLE
-    #define wxSEH_DUMMY_RETURN(rc)
-
     // macros which allow to avoid many #if wxUSE_ON_FATAL_EXCEPTION in the code
     // which uses them
     #define wxSEH_TRY __try
@@ -29,8 +26,6 @@
         {                                                                     \
             /* use the same exit code as abort() */                           \
             ::ExitProcess(3);                                                 \
-                                                                              \
-            wxSEH_DUMMY_RETURN(rc)                                            \
         }
 
 #else // wxUSE_ON_FATAL_EXCEPTION

--- a/include/wx/msw/seh.h
+++ b/include/wx/msw/seh.h
@@ -24,8 +24,7 @@
     #define wxSEH_HANDLE(rc)                                                  \
         __except ( wxGlobalSEHandler(GetExceptionInformation()) )             \
         {                                                                     \
-            /* use the same exit code as abort() */                           \
-            ::ExitProcess(3);                                                 \
+            ::ExitProcess(rc);                                                \
         }
 
 #else // wxUSE_ON_FATAL_EXCEPTION

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -388,8 +388,24 @@ public:
         that the function returns @true.
 
         Notice that if you want to use the command line processing provided by
-        wxWidgets you have to call the base class version in the derived class
-        OnInit().
+        wxWidgets (see OnInitCmdLine() and OnCmdLineParsed() functions) you
+        have to call the base class version in the derived class OnInit(),
+        e.g.:
+
+        @code
+        bool MyApp::OnInit() {
+            if ( !wxApp::OnInit() ) {
+                // The most likely reason for the error here is that incorrect
+                // command line arguments have been specified, so just exit:
+                // error message has already been given.
+                return false;
+            }
+
+            // Perform any additional initialization here.
+
+            return true;
+        }
+        @endcode
 
         Return @true to continue processing, @false to exit the application
         immediately.

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -410,14 +410,23 @@ public:
     virtual void OnInitCmdLine(wxCmdLineParser& parser);
 
     /**
-        This virtual function is where the execution of a program written in wxWidgets
-        starts. The default implementation just enters the main loop and starts
-        handling the events until it terminates, either because ExitMainLoop() has
-        been explicitly called or because the last frame has been deleted and
-        GetExitOnFrameDelete() flag is @true (this is the default).
+        Virtual function executing the application's main event loop.
 
-        The return value of this function becomes the exit code of the program, so it
-        should return 0 in case of successful termination.
+        For the GUI applications, it is typically not necessary to override
+        this function, as the default implementation, which enters the main
+        event loop and dispatches all events until ExitMainLoop() is called
+        (either explicitly or because the last top level window was closed),
+        rarely needs to be customized.
+
+        For the console applications not using event loops, this function can
+        be used as the equivalent of the traditional @c main() function by
+        putting most of the program logic here.
+
+        The return value of this function becomes the exit code of the program,
+        so it should return 0 in case of successful termination.
+
+        Note that this function is not called at all if OnInit() had returned
+        @false.
     */
     virtual int OnRun();
 

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -408,7 +408,8 @@ public:
         @endcode
 
         Return @true to continue processing, @false to exit the application
-        immediately.
+        immediately. In the latter case, you may want to call SetErrorExitCode()
+        to set the process exit code to use when the application terminates.
     */
     virtual bool OnInit();
 
@@ -784,6 +785,29 @@ public:
         @since 2.9.5
      */
     void SetCLocale();
+
+    /**
+        Sets the error code to use in case of exit on error.
+
+        This function is mostly useful to customize the error code returned by
+        the application when it exits due to OnInit() returning @false and can
+        be called from OnInit() itself or other virtual functions called from
+        it, for example OnCmdLineError().
+
+        By default, the exit code depends on the compiler being used, e.g. it
+        is @c 255 with typical Unix compilers (gcc, clang) and @c 127 with
+        MSVC, so it is recommended to call this function to set a consistent
+        exit code, e.g. @c 2 which is a de facto standard exit code if command
+        line parsing fails.
+
+        SetErrorExitCode() can be overridden by the application to perform
+        additional actions, but the overridden version should call the base
+        class version to update the value returned by GetErrorExitCode() and
+        actually used when exiting the application.
+
+        @since 3.3.0
+     */
+    virtual void SetErrorExitCode(int code);
 
     /**
         Number of command line arguments (after environment-specific processing).

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -805,9 +805,44 @@ public:
         class version to update the value returned by GetErrorExitCode() and
         actually used when exiting the application.
 
+        @see SetFatalErrorExitCode()
+
         @since 3.3.0
      */
     virtual void SetErrorExitCode(int code);
+
+    /**
+        Allows to set a custom process exit code if a fatal error happens.
+
+        If the program can't continue due to a fatal error, such as receiving
+        an unhandled exception or failing to initialize the graphical
+        environment for the GUI applications, it terminates with the default
+        fatal error exit code which is @c -1.
+
+        This function can be used to change this default value to something
+        else. Notice that it has to be called as early as possible to take
+        effect even during the early application initialization, e.g.
+
+        @code
+        struct FatalErrorCodeInitializer {
+            FatalErrorCodeInitializer() {
+                wxApp::SetFatalErrorExitCode(3); // same as abort()
+            }
+        };
+
+        // Create a global variable to call SetFatalErrorExitCode() in its ctor.
+        static FatalErrorCodeInitializer s_fatalErrorCodeInitializer;
+        @endcode
+
+        Note that this function doesn't change the exit code returned if
+        OnInit() returns @false, so if you change the default value of this
+        exit code you may want to call SetErrorExitCode() to change the other
+        one too.
+
+        @since 3.3.0
+     */
+    static void SetFatalErrorExitCode(int code);
+
 
     /**
         Number of command line arguments (after environment-specific processing).

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -794,11 +794,16 @@ public:
         be called from OnInit() itself or other virtual functions called from
         it, for example OnCmdLineError().
 
-        By default, the exit code depends on the compiler being used, e.g. it
-        is @c 255 with typical Unix compilers (gcc, clang) and @c 127 with
-        MSVC, so it is recommended to call this function to set a consistent
-        exit code, e.g. @c 2 which is a de facto standard exit code if command
-        line parsing fails.
+        By default, the exit code is @c 255 which indicates a generic error,
+        so it is may be useful to call this function to set a more precise exit
+        code, e.g. @c 2 which is a de facto standard exit code if command line
+        parsing fails.
+
+        Please also note that in the previous versions of wxWidgets this exit
+        code was @c -1, which corresponds to either @c 255 or @c 127 depending
+        on the platform and compiler used, so you may want to call this
+        function with @c -1 argument if you need to preserve compatibility with
+        the old behaviour.
 
         SetErrorExitCode() can be overridden by the application to perform
         additional actions, but the overridden version should call the base
@@ -817,11 +822,15 @@ public:
         If the program can't continue due to a fatal error, such as receiving
         an unhandled exception or failing to initialize the graphical
         environment for the GUI applications, it terminates with the default
-        fatal error exit code which is @c -1.
+        fatal error exit code which is @c 255.
 
         This function can be used to change this default value to something
-        else. Notice that it has to be called as early as possible to take
-        effect even during the early application initialization, e.g.
+        else, e.g. @c -1 which used to be returned in the previous versions of
+        wxWidgets (and corresponds to either @c 255 or @c 127 depending on the
+        platform and compiler used) if compatibility is important.
+
+        Notice that it has to be called as early as possible to take effect
+        even during the early application initialization, e.g.
 
         @code
         struct FatalErrorCodeInitializer {

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -112,6 +112,8 @@ wxAppConsole *wxAppConsoleBase::ms_appInstance = nullptr;
 
 wxAppInitializerFunction wxAppConsoleBase::ms_appInitFn = nullptr;
 
+int wxAppConsoleBase::ms_fatalErrorExitCode = 255;
+
 wxSocketManager *wxAppTraitsBase::ms_manager = nullptr;
 
 WXDLLIMPEXP_DATA_BASE(wxList) wxPendingDelete;

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -550,7 +550,7 @@ int wxEntryReal(int& argc, wxChar **argv)
         // flush any log messages explaining why we failed
         delete wxLog::SetActiveTarget(nullptr);
 #endif
-        return -1;
+        return wxApp::GetFatalErrorExitCode();
     }
 
     wxTRY
@@ -574,7 +574,10 @@ int wxEntryReal(int& argc, wxChar **argv)
         // app execution
         return wxTheApp->OnRun();
     }
-    wxCATCH_ALL( wxTheApp->OnUnhandledException(); return -1; )
+    wxCATCH_ALL(
+        wxTheApp->OnUnhandledException();
+        return wxApp::GetFatalErrorExitCode();
+    )
 }
 
 // as with wxEntryStart, we provide an ANSI wrapper

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -559,7 +559,7 @@ int wxEntryReal(int& argc, wxChar **argv)
         if ( !wxTheApp->CallOnInit() )
         {
             // don't call OnExit() if OnInit() failed
-            return -1;
+            return wxTheApp->GetErrorExitCode();
         }
 
         // ensure that OnExit() is called if OnInit() had succeeded

--- a/src/msw/main.cpp
+++ b/src/msw/main.cpp
@@ -170,7 +170,7 @@ int wxEntry(int& argc, wxChar **argv)
     {
         return wxEntryReal(argc, argv);
     }
-    wxSEH_HANDLE(-1)
+    wxSEH_HANDLE(wxApp::GetFatalErrorExitCode())
 }
 
 #else // !wxUSE_ON_FATAL_EXCEPTION
@@ -225,7 +225,7 @@ WXDLLIMPEXP_CORE int wxEntry(HINSTANCE hInstance,
                         int nCmdShow)
 {
     if ( !wxMSWEntryCommon(hInstance, nCmdShow) )
-        return -1;
+        return wxApp::GetFatalErrorExitCode();
 
     auto& initData = wxInitData::Get();
     return wxEntry(initData.argc, initData.argv);


### PR DESCRIPTION
The important commit here is the last one.

Any comments are welcome, as always.