### PR TITLE
Fix crash in assertions happening before `wxApp` is fully initialized

### DIFF
--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -1124,10 +1124,6 @@ wxDefaultAssertHandler(const wxString& file,
                        const wxString& cond,
                        const wxString& msg)
 {
-    // If this option is set, we should abort immediately when assert happens.
-    if ( wxSystemOptions::GetOptionInt("exit-on-assert") )
-        wxAbort();
-
     // FIXME MT-unsafe
     static int s_bInAssert = 0;
 
@@ -1139,6 +1135,10 @@ wxDefaultAssertHandler(const wxString& file,
 
         return;
     }
+
+    // If this option is set, we should abort immediately when assert happens.
+    if ( wxSystemOptions::GetOptionInt("exit-on-assert") )
+        wxAbort();
 
     if ( !wxTheApp )
     {

--- a/src/common/stdpbase.cpp
+++ b/src/common/stdpbase.cpp
@@ -54,10 +54,7 @@ static wxStandardPathsDefault gs_stdPaths;
 /* static */
 wxStandardPaths& wxStandardPathsBase::Get()
 {
-    wxAppTraits * const traits = wxApp::GetTraitsIfExists();
-    wxCHECK_MSG( traits, gs_stdPaths, wxT("create wxApp before calling this") );
-
-    return traits->GetStandardPaths();
+    return wxApp::GetValidTraits().GetStandardPaths();
 }
 
 wxString wxStandardPathsBase::GetExecutablePath() const

--- a/src/common/timercmn.cpp
+++ b/src/common/timercmn.cpp
@@ -55,12 +55,10 @@ wxTimer::~wxTimer()
 void wxTimer::Init()
 {
     wxAppTraits * const traits = wxApp::GetTraitsIfExists();
-    m_impl = traits ? traits->CreateTimerImpl(this) : nullptr;
-    if ( !m_impl )
-    {
-        wxFAIL_MSG( wxT("No timer implementation for this platform") );
+    wxCHECK_RET( traits, wxT("Can't create timer, is wxApp fully initialized?") );
 
-    }
+    m_impl = traits->CreateTimerImpl(this);
+    wxCHECK_RET( m_impl, wxT("No timer implementation for this platform") );
 }
 
 // ============================================================================


### PR DESCRIPTION
This mostly addresses #24856, but also improves a couple of other things.