### PR TITLE
Fix defining wxNODISCARD for gcc

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -273,7 +273,7 @@ typedef short int WXTYPE;
     #define wxNODISCARD [[nodiscard]]
 #elif defined(__VISUALC__)
     #define wxNODISCARD _Check_return_
-#elif defined(__clang__) || defined(__GNUCC__)
+#elif defined(__clang__) || defined(__GNUC__)
     #define wxNODISCARD __attribute__ ((warn_unused_result))
 #else
     #define wxNODISCARD


### PR DESCRIPTION
Fix the check in f1985c6ba2 (Use [[nodiscard]] with functions returning object to be freed, 2022-11-04) for gcc which didn't work properly due to a typo.

See #22943.