### PR TITLE
Remove unused wxString variables

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -282,13 +282,13 @@ typedef short int WXTYPE;
 /* wxWARN_UNUSED is used as an attribute to a class, stating that unused instances
    should be warned about (in case such warnings are enabled in the first place) */
 
-#ifdef __has_attribute
-#if __has_attribute(warn_unused)
-#define wxWARN_UNUSED __attribute__((warn_unused))
-#endif
+#ifdef __has_cpp_attribute
+    #if __has_cpp_attribute(warn_unused)
+        #define wxWARN_UNUSED __attribute__((warn_unused))
+    #endif
 #endif
 #ifndef wxWARN_UNUSED
-#define wxWARN_UNUSED
+    #define wxWARN_UNUSED
 #endif
 
 /* these macros are obsolete, use the standard C++ casts directly now */

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -279,6 +279,17 @@ typedef short int WXTYPE;
     #define wxNODISCARD
 #endif
 
+/* wxWARN_UNUSED is used as an attribute to a class, stating that unused instances
+   should be warned about (in case such warnings are enabled in the first place) */
+
+#ifdef __has_attribute
+#if __has_attribute(warn_unused)
+#define wxWARN_UNUSED __attribute__((warn_unused))
+#endif
+#endif
+#ifndef wxWARN_UNUSED
+#define wxWARN_UNUSED
+#endif
 
 /* these macros are obsolete, use the standard C++ casts directly now */
 #define wx_static_cast(t, x) static_cast<t>(x)

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -355,7 +355,7 @@ private:
 };
 #endif // wxUSE_UNICODE_UTF8
 
-class WXDLLIMPEXP_BASE wxString
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxString
 {
   // NB: special care was taken in arranging the member functions in such order
   //     that all inline functions can be effectively inlined, verify that all

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1860,6 +1860,16 @@ template <typename T> void wxDELETEA(T*& array);
 #define wxSUPPRESS_GCC_PRIVATE_DTOR_WARNING(name)
 
 /**
+    Expands to the "warn_unused" attribute (also known as [[gnu::warn_unused]])
+    on compilers supporting it (GCC and Clang), otherwise to nothing.
+
+    @header{wx/defs.h}
+
+    @since 3.3.0
+*/
+#define wxWARN_UNUSED [[gnu::warn_unused]]
+
+/**
     Swaps the contents of two variables.
 
     This is similar to std::swap() but can be used even on the platforms where

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1867,7 +1867,7 @@ template <typename T> void wxDELETEA(T*& array);
 
     @since 3.3.0
 */
-#define wxWARN_UNUSED [[gnu::warn_unused]]
+#define wxWARN_UNUSED __attribute__((warn_unused))
 
 /**
     Swaps the contents of two variables.

--- a/samples/fswatcher/fswatcher.cpp
+++ b/samples/fswatcher/fswatcher.cpp
@@ -481,7 +481,7 @@ void MyFrame::OnFileSystemEvent(wxFileSystemWatcherEvent& event)
         bool found(false);
         for (size_t n = m_filesList->GetItemCount(); n > 0; --n)
         {
-            wxString path, foo = m_filesList->GetItemText(n-1);
+            wxString path;
             if ((!m_filesList->GetItemText(n-1).StartsWith("Dir:  ", &path)) &&
                 (!m_filesList->GetItemText(n-1).StartsWith("Tree: ", &path)))
             {

--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -569,7 +569,6 @@ void MyFrame::OnTestLocaleAvail(wxCommandEvent& WXUNUSED(event))
     {
         wxLayoutDirection layout = uiLocale.GetLayoutDirection();
         wxString strLayout = (layout == wxLayout_RightToLeft) ? "RTL" : "LTR";
-        wxString strLocale = uiLocale.GetLocalizedName(wxLOCALE_NAME_LOCALE, wxLOCALE_FORM_NATIVE);
         wxLogMessage(_("Locale \"%s\" is available.\nIdentifier: %s; Layout: %s\nEnglish name: %s\nLocalized name: %s"),
                      s_locale, uiLocale.GetName(), strLayout,
                      uiLocale.GetLocalizedName(wxLOCALE_NAME_LOCALE, wxLOCALE_FORM_ENGLISH),

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -515,7 +515,6 @@ wxBitmapBundle wxBitmapBundle::FromFiles(const wxString& path, const wxString& f
     wxVector<wxBitmap> bitmaps;
 
     wxFileName fn(path, filename, extension);
-    wxString ext = extension.Lower();
 
     for ( int dpiFactor = 1 ; dpiFactor <= 2 ; ++dpiFactor)
     {

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -394,7 +394,7 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
     tmTimeOnly.tm_year = 76;
     tmTimeOnly.tm_isdst = 0;        // no DST, we adjust for tz ourselves
 
-    wxString tmp, res, fmt;
+    wxString res, fmt;
     for ( wxString::const_iterator p = format.begin(); p != format.end(); ++p )
     {
         if ( *p != wxT('%') )
@@ -1044,7 +1044,6 @@ wxDateTime::ParseFormat(const wxString& date,
     wxCHECK_MSG( !format.empty(), false, "format can't be empty" );
     wxCHECK_MSG( endParse, false, "end iterator pointer must be specified" );
 
-    wxString str;
     unsigned long num;
 
     // what fields have we found?

--- a/src/common/http.cpp
+++ b/src/common/http.cpp
@@ -481,8 +481,6 @@ wxInputStream *wxHTTP::GetInputStream(const wxString& path)
 {
     wxHTTPStream *inp_stream;
 
-    wxString new_path;
-
     m_lastError = wxPROTO_CONNERR;  // all following returns share this type of error
     if (!m_addr)
         return nullptr;

--- a/src/common/mimecmn.cpp
+++ b/src/common/mimecmn.cpp
@@ -164,7 +164,6 @@ wxString wxFileType::ExpandCommand(const wxString& command,
                     {
                         const wxChar *pEnd = wxStrchr(pc, wxT('}'));
                         if ( pEnd == nullptr ) {
-                            wxString mimetype;
                             wxLogWarning(_("Unmatched '{' in an entry for mime type %s."),
                                          params.GetMimeType().c_str());
                             str << wxT("%{");

--- a/src/common/variant.cpp
+++ b/src/common/variant.cpp
@@ -2065,7 +2065,6 @@ bool wxVariantDataList::Write(wxString& str) const
         wxVariant* var = node->GetData();
         if (node != m_value.GetFirst())
           str += wxT(" ");
-        wxString str1;
         str += var->MakeString();
         node = node->GetNext();
     }

--- a/src/html/helpdata.cpp
+++ b/src/html/helpdata.cpp
@@ -276,7 +276,6 @@ bool wxHtmlHelpData::LoadMSProject(wxHtmlBookRecord *book, wxFileSystem& fsys,
     wxFSFile *f;
     wxHtmlFilterHTML filter;
     wxString buf;
-    wxString string;
 
     HP_Parser parser;
     HP_TagHandler *handler = new HP_TagHandler(book);
@@ -642,7 +641,6 @@ bool wxHtmlHelpData::AddBook(const wxString& book)
     wxFileSystem fsys;
 
     wxString title = _("noname"),
-             safetitle,
              start,
              contents,
              index,

--- a/src/html/helpwnd.cpp
+++ b/src/html/helpwnd.cpp
@@ -1066,7 +1066,6 @@ void wxHtmlHelpWindow::RefreshLists()
 void wxHtmlHelpWindow::ReadCustomization(wxConfigBase *cfg, const wxString& path)
 {
     wxString oldpath;
-    wxString tmp;
 
     if (!path.empty())
     {
@@ -1124,7 +1123,6 @@ void wxHtmlHelpWindow::ReadCustomization(wxConfigBase *cfg, const wxString& path
 void wxHtmlHelpWindow::WriteCustomization(wxConfigBase *cfg, const wxString& path)
 {
     wxString oldpath;
-    wxString tmp;
 
     if (!path.empty())
     {

--- a/src/html/m_image.cpp
+++ b/src/html/m_image.cpp
@@ -72,7 +72,7 @@ class wxHtmlImageMapAreaCell : public wxHtmlCell
 wxHtmlImageMapAreaCell::wxHtmlImageMapAreaCell( wxHtmlImageMapAreaCell::celltype t, wxString &incoords, double pixel_scale )
 {
     int i;
-    wxString x = incoords, y;
+    wxString x = incoords;
 
     type = t;
     while ((i = x.Find( ',' )) != wxNOT_FOUND)

--- a/src/msw/volume.cpp
+++ b/src/msw/volume.cpp
@@ -365,15 +365,12 @@ static bool BuildRemoteList(wxArrayString& list, NETRESOURCE* pResSrc,
         for (ssize_t iMounted = mounted.GetCount()-1; iMounted >= 0 && iList >= 0; iMounted--)
         {
             int compare;
-            wxString all(list[iList]);
-            wxString mount(mounted[iMounted]);
 
             while (compare =
                      wxStricmp(list[iList].c_str(), mounted[iMounted].c_str()),
                    compare > 0 && iList >= 0)
             {
                 iList--;
-                all = list[iList];
             }
 
 

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -967,7 +967,6 @@ void wxWebViewIE::ClearSelection()
     if(document)
     {
         wxCOMPtr<IHTMLSelectionObject> selection;
-        wxString selected;
         HRESULT hr = document->get_selection(&selection);
         if(SUCCEEDED(hr))
         {

--- a/src/richtext/richtextxml.cpp
+++ b/src/richtext/richtextxml.cpp
@@ -1917,7 +1917,6 @@ void wxRichTextXMLHelper::OutputIndentation(wxOutputStream& stream, int indent)
 void wxRichTextXMLHelper::OutputStringEnt(wxOutputStream& stream, const wxString& str,
                             wxMBConv *convMem, wxMBConv *convFile)
 {
-    wxString buf;
     size_t i, last, len;
     wxChar c;
 

--- a/src/unix/mimetype.cpp
+++ b/src/unix/mimetype.cpp
@@ -316,7 +316,7 @@ size_t wxFileTypeImpl::GetAllCommands(wxArrayString *verbs,
                                   wxArrayString *commands,
                                   const wxFileType::MessageParameters& params) const
 {
-    wxString vrb, cmd, sTmp;
+    wxString vrb, cmd;
     size_t count = 0;
     wxMimeTypeCommands * sPairs;
 
@@ -955,7 +955,7 @@ wxFileType * wxMimeTypesManagerImpl::GetFileTypeFromMimeType(const wxString& mim
 
 wxString wxMimeTypesManagerImpl::GetCommand(const wxString & verb, size_t nIndex) const
 {
-    wxString command, testcmd, sV, sTmp;
+    wxString command, sV, sTmp;
     sV = verb + wxT("=");
 
     // list of verb = command pairs for this mimetype

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -896,11 +896,10 @@ long wxExecute(const char* const* argv, int flags, wxProcess* process,
 const wxChar* wxGetHomeDir( wxString *home  )
 {
     *home = wxGetUserHome();
-    wxString tmp;
     if ( home->empty() )
         *home = wxT("/");
 #ifdef __VMS
-    tmp = *home;
+    wxString tmp = *home;
     if ( tmp.Last() != wxT(']'))
         if ( tmp.Last() != wxT('/')) *home << wxT('/');
 #endif

--- a/src/xrc/xh_propgrid.cpp
+++ b/src/xrc/xh_propgrid.cpp
@@ -150,7 +150,6 @@ wxObject *wxPropertyGridXmlHandler::DoCreateResource()
             return nullptr;
 
         wxString sFlags(wxT("flags"));
-        wxString flags;
         if ( HasParam(sFlags) )
             property->SetFlagsFromString( GetText(sFlags) );
 

--- a/tests/config/config.cpp
+++ b/tests/config/config.cpp
@@ -145,10 +145,10 @@ size_t ReadValues(const wxConfig& config, bool has_values)
     size_t read = 0;
     bool r;
 
-    wxString string1 = config.Read("string1", "abc");
+    config.Read("string1", "abc");
     read++;
 
-    wxString string2 = config.Read("string2", wxString("def"));
+    config.Read("string2", wxString("def"));
     read++;
 
     wxString string3;

--- a/tests/controls/propgridtest.cpp
+++ b/tests/controls/propgridtest.cpp
@@ -827,9 +827,6 @@ TEST_CASE("PropertyGridTestCase", "[propgrid]")
         dt2.SetYear(dt2.GetYear() - 10);
 #endif
 
-        wxColour colWithAlpha(1, 128, 254, 100);
-        wxString colWithAlphaStr(colWithAlpha.GetAsString(wxC2S_CSS_SYNTAX));
-
         pgManager->SetPropertyValue("StringProperty", "Text1");
         pgManager->SetPropertyValue("IntProperty", 1024);
         pgManager->SetPropertyValue("FloatProperty", 1024.0000000001);

--- a/tests/strings/stdstrings.cpp
+++ b/tests/strings/stdstrings.cpp
@@ -228,7 +228,7 @@ TEST_CASE("StdString::AssignOp", "[stdstring]")
 
 TEST_CASE("StdString::Compare", "[stdstring]")
 {
-    wxString s1, s2, s3, s4, s5, s6, s7, s8;
+    wxString s1, s2, s3, s4, s5, s6;
 
     s1 = wxT("abcdefgh");
     s2 = wxT("abcdefgh");
@@ -250,14 +250,12 @@ TEST_CASE("StdString::Compare", "[stdstring]")
 
 TEST_CASE("StdString::Erase", "[stdstring]")
 {
-    wxString s1, s2, s3, s4, s5, s6, s7;
+    wxString s1, s2, s3, s4, s7;
 
     s1 = wxT("abcdefgh");
     s2 = wxT("abcdefgh");
     s3 = wxT("abc");
     s4 = wxT("abcdefghi");
-    s5 = wxT("aaa");
-    s6 = wxT("zzz");
     s7 = wxT("zabcdefg");
 
     s1.erase(1, 1);

--- a/tests/strings/tokenizer.cpp
+++ b/tests/strings/tokenizer.cpp
@@ -271,15 +271,15 @@ void TokenizerTestCase::CopyObj()
     wxStringTokenizer tkzSrc(wxT("first:second:third:fourth"), wxT(":"));
     while ( tkzSrc.HasMoreTokens() )
     {
-        wxString tokenSrc = tkzSrc.GetNextToken();
+        tkzSrc.GetNextToken();
         wxStringTokenizer tkz = tkzSrc;
 
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetPosition(), tkz.GetPosition() );
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetString(), tkz.GetString() );
 
         // Change the state of both objects and compare again...
-        tokenSrc = tkzSrc.GetNextToken();
-        wxString token = tkz.GetNextToken();
+        tkzSrc.GetNextToken();
+        tkz.GetNextToken();
 
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetPosition(), tkz.GetPosition() );
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetString(), tkz.GetString() );
@@ -293,15 +293,15 @@ void TokenizerTestCase::AssignObj()
     wxStringTokenizer tkz;
     while ( tkzSrc.HasMoreTokens() )
     {
-        wxString tokenSrc = tkzSrc.GetNextToken();
+        tkzSrc.GetNextToken();
         tkz = tkzSrc;
 
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetPosition(), tkz.GetPosition() );
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetString(), tkz.GetString() );
 
         // Change the state of both objects and compare again...
-        tokenSrc = tkzSrc.GetNextToken();
-        wxString token = tkz.GetNextToken();
+        tkzSrc.GetNextToken();
+        tkz.GetNextToken();
 
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetPosition(), tkz.GetPosition() );
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetString(), tkz.GetString() );

--- a/tests/strings/vsnprintf.cpp
+++ b/tests/strings/vsnprintf.cpp
@@ -515,7 +515,6 @@ TEST_CASE_METHOD(VsnprintfTestCase, "Vsnprintf::GlibcMisc1", "[vsnprintf]")
 TEST_CASE_METHOD(VsnprintfTestCase, "Vsnprintf::GlibcMisc2", "[vsnprintf]")
 {
     int prec;
-    wxString test_format;
 
     prec = 0;
     CMP("3", "%.*g", prec, 3.3);

--- a/tests/uris/uris.cpp
+++ b/tests/uris/uris.cpp
@@ -285,7 +285,7 @@ void URITestCase::Paths()
     try
     {
         wxURI test("http://user:password@192.256.1.100:5050/../path");
-        wxString sTest = test.BuildURI(); // This isn't a unit test, just a niche parsing crash test
+        test.BuildURI(); // This isn't a unit test, just a niche parsing crash test
     }
     catch (...)
     {


### PR DESCRIPTION
A few unused were left under tests/, because they may exist for readability. The second commit (which could be squashed, or removed) removes them, too.

There were no cases where the unused variable obviously should have been used for something, though the lines in [tests/controls/propgridtest.cpp](https://github.com/wxWidgets/wxWidgets/compare/master...lanurmi:rm-unused-wxstring?expand=1#diff-ce81c0a061e3e7632d89dbac19ed3b0434eaf33743ac9355c34ddefe957ad29f) are suspicious.

The unused `wxString`s were found by adding the `[[gnu:warn_unused]]` attribute to the `wxString` class. The attribute is not a part of this PR, but something to consider for `wxString` and some other classes.