### PR TITLE
Fix wxALWAYS_SHOW_SB comment

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1452,8 +1452,6 @@ wxALLOW_COMBINING_ENUMS(wxSizerFlagBits, wxStretch)
 
 /*  wxALWAYS_SHOW_SB: instead of hiding the scrollbar when it is not needed, */
 /*  disable it - but still show (see also wxLB_ALWAYS_SB style) */
-/*  */
-/*  NB: as this style is only supported by wxUniversal and wxMSW so far */
 #define wxALWAYS_SHOW_SB        0x00800000
 
 /*  Clip children when painting, which reduces flicker in e.g. frames and */


### PR DESCRIPTION
Comment says that `wxALWAYS_SHOW_SB` is Universal and MSW only, but I don't think that is correct anymore. MSW and OSX (from what I can tell) use generic which supports `wxALWAYS_SHOW_SB`. GTK+ explicitly supports `wxALWAYS_SHOW_SB`.  I can't find any other implementation in code base of `wxScrolled` which does **NOT** support this.