### PR TITLE
Fix wxAuiTabArt font veiling after SetArtProvider

### DIFF
--- a/include/wx/aui/tabart.h
+++ b/include/wx/aui/tabart.h
@@ -57,6 +57,9 @@ public:
     virtual void SetColour(const wxColour& colour) = 0;
     virtual void SetActiveColour(const wxColour& colour) = 0;
 
+    virtual wxFont GetNormalFont() const = 0;
+    virtual wxFont GetSelectedFont() const = 0;
+
     virtual void DrawBorder(
                  wxDC& dc,
                  wxWindow* wnd,
@@ -137,6 +140,9 @@ public:
     void SetMeasuringFont(const wxFont& font) override;
     void SetColour(const wxColour& colour) override;
     void SetActiveColour(const wxColour& colour) override;
+
+    wxFont GetNormalFont() const override;
+    wxFont GetSelectedFont() const override;
 
     void DrawBorder(
                  wxDC& dc,
@@ -240,6 +246,9 @@ public:
     void SetMeasuringFont(const wxFont& font) override;
     void SetColour(const wxColour& colour) override;
     void SetActiveColour(const wxColour& colour) override;
+
+    wxFont GetNormalFont() const override;
+    wxFont GetSelectedFont() const override;
 
     void DrawBorder(
                  wxDC& dc,

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1799,6 +1799,8 @@ wxAuiNotebook::~wxAuiNotebook()
 void wxAuiNotebook::SetArtProvider(wxAuiTabArt* art)
 {
     m_tabs.SetArtProvider(art);
+    m_selectedFont = art->GetSelectedFont();
+    m_normalFont = art->GetNormalFont();
 
     // Update the height and do nothing else if it did something but otherwise
     // (i.e. if the new art provider uses the same height as the old one) we

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -920,6 +920,16 @@ void wxAuiGenericTabArt::SetActiveColour(const wxColour& colour)
     m_activeColour = colour;
 }
 
+wxFont wxAuiGenericTabArt::GetNormalFont() const
+{
+    return m_normalFont;
+}
+
+wxFont wxAuiGenericTabArt::GetSelectedFont() const
+{
+    return m_selectedFont;
+}
+
 // -- wxAuiSimpleTabArt class implementation --
 
 wxAuiSimpleTabArt::wxAuiSimpleTabArt()
@@ -1396,6 +1406,16 @@ void wxAuiSimpleTabArt::SetSelectedFont(const wxFont& font)
 void wxAuiSimpleTabArt::SetMeasuringFont(const wxFont& font)
 {
     m_measuringFont = font;
+}
+
+wxFont wxAuiSimpleTabArt::GetNormalFont() const
+{
+    return m_normalFont;
+}
+
+wxFont wxAuiSimpleTabArt::GetSelectedFont() const
+{
+    return m_selectedFont;
 }
 
 #endif // wxUSE_AUI


### PR DESCRIPTION
Bug fix. 

**Problem:** 
When a new wxAuiTabArt derivative class object is created and configured to be passed as argument in `wxAuiNotebook::SetArtProvider()`, it veils member variables `m_selectedFont` and `m_normalFont` of art provider. This is not immediately clear because it works while setting the art provider. But wxAuiNotebook has its own member variables with the same names, and `wxAuiNotebook::DoModifySelection()` uses these every time the active tab is switched. 

Solution: 
Create accessor functions in `tabart.h` and `tabart.cpp` for these variables, and call these functions in `wxAuiNotebook::SetArtProvider()`. The bug only seems to affect the active tab's title font, but I also fixed normal font because it is the proper way. 