### PR TITLE
Make wxSocketImpl::GetLastError() be called only once, and store the error

### DIFF
--- a/include/wx/msw/private/sockmsw.h
+++ b/include/wx/msw/private/sockmsw.h
@@ -47,8 +47,6 @@ public:
 
     virtual ~wxSocketImplMSW();
 
-    virtual wxSocketError GetLastError() wxOVERRIDE;
-
     virtual void ReenableEvents(wxSocketEventFlags WXUNUSED(flags)) wxOVERRIDE
     {
         // notifications are never disabled in this implementation, there is no
@@ -82,6 +80,9 @@ public:
             wxSocketManager::Get()->Install_Callback(this);
         }
     }
+
+protected:
+    virtual void UpdateLastError() = 0;
 
 private:
     virtual void DoClose() wxOVERRIDE;

--- a/include/wx/msw/private/sockmsw.h
+++ b/include/wx/msw/private/sockmsw.h
@@ -82,7 +82,7 @@ public:
     }
 
 protected:
-    virtual void UpdateLastError() = 0;
+    virtual void UpdateLastError();
 
 private:
     virtual void DoClose() wxOVERRIDE;

--- a/include/wx/msw/private/sockmsw.h
+++ b/include/wx/msw/private/sockmsw.h
@@ -47,7 +47,7 @@ public:
 
     virtual ~wxSocketImplMSW();
 
-    virtual wxSocketError GetLastError() const wxOVERRIDE;
+    virtual wxSocketError GetLastError() wxOVERRIDE;
 
     virtual void ReenableEvents(wxSocketEventFlags WXUNUSED(flags)) wxOVERRIDE
     {

--- a/include/wx/private/socket.h
+++ b/include/wx/private/socket.h
@@ -202,11 +202,8 @@ public:
     const wxSockAddressImpl& GetPeer() const { return m_peer; }
 
     wxSocketError GetError() const { return m_error; }
+    void SetError(wxSocketError error) { m_error = error; }
     bool IsOk() const { return m_error == wxSOCKET_NOERROR; }
-
-    // get the error code corresponding to the last operation
-    virtual wxSocketError GetLastError() const = 0;
-
 
     // creating/closing the socket
     // --------------------------
@@ -306,7 +303,6 @@ public:
 
     wxSockAddressImpl m_local,
                       m_peer;
-    wxSocketError m_error;
 
     bool m_stream;
     bool m_establishing;
@@ -321,6 +317,11 @@ protected:
 
     // get the associated socket flags
     wxSocketFlags GetSocketFlags() const { return m_wxsocket->GetFlags(); }
+
+    // get the error code corresponding to the last operation
+    virtual wxSocketError GetLastError() = 0;
+
+    wxSocketError m_error;
 
     // true if we're a listening stream socket
     bool m_server;

--- a/include/wx/private/socket.h
+++ b/include/wx/private/socket.h
@@ -318,8 +318,8 @@ protected:
     // get the associated socket flags
     wxSocketFlags GetSocketFlags() const { return m_wxsocket->GetFlags(); }
 
-    // get the error code corresponding to the last operation
-    virtual wxSocketError GetLastError() = 0;
+    // update the error code to correspond to the outcome of the last operation
+    virtual void UpdateLastError() = 0;
 
     wxSocketError m_error;
 

--- a/include/wx/unix/private/sockunix.h
+++ b/include/wx/unix/private/sockunix.h
@@ -73,7 +73,7 @@ public:
     virtual bool IsOk() const wxOVERRIDE { return m_fd != INVALID_SOCKET; }
 
 protected:
-    virtual void UpdateLastError() = 0;
+    virtual void UpdateLastError();
 
 private:
     virtual void DoClose() wxOVERRIDE

--- a/include/wx/unix/private/sockunix.h
+++ b/include/wx/unix/private/sockunix.h
@@ -36,7 +36,7 @@ public:
         m_fds[1] = -1;
     }
 
-    virtual wxSocketError GetLastError() const wxOVERRIDE;
+    virtual wxSocketError GetLastError() wxOVERRIDE;
 
     virtual void ReenableEvents(wxSocketEventFlags flags) wxOVERRIDE
     {

--- a/include/wx/unix/private/sockunix.h
+++ b/include/wx/unix/private/sockunix.h
@@ -36,8 +36,6 @@ public:
         m_fds[1] = -1;
     }
 
-    virtual wxSocketError GetLastError() wxOVERRIDE;
-
     virtual void ReenableEvents(wxSocketEventFlags flags) wxOVERRIDE
     {
         // Events are only ever used for non-blocking sockets.
@@ -73,6 +71,9 @@ public:
     virtual void OnWriteWaiting() wxOVERRIDE;
     virtual void OnExceptionWaiting() wxOVERRIDE;
     virtual bool IsOk() const wxOVERRIDE { return m_fd != INVALID_SOCKET; }
+
+protected:
+    virtual void UpdateLastError() = 0;
 
 private:
     virtual void DoClose() wxOVERRIDE

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -752,7 +752,7 @@ int wxSocketImpl::Read(void *buffer, int size)
     {
         m_error = wxSOCKET_NOERROR;
     }
-    
+
     return ret;
 }
 

--- a/src/msw/sockmsw.cpp
+++ b/src/msw/sockmsw.cpp
@@ -285,26 +285,25 @@ void wxSocketImplMSW::DoClose()
     wxCloseSocket(m_fd);
 }
 
-wxSocketError wxSocketImplMSW::GetLastError()
+void wxSocketImplMSW::UpdateLastError()
 {
     switch ( WSAGetLastError() )
     {
         case 0:
             m_error = wxSOCKET_NOERROR;
-	    break;
+            return;
 
         case WSAENOTSOCK:
             m_error = wxSOCKET_INVSOCK;
-	    break;
+            return;
 
         case WSAEWOULDBLOCK:
             m_error = wxSOCKET_WOULDBLOCK;
-	    break;
+            return;
 
         default:
             m_error = wxSOCKET_IOERR;
     }
-    return m_error;
 }
 
 #endif  // wxUSE_SOCKETS

--- a/src/msw/sockmsw.cpp
+++ b/src/msw/sockmsw.cpp
@@ -285,22 +285,26 @@ void wxSocketImplMSW::DoClose()
     wxCloseSocket(m_fd);
 }
 
-wxSocketError wxSocketImplMSW::GetLastError() const
+wxSocketError wxSocketImplMSW::GetLastError()
 {
     switch ( WSAGetLastError() )
     {
         case 0:
-            return wxSOCKET_NOERROR;
+            m_error = wxSOCKET_NOERROR;
+	    break;
 
         case WSAENOTSOCK:
-            return wxSOCKET_INVSOCK;
+            m_error = wxSOCKET_INVSOCK;
+	    break;
 
         case WSAEWOULDBLOCK:
-            return wxSOCKET_WOULDBLOCK;
+            m_error = wxSOCKET_WOULDBLOCK;
+	    break;
 
         default:
-            return wxSOCKET_IOERR;
+            m_error = wxSOCKET_IOERR;
     }
+    return m_error;
 }
 
 #endif  // wxUSE_SOCKETS

--- a/src/unix/sockunix.cpp
+++ b/src/unix/sockunix.cpp
@@ -55,15 +55,17 @@
 // wxSocketImpl implementation
 // ============================================================================
 
-wxSocketError wxSocketImplUnix::GetLastError() const
+wxSocketError wxSocketImplUnix::GetLastError()
 {
     switch ( errno )
     {
         case 0:
-            return wxSOCKET_NOERROR;
+            m_error = wxSOCKET_NOERROR;
+	    break;
 
         case ENOTSOCK:
-            return wxSOCKET_INVSOCK;
+            m_error = wxSOCKET_INVSOCK;
+	    break;
 
         // unfortunately EAGAIN only has the "would block" meaning for read(),
         // not for connect() for which it means something rather different but
@@ -79,11 +81,13 @@ wxSocketError wxSocketImplUnix::GetLastError() const
     #endif
 #endif // EWOULDBLOCK
         case EINPROGRESS:
-            return wxSOCKET_WOULDBLOCK;
+            m_error = wxSOCKET_WOULDBLOCK;
+	    break;
 
         default:
-            return wxSOCKET_IOERR;
+            m_error = wxSOCKET_IOERR;
     }
+    return m_error;
 }
 
 void wxSocketImplUnix::DoEnableEvents(int flags, bool enable)


### PR DESCRIPTION
Fix to address a side issue identified in https://github.com/wxWidgets/wxWidgets/issues/24639#issuecomment-2297094102.

In a socket read, there are potentially two calls going to `WSAGetLastError` (via `wxSocketImplMSW::GetLastError()`). The changes here allow only one call and stores the result, in case any intervening system error occurs.

- `wxSocketBase::DoRead()` and `wxSocketBase::DoWrite()` now use `wxSocketImpl::GetError()` instead of `wxSocketImpl::GetLastError()`. In addition, `Accept()` also used `GetLastError()` so it has been changed as well.
- It occured to me that to prevent this error happening in the future, `GetLastError()` should be protected and should be called only by `wxSocketImpl`, ideally as close to when the error occurs in order to set `m_error`.
- Because `GetLastError()` now sets `m_error`, we remove its `const` declaration. 
-  There was a TODO comment in [include/wx/private/socket.h](https://github.com/wxWidgets/wxWidgets/compare/3.2...jpmattia:wxWidgets:jpm_fix_for_socket_double_call#diff-14b41fe3a98df8b1a8a89a6766cba37d518ba37252248e38f92f77c07588b716) listing m_error as something that should be protected, so it is now protected and a `SetError()` accessor added. The accessor is then used by `wxSocketBase` rather than setting `m_error` directly.

