### PR TITLE
Allow wxDataViewCustomRenderer::GetSize() return 0 in wxGTK

### DIFF
--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -1564,6 +1564,15 @@ gtk_wx_cell_renderer_get_size (GtkCellRenderer *renderer,
 
     wxSize size = cell->GetSize();
 
+    // Somehow returning 0 or negative width prevents the returned height from
+    // being taken into account at all, even if we return strictly positive
+    // width from later calls to GetSize(), meaning that it's enough to return
+    // 0 from it once to completely break the layout for the entire lifetime of
+    // the control.
+    //
+    // As this is completely unexpected, forcefully prevent this from happening
+    size.IncTo(wxSize(1, 1));
+
     wxDataViewCtrl * const ctrl = cell->GetOwner()->GetOwner();
 
     // Uniform row height, if specified, overrides the value returned by the


### PR DESCRIPTION
Returning 0 width even once from the overridden GetSize() function in wxDataViewCustomRenderer prevented the height returned by it from being taken into account at all by the GtkTreeView, probably due to some weird caching going on inside GTK.

Work around this by ensuring that both size components are always strictly positive.

Closes #24227.