### PR TITLE
Install Go 1.21 or later as it is required by go-httpbin

### DIFF
--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -205,7 +205,7 @@ jobs:
       if: matrix.skip_testing != true
       uses: actions/setup-go@v5
       with:
-        go-version: '1'
+        go-version: '>=1.21.0'
         cache: false
 
     - name: Testing


### PR DESCRIPTION
The latest go-httpbin version uses log/slog library only available starting from this Go version, so ensure that we have it.