### PR TITLE
Remember last error in wxSocketImpl

### DIFF
--- a/include/wx/msw/private/sockmsw.h
+++ b/include/wx/msw/private/sockmsw.h
@@ -47,8 +47,6 @@ public:
 
     virtual ~wxSocketImplMSW();
 
-    virtual wxSocketError GetLastError() const override;
-
     virtual void ReenableEvents(wxSocketEventFlags WXUNUSED(flags)) override
     {
         // notifications are never disabled in this implementation, there is no
@@ -84,6 +82,7 @@ public:
     }
 
 private:
+    virtual wxSocketError GetLastError() const override;
     virtual void DoClose() override;
 
     int m_msgnumber;

--- a/include/wx/private/socket.h
+++ b/include/wx/private/socket.h
@@ -204,10 +204,6 @@ public:
     wxSocketError GetError() const { return m_error; }
     bool IsOk() const { return m_error == wxSOCKET_NOERROR; }
 
-    // get the error code corresponding to the last operation
-    virtual wxSocketError GetLastError() const = 0;
-
-
     // creating/closing the socket
     // --------------------------
 
@@ -322,10 +318,18 @@ protected:
     // get the associated socket flags
     wxSocketFlags GetSocketFlags() const { return m_wxsocket->GetFlags(); }
 
+    // set m_error to the outcome of the last operation and return it
+    wxSocketError UpdateLastError() { m_error = GetLastError(); return m_error; }
+
     // true if we're a listening stream socket
     bool m_server;
 
 private:
+    // get the error code corresponding to the last operation
+    //
+    // this is private because it's only used by UpdateLastError()
+    virtual wxSocketError GetLastError() const = 0;
+
     // called by Close() if we have a valid m_fd
     virtual void DoClose() = 0;
 

--- a/include/wx/unix/private/sockunix.h
+++ b/include/wx/unix/private/sockunix.h
@@ -36,8 +36,6 @@ public:
         m_fds[1] = -1;
     }
 
-    virtual wxSocketError GetLastError() const override;
-
     virtual void ReenableEvents(wxSocketEventFlags flags) override
     {
         // Events are only ever used for non-blocking sockets.
@@ -75,6 +73,8 @@ public:
     virtual bool IsOk() const override { return m_fd != INVALID_SOCKET; }
 
 private:
+    virtual wxSocketError GetLastError() const override;
+
     virtual void DoClose() override
     {
         DisableEvents();

--- a/src/unix/sockunix.cpp
+++ b/src/unix/sockunix.cpp
@@ -177,7 +177,7 @@ void wxSocketImplUnix::OnReadWaiting()
                 wxFALLTHROUGH;
 
             case -1:
-                if ( GetLastError() == wxSOCKET_WOULDBLOCK )
+                if ( UpdateLastError() == wxSOCKET_WOULDBLOCK )
                 {
                     // just a spurious wake up
                     EnableEvents(wxSOCKET_INPUT_FLAG);


### PR DESCRIPTION
Instead of calling GetLastError() multiple times, and possibly getting different errors, make it private and call UpdateLastError(), which remembers the value returned by GetLastError() in m_error, so that we can be sure it doesn't change.

This commit is best viewed with Git --color-moved option.

See #24796.