### PR TITLE
Make sizes in wxAuiDockArt metrics DPI independent

### DIFF
--- a/interface/wx/aui/dockart.h
+++ b/interface/wx/aui/dockart.h
@@ -265,6 +265,7 @@ public:
     /**
         Get the value of a certain setting.
         @a id can be one of the size values of @b wxAuiPaneDockArtSetting.
+        Sizes are in DPI-independent pixel values.
     */
     virtual int GetMetric(int id) = 0;
 
@@ -282,6 +283,7 @@ public:
     /**
         Set a certain setting with the value @e new_val.
         @a id can be one of the size values of @b wxAuiPaneDockArtSetting.
+        Sizes should be in DPI-independent pixel values.
     */
     virtual void SetMetric(int id, int new_val) = 0;
 };

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -298,13 +298,15 @@ public:
 
         //vert->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
 
+        wxSize const elementSize = FromDIP(wxSize(180, 20));
+
         wxBoxSizer* s1 = new wxBoxSizer(wxHORIZONTAL);
         m_border_size = new wxSpinCtrl(this, ID_PaneBorderSize, wxString::Format("%d", frame->GetDockArt()->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE)), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, FromDIP(100), frame->GetDockArt()->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
         s1->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s1->Add(new wxStaticText(this, wxID_ANY, "Pane Border Size:"));
         s1->Add(m_border_size);
         s1->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s1->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s1->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s1, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
         wxBoxSizer* s2 = new wxBoxSizer(wxHORIZONTAL);
@@ -313,7 +315,7 @@ public:
         s2->Add(new wxStaticText(this, wxID_ANY, "Sash Size:"));
         s2->Add(m_sash_size);
         s2->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s2->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s2->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s2, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
         wxBoxSizer* s3 = new wxBoxSizer(wxHORIZONTAL);
@@ -322,93 +324,94 @@ public:
         s3->Add(new wxStaticText(this, wxID_ANY, "Caption Size:"));
         s3->Add(m_caption_size);
         s3->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s3->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s3->SetItemMinSize((size_t)1, elementSize);
         //vert->Add(s3, 0, wxEXPAND | wxLEFT | wxBOTTOM, FromDIP(5));
 
         //vert->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
 
 
-        wxBitmap b = CreateColorBitmap(*wxBLACK);
+        wxBitmapBundle const b = CreateColorBitmap(*wxBLACK);
+        wxSize const bitmapSize = FromDIP(wxSize(50, 25));
 
         wxBoxSizer* s4 = new wxBoxSizer(wxHORIZONTAL);
-        m_background_color = new wxBitmapButton(this, ID_BackgroundColor, b, wxDefaultPosition, FromDIP(wxSize(50,25)));
+        m_background_color = new wxBitmapButton(this, ID_BackgroundColor, b, wxDefaultPosition, bitmapSize);
         s4->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s4->Add(new wxStaticText(this, wxID_ANY, "Background Color:"));
         s4->Add(m_background_color);
         s4->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s4->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s4->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s5 = new wxBoxSizer(wxHORIZONTAL);
-        m_sash_color = new wxBitmapButton(this, ID_SashColor, b, wxDefaultPosition, wxSize(50,25));
+        m_sash_color = new wxBitmapButton(this, ID_SashColor, b, wxDefaultPosition, bitmapSize);
         s5->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s5->Add(new wxStaticText(this, wxID_ANY, "Sash Color:"));
         s5->Add(m_sash_color);
         s5->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s5->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s5->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s6 = new wxBoxSizer(wxHORIZONTAL);
-        m_inactive_caption_color = new wxBitmapButton(this, ID_InactiveCaptionColor, b, wxDefaultPosition, wxSize(50,25));
+        m_inactive_caption_color = new wxBitmapButton(this, ID_InactiveCaptionColor, b, wxDefaultPosition, bitmapSize);
         s6->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s6->Add(new wxStaticText(this, wxID_ANY, "Normal Caption:"));
         s6->Add(m_inactive_caption_color);
         s6->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s6->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s6->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s7 = new wxBoxSizer(wxHORIZONTAL);
-        m_inactive_caption_gradient_color = new wxBitmapButton(this, ID_InactiveCaptionGradientColor, b, wxDefaultPosition, wxSize(50,25));
+        m_inactive_caption_gradient_color = new wxBitmapButton(this, ID_InactiveCaptionGradientColor, b, wxDefaultPosition, bitmapSize);
         s7->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s7->Add(new wxStaticText(this, wxID_ANY, "Normal Caption Gradient:"));
         s7->Add(m_inactive_caption_gradient_color);
         s7->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s7->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s7->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s8 = new wxBoxSizer(wxHORIZONTAL);
-        m_inactive_caption_text_color = new wxBitmapButton(this, ID_InactiveCaptionTextColor, b, wxDefaultPosition, wxSize(50,25));
+        m_inactive_caption_text_color = new wxBitmapButton(this, ID_InactiveCaptionTextColor, b, wxDefaultPosition, bitmapSize);
         s8->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s8->Add(new wxStaticText(this, wxID_ANY, "Normal Caption Text:"));
         s8->Add(m_inactive_caption_text_color);
         s8->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s8->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s8->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s9 = new wxBoxSizer(wxHORIZONTAL);
-        m_active_caption_color = new wxBitmapButton(this, ID_ActiveCaptionColor, b, wxDefaultPosition, wxSize(50,25));
+        m_active_caption_color = new wxBitmapButton(this, ID_ActiveCaptionColor, b, wxDefaultPosition, bitmapSize);
         s9->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s9->Add(new wxStaticText(this, wxID_ANY, "Active Caption:"));
         s9->Add(m_active_caption_color);
         s9->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s9->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s9->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s10 = new wxBoxSizer(wxHORIZONTAL);
-        m_active_caption_gradient_color = new wxBitmapButton(this, ID_ActiveCaptionGradientColor, b, wxDefaultPosition, wxSize(50,25));
+        m_active_caption_gradient_color = new wxBitmapButton(this, ID_ActiveCaptionGradientColor, b, wxDefaultPosition, bitmapSize);
         s10->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s10->Add(new wxStaticText(this, wxID_ANY, "Active Caption Gradient:"));
         s10->Add(m_active_caption_gradient_color);
         s10->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s10->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s10->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s11 = new wxBoxSizer(wxHORIZONTAL);
-        m_active_caption_text_color = new wxBitmapButton(this, ID_ActiveCaptionTextColor, b, wxDefaultPosition, wxSize(50,25));
+        m_active_caption_text_color = new wxBitmapButton(this, ID_ActiveCaptionTextColor, b, wxDefaultPosition, bitmapSize);
         s11->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s11->Add(new wxStaticText(this, wxID_ANY, "Active Caption Text:"));
         s11->Add(m_active_caption_text_color);
         s11->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s11->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s11->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s12 = new wxBoxSizer(wxHORIZONTAL);
-        m_border_color = new wxBitmapButton(this, ID_BorderColor, b, wxDefaultPosition, wxSize(50,25));
+        m_border_color = new wxBitmapButton(this, ID_BorderColor, b, wxDefaultPosition, bitmapSize);
         s12->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s12->Add(new wxStaticText(this, wxID_ANY, "Border Color:"));
         s12->Add(m_border_color);
         s12->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s12->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s12->SetItemMinSize((size_t)1, elementSize);
 
         wxBoxSizer* s13 = new wxBoxSizer(wxHORIZONTAL);
-        m_gripper_color = new wxBitmapButton(this, ID_GripperColor, b, wxDefaultPosition, wxSize(50,25));
+        m_gripper_color = new wxBitmapButton(this, ID_GripperColor, b, wxDefaultPosition, bitmapSize);
         s13->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
         s13->Add(new wxStaticText(this, wxID_ANY, "Gripper Color:"));
         s13->Add(m_gripper_color);
         s13->Add(FromDIP(1), FromDIP(1), 1, wxEXPAND);
-        s13->SetItemMinSize((size_t)1, FromDIP(wxSize(180, 20)));
+        s13->SetItemMinSize((size_t)1, elementSize);
 
         wxGridSizer* grid_sizer = new wxGridSizer(2);
         grid_sizer->SetHGap(FromDIP(5));
@@ -434,20 +437,26 @@ public:
 
 private:
 
-    wxBitmap CreateColorBitmap(const wxColour& c)
+    wxBitmapBundle CreateColorBitmap(const wxColour& c)
     {
-        wxImage image;
-        wxSize size = FromDIP(wxSize(25, 14));
-        image.Create(size);
-        for (int x = 0; x < size.x; ++x)
-            for (int y = 0; y < size.y; ++y)
-            {
-                wxColour pixcol = c;
-                if (x == 0 || x == size.x || y == 0 || y == size.y)
-                    pixcol = *wxBLACK;
-                image.SetRGB(x, y, pixcol.Red(), pixcol.Green(), pixcol.Blue());
-            }
-        return wxBitmap(image);
+        wxVector<wxBitmap> bitmaps;
+
+        for (int i = 100; i <= 400; i += 25)
+        {
+            wxSize size(25 * i / 100, 14 * i / 100);
+            wxImage image(size);
+            for (int x = 0; x < size.x; ++x)
+                for (int y = 0; y < size.y; ++y)
+                {
+                    wxColour pixcol = c;
+                    if (x == 0 || x == size.x || y == 0 || y == size.y)
+                        pixcol = *wxBLACK;
+                    image.SetRGB(x, y, pixcol.Red(), pixcol.Green(), pixcol.Blue());
+                }
+            bitmaps.push_back(wxBitmap(image));
+        }
+
+        return wxBitmapBundle::FromBitmaps(bitmaps);
     }
 
     void UpdateColors()

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -967,7 +967,7 @@ MyFrame::MyFrame(wxWindow* parent,
     wxWindow* wnd10 = CreateTextCtrl("This pane will prompt the user before hiding.");
 
     // Give this pane an icon, too, just for testing.
-    int iconSize = m_mgr.GetArtProvider()->GetMetric(wxAUI_DOCKART_CAPTION_SIZE);
+    int iconSize = FromDIP(m_mgr.GetArtProvider()->GetMetric(wxAUI_DOCKART_CAPTION_SIZE));
 
     // Make it even to use 16 pixel icons with default 17 caption height.
     iconSize &= ~1;

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -205,12 +205,12 @@ wxAuiDefaultDockArt::wxAuiDefaultDockArt()
 #elif defined(__WXGTK__)
     m_sashSize     = wxRendererNative::Get().GetSplitterParams(nullptr).widthSash;
 #else
-    m_sashSize     = wxWindow::FromDIP( 4, nullptr);
+    m_sashSize     = 4;
 #endif
-    m_captionSize  = wxWindow::FromDIP(17, nullptr);
+    m_captionSize  = 17;
     m_borderSize   = 1;
-    m_buttonSize   = wxWindow::FromDIP(14, nullptr);
-    m_gripperSize  = wxWindow::FromDIP( 9, nullptr);
+    m_buttonSize   = 14;
+    m_gripperSize  = 9;
     m_gradientType = wxAUI_GRADIENT_VERTICAL;
 
     InitBitmaps();
@@ -518,7 +518,7 @@ void wxAuiDefaultDockArt::DrawBorder(wxDC& dc, wxWindow* window, const wxRect& _
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
 
     wxRect rect = _rect;
-    int i, border_width = GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE);
+    int i, border_width = window->FromDIP(GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
 
     if (pane.IsToolbar())
     {
@@ -640,11 +640,11 @@ void wxAuiDefaultDockArt::DrawCaption(wxDC& dc,
     clip_rect.width -= window->FromDIP(3); // text offset
     clip_rect.width -= window->FromDIP(2); // button padding
     if (pane.HasCloseButton())
-        clip_rect.width -= m_buttonSize;
+        clip_rect.width -= window->FromDIP(m_buttonSize);
     if (pane.HasPinButton())
-        clip_rect.width -= m_buttonSize;
+        clip_rect.width -= window->FromDIP(m_buttonSize);
     if (pane.HasMaximizeButton())
-        clip_rect.width -= m_buttonSize;
+        clip_rect.width -= window->FromDIP(m_buttonSize);
 
     wxString draw_text = wxAuiChopText(dc, text, clip_rect.width);
 

--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -148,9 +148,9 @@ void wxAuiFloatingFrame::SetPaneWindow(const wxAuiPaneInfo& pane)
         if (m_ownerMgr && pane.HasGripper())
         {
             if (pane.HasGripperTop())
-                size.y += m_ownerMgr->m_art->GetMetric(wxAUI_DOCKART_GRIPPER_SIZE);
+                size.y += m_paneWindow->FromDIP(m_ownerMgr->m_art->GetMetric(wxAUI_DOCKART_GRIPPER_SIZE));
             else
-                size.x += m_ownerMgr->m_art->GetMetric(wxAUI_DOCKART_GRIPPER_SIZE);
+                size.x += m_paneWindow->FromDIP(m_ownerMgr->m_art->GetMetric(wxAUI_DOCKART_GRIPPER_SIZE));
         }
 
         SetClientSize(size);

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -1344,10 +1344,6 @@ void wxAuiManager::GetPanePositionsAndSizes(wxAuiDockInfo& dock,
                                             wxArrayInt& positions,
                                             wxArrayInt& sizes)
 {
-    int caption_size = m_art->GetMetric(wxAUI_DOCKART_CAPTION_SIZE);
-    int pane_borderSize = m_art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE);
-    int gripperSize = m_art->GetMetric(wxAUI_DOCKART_GRIPPER_SIZE);
-
     positions.Empty();
     sizes.Empty();
 
@@ -1372,6 +1368,10 @@ void wxAuiManager::GetPanePositionsAndSizes(wxAuiDockInfo& dock,
     for (pane_i = 0; pane_i < pane_count; ++pane_i)
     {
         wxAuiPaneInfo& pane = *(dock.panes.Item(pane_i));
+        int caption_size = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_CAPTION_SIZE));
+        int pane_borderSize = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
+        int gripperSize = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_GRIPPER_SIZE));
+
         positions.Add(pane.dock_pos);
         int size = 0;
 
@@ -1437,10 +1437,10 @@ void wxAuiManager::LayoutAddPane(wxSizer* cont,
     wxAuiDockUIPart part;
     wxSizerItem* sizer_item;
 
-    int caption_size = m_art->GetMetric(wxAUI_DOCKART_CAPTION_SIZE);
-    int gripperSize = m_art->GetMetric(wxAUI_DOCKART_GRIPPER_SIZE);
-    int pane_borderSize = m_art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE);
-    int pane_button_size = m_art->GetMetric(wxAUI_DOCKART_PANE_BUTTON_SIZE);
+    int caption_size = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_CAPTION_SIZE));
+    int gripperSize = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_GRIPPER_SIZE));
+    int pane_borderSize = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
+    int pane_button_size = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_PANE_BUTTON_SIZE));
 
     // find out the orientation of the item (orientation for panes
     // is the same as the dock's orientation)
@@ -1619,7 +1619,7 @@ void wxAuiManager::LayoutAddDock(wxSizer* cont,
     wxSizerItem* sizer_item;
     wxAuiDockUIPart part;
 
-    int sashSize = m_art->GetMetric(wxAUI_DOCKART_SASH_SIZE);
+    int sashSize = m_frame->FromDIP(m_art->GetMetric(wxAUI_DOCKART_SASH_SIZE));
     int orientation = dock.IsHorizontal() ? wxHORIZONTAL : wxVERTICAL;
 
     // resizable bottom and right docks have a sash before them
@@ -1774,8 +1774,8 @@ wxSizer* wxAuiManager::LayoutAll(wxAuiPaneInfoArray& panes,
 {
     wxBoxSizer* container = new wxBoxSizer(wxVERTICAL);
 
-    int pane_borderSize = m_art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE);
-    int caption_size = m_art->GetMetric(wxAUI_DOCKART_CAPTION_SIZE);
+    int pane_borderSize = m_frame->FromDIP(m_art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
+    int caption_size = m_frame->FromDIP(m_art->GetMetric(wxAUI_DOCKART_CAPTION_SIZE));
     wxSize cli_size = m_frame->GetClientSize();
     int i, dock_count, pane_count;
 
@@ -3869,7 +3869,7 @@ bool wxAuiManager::DoEndResizeAction(wxMouseEvent& event)
     if (m_actionPart && m_actionPart->type==wxAuiDockUIPart::typeDockSizer)
     {
         // first, we must calculate the maximum size the dock may be
-        int sashSize = m_art->GetMetric(wxAUI_DOCKART_SASH_SIZE);
+        int sashSize = m_frame->FromDIP(m_art->GetMetric(wxAUI_DOCKART_SASH_SIZE));
 
         int used_width = 0, used_height = 0;
 
@@ -3961,9 +3961,9 @@ bool wxAuiManager::DoEndResizeAction(wxMouseEvent& event)
         int dock_pixels = 0;
         int new_pixsize = 0;
 
-        int caption_size = m_art->GetMetric(wxAUI_DOCKART_CAPTION_SIZE);
-        int pane_borderSize = m_art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE);
-        int sashSize = m_art->GetMetric(wxAUI_DOCKART_SASH_SIZE);
+        int caption_size = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_CAPTION_SIZE));
+        int pane_borderSize = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
+        int sashSize = pane.window->FromDIP(m_art->GetMetric(wxAUI_DOCKART_SASH_SIZE));
 
         wxPoint new_pos(event.m_x - m_actionOffset.x,
             event.m_y - m_actionOffset.y);

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -666,7 +666,7 @@ int wxAuiGenericTabArt::GetBorderWidth(wxWindow* wnd)
     {
         wxAuiDockArt* art = mgr->GetArtProvider();
         if (art)
-            return art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE);
+            return wnd->FromDIP(art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
     }
     return 1;
 }
@@ -1212,7 +1212,7 @@ int wxAuiSimpleTabArt::GetBorderWidth(wxWindow* wnd)
     {
        wxAuiDockArt*  art = mgr->GetArtProvider();
         if (art)
-            return art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE);
+            return wnd->FromDIP(art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE));
     }
     return 1;
 }


### PR DESCRIPTION
When using the wxAuiDockArt sizes, convert them to the DPI of the current window/pane.

Fixes https://github.com/wxWidgets/wxWidgets/issues/23420