### PR TITLE
IPC sample: Log window for the client should expand vertically as well as horizontally.

### DIFF
--- a/samples/ipc/client.cpp
+++ b/samples/ipc/client.cpp
@@ -124,87 +124,92 @@ MyFrame::MyFrame(wxFrame *frame, const wxString& title)
         IPC_TOPIC, "..."
     };
 
-    wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
+    wxPanel * const panel = new wxPanel(this);
 
-    wxBoxSizer *item1 = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer * const sizerMain = new wxBoxSizer( wxVERTICAL );
 
-    wxGridSizer *item2 = new wxGridSizer( 4, 0, 0 );
+    // wxBoxSizer *item1 = new wxBoxSizer( wxHORIZONTAL );
 
-    wxButton *item3 = new wxButton( this, ID_START, "Connect to server", wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    wxGridSizer * const sizerCmds = new wxGridSizer( 4, 0, 0 );
 
-    wxChoice *item5 = new wxChoice( this, ID_HOSTNAME, wxDefaultPosition, wxSize(100,-1), 2, strs5, 0 );
-    item2->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
+    wxButton *btn;
 
-    wxChoice *item4 = new wxChoice( this, ID_SERVERNAME, wxDefaultPosition, wxSize(100,-1), 2, strs4, 0 );
-    item2->Add( item4, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    btn = new wxButton( panel, ID_START, "Connect to server", wxDefaultPosition, wxDefaultSize, 0 );
+    sizerCmds->Add( btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    wxChoice *item6 = new wxChoice( this, ID_TOPIC, wxDefaultPosition, wxSize(100,-1), 2, strs6, 0 );
-    item2->Add( item6, 0, wxALIGN_CENTER|wxALL, 5 );
+    wxChoice *choice;
 
-    wxButton *item7 = new wxButton( this, ID_DISCONNECT, "Disconnect ", wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    choice = new wxChoice( panel, ID_HOSTNAME, wxDefaultPosition, wxSize(100,-1), 2, strs5, 0 );
+    sizerCmds->Add( choice, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    choice = new wxChoice( panel, ID_SERVERNAME, wxDefaultPosition, wxSize(100,-1), 2, strs4, 0 );
+    sizerCmds->Add( choice, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    choice = new wxChoice( panel, ID_TOPIC, wxDefaultPosition, wxSize(100,-1), 2, strs6, 0 );
+    sizerCmds->Add( choice, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    btn = new wxButton( panel, ID_DISCONNECT, "Disconnect ", wxDefaultPosition, wxDefaultSize, 0 );
+    sizerCmds->Add( btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    wxButton *item8 = new wxButton( this, ID_STARTADVISE, "StartAdvise", wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item8, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    wxButton *item9 = new wxButton( this, ID_STOPADVISE, "StopAdvise", wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item9, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    btn= new wxButton( panel, ID_STARTADVISE, "StartAdvise", wxDefaultPosition, wxDefaultSize, 0 );
+    sizerCmds->Add( btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    wxButton *item10 = new wxButton( this, ID_EXECUTE, "Execute", wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item10, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    btn = new wxButton( panel, ID_STOPADVISE, "StopAdvise", wxDefaultPosition, wxDefaultSize, 0 );
+    sizerCmds->Add( btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    btn = new wxButton( panel, ID_EXECUTE, "Execute", wxDefaultPosition, wxDefaultSize, 0 );
+    sizerCmds->Add( btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    wxButton *item11 = new wxButton( this, ID_POKE, "Poke", wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item11, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    btn = new wxButton( panel, ID_POKE, "Poke", wxDefaultPosition, wxDefaultSize, 0 );
+    sizerCmds->Add( btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    wxButton *item12 = new wxButton( this, ID_REQUEST, "Request", wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item12, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item2, 1, wxALIGN_CENTER|wxALL, 5 );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item1, wxSizerFlags().Expand().Border(wxALL, 5) );
+    btn = new wxButton( panel, ID_REQUEST, "Request", wxDefaultPosition, wxDefaultSize, 0 );
+    sizerCmds->Add( btn, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    wxStaticBox *item14 = new wxStaticBox( this, -1, "Client log" );
-    wxStaticBoxSizer *item13 = new wxStaticBoxSizer( item14, wxVERTICAL );
+    sizerCmds->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    wxTextCtrl *item15 = new wxTextCtrl( this, ID_LOG, wxEmptyString, wxDefaultPosition, wxSize(500,140), wxTE_MULTILINE );
-    item13->Add( item15, wxSizerFlags(1).Expand().Border(wxALL, 5) );
+    sizerMain->Add( sizerCmds, wxSizerFlags().Expand().Border(wxALL, 5) );
 
-    item0->Add( item13, wxSizerFlags(0).Expand().Border(wxALL, 5) );
+    wxStaticBoxSizer * const
+        sizerLog = new wxStaticBoxSizer(wxVERTICAL, panel, "Client log");
 
-    this->SetSizer( item0 );
-    item0->SetSizeHints( this );
+    wxTextCtrl * const textLog = new wxTextCtrl( panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(500,140), wxTE_MULTILINE );
+    sizerLog->Add( textLog, wxSizerFlags(1).Expand().Border(wxALL, 5) );
+
+    sizerMain->Add( sizerLog, wxSizerFlags(1).Expand().Border(wxALL, 5) );
+
+    panel->SetSizer( sizerMain );
+    sizerMain->SetSizeHints( panel );
+    SetClientSize(panel->GetSize());
 
     // status
     m_client = NULL;
     GetServername()->SetSelection(0);
     GetHostname()->SetSelection(0);
     GetTopic()->SetSelection(0);
-    wxLogTextCtrl *logWindow = new wxLogTextCtrl(GetLog());
+    wxLogTextCtrl *logWindow = new wxLogTextCtrl(textLog);
     delete wxLog::SetActiveTarget(logWindow);
     wxLogMessage("Click on Connect to connect to the server");
     EnableControls();


### PR DESCRIPTION
In the IPC sample, the log window in the gui produced by client.cpp does not expand vertically like it does for server.cpp. This fix makes the creation of window elements in the client mirror that of the server, and the log window now expands vertically.

This fix is in response to a side issue that was mentioned in https://github.com/wxWidgets/wxWidgets/issues/24639#issuecomment-2297094102.