### PR TITLE
Add possibility to retrieve both build- and run-time wxWebView version

### DIFF
--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -226,7 +226,7 @@ public:
     }
 
 #if wxUSE_WEBVIEW_WEBKIT2
-    virtual wxVersionInfo GetVersionInfo() override;
+    virtual wxVersionInfo GetVersionInfo(wxVersionContext context) override;
     virtual wxWebViewConfiguration CreateConfiguration() override;
     virtual wxWebView* CreateWithConfig(const wxWebViewConfiguration& config) override;
 #endif

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -143,7 +143,7 @@ public:
         return new wxWebViewEdge(parent, id, url, pos, size, style, name);
     }
     virtual bool IsAvailable() override;
-    virtual wxVersionInfo GetVersionInfo() override;
+    virtual wxVersionInfo GetVersionInfo(wxVersionContext context) override;
     virtual wxWebViewConfiguration CreateConfiguration() override;
 };
 

--- a/include/wx/msw/webview_ie.h
+++ b/include/wx/msw/webview_ie.h
@@ -192,7 +192,7 @@ public:
                               long style = 0,
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) override
     { return new wxWebViewIE(parent, id, url, pos, size, style, name); }
-    virtual wxVersionInfo GetVersionInfo() override;
+    virtual wxVersionInfo GetVersionInfo(wxVersionContext context) override;
 };
 
 #endif // wxUSE_WEBVIEW && wxUSE_WEBVIEW_IE && defined(__WXMSW__)

--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -136,7 +136,7 @@ public:
         else
             return nullptr;
     }
-    virtual wxVersionInfo GetVersionInfo() override;
+    virtual wxVersionInfo GetVersionInfo(wxVersionContext context) override;
     virtual wxWebViewConfiguration CreateConfiguration() override;
 };
 

--- a/include/wx/versioninfo.h
+++ b/include/wx/versioninfo.h
@@ -61,6 +61,12 @@ public:
         return m_micro >= micro;
     }
 
+    // Return true if this version object actually has any version information.
+    bool IsOk() const
+    {
+        return AtLeast(0) || !m_name.empty() || !m_description.empty();
+    }
+
     const wxString& GetName() const { return m_name; }
 
     int GetMajor() const { return m_major; }

--- a/include/wx/versioninfo.h
+++ b/include/wx/versioninfo.h
@@ -13,6 +13,16 @@
 #include "wx/string.h"
 
 // ----------------------------------------------------------------------------
+// wxVersionContext: defines which version information to retrieve
+// ----------------------------------------------------------------------------
+
+enum class wxVersionContext
+{
+    RunTime,        // Version used during run-time.
+    BuildTime       // Version that the application was built with.
+};
+
+// ----------------------------------------------------------------------------
 // wxVersionInfo: represents version information
 // ----------------------------------------------------------------------------
 

--- a/include/wx/versioninfo.h
+++ b/include/wx/versioninfo.h
@@ -73,16 +73,24 @@ public:
         return HasDescription() ? GetDescription() : GetVersionString();
     }
 
-    wxString GetVersionString() const
+    wxString GetNumericVersionString() const
     {
         wxString str;
-        str << m_name << ' ' << GetMajor() << '.' << GetMinor();
+        str << GetMajor() << '.' << GetMinor();
         if ( GetMicro() || GetRevision() )
         {
             str << '.' << GetMicro();
             if ( GetRevision() )
                 str << '.' << GetRevision();
         }
+
+        return str;
+    }
+
+    wxString GetVersionString() const
+    {
+        wxString str;
+        str << m_name << ' ' << GetNumericVersionString();
 
         return str;
     }

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -185,7 +185,11 @@ public:
                               long style = 0,
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) = 0;
     virtual bool IsAvailable() { return true; }
-    virtual wxVersionInfo GetVersionInfo() { return wxVersionInfo(); }
+    virtual wxVersionInfo
+    GetVersionInfo(wxVersionContext WXUNUSED(context) = wxVersionContext::RunTime)
+    {
+        return wxVersionInfo();
+    }
     virtual wxWebViewConfiguration CreateConfiguration();
 };
 
@@ -226,7 +230,10 @@ public:
     static void RegisterFactory(const wxString& backend,
                                 wxSharedPtr<wxWebViewFactory> factory);
     static bool IsBackendAvailable(const wxString& backend);
-    static wxVersionInfo GetBackendVersionInfo(const wxString& backend = wxASCII_STR(wxWebViewBackendDefault));
+    static wxVersionInfo GetBackendVersionInfo(
+        const wxString& backend = wxASCII_STR(wxWebViewBackendDefault),
+        wxVersionContext context = wxVersionContext::RunTime
+    );
     static wxWebViewConfiguration NewConfiguration(const wxString& backend = wxASCII_STR(wxWebViewBackendDefault));
 
     // General methods

--- a/interface/wx/versioninfo.h
+++ b/interface/wx/versioninfo.h
@@ -63,6 +63,17 @@ public:
     bool AtLeast(int major, int minor = 0, int micro = 0) const;
 
     /**
+        Return true if there is actually at least some version information.
+
+        For the default-constructed object, this function returns @false,
+        allowing to distinguish it from any object filled with the version
+        information.
+
+        @since 3.3.0
+     */
+    bool IsOk() const;
+
+    /**
         Get the name of the object (library).
 
         @return Name string.

--- a/interface/wx/versioninfo.h
+++ b/interface/wx/versioninfo.h
@@ -114,11 +114,27 @@ public:
     wxString ToString() const;
 
     /**
+        Get the string representation of only numeric version components.
+
+        The micro and revision components of the version are ignored/not used
+        if they are both zero. If the revision component is non-zero all four
+        parts will be used even if the micro component is zero.
+
+        @return The version string in the form "major.minor[.micro[.revision]]".
+
+        @since 3.3.0
+     */
+    wxString GetNumericVersionString() const;
+
+    /**
         Get the string representation.
 
         The micro and revision components of the version are ignored/not used
         if they are both zero. If the revision component is non-zero all four
         parts will be used even if the micro component is zero.
+
+        Note that this function includes the name of the object this version is
+        defined for, if this is undesired, use GetNumericVersionString() instead.
 
         @return The version string in the form "name major.minor[.micro[.revision]]".
     */

--- a/interface/wx/versioninfo.h
+++ b/interface/wx/versioninfo.h
@@ -6,6 +6,24 @@
 /////////////////////////////////////////////////////////////////////////////
 
 /**
+    Defines the context in which the version information is requested.
+
+    Elements of this enum can be used to select between getting the compile- or
+    run-time wxVersionInfo object for the components supporting this.
+
+    @since 3.3.0
+ */
+enum class wxVersionContext
+{
+    /// Ask for the version used during run-time.
+    RunTime,
+
+    /// Ask for the version that the application was built with.
+    BuildTime
+};
+
+
+/**
     @class wxVersionInfo
 
     wxVersionInfo contains version information.

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -625,9 +625,17 @@ public:
     /**
         Retrieve the version information about this backend implementation.
 
-        @since 3.1.5
+        @param context
+            The context in which the version information is requested, by
+            default it is the run-time version. Currently only GTK WebKit and
+            CEF backends support returning compile-time version information,
+            all the other backends return an empty wxVersionInfo object in this
+            case.
+
+        @since 3.1.5 (@a context parameter was added in 3.3.0)
     */
-    virtual wxVersionInfo GetVersionInfo();
+    virtual wxVersionInfo
+    GetVersionInfo(wxVersionContext context = wxVersionContext::RunTime);
 
     /**
         Create a wxWebViewConfiguration object for wxWebView instances
@@ -1088,9 +1096,23 @@ public:
     /**
         Retrieve the version information about the backend implementation.
 
-        @since 3.1.5
+        @param backend
+            The name of the backend to retrieve the version information for,
+            can be left unspecified to use the default backend.
+        @param context
+            The context in which the version information is requested, by
+            default it is the run-time version. Currently only GTK WebKit and
+            CEF backends support returning compile-time version information,
+            all the other backends return an empty wxVersionInfo object in this
+            case.
+
+        @since 3.1.5 (@a context parameter was added in 3.3.0)
     */
-    static wxVersionInfo GetBackendVersionInfo(const wxString& backend = wxWebViewBackendDefault);
+    static wxVersionInfo
+    GetBackendVersionInfo(
+        const wxString& backend = wxWebViewBackendDefault,
+        wxVersionContext context = wxVersionContext::RunTime
+    );
 
     /**
         Create a new wxWebViewConfiguration object.

--- a/misc/suppressions/codespell-lines
+++ b/misc/suppressions/codespell-lines
@@ -31,3 +31,4 @@ expressions</em> (BRE). EREs are roughly those of the traditional @e egrep,
     makefile.unx</code> in the sample directory to build it.
     bool AtLeast(int major, int minor = 0, int micro = 0) const
     bool AtLeast(int major, int minor = 0, int micro = 0) const;
+        return AtLeast(0) || !m_name.empty() || !m_description.empty();

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -551,15 +551,32 @@ WebFrame::WebFrame(const wxString& url, int flags, wxWebViewWindowFeatures* wind
         wxLog::SetActiveTarget(new wxLogTextCtrl(m_log_textCtrl));
 
         // Log backend information
-        const auto& version = wxWebView::GetBackendVersionInfo(backend);
-        wxString description;
-        if ( version.HasDescription() )
-            description.Printf(" (%s)", version.GetDescription());
 
-        wxLogMessage("Backend: %s version=%s%s",
+        const auto formatVersion = [](const char* context,
+                                      const wxVersionInfo& version) {
+            wxString str;
+
+            if ( version.IsOk() )
+            {
+                str.Printf(", %s version=%s",
+                           context, version.GetNumericVersionString());
+
+                if ( version.HasDescription() )
+                    str += wxString::Format(" (%s)", version.GetDescription());
+            }
+
+            return str;
+        };
+
+        const auto versionRunTime = formatVersion("run-time", wxWebView::GetBackendVersionInfo(backend));
+        const auto versionBuildTime = formatVersion("build-time", wxWebView::GetBackendVersionInfo(
+            backend, wxVersionContext::BuildTime
+        ));
+
+        wxLogMessage("Backend: %s%s%s",
                      m_browser->GetClassInfo()->GetClassName(),
-                     version.GetNumericVersionString(),
-                     description);
+                     versionRunTime,
+                     versionBuildTime);
 
         // Chromium backend can't be used immediately after creation, so wait
         // until the browser is created before calling GetUserAgent(), but we

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -551,8 +551,15 @@ WebFrame::WebFrame(const wxString& url, int flags, wxWebViewWindowFeatures* wind
         wxLog::SetActiveTarget(new wxLogTextCtrl(m_log_textCtrl));
 
         // Log backend information
-        wxLogMessage("Backend: %s Version: %s", m_browser->GetClassInfo()->GetClassName(),
-            wxWebView::GetBackendVersionInfo(backend).ToString());
+        const auto& version = wxWebView::GetBackendVersionInfo(backend);
+        wxString description;
+        if ( version.HasDescription() )
+            description.Printf(" (%s)", version.GetDescription());
+
+        wxLogMessage("Backend: %s version=%s%s",
+                     m_browser->GetClassInfo()->GetClassName(),
+                     version.GetNumericVersionString(),
+                     description);
 
         // Chromium backend can't be used immediately after creation, so wait
         // until the browser is created before calling GetUserAgent(), but we

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -476,11 +476,13 @@ bool wxWebView::IsBackendAvailable(const wxString& backend)
         return false;
 }
 
-wxVersionInfo wxWebView::GetBackendVersionInfo(const wxString& backend)
+wxVersionInfo
+wxWebView::GetBackendVersionInfo(const wxString& backend,
+                                 wxVersionContext context)
 {
     wxStringWebViewFactoryMap::iterator iter = FindFactory(backend);
     if (iter != m_factoryMap.end())
-        return iter->second->GetVersionInfo();
+        return iter->second->GetVersionInfo(context);
     else
         return wxVersionInfo();
 }

--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -1959,16 +1959,30 @@ public:
         return true;
     }
 
-    virtual wxVersionInfo GetVersionInfo() override
+    virtual wxVersionInfo GetVersionInfo(wxVersionContext context) override
     {
-        return {
-            "CEF",
-            CEF_VERSION_MAJOR,
-            CEF_VERSION_MINOR,
-            CEF_VERSION_PATCH,
-            CEF_COMMIT_NUMBER,
-            CEF_VERSION
-        };
+        wxString version;
+        int major, minor, micro, build;
+        switch ( context )
+        {
+            case wxVersionContext::RunTime:
+                major = cef_version_info(0);
+                minor = cef_version_info(1);
+                micro = cef_version_info(2);
+                build = cef_version_info(3);
+                break;
+
+            case wxVersionContext::BuildTime:
+                major = CEF_VERSION_MAJOR;
+                minor = CEF_VERSION_MINOR;
+                micro = CEF_VERSION_PATCH;
+                build = CEF_COMMIT_NUMBER;
+
+                version = CEF_VERSION;
+                break;
+        }
+
+        return {"CEF", major, minor, micro, build, version};
     }
 
     virtual wxWebViewConfiguration CreateConfiguration() override

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -803,7 +803,9 @@ private:
 
 wxVersionInfo wxWebViewFactoryWebKit::GetVersionInfo(wxVersionContext context)
 {
-    int major, minor, micro;
+    int major = 0,
+        minor = 0,
+        micro = 0;
 
     switch ( context )
     {

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -801,10 +801,26 @@ private:
 // wxWebViewFactoryWebKit
 //-----------------------------------------------------------------------------
 
-wxVersionInfo wxWebViewFactoryWebKit::GetVersionInfo()
+wxVersionInfo wxWebViewFactoryWebKit::GetVersionInfo(wxVersionContext context)
 {
-    return wxVersionInfo("webkit2", webkit_get_major_version(),
-        webkit_get_minor_version(), webkit_get_micro_version());
+    int major, minor, micro;
+
+    switch ( context )
+    {
+        case wxVersionContext::RunTime:
+            major = webkit_get_major_version();
+            minor = webkit_get_minor_version();
+            micro = webkit_get_micro_version();
+            break;
+
+        case wxVersionContext::BuildTime:
+            major = WEBKIT_MAJOR_VERSION;
+            minor = WEBKIT_MINOR_VERSION;
+            micro = WEBKIT_MICRO_VERSION;
+            break;
+    }
+
+    return wxVersionInfo("webkit2", major, minor, micro);
 }
 
 wxWebViewConfiguration wxWebViewFactoryWebKit::CreateConfiguration()

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -1575,32 +1575,42 @@ bool wxWebViewFactoryEdge::IsAvailable()
     return wxWebViewEdgeImpl::Initialize();
 }
 
-wxVersionInfo wxWebViewFactoryEdge::GetVersionInfo()
+wxVersionInfo wxWebViewFactoryEdge::GetVersionInfo(wxVersionContext context)
 {
-    long major = 0,
-         minor = 0,
-         micro = 0,
-         revision = 0;
-
-    if (wxWebViewEdgeImpl::Initialize())
+    switch ( context )
     {
-        wxCoTaskMemPtr<wchar_t> nativeVersionStr;
-        HRESULT hr = wxGetAvailableCoreWebView2BrowserVersionString(
-            wxWebViewConfigurationImplEdge::ms_browserExecutableDir.wc_str(), &nativeVersionStr);
-        if (SUCCEEDED(hr) && nativeVersionStr)
-        {
-            wxStringTokenizer tk(wxString(nativeVersionStr), ". ");
-            // Ignore the return value because if the version component is missing
-            // or invalid (i.e. non-numeric), the only thing we can do is to ignore
-            // it anyhow.
-            tk.GetNextToken().ToLong(&major);
-            tk.GetNextToken().ToLong(&minor);
-            tk.GetNextToken().ToLong(&micro);
-            tk.GetNextToken().ToLong(&revision);
-        }
+        case wxVersionContext::BuildTime:
+            // There is no build-time version for this backend.
+            break;
+
+        case wxVersionContext::RunTime:
+            long major = 0,
+                 minor = 0,
+                 micro = 0,
+                 revision = 0;
+
+            if (wxWebViewEdgeImpl::Initialize())
+            {
+                wxCoTaskMemPtr<wchar_t> nativeVersionStr;
+                HRESULT hr = wxGetAvailableCoreWebView2BrowserVersionString(
+                    wxWebViewConfigurationImplEdge::ms_browserExecutableDir.wc_str(), &nativeVersionStr);
+                if (SUCCEEDED(hr) && nativeVersionStr)
+                {
+                    wxStringTokenizer tk(wxString(nativeVersionStr), ". ");
+                    // Ignore the return value because if the version component is missing
+                    // or invalid (i.e. non-numeric), the only thing we can do is to ignore
+                    // it anyhow.
+                    tk.GetNextToken().ToLong(&major);
+                    tk.GetNextToken().ToLong(&minor);
+                    tk.GetNextToken().ToLong(&micro);
+                    tk.GetNextToken().ToLong(&revision);
+                }
+            }
+
+            return wxVersionInfo("Microsoft Edge WebView2", major, minor, micro, revision);
     }
 
-    return wxVersionInfo("Microsoft Edge WebView2", major, minor, micro, revision);
+    return {};
 }
 
 wxWebViewConfiguration wxWebViewFactoryEdge::CreateConfiguration()

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -53,24 +53,34 @@ enum //Internal find flags
 }
 
 // wxWebViewFactoryIE
-wxVersionInfo wxWebViewFactoryIE::GetVersionInfo()
+wxVersionInfo wxWebViewFactoryIE::GetVersionInfo(wxVersionContext context)
 {
-    wxRegKey key(wxRegKey::HKLM, "Software\\Microsoft\\Internet Explorer");
-    wxString value;
-    key.QueryValue("Version", value);
-    long major = 0,
-         minor = 0,
-         micro = 0,
-         revision = 0;
-    wxStringTokenizer tk(value, ". ");
-    // Ignore the return value because if the version component is missing
-    // or invalid (i.e. non-numeric), the only thing we can do is to ignore
-    // it anyhow.
-    tk.GetNextToken().ToLong(&major);
-    tk.GetNextToken().ToLong(&minor);
-    tk.GetNextToken().ToLong(&micro);
-    tk.GetNextToken().ToLong(&revision);
-    return wxVersionInfo("Internet Explorer", major, minor, micro, revision);
+    switch ( context )
+    {
+        case wxVersionContext::BuildTime:
+            // There is no build-time version for this backend.
+            break;
+
+        case wxVersionContext::RunTime:
+            wxRegKey key(wxRegKey::HKLM, "Software\\Microsoft\\Internet Explorer");
+            wxString value;
+            key.QueryValue("Version", value);
+            long major = 0,
+                 minor = 0,
+                 micro = 0,
+                 revision = 0;
+            wxStringTokenizer tk(value, ". ");
+            // Ignore the return value because if the version component is missing
+            // or invalid (i.e. non-numeric), the only thing we can do is to ignore
+            // it anyhow.
+            tk.GetNextToken().ToLong(&major);
+            tk.GetNextToken().ToLong(&minor);
+            tk.GetNextToken().ToLong(&micro);
+            tk.GetNextToken().ToLong(&revision);
+            return wxVersionInfo("Internet Explorer", major, minor, micro, revision);
+    }
+
+    return {};
 }
 
 //Convenience function for error conversion

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -134,11 +134,21 @@ public:
 // wxWebViewFactoryWebKit
 //-----------------------------------------------------------------------------
 
-wxVersionInfo wxWebViewFactoryWebKit::GetVersionInfo()
+wxVersionInfo wxWebViewFactoryWebKit::GetVersionInfo(wxVersionContext context)
 {
-    int verMaj, verMin, verMicro;
-    wxGetOsVersion(&verMaj, &verMin, &verMicro);
-    return wxVersionInfo("WKWebView", verMaj, verMin, verMicro);
+    switch ( context )
+    {
+        case wxVersionContext::BuildTime:
+            // There is no build-time version for this backend.
+            break;
+
+        case wxVersionContext::RunTime:
+            int verMaj, verMin, verMicro;
+            wxGetOsVersion(&verMaj, &verMin, &verMicro);
+            return wxVersionInfo("WKWebView", verMaj, verMin, verMicro);
+    }
+
+    return {};
 }
 
 wxWebViewConfiguration wxWebViewFactoryWebKit::CreateConfiguration()


### PR DESCRIPTION
This also makes Chromium backend consistent with all the other ones by returning the run-time version from its `GetVersionInfo()` by default — but still allows to get the compile-time version, which was returned before, if necessary.