### PR TITLE
Don't use themed borders in dark mode in wxMSW

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1553,6 +1553,14 @@ wxBorder wxWindowMSW::DoTranslateBorder(wxBorder border) const
 {
     if (border == wxBORDER_THEME)
     {
+        // In dark mode the standard sunken border is too bright, so prefer
+        // using a simple(r) and darker border instead.
+        //
+        // And themed borders don't look good neither in dark mode, so don't
+        // use them in it.
+        if ( wxMSWDarkMode::IsActive() )
+            return wxBORDER_SIMPLE;
+
 #if wxUSE_UXTHEME
         if (CanApplyThemeBorder())
         {
@@ -1561,9 +1569,7 @@ wxBorder wxWindowMSW::DoTranslateBorder(wxBorder border) const
         }
 #endif // wxUSE_UXTHEME
 
-        // In dark mode the standard sunken border is too bright, so prefer
-        // using a simple(r) and darker border instead.
-        return wxMSWDarkMode::IsActive() ? wxBORDER_SIMPLE : wxBORDER_SUNKEN;
+        return wxBORDER_SUNKEN;
     }
 
     return border;


### PR DESCRIPTION
They don't look good and while they're not seen often, as many classes already override CanApplyThemeBorder() to return false, when they are, as for wxSearchCtrl, they appear very out of place in the dark mode UI.

See #24625.

----

I'd like to ask people to test this PR before it's merged and let me know if they see any visual regressions due to it in dark mode. AFAICS this can only improve things, but perhaps I'm forgetting about some weird controls which do look good with themed border in dark mode and don't with simple one. Please let me know if you find any!