### PR TITLE
Fix background of controls with transparent areas in `wxAuiToolBar` in wxMSW

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -657,7 +657,6 @@ protected: // handlers
     void OnIdle(wxIdleEvent& evt);
     void OnDPIChanged(wxDPIChangedEvent& evt);
     void OnPaint(wxPaintEvent& evt);
-    void OnEraseBackground(wxEraseEvent& evt);
     void OnLeftDown(wxMouseEvent& evt);
     void OnLeftUp(wxMouseEvent& evt);
     void OnRightDown(wxMouseEvent& evt);

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -16,6 +16,7 @@
 
 #include "wx/bmpbndl.h"
 #include "wx/control.h"
+#include "wx/custombgwin.h"
 #include "wx/sizer.h"
 #include "wx/pen.h"
 
@@ -461,7 +462,7 @@ protected:
 
 
 
-class WXDLLIMPEXP_AUI wxAuiToolBar : public wxControl
+class WXDLLIMPEXP_AUI wxAuiToolBar : public wxCustomBackgroundWindow<wxControl>
 {
 public:
     wxAuiToolBar() { Init(); }
@@ -714,6 +715,10 @@ private:
     void DoResetMouseState();
 
     wxSize RealizeHelper(wxReadOnlyDC& dc, wxOrientation orientation);
+
+    void UpdateBackgroundBitmap(const wxSize& size);
+
+    wxBitmap m_backgroundBitmap;
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_CLASS(wxAuiToolBar);

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -862,9 +862,10 @@ MyFrame::MyFrame(wxWindow* parent,
     tb4->AddTool(ID_SampleItem+29, "Item 8", tb4_bmp1);
     tb4->SetToolDropDown(ID_DropDownToolbarItem, true);
     tb4->SetCustomOverflowItems(prepend_items, append_items);
+    tb4->AddControl(new wxStaticText(tb4, wxID_ANY, "Choose wisely: "));
     wxChoice* choice = new wxChoice(tb4, ID_SampleItem+35);
-    choice->AppendString("One choice");
-    choice->AppendString("Another choice");
+    choice->AppendString("Good choice");
+    choice->AppendString("Better choice");
     tb4->AddControl(choice);
     tb4->Realize();
 

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -825,7 +825,6 @@ wxBEGIN_EVENT_TABLE(wxAuiToolBar, wxControl)
     EVT_SIZE(wxAuiToolBar::OnSize)
     EVT_IDLE(wxAuiToolBar::OnIdle)
     EVT_DPI_CHANGED(wxAuiToolBar::OnDPIChanged)
-    EVT_ERASE_BACKGROUND(wxAuiToolBar::OnEraseBackground)
     EVT_PAINT(wxAuiToolBar::OnPaint)
     EVT_LEFT_DOWN(wxAuiToolBar::OnLeftDown)
     EVT_LEFT_DCLICK(wxAuiToolBar::OnLeftDown)
@@ -2512,11 +2511,6 @@ void wxAuiToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
         wxRect dropDownRect = GetOverflowRect();
         m_art->DrawOverflowButton(dc, this, dropDownRect, m_overflowState);
     }
-}
-
-void wxAuiToolBar::OnEraseBackground(wxEraseEvent& WXUNUSED(evt))
-{
-    // empty
 }
 
 void wxAuiToolBar::OnLeftDown(wxMouseEvent& evt)

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -895,7 +895,6 @@ bool wxAuiToolBar::Create(wxWindow* parent,
     SetExtraStyle(wxWS_EX_PROCESS_IDLE);
     if (style & wxAUI_TB_HORZ_LAYOUT)
         SetToolTextOrientation(wxAUI_TBTOOL_TEXT_RIGHT);
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     return true;
 }
@@ -2445,13 +2444,11 @@ void wxAuiToolBar::UpdateBackgroundBitmap(const wxSize& size)
 
 void wxAuiToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 {
-    wxAutoBufferedPaintDC dc(this);
+    wxPaintDC dc(this);
     wxRect cli_rect(wxPoint(0,0), GetClientSize());
 
 
     bool horizontal = m_orientation == wxHORIZONTAL;
-
-    dc.DrawBitmap(m_backgroundBitmap, 0, 0);
 
     int gripperSize = m_art->GetElementSize(wxAUI_TBART_GRIPPER_SIZE);
     int overflowSize = m_art->GetElementSize(wxAUI_TBART_OVERFLOW_SIZE);

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -915,8 +915,6 @@ void wxAuiToolBar::SetWindowStyleFlag(long style)
 
     wxControl::SetWindowStyleFlag(style);
 
-    m_windowStyle = style;
-
     if (m_art)
     {
         SetArtFlags();


### PR DESCRIPTION
The main commit here is 32f3dbd8f4512f021ebad3db5a4deb256964aee7, the rest are just minor cleanups.