### PR TITLE
Fix another bug in UI language matching (regression since 3.0)

### DIFF
--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -133,6 +133,11 @@ wxString GetPreferredUILanguage(const wxArrayString& available)
           j != preferred.end();
           ++j )
     {
+        // try exact match first:
+        if (available.Index(*j, /*bCase=*/false) != wxNOT_FOUND)
+            return *j;
+
+        // try looking up as a POSIX locale:
         wxLocaleIdent localeId = wxLocaleIdent::FromTag(*j);
         wxString lang = localeId.GetTag(wxLOCALE_TAGTYPE_POSIX);
 


### PR DESCRIPTION
This is another bug similar to the one from a few months back (sorry, don't have issue numbers handy). I think I was aware of them back then, but forgot about it after I took a break from the topic and didn't realize the underlying cause is something else. 

This (I think) only affects "well-behaved" apps that use `.lproj` folders on Mac, which are named with BCP-47 language tags. But that's something that wx-3.0 supported and that should be done to support some OS features (language override, localizing system strings, ...).

See this nicely absurd log: the requested translation is available, but won't be used:
```
Trace: (i18n) choosing best language for domain 'poedit'
Trace: (i18n)  - available translations: [de,el,zh-Hans,ja,fa,sq,eu,co,uk,kab,nb,pa,en-GB,es,is,sl,da,gl,it,bg,sk,sr,ms,be,sv,cs,ko,hy,zh-Hant,tg,hu,ga,tr,pl,pt-BR,vi,lt,ru,af,uz,fr,fi,id,nl,th,az,pt,pt-PT,ro,bs,hr,ca,en,en,en]
Trace: (i18n)  - system preferred languages: [zh-Hant]
Trace: (i18n)  => using language 'zh-Hans'
```

Or this one (deceptively this looks OK, but macOS uses `pt.lproj` for pt-BR and so it’s not; in any case, the more specific pt-PT match should have been used regardless):
```
Trace: (i18n) choosing best language for domain 'poedit'
Trace: (i18n)  - available translations: [de,el,zh-Hans,ja,fa,sq,eu,co,uk,kab,nb,pa,en-GB,es,is,sl,da,gl,it,bg,sk,sr,ms,be,sv,cs,ko,hy,zh-Hant,tg,hu,ga,tr,pl,pt-BR,vi,lt,ru,af,uz,fr,fi,id,nl,th,az,pt,pt-PT,ro,bs,hr,ca,en,en,en]
Trace: (i18n)  - system preferred languages: [pt-PT]
Trace: (i18n)  => using language 'pt'
```

This is caused by a combination of ill-defined values and good intentions (I *think* it traces back to 8ab635b by @utelle). `GetPreferredUILanguages()` doesn't say what the returned value *is*; in `wx/private/uilocale.h` it even says "The entries contain platform-dependent identifiers" (this is Very Bad™ !). `GetAvailableTranslations()` doesn't say either, but in practice returns what it finds on the filenames (this traces back to me). In macOS case, when you use `.lproj` resources, both lists use language tags.

But elsewhere the latter is typically POSIX locale-like names, while the former is language tags on Windows too I think. And so to "improve compatiblity", this code was changed to — not unreasonably, but subtly incorrectly — normalize to `wxLOCALE_TAGTYPE_POSIX`... which is not necessarily used by the `available` list values.

### Simple fix

This PR does **NOT** implement proper fix. I'm sorry, I lack the mental energy to do that, do it in 3.2 compatible way and get the patch approved right now. Instead, this PR does the minimal, obviously correct [^1] change to fix this particular situation.

Specifically, it looks for an exact match first. I think this isn't a hack, but a reasonable thing to do: both lists come from the same source, it's not unreasonable to expect them to use the same language-code syntax.

This should be applied to both `master` and `3.2` (and is based off the latter).

### Doing it right

I think the only way to properly untangle this is to normalize to use BCP-47 language tags everywhere and particularly in the functions mentioned above and all related APIs. Then convert down to POSIX locales only when trying to load MO files.

wx certainly *should not* do the opposite and convert things into POSIX locales, because some languages cannot be accurately represented by the latter (e.g. zh-Hant and zh-Hans). (Well, and because the rest of the world standardized on the tags.)

The algorithm we use to determine the best language is naive too. See [Unicode Technical Standard \#35](https://unicode.org/reports/tr35/) for the correct algorithm, particularly the “Likely Subtags” and “Language Matching” sections. The latter is somewhat dense and non entirely trivial, but it only took it two paragraphs to say that the truncation-fallback algorithm (which is what wx does, with subsequent broad expansation) is naive and unable to handle the complexities of the real word.

[^1]: I'm going to regret saying this, am I not?