### PR TITLE
Add missing #include "wx/string.h" for wx/sysopt.h

### DIFF
--- a/include/wx/sysopt.h
+++ b/include/wx/sysopt.h
@@ -11,6 +11,7 @@
 #define _WX_SYSOPT_H_
 
 #include "wx/object.h"
+#include "wx/string.h"
 
 // ----------------------------------------------------------------------------
 // Enables an application to influence the wxWidgets implementation


### PR DESCRIPTION
wxSystemOptions depends on `wxString`, but wx/string.h is not included, except via wx/object.h when `WXBUILDING` is not defined.