### PR TITLE
Improve documentation for convenience input functions and wxDirDialog

### DIFF
--- a/docs/doxygen/overviews/commondialogs.h
+++ b/docs/doxygen/overviews/commondialogs.h
@@ -182,8 +182,8 @@ description for each, such as:
 
 Classes: wxDirDialog
 
-This dialog shows a directory selector dialog, allowing the user to select a
-single directory.
+This dialog shows a directory selector dialog, allowing the user to select
+one or multiple directories.
 
 
 

--- a/interface/wx/colordlg.h
+++ b/interface/wx/colordlg.h
@@ -158,8 +158,8 @@ wxEventType wxEVT_COLOUR_CHANGED;
 
     @header{wx/colordlg.h}
 */
-wxColour wxGetColourFromUser(wxWindow* parent,
-                             const wxColour& colInit,
+wxColour wxGetColourFromUser(wxWindow* parent = nullptr,
+                             const wxColour& colInit = wxNullColour,
                              const wxString& caption = wxEmptyString,
                              wxColourData* data = nullptr);
 

--- a/interface/wx/dirdlg.h
+++ b/interface/wx/dirdlg.h
@@ -37,12 +37,12 @@ const char wxDirDialogNameStr[] = "wxDirCtrl";
 
     @beginStyleTable
     @style{wxDD_DEFAULT_STYLE}
-           Equivalent to a combination of wxDEFAULT_DIALOG_STYLE and
-           wxRESIZE_BORDER.
+           Equivalent to a combination of @c wxDEFAULT_DIALOG_STYLE and
+           @c wxRESIZE_BORDER.
     @style{wxDD_DIR_MUST_EXIST}
            The dialog will allow the user to choose only an existing folder.
            When this style is not given, a "Create new directory" button is
-           added to the dialog (on Windows) or some other way is provided to
+           added to the dialog or some other way is provided to
            the user to type the name of a new folder.
     @style{wxDD_CHANGE_DIR}
            Change the current working directory to the directory chosen by the
@@ -50,36 +50,21 @@ const char wxDirDialogNameStr[] = "wxDirCtrl";
            This flag cannot be used with the @c wxDD_MULTIPLE style.
     @style{wxDD_MULTIPLE}
            Allow the user to select multiple directories.
-           This flag is only available since wxWidgets 3.1.4
+           This flag is only available since wxWidgets 3.1.4.
     @style{wxDD_SHOW_HIDDEN}
            Show hidden and system folders.
-           This flag is only available since wxWidgets 3.1.4
+           This flag is only available since wxWidgets 3.1.4.
     @endStyleTable
 
-    Notice that @c wxRESIZE_BORDER has special side effect under Windows
-    where two different directory selection dialogs are available and this
-    style also implicitly selects the new version as the old one always has
-    fixed size. As the new version is almost always preferable, it is
-    recommended that @c wxRESIZE_BORDER style be always used.
-    This is the case if the dialog is created with the default style value but
-    if you need to use any additional styles you should still specify @c
-    wxDD_DEFAULT_STYLE unless you explicitly need to use the old dialog version
-    under Windows. E.g. do
-    @code
-        wxDirDialog dlg(nullptr, "Choose input directory", "",
-                        wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
-    @endcode
-    instead of just using @c wxDD_DIR_MUST_EXIST style alone.
-
-    @remarks MacOS 10.11+ does not display a title bar on the dialog. Use SetMessage()
+    @remarks macOS 10.11+ does not display a title bar on the dialog. Use SetMessage()
              to change the string displayed to the user at the top of the dialog after creation.
-             The SetTitle() method is provided for compatibility with pre-10.11 MacOS versions
+             The SetTitle() method is provided for compatibility with pre-10.11 macOS versions
              that do still support displaying the title bar.
 
     @library{wxcore}
     @category{cmndlg}
 
-    @see @ref overview_cmndlg_dir, wxFileDialog
+    @see @ref overview_cmndlg_dir, ::wxDirSelector(), wxDirPickerCtrl, wxFileDialog
 */
 class wxDirDialog : public wxDialog
 {
@@ -94,7 +79,7 @@ public:
         @param defaultPath
             The default path, or the empty string.
         @param style
-            The dialog style. See wxDirDialog
+            The dialog style, see @c wxDD_* styles for more info.
         @param pos
             Dialog position. Ignored under Windows.
         @param size
@@ -149,8 +134,8 @@ public:
     virtual void SetPath(const wxString& path);
 
     /**
-        Shows the dialog, returning wxID_OK if the user pressed OK, and
-        wxID_CANCEL otherwise.
+        Shows the dialog, returning @c wxID_OK if the user pressed OK, and
+        @c wxID_CANCEL otherwise.
     */
     int ShowModal();
 };

--- a/interface/wx/dirdlg.h
+++ b/interface/wx/dirdlg.h
@@ -167,13 +167,13 @@ public:
 /**
     Pops up a directory selector dialog. The arguments have the same meaning
     as those of wxDirDialog::wxDirDialog(). The message is displayed at the
-    top, and the default_path, if specified, is set as the initial selection.
+    top, and the @a defaultPath, if specified, is set as the initial selection.
 
     The application must check for an empty return value (if the user pressed
     Cancel). For example:
 
     @code
-    const wxString& dir = wxDirSelector("Choose a folder");
+    const wxString dir = wxDirSelector("Choose a folder");
     if ( !dir.empty() )
     {
         ...
@@ -183,8 +183,8 @@ public:
     @header{wx/dirdlg.h}
 */
 wxString wxDirSelector(const wxString& message = wxDirSelectorPromptStr,
-                       const wxString& default_path = wxEmptyString,
-                       long style = 0,
+                       const wxString& defaultPath = wxEmptyString,
+                       long style = wxDD_DEFAULT_STYLE,
                        const wxPoint& pos = wxDefaultPosition,
                        wxWindow* parent = nullptr);
 

--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -495,9 +495,9 @@ public:
     default filename will be supplied. The wildcard determines what files are
     displayed in the file selector, and file extension supplies a type
     extension for the required filename. Flags may be a combination of
-    wxFD_OPEN, wxFD_SAVE, wxFD_OVERWRITE_PROMPT or wxFD_FILE_MUST_EXIST.
+    @c wxFD_OPEN, @c wxFD_SAVE, @c wxFD_OVERWRITE_PROMPT or @c wxFD_FILE_MUST_EXIST.
 
-    @note wxFD_MULTIPLE can only be used with wxFileDialog and not here since
+    @note @c wxFD_MULTIPLE can only be used with wxFileDialog and not here since
           this function only returns a single file name.
 
     Both the Unix and Windows versions implement a wildcard filter. Typing a
@@ -555,6 +555,8 @@ wxString wxFileSelectorEx(const wxString& message = wxFileSelectorPromptStr,
 /**
     Shows a file dialog asking the user for a file name for opening a file.
 
+    The file dialog will have @c wxFD_FILE_MUST_EXIST flag set.
+
     @see wxFileSelector(), wxFileDialog
 
     @header{wx/filedlg.h}
@@ -566,6 +568,8 @@ wxString wxLoadFileSelector(const wxString& what,
 
 /**
     Shows a file dialog asking the user for a file name for saving a file.
+
+    The file dialog will not have @c wxFD_OVERWRITE_PROMPT flag set.
 
     @see wxFileSelector(), wxFileDialog
 

--- a/interface/wx/fontdlg.h
+++ b/interface/wx/fontdlg.h
@@ -97,8 +97,8 @@ public:
 
     @header{wx/fontdlg.h}
 */
-wxFont wxGetFontFromUser(wxWindow* parent,
-                         const wxFont& fontInit,
+wxFont wxGetFontFromUser(wxWindow* parent = nullptr,
+                         const wxFont& fontInit = wxNullFont,
                          const wxString& caption = wxEmptyString);
 
 ///@}


### PR DESCRIPTION
Regarding the `wxDirDialog` commit:
1. Does `wxRESIZE_BORDER` still have to be used at all there?
2. The description of `wxDD_DIR_MUST_EXIST` is IMO still inaccurate. E.g., AFAICT, on Windows presence/absence of this flag has zero effect on the (`IFileDialog`-based) dialog appearance.