### PR TITLE
Fix docs generation for datetime with doxygen 1.11.0

### DIFF
--- a/interface/wx/datetime.h
+++ b/interface/wx/datetime.h
@@ -96,7 +96,7 @@ public:
 
         ///@{
         /// zones from GMT (= Greenwich Mean Time): they're guaranteed to be
-        /// consequent numbers, so writing something like `GMT0 + offset' is
+        /// consequent numbers, so writing something like `GMT0 + offset` is
         /// safe if abs(offset) <= 12
 
         // underscore stands for minus


### PR DESCRIPTION
It seems that as of the below commit, doxygen changed its handling of parsing backticks in comments such that it now fails to properly generate documentation for the entire datetime.h file.  Fix this by closing the open backtick.

See: https://github.com/doxygen/doxygen/commit/f18767307be20ca8d2ca81f74cc1f3446205282b