### PR TITLE
Avoid trailing space with wx-config --c[xx]flags

### DIFF
--- a/wx-config.in
+++ b/wx-config.in
@@ -1297,8 +1297,8 @@ _cppflags=`echo "-I${libdir}/wx/include/@TOOLCHAIN_FULLNAME@" $_include_cppflags
 
 # now without further ado, we can answer these too.
 [ -z "$output_option_cppflags" ] || echo $_cppflags
-[ -z "$output_option_cflags"   ] || echo $_cppflags "@WXCONFIG_CFLAGS@"
-[ -z "$output_option_cxxflags" ] || echo $_cppflags "@WXCONFIG_CXXFLAGS@"
+[ -z "$output_option_cflags"   ] || echo $_cppflags @WXCONFIG_CFLAGS@
+[ -z "$output_option_cxxflags" ] || echo $_cppflags @WXCONFIG_CXXFLAGS@
 [ -z "$output_option_gl_libs"  ] || echo `lib_flags_for gl`
 [ -z "$output_option_linkdeps" ] || echo $link_deps
 


### PR DESCRIPTION
When WXCONFIG_C[XX]FLAGS is empty, this ends up being: `echo $._cppflags ""` which results in a trailing space being printed. This is a minor issue but it may confuse tools trying to parse the output of wx-config (https://github.com/haxeui/hxWidgets/pull/113).

Removing the quotes would instead give `echo $._cppflags `, which does not print a trailing space.