### PR TITLE
Fix using `wxAuiTabArt` fonts

### DIFF
--- a/include/wx/aui/tabart.h
+++ b/include/wx/aui/tabart.h
@@ -57,6 +57,12 @@ public:
     virtual void SetColour(const wxColour& colour) = 0;
     virtual void SetActiveColour(const wxColour& colour) = 0;
 
+    // These functions should be overridden in the derived class to return the
+    // actually used fonts, but they're not pure virtual for compatibility
+    // reasons.
+    virtual wxFont GetNormalFont() const { return wxFont{}; }
+    virtual wxFont GetSelectedFont() const { return wxFont{}; }
+
     virtual void DrawBorder(
                  wxDC& dc,
                  wxWindow* wnd,
@@ -137,6 +143,9 @@ public:
     void SetMeasuringFont(const wxFont& font) override;
     void SetColour(const wxColour& colour) override;
     void SetActiveColour(const wxColour& colour) override;
+
+    wxFont GetNormalFont() const override;
+    wxFont GetSelectedFont() const override;
 
     void DrawBorder(
                  wxDC& dc,
@@ -240,6 +249,9 @@ public:
     void SetMeasuringFont(const wxFont& font) override;
     void SetColour(const wxColour& colour) override;
     void SetActiveColour(const wxColour& colour) override;
+
+    wxFont GetNormalFont() const override;
+    wxFont GetSelectedFont() const override;
 
     void DrawBorder(
                  wxDC& dc,

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -659,6 +659,31 @@ public:
     virtual int GetIndentSize() = 0;
 
     /**
+        Returns the font to use for normal, non-selected, tabs.
+
+        By default, returns an invalid font, meaning that the font set for
+        wxAuiNotebook itself should be used.
+
+        This function should be overridden for SetNormalFont() to actually work.
+
+        @since 3.3.0
+    */
+    virtual wxFont GetNormalFont() const;
+
+    /**
+        Returns the font to use for the selected tab.
+
+        By default, returns an invalid font, meaning that the font set for
+        wxAuiNotebook itself should be used.
+
+        This function should be overridden for SetSelectedFont() to actually
+        work.
+
+        @since 3.3.0
+    */
+    virtual wxFont GetSelectedFont() const;
+
+    /**
         Returns the tab size for the given caption, bitmap and state.
     */
     virtual wxSize GetTabSize(wxDC& dc, wxWindow* wnd, const wxString& caption,
@@ -677,11 +702,15 @@ public:
 
     /**
         Sets the normal font for drawing labels.
+
+        @see GetNormalFont()
     */
     virtual void SetNormalFont(const wxFont& font) = 0;
 
     /**
         Sets the font for drawing text for selected UI elements.
+
+        @see GetSelectedFont()
     */
     virtual void SetSelectedFont(const wxFont& font) = 0;
 

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -180,7 +180,6 @@ private:
     wxArrayString m_perspectives;
     wxMenu* m_perspectives_menu;
     long m_notebook_style;
-    long m_notebook_theme;
 
     wxDECLARE_EVENT_TABLE();
 };
@@ -687,7 +686,6 @@ MyFrame::MyFrame(wxWindow* parent,
 
     // set up default notebook style
     m_notebook_style = wxAUI_NB_DEFAULT_STYLE | wxAUI_NB_TAB_EXTERNAL_MOVE | wxNO_BORDER;
-    m_notebook_theme = 0;
 
     // create menu
     wxMenuBar* mb = new wxMenuBar;
@@ -1235,12 +1233,10 @@ void MyFrame::OnNotebookFlag(wxCommandEvent& event)
             if (id == ID_NotebookArtGloss)
             {
                 nb->SetArtProvider(new wxAuiDefaultTabArt);
-                m_notebook_theme = 0;
             }
-             else if (id == ID_NotebookArtSimple)
+            else if (id == ID_NotebookArtSimple)
             {
                 nb->SetArtProvider(new wxAuiSimpleTabArt);
-                m_notebook_theme = 1;
             }
 
 

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1230,13 +1230,19 @@ void MyFrame::OnNotebookFlag(wxCommandEvent& event)
         {
             wxAuiNotebook* nb = (wxAuiNotebook*)pane.window;
 
+            wxAuiTabArt* art = nullptr;
             if (id == ID_NotebookArtGloss)
             {
-                nb->SetArtProvider(new wxAuiDefaultTabArt);
+                art = new wxAuiDefaultTabArt;
             }
             else if (id == ID_NotebookArtSimple)
             {
-                nb->SetArtProvider(new wxAuiSimpleTabArt);
+                art = new wxAuiSimpleTabArt;
+            }
+
+            if (art)
+            {
+                nb->SetArtProvider(art);
             }
 
 

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1800,6 +1800,16 @@ void wxAuiNotebook::SetArtProvider(wxAuiTabArt* art)
 {
     m_tabs.SetArtProvider(art);
 
+    // If the art provider implements GetXXXFont() functions, use them.
+    //
+    // Otherwise keep using our own fonts.
+    wxFont font = art->GetNormalFont();
+    if ( font.IsOk() )
+        m_normalFont = font;
+    font = art->GetSelectedFont();
+    if ( font.IsOk() )
+        m_selectedFont = font;
+
     // Update the height and do nothing else if it did something but otherwise
     // (i.e. if the new art provider uses the same height as the old one) we
     // need to manually set the art provider for all tabs ourselves.

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -920,6 +920,16 @@ void wxAuiGenericTabArt::SetActiveColour(const wxColour& colour)
     m_activeColour = colour;
 }
 
+wxFont wxAuiGenericTabArt::GetNormalFont() const
+{
+    return m_normalFont;
+}
+
+wxFont wxAuiGenericTabArt::GetSelectedFont() const
+{
+    return m_selectedFont;
+}
+
 // -- wxAuiSimpleTabArt class implementation --
 
 wxAuiSimpleTabArt::wxAuiSimpleTabArt()
@@ -1396,6 +1406,16 @@ void wxAuiSimpleTabArt::SetSelectedFont(const wxFont& font)
 void wxAuiSimpleTabArt::SetMeasuringFont(const wxFont& font)
 {
     m_measuringFont = font;
+}
+
+wxFont wxAuiSimpleTabArt::GetNormalFont() const
+{
+    return m_normalFont;
+}
+
+wxFont wxAuiSimpleTabArt::GetSelectedFont() const
+{
+    return m_selectedFont;
 }
 
 #endif // wxUSE_AUI


### PR DESCRIPTION
The effect of the last commit can be seen with

```diff
diff --git a/samples/aui/auidemo.cpp b/samples/aui/auidemo.cpp
index 5436ec8ea4..5eedd46a17 100644
--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1242,6 +1242,7 @@ void MyFrame::OnNotebookFlag(wxCommandEvent& event)
 
             if (art)
             {
+                art->SetSelectedFont(*wxITALIC_FONT);
                 nb->SetArtProvider(art);
             }
```

Without this commit, the font only becomes italic until the tab is changed. With it, things work correctly.

This replaces #24783.