### PR TITLE
Do not use !str for checking wxString emptiness

### DIFF
--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -930,7 +930,7 @@ void TextWidgetsPage::OnButtonLoad(wxCommandEvent& WXUNUSED(event))
     pathlist.Add("../../../samples/widgets");
 
     wxString filename = pathlist.FindValidPath("textctrl.cpp");
-    if ( !filename )
+    if ( filename.empty() )
     {
         wxLogError("File textctrl.cpp not found.");
     }

--- a/src/common/cmdline.cpp
+++ b/src/common/cmdline.cpp
@@ -1176,7 +1176,7 @@ int wxCmdLineParser::Parse(bool showUsage)
             if ( (opt.flags & wxCMD_LINE_OPTION_MANDATORY) && !opt.HasValue() )
             {
                 wxString optName;
-                if ( !opt.longName )
+                if ( opt.longName.empty() )
                 {
                     optName = opt.shortName;
                 }
@@ -1293,8 +1293,8 @@ wxString wxCmdLineParser::GetUsageString() const
 
     // the switch char is usually '-' but this can be changed with
     // SetSwitchChars() and then the first one of possible chars is used
-    wxChar chSwitch = !m_data->m_switchChars ? wxT('-')
-                                             : m_data->m_switchChars[0u];
+    wxChar chSwitch = m_data->m_switchChars.empty() ? wxT('-')
+                                                    : m_data->m_switchChars[0u];
 
     bool areLongOptionsEnabled = AreLongOptionsEnabled();
     size_t n, count = m_data->m_options.size();
@@ -1354,7 +1354,7 @@ wxString wxCmdLineParser::GetUsageString() const
                 wxString val;
                 val << wxT('<') << GetTypeName(opt.type) << wxT('>');
                 usage << wxT(' ') << val;
-                option << (!opt.longName ? wxT(':') : wxT('=')) << val;
+                option << (opt.longName.empty() ? wxT(':') : wxT('=')) << val;
             }
 
             if ( !(opt.flags & wxCMD_LINE_OPTION_MANDATORY) )

--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -396,7 +396,7 @@ bool wxDocument::SaveAs()
 
 bool wxDocument::OnSaveDocument(const wxString& file)
 {
-    if ( !file )
+    if ( file.empty() )
         return false;
 
     if ( !DoSaveDocument(file) )

--- a/src/common/fileconf.cpp
+++ b/src/common/fileconf.cpp
@@ -501,7 +501,7 @@ wxFileConfig::wxFileConfig(const wxString& appName, const wxString& vendorName,
                            const wxString& strLocal, const wxString& strGlobal,
                            long style,
                            const wxMBConv& conv)
-            : wxConfigBase(( !appName && wxTheApp ) ? wxTheApp->GetAppName() : appName,
+            : wxConfigBase(( appName.empty() && wxTheApp ) ? wxTheApp->GetAppName() : appName,
                            vendorName,
                            strLocal, strGlobal,
                            style),
@@ -1135,7 +1135,7 @@ bool wxFileConfig::DoWriteBinary(const wxString& key, const wxMemoryBuffer& buf)
 
 bool wxFileConfig::Flush(bool /* bCurrentOnly */)
 {
-  if ( !IsDirty() || !m_fnLocalFile.GetFullPath() )
+  if ( !IsDirty() || m_fnLocalFile.GetFullPath().empty() )
     return true;
 
   // Create the directory containing the file if it doesn't exist. Although we
@@ -2168,7 +2168,7 @@ static wxString FilterInValue(const wxString& str)
 // quote the string before writing it to file
 static wxString FilterOutValue(const wxString& str)
 {
-   if ( !str )
+   if ( str.empty() )
       return str;
 
   wxString strResult;

--- a/src/common/fmapbase.cpp
+++ b/src/common/fmapbase.cpp
@@ -505,7 +505,7 @@ wxConfigBase *wxFontMapperBase::GetConfig()
 
 const wxString& wxFontMapperBase::GetConfigPath()
 {
-    if ( !m_configRootPath )
+    if ( m_configRootPath.empty() )
     {
         // use the default
         m_configRootPath = GetDefaultConfigPath();
@@ -532,7 +532,7 @@ bool wxFontMapperBase::ChangePath(const wxString& pathNew, wxString *pathOld)
         path += wxCONFIG_PATH_SEPARATOR;
     }
 
-    wxASSERT_MSG( !pathNew || (pathNew[0] != wxCONFIG_PATH_SEPARATOR),
+    wxASSERT_MSG( pathNew.empty() || (pathNew[0] != wxCONFIG_PATH_SEPARATOR),
                   wxT("should be a relative path") );
 
     path += pathNew;

--- a/src/common/fontmap.cpp
+++ b/src/common/fontmap.cpp
@@ -191,7 +191,7 @@ wxFontMapper::CharsetToEncoding(const wxString& charset, bool interactive)
 
         // the dialog title
         wxString title(m_titleDialog);
-        if ( !title )
+        if ( title.empty() )
             title << wxTheApp->GetAppDisplayName() << _(": unknown charset");
 
         // the message
@@ -405,7 +405,7 @@ bool wxFontMapper::GetAltForEncoding(wxFontEncoding encoding,
     if ( interactive )
     {
         wxString title(m_titleDialog);
-        if ( !title )
+        if ( title.empty() )
             title << wxTheApp->GetAppDisplayName() << _(": unknown encoding");
 
         // built the message

--- a/src/common/ftp.cpp
+++ b/src/common/ftp.cpp
@@ -105,7 +105,7 @@ bool wxFTP::Connect(const wxSockAddress& addr, bool WXUNUSED(wait))
         return false;
     }
 
-    if ( !m_username )
+    if ( m_username.empty() )
     {
         m_lastError = wxPROTO_CONNERR;
         return false;

--- a/src/common/url.cpp
+++ b/src/common/url.cpp
@@ -356,7 +356,7 @@ wxInputStream *wxURL::GetInputStream()
 #if wxUSE_PROTOCOL_HTTP
 void wxURL::SetDefaultProxy(const wxString& url_proxy)
 {
-    if ( !url_proxy )
+    if ( url_proxy.empty() )
     {
         if ( ms_proxyDefault )
         {
@@ -391,7 +391,7 @@ void wxURL::SetDefaultProxy(const wxString& url_proxy)
 
 void wxURL::SetProxy(const wxString& url_proxy)
 {
-    if ( !url_proxy )
+    if ( url_proxy.empty() )
     {
         if ( m_proxy && m_proxy != ms_proxyDefault )
         {

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -385,7 +385,7 @@ bool wxPlatform::Is(int platform)
 bool wxGetEmailAddress(wxChar *address, int maxSize)
 {
     wxString email = wxGetEmailAddress();
-    if ( !email )
+    if ( email.empty() )
         return false;
 
     wxStrlcpy(address, email.t_str(), maxSize);

--- a/src/common/zstream.cpp
+++ b/src/common/zstream.cpp
@@ -244,7 +244,7 @@ size_t wxZlibInputStream::OnSysRead(void *buffer, size_t size)
 
     default:
       wxString msg(m_inflate->msg, *wxConvCurrent);
-      if (!msg)
+      if (msg.empty())
         msg = wxString::Format(_("zlib error %d"), err);
       wxLogError(_("Can't read from inflate stream: %s"), msg);
       m_lasterror = wxSTREAM_READ_ERROR;
@@ -419,7 +419,7 @@ size_t wxZlibOutputStream::OnSysWrite(const void *buffer, size_t size)
   if (err != Z_OK) {
     m_lasterror = wxSTREAM_WRITE_ERROR;
     wxString msg(m_deflate->msg, *wxConvCurrent);
-    if (!msg)
+    if (msg.empty())
       msg = wxString::Format(_("zlib error %d"), err);
     wxLogError(_("Can't write to deflate stream: %s"), msg);
   }

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -825,7 +825,7 @@ wxString wxGridCellFloatRenderer::GetString(const wxGrid& grid, int row, int col
 
     if ( hasDouble )
     {
-        if ( !m_format )
+        if ( m_format.empty() )
         {
             if ( m_width == -1 )
             {
@@ -894,7 +894,7 @@ wxSize wxGridCellFloatRenderer::GetBestSize(wxGrid& grid,
 
 void wxGridCellFloatRenderer::SetParameters(const wxString& params)
 {
-    if ( !params )
+    if ( params.empty() )
     {
         // reset to defaults
         SetWidth(-1);

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -629,7 +629,7 @@ void wxGridCellTextEditor::HandleReturn( wxKeyEvent&
 
 void wxGridCellTextEditor::SetParameters(const wxString& params)
 {
-    if ( !params )
+    if ( params.empty() )
     {
         // reset to default
         m_maxChars = 0;
@@ -884,7 +884,7 @@ void wxGridCellNumberEditor::StartingKey(wxKeyEvent& event)
 
 void wxGridCellNumberEditor::SetParameters(const wxString& params)
 {
-    if ( !params )
+    if ( params.empty() )
     {
         // reset to default
         m_min =
@@ -1038,7 +1038,7 @@ void wxGridCellFloatEditor::StartingKey(wxKeyEvent& event)
 
 void wxGridCellFloatEditor::SetParameters(const wxString& params)
 {
-    if ( !params )
+    if ( params.empty() )
     {
         // reset to default
         m_width =
@@ -1118,7 +1118,7 @@ void wxGridCellFloatEditor::SetParameters(const wxString& params)
 
 wxString wxGridCellFloatEditor::GetString()
 {
-    if ( !m_format )
+    if ( m_format.empty() )
     {
         if ( m_precision == -1 && m_width != -1)
         {
@@ -1577,7 +1577,7 @@ void wxGridCellChoiceEditor::Reset()
 
 void wxGridCellChoiceEditor::SetParameters(const wxString& params)
 {
-    if ( !params )
+    if ( params.empty() )
     {
         // what can we do?
         return;

--- a/src/generic/logg.cpp
+++ b/src/generic/logg.cpp
@@ -1002,7 +1002,7 @@ static int OpenLogFile(wxFile& file, wxString *pFilename, wxWindow *parent)
     // get the file name
     // -----------------
     wxString filename = wxSaveFileSelector(wxT("log"), wxT("txt"), wxT("log.txt"), parent);
-    if ( !filename ) {
+    if ( filename.empty() ) {
         // cancelled
         return -1;
     }

--- a/src/html/helpwnd.cpp
+++ b/src/html/helpwnd.cpp
@@ -1524,7 +1524,7 @@ void wxHtmlHelpWindow::OnToolbar(wxCommandEvent& event)
             {
                 if (m_Printer == nullptr)
                     m_Printer = new wxHtmlEasyPrinting(_("Help Printing"), this);
-                if (!m_HtmlWin->GetOpenedPage())
+                if (m_HtmlWin->GetOpenedPage().empty())
                 {
                     wxLogWarning(_("Cannot print empty page."));
                 }

--- a/src/msw/dialup.cpp
+++ b/src/msw/dialup.cpp
@@ -701,7 +701,7 @@ bool wxDialUpManagerMSW::Dial(const wxString& nameOfISP,
 
     // get the default ISP if none given
     wxString entryName(nameOfISP);
-    if ( !entryName )
+    if ( entryName.empty() )
     {
         wxArrayString names;
         size_t count = GetISPNames(names);
@@ -737,7 +737,7 @@ bool wxDialUpManagerMSW::Dial(const wxString& nameOfISP,
 
                     delete [] strings;
 
-                    if ( !entryName )
+                    if ( entryName.empty() )
                     {
                         // cancelled by user
                         return false;
@@ -751,7 +751,7 @@ bool wxDialUpManagerMSW::Dial(const wxString& nameOfISP,
     wxStrlcpy(rasDialParams.szEntryName, entryName.c_str(), RAS_MaxEntryName);
 
     // do we have the username and password?
-    if ( !username || !password )
+    if ( username.empty() || password.empty() )
     {
         BOOL gotPassword;
         DWORD dwRet = ms_pfnRasGetEntryDialParams

--- a/src/msw/dir.cpp
+++ b/src/msw/dir.cpp
@@ -222,7 +222,7 @@ bool wxDirData::Read(wxString *filename)
         {
             filespec += wxT('\\');
         }
-        if ( !m_filespec )
+        if ( m_filespec.empty() )
             filespec += wxT("*.*");
         else
             filespec += m_filespec;

--- a/src/msw/enhmeta.cpp
+++ b/src/msw/enhmeta.cpp
@@ -55,7 +55,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxEnhMetaFile, wxObject);
 
 // we must pass nullptr if the string is empty to metafile functions
 static inline const wxChar *GetMetaFileName(const wxString& fn)
-    { return !fn ? nullptr : wxMSW_CONV_LPCTSTR(fn); }
+    { return fn.empty() ? nullptr : wxMSW_CONV_LPCTSTR(fn); }
 
 // ============================================================================
 // implementation

--- a/src/msw/mimetype.cpp
+++ b/src/msw/mimetype.cpp
@@ -140,7 +140,7 @@ void wxFileTypeImpl::Init(const wxString& strFileType, const wxString& ext)
     m_ext << ext;
 
     m_strFileType = strFileType;
-    if ( !strFileType ) {
+    if ( strFileType.empty() ) {
         m_strFileType = m_ext.AfterFirst('.') + wxT("_auto_file");
     }
 

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -861,7 +861,7 @@ bool wxShell(const wxString& command)
     if ( !shell )
         shell = wxT("\\COMMAND.COM");
 
-    if ( !command )
+    if ( command.empty() )
     {
         // just the shell
         cmd = shell;

--- a/src/osx/fontutil.cpp
+++ b/src/osx/fontutil.cpp
@@ -33,11 +33,11 @@ bool wxNativeEncodingInfo::FromString( const wxString& s )
     wxStringTokenizer tokenizer(s, wxT(";"));
 
     facename = tokenizer.GetNextToken();
-    if ( !facename )
+    if ( facename.empty() )
         return false;
 
     wxString tmp = tokenizer.GetNextToken();
-    if ( !tmp )
+    if ( tmp.empty() )
     {
         // default charset
         charset = 0;

--- a/src/unix/dialup.cpp
+++ b/src/unix/dialup.cpp
@@ -774,7 +774,7 @@ wxDialUpManagerImpl::NetConnection wxDialUpManagerImpl::CheckPing()
         else if (wxFileExists( wxT("/usr/sbin/ping") ))
             m_PingPath = wxT("/usr/sbin/ping");
 #endif
-        if (!m_PingPath)
+        if (m_PingPath.empty())
         {
             m_CanUsePing = 0;
         }

--- a/src/unix/mimetype.cpp
+++ b/src/unix/mimetype.cpp
@@ -68,7 +68,7 @@ public:
        {
           wxString t = tok.GetNextToken();
           t.MakeLower();
-          if ((!!t) && (t.Find( "comment" ) != 0) && (t.Find( "#" ) != 0) && (t.Find( "generic" ) != 0))
+          if (!t.empty() && (t.Find( "comment" ) != 0) && (t.Find( "#" ) != 0) && (t.Find( "generic" ) != 0))
              m_text.Add( t );
        }
        return true;

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -401,7 +401,7 @@ size_t wxPipeOutputStream::OnSysWrite(const void *buffer, size_t size)
 static wxString wxMakeShellCommand(const wxString& command)
 {
     wxString cmd;
-    if ( !command )
+    if ( command.empty() )
     {
         // just an interactive shell
         cmd = wxT("xterm");
@@ -911,7 +911,7 @@ wxString wxGetUserHome( const wxString &user )
 {
     struct passwd *who = (struct passwd *) nullptr;
 
-    if ( !user )
+    if ( user.empty() )
     {
         wxChar *ptr;
 

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -1535,7 +1535,7 @@ int wxXmlResourceHandlerImpl::GetStyle(const wxString& param, int defaults)
 {
     wxString s = GetParamValue(param);
 
-    if (!s) return defaults;
+    if (s.empty()) return defaults;
 
     wxStringTokenizer tkn(s, wxT("| \t\n"), wxTOKEN_STRTOK);
     int style = 0;

--- a/tests/controls/webtest.cpp
+++ b/tests/controls/webtest.cpp
@@ -387,7 +387,7 @@ TEST_CASE_METHOD(WebViewTestCase, "WebView", "[wxWebView]")
 
         result = "";
         CHECK(!m_browser->RunScript("int main() { return 0; }", &result));
-        CHECK(!result);
+        CHECK(result.empty());
 
         CHECK(m_browser->RunScript("function a() { return eval(\"function b() { \
             return eval(\\\"function c() { return eval(\\\\\\\"function d() { \

--- a/utils/wxrc/wxrc.cpp
+++ b/utils/wxrc/wxrc.cpp
@@ -300,7 +300,7 @@ void XmlResApp::ParseParams(const wxCmdLineParser& cmdline)
         parOutput = wxFileName(parOutput).GetAbsolutePath();
         parOutputPath = wxPathOnly(parOutput);
     }
-    if (!parOutputPath) parOutputPath = wxT(".");
+    if (parOutputPath.empty()) parOutputPath = wxT(".");
 
     if (!cmdline.Found("n", &parFuncname))
         parFuncname = wxT("InitXmlResource");
@@ -901,7 +901,7 @@ void XmlResApp::OutputGettext()
         fout.Write("_(\"" + i->str + "\");\n");
     }
 
-    if (!parOutput) fout.Detach();
+    if (parOutput.empty()) fout.Detach();
 }
 
 


### PR DESCRIPTION
While `wxString::operator!()` is a documented alternative to `.empty()` since 25 years, using it in just a handful of places in the codebase is not consistent.

`!str` is arguably not very readable either, because `std::string` does not have such an operator, and neither does e.g. Qt's `QString`. People would generally except `!` in the context of any kind of strings to check for null pointer (`char*`), or an optional with a missing value (`std::optional`).

This is all a matter of opinion, of course.