### PR TITLE
Fixes for computing `wxStaticText` best size in wxGTK

### DIFF
--- a/include/wx/gtk/stattext.h
+++ b/include/wx/gtk/stattext.h
@@ -61,6 +61,9 @@ private:
 
     void GTKDoSetLabel(GTKLabelSetter setter, const wxString& label);
 
+    // If our font has been changed, we compute the best size ourselves because
+    // GTK doesn't always do it correctly, see DoGetBestSize().
+    bool m_computeOurOwnBestSize = false;
 
     wxDECLARE_DYNAMIC_CLASS(wxStaticText);
 };


### PR DESCRIPTION
See the previous discussion in #19053.