### PR TITLE
Fix issues in IPC using TCP sockets

### DIFF
--- a/build/cmake/tests/base/CMakeLists.txt
+++ b/build/cmake/tests/base/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TEST_SRC
     misc/pathlist.cpp
     misc/typeinfotest.cpp
     net/ipc.cpp
+    net/ipc_test_server.cpp
     net/socket.cpp
     net/webrequest.cpp
     regex/regextest.cpp
@@ -124,6 +125,7 @@ set(TEST_DATA
 wx_add_test(test_base CONSOLE ${TEST_SRC}
     DATA ${TEST_DATA}
     )
+target_compile_definitions(test_base PRIVATE TEST_HAS_IPC_SERVER)
 if(wxUSE_SOCKETS)
     wx_exe_link_libraries(test_base wxnet)
 endif()

--- a/include/wx/sckipc.h
+++ b/include/wx/sckipc.h
@@ -21,8 +21,6 @@
 
 #include "wx/ipcbase.h"
 #include "wx/socket.h"
-#include "wx/sckstrm.h"
-#include "wx/datstrm.h"
 
 /*
  * Mini-DDE implementation
@@ -51,7 +49,6 @@
 class WXDLLIMPEXP_FWD_NET wxTCPServer;
 class WXDLLIMPEXP_FWD_NET wxTCPClient;
 
-class wxIPCSocketStreams;
 
 class WXDLLIMPEXP_NET wxTCPConnection : public wxConnectionBase
 {
@@ -94,8 +91,6 @@ protected:
     // for IPC server)
     wxSocketBase *m_sock;
 
-    // various streams that we use
-    wxIPCSocketStreams *m_streams;
 
     // the topic of this connection
     wxString m_topic;

--- a/include/wx/sckipc.h
+++ b/include/wx/sckipc.h
@@ -122,7 +122,7 @@ public:
     virtual wxConnectionBase *OnAcceptConnection(const wxString& topic) override;
 
 protected:
-    wxSocketServer *m_server;
+    wxSocketServer *m_server = nullptr;
 
 #ifdef __UNIX_LIKE__
     // the name of the file associated to the Unix domain socket, may be empty

--- a/include/wx/sckipc.h
+++ b/include/wx/sckipc.h
@@ -49,6 +49,7 @@
 class WXDLLIMPEXP_FWD_NET wxTCPServer;
 class WXDLLIMPEXP_FWD_NET wxTCPClient;
 
+class wxTCPEventHandler;
 
 class WXDLLIMPEXP_NET wxTCPConnection : public wxConnectionBase
 {
@@ -91,6 +92,8 @@ protected:
     // for IPC server)
     wxSocketBase *m_sock;
 
+    // Handler of events and r/w of messages to the socket
+    wxTCPEventHandler *m_handler;
 
     // the topic of this connection
     wxString m_topic;

--- a/include/wx/socket.h
+++ b/include/wx/socket.h
@@ -191,6 +191,7 @@ public:
     // event handling
     void *GetClientData() const { return m_clientData; }
     void SetClientData(void *data) { m_clientData = data; }
+    wxEvtHandler* GetEventHandler() const { return m_handler; }
     void SetEventHandler(wxEvtHandler& handler, int id = wxID_ANY);
     void SetNotify(wxSocketEventFlags flags);
     void Notify(bool notify);
@@ -456,4 +457,3 @@ typedef void (wxEvtHandler::*wxSocketEventFunction)(wxSocketEvent&);
 #endif // wxUSE_SOCKETS
 
 #endif // _WX_SOCKET_H_
-

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1291,74 +1291,22 @@ void wxTCPEventHandler::HandleDisconnect(wxTCPConnection *connection)
     }
 
 
-void wxTCPEventHandler::Server_OnRequest(wxSocketEvent &event)
-{
-    wxSocketServer *server = (wxSocketServer *) event.GetSocket();
-    if (!server)
-        return;
-    wxTCPServer *ipcserv = (wxTCPServer *) server->GetClientData();
 
-    // This socket is being deleted; skip this event
-    if (!ipcserv)
-        return;
 
-    if (event.GetSocketEvent() != wxSOCKET_CONNECTION)
-        return;
 
-    // Accept the connection, getting a new socket
-    wxSocketBase *sock = server->Accept();
-    if (!sock)
-        return;
-    if (!sock->IsOk())
     {
-        sock->Destroy();
-        return;
     }
 
-    wxIPCSocketStreams *streams = new wxIPCSocketStreams(*sock);
 
     {
-        IPCOutput out(streams);
 
-        const int msg = streams->Read8();
-        if ( msg == IPC_CONNECT )
         {
-            const wxString topic = streams->ReadString();
 
-            wxTCPConnection *new_connection =
-                (wxTCPConnection *)ipcserv->OnAcceptConnection (topic);
-
-            if (new_connection)
             {
-                if (wxDynamicCast(new_connection, wxTCPConnection))
-                {
-                    // Acknowledge success
-                    out.Write8(IPC_CONNECT);
-
-                    new_connection->m_sock = sock;
-                    new_connection->m_streams = streams;
-                    new_connection->m_topic = topic;
-                    sock->SetEventHandler(wxTCPEventHandlerModule::GetHandler(),
-                                          _CLIENT_ONREQUEST_ID);
-                    sock->SetClientData(new_connection);
-                    sock->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
-                    sock->Notify(true);
-                    return;
-                }
-                else
-                {
-                    delete new_connection;
-                    // and fall through to delete everything else
-                }
             }
         }
 
-        // Something went wrong, send failure message and delete everything
-        out.Write8(IPC_FAIL);
-    } // IPCOutput object is destroyed here, before destroying stream
 
-    delete streams;
-    sock->Destroy();
 // Reads a single message from the socket. Returns wxIPCMessageNull when no
 // message was read.  The returned message must be freed by the caller.
 wxIPCMessageBase* wxTCPEventHandler::ReadMessageFromSocket(wxSocketBase* socket)

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1194,17 +1194,11 @@ bool wxTCPConnection::DoExecute(const void *data,
                                 size_t size,
                                 wxIPCFormat format)
 {
-    if ( !m_sock->IsConnected() )
+    if ( !m_handler )
         return false;
 
-    // Prepare EXECUTE message
-    IPCOutput out(m_streams);
-    out.Write8(IPC_EXECUTE);
-    out.Write8(format);
-
-    out.WriteData(data, size);
-
-    return true;
+    wxIPCMessageExecute msg(m_sock, data, size, format);
+    return m_handler->WriteMessageToSocket(msg);
 }
 
 const void *wxTCPConnection::Request(const wxString& item,

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1251,160 +1251,45 @@ void wxTCPEventHandler::HandleDisconnect(wxTCPConnection *connection)
     connection->OnDisconnect();
 }
 
-void wxTCPEventHandler::Client_OnRequest(wxSocketEvent &event)
 {
-    wxSocketBase *sock = event.GetSocket();
-    if (!sock)
         return;
-
-    wxSocketNotify evt = event.GetSocketEvent();
-    wxTCPConnection * const
-        connection = static_cast<wxTCPConnection *>(sock->GetClientData());
 
     // This socket is being deleted; skip this event
-    if (!connection)
         return;
 
-    if ( evt == wxSOCKET_LOST )
-    {
-        HandleDisconnect(connection);
         return;
-    }
 
-    // Receive message number.
-    wxIPCSocketStreams * const streams = connection->m_streams;
 
-    const wxString topic = connection->m_topic;
-    wxString item;
 
-    bool error = false;
 
-    const int msg = streams->Read8();
-    switch ( msg )
     {
-        case IPC_EXECUTE:
+
             {
-                wxIPCFormat format;
-                size_t size wxDUMMY_INITIALIZE(0);
-                void * const
-                    data = streams->ReadFormatData(connection, &format, &size);
-                if ( data )
-                    connection->OnExecute(topic, data, size, format);
-                else
-                    error = true;
+
+
             }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             break;
 
-        case IPC_ADVISE:
-            {
-                item = streams->ReadString();
 
-                wxIPCFormat format;
-                size_t size wxDUMMY_INITIALIZE(0);
-                void * const
-                    data = streams->ReadFormatData(connection, &format, &size);
-
-                if ( data )
-                    connection->OnAdvise(topic, item, data, size, format);
-                else
-                    error = true;
-            }
             break;
 
-        case IPC_ADVISE_START:
-            {
-                item = streams->ReadString();
-
-                IPCOutput(streams).Write8(connection->OnStartAdvise(topic, item)
-                                            ? IPC_ADVISE_START
-                                            : IPC_FAIL);
-            }
-            break;
-
-        case IPC_ADVISE_STOP:
-            {
-                item = streams->ReadString();
-
-                IPCOutput(streams).Write8(connection->OnStopAdvise(topic, item)
-                                             ? IPC_ADVISE_STOP
-                                             : IPC_FAIL);
-            }
-            break;
-
-        case IPC_POKE:
-            {
-                item = streams->ReadString();
-                wxIPCFormat format = (wxIPCFormat)streams->Read8();
-
-                size_t size wxDUMMY_INITIALIZE(0);
-                void * const data = streams->ReadData(connection, &size);
-
-                if ( data )
-                    connection->OnPoke(topic, item, data, size, format);
-                else
-                    error = true;
-            }
-            break;
-
-        case IPC_REQUEST:
-            {
-                item = streams->ReadString();
-
-                wxIPCFormat format = (wxIPCFormat)streams->Read8();
-
-                size_t user_size = wxNO_LEN;
-                const void *user_data = connection->OnRequest(topic,
-                                                              item,
-                                                              &user_size,
-                                                              format);
-
-                if ( !user_data )
-                {
-                    IPCOutput(streams).Write8(IPC_FAIL);
-                    break;
-                }
-
-                IPCOutput out(streams);
-                out.Write8(IPC_REQUEST_REPLY);
-
-                if ( user_size == wxNO_LEN )
-                {
-                    switch ( format )
-                    {
-                        case wxIPC_TEXT:
-                        case wxIPC_UTF8TEXT:
-                            user_size = strlen((const char *)user_data) + 1;  // includes final NUL
-                            break;
-                        case wxIPC_UNICODETEXT:
-                            user_size = (wcslen((const wchar_t *)user_data) + 1) * sizeof(wchar_t);  // includes final NUL
-                            break;
-                        default:
-                            user_size = 0;
-                    }
-                }
-
-                out.WriteData(user_data, user_size);
-            }
-            break;
-
-        case IPC_DISCONNECT:
-            HandleDisconnect(connection);
-            break;
-
-        case IPC_FAIL:
-            wxLogDebug("Unexpected IPC_FAIL received");
-            error = true;
-            break;
-
-        default:
-            wxLogDebug("Unknown message code %d received.", msg);
-            error = true;
             break;
     }
 
-    if ( error )
-        IPCOutput(streams).Write8(IPC_FAIL);
-}
 
 void wxTCPEventHandler::Server_OnRequest(wxSocketEvent &event)
 {

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -784,6 +784,21 @@ protected:
     wxDECLARE_DYNAMIC_CLASS(wxIPCMessageDisconnect);
 };
 
+// Utility to ensure deletion of wxIPCMessageBase after use
+class wxIPCMessageBaseLocker
+{
+public:
+    wxIPCMessageBaseLocker(wxIPCMessageBase* msg)
+    {
+        m_msg = msg;
+    }
+
+    ~wxIPCMessageBaseLocker()
+    {
+        if (m_msg) delete m_msg;
+    }
+
+    wxIPCMessageBase* m_msg;
 };
 
 // ==========================================================================

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1237,14 +1237,11 @@ bool wxTCPConnection::DoPoke(const wxString& item,
                              size_t size,
                              wxIPCFormat format)
 {
-    if ( !m_sock->IsConnected() )
+    if ( !m_handler )
         return false;
 
-    IPCOutput out(m_streams);
-    out.Write(IPC_POKE, item, format);
-    out.WriteData(data, size);
-
-    return true;
+    wxIPCMessagePoke msg(m_sock, item, data, size, format);
+    return m_handler->WriteMessageToSocket(msg);
 }
 
 bool wxTCPConnection::StartAdvise(const wxString& item)

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -46,6 +46,7 @@
 #include <errno.h>
 
 #include <functional>
+#include <map>
 #include <unordered_set>
 
 #include "wx/socket.h"
@@ -105,13 +106,6 @@ constexpr auto wxNO_RETURN_MESSAGE = nullptr;
 constexpr long wxIPCTimeout = 5; // socket timeout, in seconds
 
 
-// For IPC returning a char* buffer. wxWidgets docs say that the user is not
-// supposed to free the memory.  Each buffer pointer is assigned to a list
-// sequentially, and the buffer memory is not freed until MAX_MSG_BUFFERS have
-// been assigned.
-constexpr int MAX_MSG_BUFFERS = 2048;
-
-
 // ----------------------------------------------------------------------------
 // private functions
 // ----------------------------------------------------------------------------
@@ -156,19 +150,7 @@ GetAddressFromName(const wxString& serverName,
 class wxTCPEventHandler : public wxEvtHandler
 {
 public:
-    wxTCPEventHandler() : wxEvtHandler()
-    {
-        for ( auto& buf : m_bufferList )
-            buf = nullptr;
-
-        m_nextAvailable = 0;
-    }
-
-    ~wxTCPEventHandler()
-    {
-        for ( auto& buf : m_bufferList )
-            delete[] buf;
-    }
+    wxTCPEventHandler() = default;
 
     void OnSocketInput(wxSocketEvent& event);
     void OnSocketConnection(wxSocketEvent& event);
@@ -193,8 +175,6 @@ public:
     wxIPCMessageBase* ReadMessageFromSocket(wxSocketBase *socket);
     bool WriteMessageToSocket(wxIPCMessageBase& msg);
     bool PeekAtMessageInSocket(wxSocketBase *socket);
-
-    char* GetBufPtr(size_t size);
 
     // This event handler is a single process-wide object shared by every IPC
     // connection (client and server) and it lives until the program exits.
@@ -242,11 +222,6 @@ public:
 
 private:
     wxTCPConnection* GetConnection(wxSocketBase* socket);
-
-    wxCRIT_SECT_DECLARE_MEMBER(m_cs_assign_buffer);
-
-    char* m_bufferList[MAX_MSG_BUFFERS];
-    int m_nextAvailable;
 
     wxCRIT_SECT_DECLARE_MEMBER(m_cs_connection_sockets);
     std::unordered_set<wxSocketBase*> m_connectionSockets;
@@ -345,15 +320,14 @@ wxTCPEventHandler *wxTCPEventHandlerModule::ms_handler = nullptr;
 class wxIPCMessageBase : public wxObject
 {
 public:
-    wxIPCMessageBase(wxSocketBase* socket = nullptr,
-                     wxTCPEventHandler* handler = nullptr)
-        : m_writeData(nullptr), m_handler(handler)
+    wxIPCMessageBase(wxSocketBase* socket = nullptr)
+        : m_writeData(nullptr)
     {
         Init(socket);
     }
 
     wxIPCMessageBase(wxSocketBase* socket, const void* data)
-        : m_writeData(data), m_handler(nullptr)
+        : m_writeData(data)
     {
         Init(socket);
     }
@@ -376,6 +350,14 @@ public:
 
     const void* GetReadData() const { return m_readData; }
     void SetReadData(void *data) { m_readData = data; }
+
+    // Relinquish ownership of the buffer allocated by ReadSizeAndData() to
+    // the caller, which becomes responsible for delete[]-ing it.
+    char* ReleaseReadData()
+    {
+        m_readData = nullptr;
+        return m_readDataBuf.release();
+    }
 
     size_t GetSize() const { return m_size; }
     void SetSize(size_t size) { m_size = size; }
@@ -562,7 +544,10 @@ protected:
     // pointer to data read from socket
     void* m_readData;
 
-    wxTCPEventHandler *m_handler;
+    // owns the buffer m_readData points to when it was allocated by
+    // ReadSizeAndData(), so that the data read from the socket is freed with
+    // the message unless ReleaseReadData() has passed it on
+    std::unique_ptr<char[]> m_readDataBuf;
 
     friend wxTCPEventHandler;
 
@@ -572,15 +557,15 @@ protected:
 
 // Reads a 32-bit word to get the desired buffer m_size from the socket, allocates
 // a buffer of that size, then read m_size bytes worth of data from the socket
-// into m_readData.
+// into m_readData. The buffer is owned by this message and is freed with it,
+// unless ReleaseReadData() is used to take it over.
 bool wxIPCMessageBase::ReadSizeAndData()
 {
     if (!Read32(m_size))
         return false;
 
-    wxCHECK_MSG( m_handler, false, "No handler for read allocation");
-
-    m_readData = m_handler->GetBufPtr(m_size);
+    m_readDataBuf.reset(new char[m_size]);
+    m_readData = m_readDataBuf.get();
 
     m_socket->Read(m_readData, m_size);
     return VerifyLastReadCount(m_size);
@@ -626,9 +611,8 @@ bool wxIPCMessageBase::WriteString(const wxString& str)
 class wxIPCMessageExecute : public wxIPCMessageBase
 {
 public:
-    wxIPCMessageExecute(wxSocketBase* socket = nullptr,
-                        wxTCPEventHandler* handler = nullptr)
-        : wxIPCMessageBase(socket, handler)
+    wxIPCMessageExecute(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
     {
         SetIPCCode(IPC_EXECUTE);
     }
@@ -695,9 +679,8 @@ protected:
 class wxIPCMessageRequestReply : public wxIPCMessageBase
 {
 public:
-    wxIPCMessageRequestReply(wxSocketBase* socket = nullptr,
-                             wxTCPEventHandler* handler = nullptr)
-        : wxIPCMessageBase(socket, handler)
+    wxIPCMessageRequestReply(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
     {
         SetIPCCode(IPC_REQUEST_REPLY);
     }
@@ -748,9 +731,8 @@ protected:
 class wxIPCMessagePoke : public wxIPCMessageBase
 {
 public:
-    wxIPCMessagePoke(wxSocketBase* socket = nullptr,
-                     wxTCPEventHandler* handler = nullptr)
-        : wxIPCMessageBase(socket, handler)
+    wxIPCMessagePoke(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
     {
         SetIPCCode(IPC_POKE);
     }
@@ -845,9 +827,8 @@ protected:
 class wxIPCMessageAdvise : public wxIPCMessageBase
 {
 public:
-    wxIPCMessageAdvise(wxSocketBase* socket = nullptr,
-                       wxTCPEventHandler* handler = nullptr)
-        : wxIPCMessageBase(socket, handler)
+    wxIPCMessageAdvise(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
     {
         SetIPCCode(IPC_ADVISE);
     }
@@ -1010,6 +991,95 @@ public:
 
     wxIPCMessageBase* m_msg;
 };
+
+namespace
+{
+
+/*
+    Per-thread holder for the last data buffer returned to user code by
+    Request(): wxWidgets docs say the user must not free that pointer, so we
+    keep it alive here until the same thread makes its next Request() call,
+    which replaces (and frees) it. Each thread has its own slot, so requests
+    made concurrently from several threads cannot invalidate each other's
+    returned data.
+
+    See UntranslatedStringHolder in translation.cpp for the explanation of the
+    MinGW thread_local bug requiring the first version of this class: the
+    destructor runs after the object's memory has been deallocated, so the
+    buffers are kept in a global map and the destructor only touches globals.
+ */
+#if defined(__MINGW32__) && \
+    (!defined(__MINGW64_VERSION_MAJOR) || __MINGW64_VERSION_MAJOR < 15)
+
+class IPCRequestBufferHolder
+{
+private:
+    static wxCriticalSection ms_criticalSection;
+    static std::map<wxThreadIdType, char*> ms_buffersMap;
+
+public:
+    IPCRequestBufferHolder() = default;
+
+    const void* assign(char* buf)
+    {
+        wxCriticalSectionLocker locker(ms_criticalSection);
+        char*& slot = ms_buffersMap[wxThread::GetCurrentId()];
+        delete[] slot;
+        slot = buf;
+        return buf;
+    }
+
+    ~IPCRequestBufferHolder()
+    {
+        // This code is run after this object memory has been deallocated so we
+        // cannot access any member variables, but we can access global ones.
+        wxCriticalSectionLocker locker(ms_criticalSection);
+        const auto it = ms_buffersMap.find(wxThread::GetCurrentId());
+        if ( it != ms_buffersMap.end() )
+        {
+            delete[] it->second;
+            ms_buffersMap.erase(it);
+        }
+    }
+
+    wxDECLARE_NO_COPY_CLASS(IPCRequestBufferHolder);
+};
+
+wxCriticalSection IPCRequestBufferHolder::ms_criticalSection;
+
+std::map<wxThreadIdType, char*> IPCRequestBufferHolder::ms_buffersMap;
+
+#else // !__MINGW32__
+
+class IPCRequestBufferHolder
+{
+private:
+    std::unique_ptr<char[]> m_buf;
+
+public:
+    IPCRequestBufferHolder() = default;
+
+    const void* assign(char* buf)
+    {
+        m_buf.reset(buf);
+        return buf;
+    }
+
+    wxDECLARE_NO_COPY_CLASS(IPCRequestBufferHolder);
+};
+
+#endif // __MINGW32__/!__MINGW32__
+
+// Transfer ownership of the message's read buffer to the calling thread and
+// return it: the buffer stays valid until the next call to this function on
+// the same thread, or until the thread ends.
+const void* TakeReadDataForThisThread(wxIPCMessageBase* msg)
+{
+    thread_local IPCRequestBufferHolder wxPerThreadIPCBuffer;
+    return wxPerThreadIPCBuffer.assign(msg->ReleaseReadData());
+}
+
+} // anonymous namespace
 
 // ==========================================================================
 // implementation
@@ -1333,7 +1403,10 @@ const void *wxTCPConnection::Request(const wxString& item,
     if (size)
       *size = msg_reply->GetSize();
 
-    return msg_reply->GetReadData();
+    // The reply message is deleted when this function returns, so hand its
+    // buffer over to the calling thread, which keeps it valid until the next
+    // Request() on this thread.
+    return TakeReadDataForThisThread(msg_reply);
 }
 
 bool wxTCPConnection::DoPoke(const wxString& item,
@@ -1925,25 +1998,25 @@ wxIPCMessageBase* wxTCPEventHandler::GetIPCMessageFromCode(IPCCode code, wxSocke
     switch ( code )
     {
     case IPC_EXECUTE:
-        return new wxIPCMessageExecute(socket, this);
+        return new wxIPCMessageExecute(socket);
 
     case IPC_REQUEST:
         return new wxIPCMessageRequest(socket);
 
     case IPC_POKE:
-        return new wxIPCMessagePoke(socket, this);
+        return new wxIPCMessagePoke(socket);
 
     case IPC_ADVISE_START:
         return new wxIPCMessageAdviseStart(socket);
 
     case IPC_ADVISE:
-        return new wxIPCMessageAdvise(socket, this);
+        return new wxIPCMessageAdvise(socket);
 
     case IPC_ADVISE_STOP:
         return new wxIPCMessageAdviseStop(socket);
 
     case IPC_REQUEST_REPLY:
-        return new wxIPCMessageRequestReply(socket, this);
+        return new wxIPCMessageRequestReply(socket);
 
     case IPC_FAIL:
         return new wxIPCMessageFail(socket);
@@ -2050,21 +2123,6 @@ bool wxTCPEventHandler::PeekAtMessageInSocket(wxSocketBase* socket)
     });
 
     return enough;
-}
-
-char* wxTCPEventHandler::GetBufPtr(size_t size)
-{
-    wxCRIT_SECT_LOCKER(lock, m_cs_assign_buffer);
-
-    if (m_bufferList[m_nextAvailable] != nullptr)
-        delete[] m_bufferList[m_nextAvailable];  // Free the memory from the last use
-
-    char* ptr = new char[size];
-
-    m_bufferList[m_nextAvailable] = ptr;
-    m_nextAvailable = (m_nextAvailable + 1) % MAX_MSG_BUFFERS;
-
-    return ptr;
 }
 
 wxTCPConnection* wxTCPEventHandler::GetConnection(wxSocketBase* socket)

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1071,30 +1071,26 @@ wxConnectionBase *wxTCPClient::MakeConnection(const wxString& host,
         // OK! Confirmation.
         if ( msg_reply->GetIPCCode() == IPC_CONNECT )
         {
-            wxTCPConnection *
-                connection = (wxTCPConnection *)OnMakeConnection ();
+            auto* const connectionBase = OnMakeConnection ();
 
-            if ( connection )
+            if (auto* const connection = wxDynamicCast(connectionBase, wxTCPConnection))
             {
-                if (wxDynamicCast(connection, wxTCPConnection))
-                {
-                    connection->m_sock = client;
-                    connection->m_sock->SetTimeout(wxIPCTimeout);
-                    connection->m_handler = handler;
-                    connection->m_topic = topic;
+                connection->m_sock = client;
+                connection->m_sock->SetTimeout(wxIPCTimeout);
+                connection->m_handler = handler;
+                connection->m_topic = topic;
 
-                    client->SetEventHandler(*handler, _SOCKET_INPUT_ID);
-                    client->SetClientData(connection);
-                    handler->RegisterConnectionSocket(client);
-                    client->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
-                    client->Notify(true);
-                    return connection;
-                }
-                else
-                {
-                    delete connection;
-                    // and fall through to delete everything else
-                }
+                client->SetEventHandler(*handler, _SOCKET_INPUT_ID);
+                client->SetClientData(connection);
+                handler->RegisterConnectionSocket(client);
+                client->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
+                client->Notify(true);
+                return connection;
+            }
+            else
+            {
+                delete connection;
+                // and fall through to delete everything else
             }
         }
         else if ( msg_reply->GetIPCCode() == IPC_FAIL )
@@ -1463,35 +1459,31 @@ void wxTCPEventHandler::OnSocketConnection(wxSocketEvent &event)
             {
                 wxString topic = msg_conn->GetTopic();
 
-                wxTCPConnection *new_connection =
-                    (wxTCPConnection *) ipcserv->OnAcceptConnection(topic);
+                auto* const connectionBase = ipcserv->OnAcceptConnection(topic);
 
-                if ( new_connection )
+                if ( auto* const new_connection = wxDynamicCast(connectionBase, wxTCPConnection) )
                 {
-                    if ( wxDynamicCast(new_connection, wxTCPConnection) )
+                    // Acknowledge success
+                    wxIPCMessageConnect msg_reply(sock, topic);
+
+                    if ( WriteMessageToSocket(msg_reply) )
                     {
-                        // Acknowledge success
-                        wxIPCMessageConnect msg_reply(sock, topic);
+                        new_connection->m_topic = topic;
+                        new_connection->m_sock = sock;
+                        new_connection->m_handler = &wxTCPEventHandlerModule::GetHandler();
 
-                        if ( WriteMessageToSocket(msg_reply) )
-                        {
-                            new_connection->m_topic = topic;
-                            new_connection->m_sock = sock;
-                            new_connection->m_handler = &wxTCPEventHandlerModule::GetHandler();
-
-                            sock->SetTimeout(wxIPCTimeout);
-                            sock->SetEventHandler(wxTCPEventHandlerModule::GetHandler(),
-                                                  _SOCKET_INPUT_ID);
-                            sock->SetClientData(new_connection);
-                            RegisterConnectionSocket(sock);
-                            sock->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
-                            sock->Notify(true);
-                            return;
-                        }
+                        sock->SetTimeout(wxIPCTimeout);
+                        sock->SetEventHandler(wxTCPEventHandlerModule::GetHandler(),
+                                              _SOCKET_INPUT_ID);
+                        sock->SetClientData(new_connection);
+                        RegisterConnectionSocket(sock);
+                        sock->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
+                        sock->Notify(true);
+                        return;
                     }
-
-                    delete new_connection;
                 }
+
+                delete connectionBase;
             }
         }
     }

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -176,6 +176,8 @@ public:
 
     char* GetBufPtr(size_t size);
 
+    wxCRIT_SECT_DECLARE_MEMBER(m_cs_process_msgs);
+
 private:
     wxTCPConnection* GetConnection(wxSocketBase* socket);
 
@@ -1205,20 +1207,29 @@ const void *wxTCPConnection::Request(const wxString& item,
                                      size_t *size,
                                      wxIPCFormat format)
 {
-    if ( !m_sock->IsConnected() )
+    if ( !m_handler )
         return nullptr;
 
-    IPCOutput(m_streams).Write(IPC_REQUEST, item, format);
+    // Don't let ProcessIncomingMessages interfere with getting a response
+    wxCRIT_SECT_LOCKER(lock, m_handler->m_cs_process_msgs);
 
-    const int ret = m_streams->Read8();
-    if ( ret != IPC_REQUEST_REPLY )
+    wxIPCMessageRequest msg(m_sock, item, format);
+    if ( !m_handler->WriteMessageToSocket(msg) )
         return nullptr;
 
-    // ReadData() needs a non-null size pointer but the client code can call us
-    // with null pointer (this makes sense if it knows that it always works
-    // with NUL-terminated strings)
-    size_t sizeFallback;
-    return m_streams->ReadData(this, size ? size : &sizeFallback);
+    wxIPCMessageBase* msg_reply = nullptr;
+
+    if ( !m_handler->FindMessage(IPC_REQUEST_REPLY, m_sock, &msg_reply) )
+        return nullptr;
+
+    wxIPCMessageBaseLocker lockmsg(msg_reply);
+    if ( !msg_reply || !msg_reply->IsOk() )
+        return nullptr;
+
+    if (size)
+        *size = msg_reply->GetSize();
+
+    return msg_reply->GetReadData();
 }
 
 bool wxTCPConnection::DoPoke(const wxString& item,

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -101,6 +101,14 @@ constexpr wxUint32 IPCCodeHeader = 0x439d9600;
     #include <sys/stat.h>
 #endif // __UNIX_LIKE__
 
+// headers needed for IPPROTO_TCP and TCP_NODELAY, used by DisableNagle()
+#ifdef __WINDOWS__
+    #include "wx/msw/wrapwin.h"
+#else
+    #include <netinet/in.h>
+    #include <netinet/tcp.h>
+#endif
+
 constexpr auto wxNO_RETURN_MESSAGE = nullptr;
 
 constexpr long wxIPCTimeout = 5; // socket timeout, in seconds
@@ -109,6 +117,18 @@ constexpr long wxIPCTimeout = 5; // socket timeout, in seconds
 // ----------------------------------------------------------------------------
 // private functions
 // ----------------------------------------------------------------------------
+
+// Disable Nagle's algorithm on a connection socket. IPC messages are small
+// and each one is sent as more than one short write (the code word, then the
+// payload), so with Nagle enabled every request/reply round trip stalls for
+// a delayed-ACK period (tens of milliseconds), even on loopback. The call
+// fails harmlessly on sockets where the option does not apply, such as the
+// Unix domain sockets used when the server name is a path.
+static void DisableNagle(wxSocketBase* socket)
+{
+    int nodelay = 1;
+    socket->SetOption(IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+}
 
 // get the address object for the given server name, the caller must delete it
 static std::unique_ptr<wxSockAddress>
@@ -1164,6 +1184,8 @@ wxConnectionBase *wxTCPClient::MakeConnection(const wxString& host,
 
     if ( ok )
     {
+        DisableNagle(client);
+
         wxTCPEventHandler* handler = &wxTCPEventHandlerModule::GetHandler();
 
         // Send topic name, and enquire whether this has succeeded
@@ -1552,6 +1574,8 @@ void wxTCPEventHandler::OnSocketConnection(wxSocketEvent &event)
         sock->Destroy();
         return;
     }
+
+    DisableNagle(sock);
 
     wxIPCMessageBase* msg = ReadMessageFromSocket(sock);
     wxIPCMessageBaseLocker lock(msg);

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -130,7 +130,11 @@ GetAddressFromName(const wxString& serverName,
         auto addr = std::make_unique<wxUNIXaddress>();
         addr->Filename(serverName);
 
-        return addr;
+        // The explicit conversion is needed by g++ 4.8, which can't
+        // implicitly move a returned local to the base class pointer, while
+        // "return std::move(addr)" triggers -Wredundant-move in C++20 mode
+        // with newer compilers.
+        return std::unique_ptr<wxSockAddress>(std::move(addr));
     }
 #endif // Unix/!Unix
 
@@ -141,7 +145,8 @@ GetAddressFromName(const wxString& serverName,
         addr->Hostname(host);
     }
 
-    return addr;
+    // See above.
+    return std::unique_ptr<wxSockAddress>(std::move(addr));
 }
 
 // --------------------------------------------------------------------------

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1237,15 +1237,43 @@ wxBEGIN_EVENT_TABLE(wxTCPEventHandler, wxEvtHandler)
 wxEND_EVENT_TABLE()
 
 void wxTCPEventHandler::HandleDisconnect(wxTCPConnection *connection)
+void wxTCPEventHandler::Client_OnRequest(wxSocketEvent &event)
 {
     // connection was closed (either gracefully or not): destroy everything
     connection->m_sock->Notify(false);
     connection->m_sock->Close();
+    wxSocketBase *sock = event.GetSocket();
+    wxTCPConnection * connection = GetConnection(sock);
 
     // don't leave references to this soon-to-be-dangling connection in the
     // socket as it won't be destroyed immediately as its destruction will be
     // delayed in case there are more events pending for it
     connection->m_sock->SetClientData(nullptr);
+    // This socket is being deleted
+    if ( !connection )
+        return;
+
+    if ( event.GetSocketEvent() == wxSOCKET_LOST )
+    {
+        HandleDisconnect(connection);
+        return;
+    }
+
+    // Process incoming messages. Block any IPC command that uses
+    // FindMessage until this method finishes.
+    wxCRIT_SECT_LOCKER(lock, m_cs_process_msgs);
+
+    // More than one wxIPCMessage can be sent to the socket before the socket
+    // notifies us of another read event, so loop until there are no new
+    // messages.
+    while ( PeekAtMessageInSocket(sock) )
+    {
+        wxIPCMessageBase* msg = ReadMessageFromSocket(sock);
+        wxIPCMessageBaseLocker lock_msg(msg);
+
+        if ( !ExecuteMessage(msg, sock) )
+            break;
+    };
 
     connection->SetConnected(false);
     connection->OnDisconnect();

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -245,6 +245,15 @@ private:
     wxCRIT_SECT_DECLARE_MEMBER(m_cs_connection_sockets);
     std::set<wxSocketBase*> m_connectionSockets;
 
+    // Sockets the main thread is currently reading. A WAITALL Read/Peek pumps the
+    // event loop while it waits, so on MSW the GUI message pump can re-dispatch a
+    // wxSOCKET_INPUT for a socket we are already reading; OnSocketInput() consults
+    // this set and bails to avoid a re-entrant read (which trips wxSocketReadGuard,
+    // "read reentrancy?"). All reads run on the main thread, so this needs no lock.
+    std::set<wxSocketBase*> m_socketsBeingRead;
+    bool IsReadingSocket(wxSocketBase* socket) const
+        { return m_socketsBeingRead.count(socket) != 0; }
+
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxTCPEventHandler);
 };
@@ -254,6 +263,27 @@ enum
     _SOCKET_INPUT_ID = 1000,
     _SERVER_SOCKET_CONNECTION_ID
 };
+
+namespace
+{
+
+// RAII marker recording that the main thread is reading a given socket, so a
+// re-entrant OnSocketInput() (dispatched while a WAITALL Read/Peek pumps the
+// event loop) can detect it and bail instead of re-reading the same socket.
+class MainThreadReadGuard
+{
+public:
+    MainThreadReadGuard(std::set<wxSocketBase*>& set, wxSocketBase* socket)
+        : m_set(set), m_socket(socket) { m_set.insert(m_socket); }
+    ~MainThreadReadGuard() { m_set.erase(m_socket); }
+
+private:
+    std::set<wxSocketBase*>& m_set;
+    wxSocketBase* const m_socket;
+    wxDECLARE_NO_COPY_CLASS(MainThreadReadGuard);
+};
+
+} // anonymous namespace
 
 // --------------------------------------------------------------------------
 // wxTCPEventHandlerModule (private class)
@@ -1362,6 +1392,15 @@ void wxTCPEventHandler::OnSocketInput(wxSocketEvent &event)
     if ( !IsConnectionSocket(sock) )
         return;
 
+    // Re-entrancy guard (see m_socketsBeingRead): the WAITALL Read/Peek below pumps
+    // the event loop while waiting, and on MSW the GUI message pump can re-dispatch
+    // a wxSOCKET_INPUT for a socket this thread is already reading. Bail rather than
+    // re-read it (which trips wxSocketReadGuard, "read reentrancy?"): the in-progress
+    // read consumes the data, and the outer loop / a re-posted wxSOCKET_INPUT drains
+    // anything left.
+    if ( IsReadingSocket(sock) )
+        return;
+
     wxTCPConnection * connection = GetConnection(sock);
 
     // This socket is being deleted
@@ -1379,6 +1418,7 @@ void wxTCPEventHandler::OnSocketInput(wxSocketEvent &event)
     }
 
     // Process all of the pending messages in the socket buffer.
+    MainThreadReadGuard readGuard(m_socketsBeingRead, sock);
     while ( PeekAtMessageInSocket(sock) )
     {
         wxIPCMessageBase* msg = ReadMessageFromSocket(sock);
@@ -1754,6 +1794,11 @@ bool wxTCPEventHandler::SendAndGetReply_MainThread(wxIPCMessageBase& send_msg,
     CritSectLeaver find_message_lock(m_cs_awaiting_reply);
 
     wxCRIT_SECT_LOCKER(socket_processing_lock, m_cs_socket_processing);
+
+    // Mark the socket as being read on this thread so a wxSOCKET_INPUT re-dispatched
+    // while our Read/Write below pumps the event loop bails out of OnSocketInput()
+    // instead of re-reading the socket (see m_socketsBeingRead).
+    MainThreadReadGuard readGuard(m_socketsBeingRead, socket);
 
     if ( !WriteMessageToSocket(send_msg) )
         return false;

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -50,8 +50,7 @@ class wxIPCMessageBase;
 // Global variables
 // --------------------------------------------------------------------------
 
-wxCRIT_SECT_DECLARE_MEMBER(gs_critical_read);
-wxCRIT_SECT_DECLARE_MEMBER(gs_critical_write);
+wxCRIT_SECT_DECLARE_MEMBER(gs_critical_io);
 
 // --------------------------------------------------------------------------
 // macros and constants
@@ -1614,15 +1613,17 @@ bool wxTCPEventHandler::FindMessage(IPCCode code,
             // The correct message has been found, but there may still be
             // messages waiting in the socket data buffer. Place an event in
             // the socket event queue so that they will be read out later.
-
-            if (socket && socket->GetEventHandler())
+            if ( PeekAtMessageInSocket(socket) )
             {
-                wxSocketEvent event(wxID_ANY);
-                event.m_event = wxSOCKET_INPUT;
-                event.m_clientData = socket->GetClientData();
-                event.SetEventObject(socket);
+                if (socket && socket->GetEventHandler())
+                {
+                    wxSocketEvent event(wxID_ANY);
+                    event.m_event = wxSOCKET_INPUT;
+                    event.m_clientData = socket->GetClientData();
+                    event.SetEventObject(socket);
 
-                socket->GetEventHandler()->AddPendingEvent(event);
+                    socket->GetEventHandler()->AddPendingEvent(event);
+                }
             }
 
             if (return_msgptr)
@@ -1669,9 +1670,9 @@ void wxTCPEventHandler::HandleDisconnect(wxTCPConnection *connection)
 // message was read.  The returned message must be freed by the caller.
 wxIPCMessageBase* wxTCPEventHandler::ReadMessageFromSocket(wxSocketBase* socket)
 {
-    // ensure that we read from the socket without any read call from another
-    // thread
-    wxCRIT_SECT_LOCKER(lock, gs_critical_read);
+    // Serialize all socket I/O: wxSocketBase is not safe for concurrent use
+    // from multiple threads on the same connection.
+    wxCRIT_SECT_LOCKER(lock, gs_critical_io);
 
     wxIPCMessageNull* null_msg = new wxIPCMessageNull(socket);
     if ( !null_msg->ReadIPCCode() )
@@ -1742,9 +1743,9 @@ wxIPCMessageBase* wxTCPEventHandler::ReadMessageFromSocket(wxSocketBase* socket)
 // Writes this message object to the socket.
 bool wxTCPEventHandler::WriteMessageToSocket(wxIPCMessageBase& msg)
 {
-    // ensure that we write to the socket without any write call from another
-    // thread
-    wxCRIT_SECT_LOCKER(lock, gs_critical_write);
+    // Serialize all socket I/O: wxSocketBase is not safe for concurrent use
+    // from multiple threads on the same connection.
+    wxCRIT_SECT_LOCKER(lock, gs_critical_io);
 
     return msg.WriteIPCCode() && msg.DataToSocket();
 };
@@ -1754,7 +1755,9 @@ bool wxTCPEventHandler::WriteMessageToSocket(wxIPCMessageBase& msg)
 // IPCCode.
 bool wxTCPEventHandler::PeekAtMessageInSocket(wxSocketBase* socket)
 {
-    wxCRIT_SECT_LOCKER(lock, gs_critical_read);
+    // Serialize all socket I/O: wxSocketBase is not safe for concurrent use
+    // from multiple threads on the same connection.
+    wxCRIT_SECT_LOCKER(lock, gs_critical_io);
 
     if ( !socket || !socket->IsOk() )
         return false;

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -133,16 +133,15 @@ GetAddressFromName(const wxString& serverName,
         return addr;
     }
 #endif // Unix/!Unix
-    {
-        auto addr = std::make_unique<wxIPV4address>();
-        addr->Service(serverName);
-        if ( !host.empty() )
-        {
-            addr->Hostname(host);
-        }
 
-        return addr;
+    auto addr = std::make_unique<wxIPV4address>();
+    addr->Service(serverName);
+    if ( !host.empty() )
+    {
+        addr->Hostname(host);
     }
+
+    return addr;
 }
 
 // --------------------------------------------------------------------------

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -88,7 +88,7 @@ enum IPCCode
 // A random header, which is used to detect a loss-of-sync on the IPC
 // data stream. The header is 24-bits, and the IPCCode above is sent in the
 // last 8 bits.
-const wxUint32 IPCCodeHeader=0x439d9600;
+constexpr wxUint32 IPCCodeHeader = 0x439d9600;
 
 } // anonymous namespace
 
@@ -98,16 +98,16 @@ const wxUint32 IPCCodeHeader=0x439d9600;
     #include <sys/stat.h>
 #endif // __UNIX_LIKE__
 
-#define wxNO_RETURN_MESSAGE nullptr
+constexpr auto wxNO_RETURN_MESSAGE = nullptr;
 
-const long wxIPCTimeout = 10; // socket timeout, in seconds
+constexpr long wxIPCTimeout = 10; // socket timeout, in seconds
 
 
 // For IPC returning a char* buffer. wxWidgets docs say that the user is not
 // supposed to free the memory.  Each buffer pointer is assigned to a list
 // sequentially, and the buffer memory is not freed until MAX_MSG_BUFFERS have
 // been assigned.
-#define MAX_MSG_BUFFERS 2048
+constexpr int MAX_MSG_BUFFERS = 2048;
 
 
 // ----------------------------------------------------------------------------
@@ -152,17 +152,16 @@ class wxTCPEventHandler : public wxEvtHandler
 public:
     wxTCPEventHandler() : wxEvtHandler()
     {
-        for (int i = 0; i < MAX_MSG_BUFFERS; i++)
-            m_bufferList[i] = nullptr;
+        for ( auto& buf : m_bufferList )
+            buf = nullptr;
 
         m_nextAvailable = 0;
     }
 
     ~wxTCPEventHandler()
     {
-        for (int i = 0; i < MAX_MSG_BUFFERS; i++)
-            if (m_bufferList[i])
-                delete[] m_bufferList[i];
+        for ( auto& buf : m_bufferList )
+            delete[] buf;
     }
 
     void OnSocketInput(wxSocketEvent& event);

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -43,8 +43,10 @@
 #include <errno.h>
 
 #include <set>
+#include <functional>
 
 #include "wx/socket.h"
+#include "wx/thread.h"
 
 class wxIPCMessageBase;
 
@@ -160,13 +162,22 @@ public:
                 delete[] m_bufferList[i];
     }
 
-    void Client_OnRequest(wxSocketEvent& event);
-    void Server_OnRequest(wxSocketEvent& event);
+    void OnSocketInput(wxSocketEvent& event);
+    void OnSocketConnection(wxSocketEvent& event);
 
-    bool ExecuteMessage(wxIPCMessageBase* msg, wxSocketBase *socket);
-    bool FindMessage(IPCCode code,
-                     wxSocketBase* socket,
-                     wxIPCMessageBase** msgptr);
+    bool ProcessMessage(wxIPCMessageBase* msg, wxSocketBase *socket);
+
+    bool SendAndGetReply(wxIPCMessageBase& send_msg,
+                         IPCCode expected_code,
+                         wxSocketBase* socket,
+                         wxIPCMessageBase** return_msgptr);
+    bool SendAndGetReply_MainThread(wxIPCMessageBase& send_msg,
+                                    IPCCode expected_code,
+                                    wxSocketBase* socket,
+                                    wxIPCMessageBase** return_msgptr);
+    bool SendAndGetReply_WorkerThread(wxIPCMessageBase& send_msg,
+                                      IPCCode expected_code,
+                                      wxIPCMessageBase** return_msgptr);
 
     void SendFailMessage(const wxString& reason, wxSocketBase* socket);
     void HandleDisconnect(wxTCPConnection *connection);
@@ -177,20 +188,49 @@ public:
 
     char* GetBufPtr(size_t size);
 
-    // This event handler is a process-wide singleton shared by every IPC
+    // This event handler is a single process-wide object shared by every IPC
     // connection (client and server) and it lives until the program exits.
     // Socket events are queued on it and may still be pending after the socket
-    // they refer to has been destroyed: dispatching such a stale event would
-    // dereference a dangling wxSocketBase pointer. To guard against this we
-    // keep the set of sockets that currently have a live connection and ignore
-    // events for any socket which is not in it. The check compares only
-    // pointer values, so it is safe even if the socket has already been freed.
+    // they refer to has been destroyed: Dispatching a stale event would
+    // dereference a dangling wxSocketBase pointer. To guard against this we keep
+    // the set of sockets that currently have a live connection and ignore events
+    // for any socket which is not in it. The check compares only pointer values,
+    // so it is safe even if the socket has already been freed.
     void RegisterConnectionSocket(wxSocketBase* socket);
     void UnregisterConnectionSocket(wxSocketBase* socket);
     bool IsConnectionSocket(wxSocketBase* socket);
 
-    wxCRIT_SECT_DECLARE_MEMBER(m_cs_process_msgs);
+    wxCRIT_SECT_DECLARE_MEMBER(m_cs_socket_processing);
 
+    // Runs fn on the main thread, blocking the caller until completion (on the
+    // main thread fn runs directly). All IPC socket I/O must happen on the main
+    // thread: the wxFDIODispatcher used by the main event loop in Unix+Mac is not
+    // safe to mutate from worker threads, so worker-thread socket usage is
+    // funneled through this method.
+    void RunOnMainThread(const std::function<void()>& fn);
+
+    // The handoff objects between a worker thread blocked in SendAndGetReply()
+    // and the main thread's OnSocketInput(). Only one reply is ever pending at a
+    // time, which is guaranteed by m_cs_awaiting_reply.
+    wxMutex m_replyMutex;
+    wxCondition m_replyCond{m_replyMutex};
+    struct PendingReply
+    {
+        bool              active   = false;
+        IPCCode           expected = IPC_NULL;
+        wxIPCMessageBase* reply    = nullptr;
+        bool              done     = false;
+        bool              failed   = false;
+    } m_pending;
+
+    wxCRIT_SECT_DECLARE_MEMBER(m_cs_awaiting_reply);
+
+    bool DeliverPendingReply(wxIPCMessageBase* msg);
+    void FailPendingReply();
+
+    wxIPCMessageBase* GetIPCMessageFromCode(IPCCode code, wxSocketBase* socket);
+
+    void PostSocketInputEvent(wxSocketBase* socket);
 private:
     wxTCPConnection* GetConnection(wxSocketBase* socket);
 
@@ -208,8 +248,8 @@ private:
 
 enum
 {
-    _CLIENT_ONREQUEST_ID = 1000,
-    _SERVER_ONREQUEST_ID
+    _SOCKET_INPUT_ID = 1000,
+    _SERVER_SOCKET_CONNECTION_ID
 };
 
 // --------------------------------------------------------------------------
@@ -479,8 +519,9 @@ protected:
     wxDECLARE_CLASS(wxIPCMessageBase);
 };
 
-// Reads a 32-bit size from the socket, allocates a buffer of that size, then
-// read nbytes worth of data from the socket into m_read_data.
+// Reads a 32-bit word to get the desired buffer m_size from the socket, allocates
+// a buffer of that size, then read m_size bytes worth of data from the socket
+// into m_read_data.
 bool wxIPCMessageBase::ReadSizeAndData()
 {
     if (!Read32(m_size))
@@ -803,7 +844,7 @@ protected:
     wxDECLARE_DYNAMIC_CLASS(wxIPCMessageAdvise);
 };
 
-// Member var item to be used for failure reason (for debug)
+// m_item to be used for failure reason (for debug)
 class wxIPCMessageFail : public wxIPCMessageBase
 {
 public:
@@ -1018,7 +1059,7 @@ wxConnectionBase *wxTCPClient::MakeConnection(const wxString& host,
                     connection->m_handler = handler;
                     connection->m_topic = topic;
 
-                    client->SetEventHandler(*handler, _CLIENT_ONREQUEST_ID);
+                    client->SetEventHandler(*handler, _SOCKET_INPUT_ID);
                     client->SetClientData(connection);
                     handler->RegisterConnectionSocket(client);
                     client->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
@@ -1128,7 +1169,7 @@ bool wxTCPServer::Create(const wxString& serverName)
     }
 
     m_server->SetEventHandler(wxTCPEventHandlerModule::GetHandler(),
-                              _SERVER_ONREQUEST_ID);
+                              _SERVER_SOCKET_CONNECTION_ID);
     m_server->SetClientData(this);
     m_server->SetNotify(wxSOCKET_CONNECTION_FLAG);
     m_server->Notify(true);
@@ -1229,16 +1270,10 @@ const void *wxTCPConnection::Request(const wxString& item,
     if ( !m_handler )
         return nullptr;
 
-    // Don't let ProcessIncomingMessages interfere with getting a response
-    wxCRIT_SECT_LOCKER(lock, m_handler->m_cs_process_msgs);
-
     wxIPCMessageRequest msg(m_sock, item, format);
-    if ( !m_handler->WriteMessageToSocket(msg) )
-        return nullptr;
-
     wxIPCMessageBase* msg_reply = nullptr;
 
-    if ( !m_handler->FindMessage(IPC_REQUEST_REPLY, m_sock, &msg_reply) )
+    if ( !m_handler->SendAndGetReply(msg, IPC_REQUEST_REPLY, m_sock, &msg_reply) )
         return nullptr;
 
     wxIPCMessageBaseLocker lockmsg(msg_reply);
@@ -1246,7 +1281,7 @@ const void *wxTCPConnection::Request(const wxString& item,
         return nullptr;
 
     if (size)
-        *size = msg_reply->GetSize();
+      *size = msg_reply->GetSize();
 
     return msg_reply->GetReadData();
 }
@@ -1268,14 +1303,8 @@ bool wxTCPConnection::StartAdvise(const wxString& item)
     if ( !m_handler )
         return false;
 
-    // Don't let ProcessIncomingMessages interfere with getting a response
-    wxCRIT_SECT_LOCKER(lock, m_handler->m_cs_process_msgs);
-
     wxIPCMessageAdviseStart msg(m_sock, item);
-    if ( !m_handler->WriteMessageToSocket(msg) )
-        return false;
-
-    return m_handler->FindMessage(IPC_ADVISE_START, m_sock, wxNO_RETURN_MESSAGE);
+    return m_handler->SendAndGetReply(msg, IPC_ADVISE_START, m_sock, wxNO_RETURN_MESSAGE);
 }
 
 bool wxTCPConnection::StopAdvise (const wxString& item)
@@ -1283,18 +1312,12 @@ bool wxTCPConnection::StopAdvise (const wxString& item)
     if ( !m_handler )
         return false;
 
-    // Don't let ProcessIncomingMessages interfere with getting a response
-    wxCRIT_SECT_LOCKER(lock, m_handler->m_cs_process_msgs);
-
     wxIPCMessageAdviseStop msg(m_sock, item);
-    if ( !m_handler->WriteMessageToSocket(msg) )
-        return false;
-
-    return m_handler->FindMessage(IPC_ADVISE_STOP, m_sock, wxNO_RETURN_MESSAGE);
+    return m_handler->SendAndGetReply(msg, IPC_ADVISE_STOP, m_sock, wxNO_RETURN_MESSAGE);
 }
 
 
-// Calls that SERVER can make
+// Calls that Server can make
 bool wxTCPConnection::DoAdvise(const wxString& item,
                                const void *data,
                                size_t size,
@@ -1312,22 +1335,25 @@ bool wxTCPConnection::DoAdvise(const wxString& item,
 // --------------------------------------------------------------------------
 
 wxBEGIN_EVENT_TABLE(wxTCPEventHandler, wxEvtHandler)
-    EVT_SOCKET(_CLIENT_ONREQUEST_ID, wxTCPEventHandler::Client_OnRequest)
-    EVT_SOCKET(_SERVER_ONREQUEST_ID, wxTCPEventHandler::Server_OnRequest)
+    EVT_SOCKET(_SOCKET_INPUT_ID, wxTCPEventHandler::OnSocketInput)
+    EVT_SOCKET(_SERVER_SOCKET_CONNECTION_ID, wxTCPEventHandler::OnSocketConnection)
 wxEND_EVENT_TABLE()
 
-void wxTCPEventHandler::Client_OnRequest(wxSocketEvent &event)
+// Function that gets called when wxSocket receives info. It always
+// runs on wxThread::Main
+void wxTCPEventHandler::OnSocketInput(wxSocketEvent &event)
 {
-    // This handler is a shared, process-lifetime singleton, so it may receive
-    // a socket event that was queued before its socket was destroyed (e.g. a
-    // wxSOCKET_LOST generated as a connection is being torn down). Such an
-    // event must be ignored without touching the socket, as it now points to
-    // freed memory. Even obtaining the typed pointer via GetSocket() performs a
-    // checked downcast (wxObject* -> wxSocketBase*), which is undefined behavior
-    // on a freed object and trips UBSAN's vptr check, so use reinterpret_cast
-    // (not vptr-instrumented) purely for the registry pointer-value lookup
-    // below. IsConnectionSocket() only compares the pointer value and never
-    // dereferences it, so it is safe to call here.
+    wxCRIT_SECT_LOCKER(socket_processing_lock, m_cs_socket_processing);
+
+    // The handler may receive a socket event that was queued before its socket
+    // was destroyed (e.g. a wxSOCKET_LOST generated as a connection is being torn
+    // down). Such an event must be ignored without dereferencing the socket,
+    // since it now points to freed memory. Even obtaining the typed pointer via
+    // GetSocket() performs a checked downcast (wxObject* -> wxSocketBase*), which
+    // is undefined behavior on a freed object and trips UBSAN's vptr check, so
+    // use reinterpret_cast (not vptr-instrumented) purely for the registry
+    // pointer-value lookup below. IsConnectionSocket() only compares the pointer
+    // value and never dereferences it, so it is safe to call here.
     wxSocketBase *sock =
         reinterpret_cast<wxSocketBase *>(event.GetEventObject());
     if ( !IsConnectionSocket(sock) )
@@ -1337,35 +1363,39 @@ void wxTCPEventHandler::Client_OnRequest(wxSocketEvent &event)
 
     // This socket is being deleted
     if ( !connection )
+    {
+        FailPendingReply();
         return;
+    }
 
     if ( event.GetSocketEvent() == wxSOCKET_LOST )
     {
+        FailPendingReply();
         HandleDisconnect(connection);
         return;
     }
 
-    // Process incoming messages. Block any IPC command that uses
-    // FindMessage until this method finishes.
-    wxCRIT_SECT_LOCKER(lock, m_cs_process_msgs);
-
-    // More than one wxIPCMessage can be sent to the socket before the socket
-    // notifies us of another read event, so loop until there are no new
-    // messages.
+    // Process all of the pending messages in the socket buffer.
     while ( PeekAtMessageInSocket(sock) )
     {
         wxIPCMessageBase* msg = ReadMessageFromSocket(sock);
+
+        // If a worker thread is blocked waiting for this reply, hand it over.
+        if ( DeliverPendingReply(msg) )
+            continue;   // msg ownership handed to the waiting worker
+
         wxIPCMessageBaseLocker lock_msg(msg);
-
-        if ( !ExecuteMessage(msg, sock) )
+        if ( !ProcessMessage(msg, sock) )
+        {
+            FailPendingReply();
             break;
+        }
     };
-
 }
 
-
-// This method is called for incoming connections to wxServer only.
-void wxTCPEventHandler::Server_OnRequest(wxSocketEvent &event)
+// Process a wxSOCKET_CONNECTION event for wxServer. It always runs on
+// wxThread::Main
+void wxTCPEventHandler::OnSocketConnection(wxSocketEvent &event)
 {
     wxSocketServer *server = (wxSocketServer *) event.GetSocket();
     if (!server)
@@ -1421,7 +1451,7 @@ void wxTCPEventHandler::Server_OnRequest(wxSocketEvent &event)
 
                             sock->SetTimeout(wxIPCTimeout);
                             sock->SetEventHandler(wxTCPEventHandlerModule::GetHandler(),
-                                                  _CLIENT_ONREQUEST_ID);
+                                                  _SOCKET_INPUT_ID);
                             sock->SetClientData(new_connection);
                             RegisterConnectionSocket(sock);
                             sock->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
@@ -1443,7 +1473,7 @@ void wxTCPEventHandler::Server_OnRequest(wxSocketEvent &event)
 // Process a single wxIPCMessage from the socket. Returns true if processing
 // can continue, or false if processing should stop, usually because a
 // disconnect was received.
-bool wxTCPEventHandler::ExecuteMessage(wxIPCMessageBase* msg, wxSocketBase *socket)
+bool wxTCPEventHandler::ProcessMessage(wxIPCMessageBase* msg, wxSocketBase *socket)
 {
     if ( !msg || !msg->IsOk() )
         return false;
@@ -1631,39 +1661,69 @@ bool wxTCPEventHandler::ExecuteMessage(wxIPCMessageBase* msg, wxSocketBase *sock
     return true;
 }
 
-// Find a message with IPCCode code. Returns true when a valid message with
-// the matching IPCCode is found.  If msgptr is non-null, then the message is
-// also returned and the caller is responsible for deleting the returned
-// message.
-bool wxTCPEventHandler::FindMessage(IPCCode code,
-                                    wxSocketBase* socket,
-                                    wxIPCMessageBase** return_msgptr)
+//Runs fn on the main thread, blocking the caller until completion. On the
+// main thread, fn runs directly.
+void wxTCPEventHandler::RunOnMainThread(const std::function<void()>& fn)
 {
+    if ( wxThread::IsMain() )
+    {
+        fn();
+        return;
+    }
+
+    // Marshal to the main thread and block until it has run the work. CallAfter()
+    // posts an async method-call event that the main event loop dispatches; the
+    // worker waits on the semaphore meanwhile, so the by-reference captures stay
+    // valid. The wait is bounded by wxIPCTimeout.
+    wxSemaphore done;
+    CallAfter([&fn, &done] {
+        fn();
+        done.Post();
+    });
+    done.Wait();
+}
+
+// Messages that are sent to the server with an expected reply are handled here.
+// The main complication is making sure that the request and reply are matched,
+// which is handle by making sure that there is only one pending request at a
+// time.
+bool wxTCPEventHandler::SendAndGetReply(wxIPCMessageBase& send_msg,
+                                        IPCCode expected_code,
+                                        wxSocketBase* socket,
+                                        wxIPCMessageBase** return_msgptr)
+{
+    // The structure of FindMessage changes greatly whether we are on
+    // wxThread::Main or not.  Divide them into two submethods:
+    if (wxThread::IsMain())
+        return SendAndGetReply_MainThread(send_msg, expected_code, socket, return_msgptr);
+    else
+        return SendAndGetReply_WorkerThread(send_msg, expected_code, return_msgptr);
+}
+
+// Take over socket processing from OnSocketInput until we find the
+// return message.
+bool wxTCPEventHandler::SendAndGetReply_MainThread(wxIPCMessageBase& send_msg,
+                                                   IPCCode expected_code,
+                                                   wxSocketBase* socket,
+                                                   wxIPCMessageBase** return_msgptr)
+{
+    wxCRIT_SECT_LOCKER(find_message_lock, m_cs_awaiting_reply);
+
+    wxCRIT_SECT_LOCKER(socket_processing_lock, m_cs_socket_processing);
+
+    if ( !WriteMessageToSocket(send_msg) )
+        return false;
+
     while ( GetConnection(socket) )
     {
         wxIPCMessageBase* msg = ReadMessageFromSocket(socket);
+        PostSocketInputEvent(socket); // in case more messages are waiting
 
-        if ( msg && msg->GetIPCCode() == code )
+        if ( msg && msg->GetIPCCode() == expected_code )
         {
-            // The correct message has been found, but more messages may follow
-            // it: either already buffered in the socket, or arriving just after
-            // this read. This read happened off the main event loop (a worker
-            // thread calling Request()/Advise() here), so the socket's own
-            // wxSOCKET_INPUT notification for the trailing data may already have
-            // been consumed and never reach the main loop. Unconditionally
-            // re-post a wxSOCKET_INPUT event so the main event loop is always
-            // nudged to re-scan this socket and drain any remaining messages
-            // (e.g. Advise notifications). A spurious event is harmless: the
-            // handler simply peeks, finds nothing, and returns.
-            if (socket && socket->GetEventHandler())
-            {
-                wxSocketEvent event(wxID_ANY);
-                event.m_event = wxSOCKET_INPUT;
-                event.m_clientData = socket->GetClientData();
-                event.SetEventObject(socket);
-
-                socket->GetEventHandler()->AddPendingEvent(event);
-            }
+            // The correct message has been found, but more messages
+            // may follow.
+            PostSocketInputEvent(socket);
 
             if (return_msgptr)
                 *return_msgptr = msg;
@@ -1675,11 +1735,165 @@ bool wxTCPEventHandler::FindMessage(IPCCode code,
 
         // Not the correct msg to be returned.
         wxIPCMessageBaseLocker lock(msg);
-        if (!ExecuteMessage(msg, socket) )
+        if (!ProcessMessage(msg, socket) )
             return false;
     };
 
     return false;
+}
+
+// worker thread
+bool wxTCPEventHandler::SendAndGetReply_WorkerThread(wxIPCMessageBase& send_msg,
+                                                     IPCCode expected_code,
+                                                     wxIPCMessageBase** return_msgptr)
+{
+    // Serialize reply-expecting commands: only one reply is pending at a time.
+    wxCRIT_SECT_LOCKER(txlock, m_cs_awaiting_reply);
+
+    // Register the pending reply *before* writing, so a reply that comes back
+    // before we start waiting is still recorded (DeliverPendingReply() stores it
+    // and we observe it via the predicate in the wait loop below, rather than
+    // blocking forever, so there is no lost-wakeup race even though we release
+    // m_replyMutex between here and the wait).
+    {
+        wxMutexLocker setup(m_replyMutex);
+        m_pending.active   = true;
+        m_pending.expected = expected_code;
+        m_pending.reply    = nullptr;
+        m_pending.failed   = false;
+    }
+
+    // Write WITHOUT holding m_replyMutex. WriteMessageToSocket() marshals the
+    // actual I/O to the main thread (RunOnMainThread) and blocks this worker
+    // until the main thread runs it. The main thread's OnSocketInput() needs
+    // m_replyMutex to hand replies over (DeliverPendingReply()), so holding it
+    // across the write would deadlock: the worker waits on the main thread while
+    // the main thread waits on the mutex the worker holds.
+    bool ok = false;
+    if ( WriteMessageToSocket(send_msg) )
+    {
+        wxMutexLocker waitlock(m_replyMutex);
+
+        // wxCondition requires its mutex be held around WaitTimeout() (the wait
+        // releases it while blocked and re-acquires it before returning). The
+        // predicate guards against a reply delivered between the write and here.
+        while ( !m_pending.reply && !m_pending.failed )
+        {
+            if ( m_replyCond.WaitTimeout(wxIPCTimeout * 1000) == wxCOND_TIMEOUT )
+                break;
+        }
+
+        if ( m_pending.reply && m_pending.reply->GetIPCCode() == expected_code )
+        {
+            if ( return_msgptr )
+                *return_msgptr = m_pending.reply;
+            else
+                delete m_pending.reply;
+            m_pending.reply = nullptr;
+            ok = true;
+        }
+    }
+
+    // Drop any reply we are not handing back to the caller, and clear the
+    // pending state under the lock.
+    wxMutexLocker cleanup(m_replyMutex);
+    if ( !ok && m_pending.reply )
+    {
+        delete m_pending.reply;
+        m_pending.reply = nullptr;
+    }
+    m_pending.active = false;
+    return ok;
+}
+
+bool wxTCPEventHandler::DeliverPendingReply(wxIPCMessageBase* msg)
+{
+    // The match against m_pending must be tested under m_replyMutex. Reading
+    // m_pending.active / m_pending.expected here without the lock races the
+    // worker thread updating them.
+    wxMutexLocker lock(m_replyMutex);
+
+    if ( !m_pending.active )
+        return false;
+
+    if ( !msg || msg->GetIPCCode() != m_pending.expected )
+        return false;
+
+    m_pending.reply = msg;     // worker now owns msg
+    m_replyCond.Signal();
+    return true;
+}
+
+// When a worker is waiting on a pending reply and some failure occurs,
+// FailPendingReply makes the worker fail fast instead of waiting for timeout.
+void wxTCPEventHandler::FailPendingReply()
+{
+    wxMutexLocker lock(m_replyMutex);
+    if ( !m_pending.active )
+        return;
+
+    m_pending.failed = true;
+    m_replyCond.Signal();
+}
+
+// Utility to post a wxSOCKET_INPUT event to the socket. This is sometimes
+// necessary because sometimes we receive a single wxSOCKET_INPUT for several
+// wxIPCMessages received, but we processed only one.  By reposting
+// wxSOCKET_INPUT, the main loop re-scans and drains the rest of the pending
+// IPCMessages.  A spurious event is harmless: the handler peeks, finds nothing,
+// and returns.
+void wxTCPEventHandler::PostSocketInputEvent(wxSocketBase* socket)
+{
+    if ( socket && socket->GetEventHandler() )
+    {
+        wxSocketEvent event(wxID_ANY);
+        event.m_event = wxSOCKET_INPUT;
+        event.m_clientData = socket->GetClientData();
+        event.SetEventObject(socket);
+
+        socket->GetEventHandler()->AddPendingEvent(event);
+    }
+}
+
+// Create a wxIPCMessage object from the given code. Caller is responsible for
+// deleting the message when done.
+wxIPCMessageBase* wxTCPEventHandler::GetIPCMessageFromCode(IPCCode code, wxSocketBase* socket)
+{
+    switch ( code )
+    {
+    case IPC_EXECUTE:
+        return new wxIPCMessageExecute(socket, this);
+
+    case IPC_REQUEST:
+        return new wxIPCMessageRequest(socket);
+
+    case IPC_POKE:
+        return new wxIPCMessagePoke(socket, this);
+
+    case IPC_ADVISE_START:
+        return new wxIPCMessageAdviseStart(socket);
+
+    case IPC_ADVISE:
+        return new wxIPCMessageAdvise(socket, this);
+
+    case IPC_ADVISE_STOP:
+        return new wxIPCMessageAdviseStop(socket);
+
+    case IPC_REQUEST_REPLY:
+        return new wxIPCMessageRequestReply(socket, this);
+
+    case IPC_FAIL:
+        return new wxIPCMessageFail(socket);
+
+    case IPC_CONNECT:
+        return new wxIPCMessageConnect(socket);
+
+    case IPC_DISCONNECT:
+        return new wxIPCMessageDisconnect(socket);
+
+    default:
+        return new wxIPCMessageNull(socket);
+    }
 }
 
 void wxTCPEventHandler::SendFailMessage(const wxString& reason, wxSocketBase* socket)
@@ -1692,12 +1906,12 @@ void wxTCPEventHandler::SendFailMessage(const wxString& reason, wxSocketBase* so
 
 void wxTCPEventHandler::HandleDisconnect(wxTCPConnection *connection)
 {
-    // connection was closed (either gracefully or not): destroy everything
+    // Connection was closed (either gracefully or not): destroy everything
     UnregisterConnectionSocket(connection->m_sock);
     connection->m_sock->Notify(false);
     connection->m_sock->Close();
 
-    // don't leave references to this soon-to-be-dangling connection in the
+    // Don't leave references to this soon-to-be-dangling connection in the
     // socket as it won't be destroyed immediately as its destruction will be
     // delayed in case there are more events pending for it
     connection->m_sock->SetClientData(nullptr);
@@ -1710,84 +1924,47 @@ void wxTCPEventHandler::HandleDisconnect(wxTCPConnection *connection)
 // message was read.  The returned message must be freed by the caller.
 wxIPCMessageBase* wxTCPEventHandler::ReadMessageFromSocket(wxSocketBase* socket)
 {
-    // Serialize all socket I/O: wxSocketBase is not safe for concurrent use
-    // from multiple threads on the same connection.
-    wxCRIT_SECT_LOCKER(lock, gs_critical_io);
-
-    wxIPCMessageNull* null_msg = new wxIPCMessageNull(socket);
-    if ( !null_msg->ReadIPCCode() )
-        return null_msg;
-
     // ptr to returned message when successful
     wxIPCMessageBase *msg = nullptr;
+    IPCCode code = IPC_NULL;
+    bool ok_read = false;
 
-    switch ( null_msg->GetIPCCode() )
-    {
-    case IPC_EXECUTE:
-        msg = new wxIPCMessageExecute(socket, this);
-        break;
+    RunOnMainThread( [&] {
+        // Serialize all socket I/O: wxSocketBase is not safe for concurrent use
+        // from multiple threads on the same connection. The lock is taken here,
+        // inside the marshalled work, so it is only ever held on the thread that
+        // actually performs the I/O.
+        wxCRIT_SECT_LOCKER(lock, gs_critical_io);
+        wxIPCMessageNull null_msg(socket);
+        ok_read = null_msg.ReadIPCCode();
+        if (ok_read)
+        {
+            code = null_msg.GetIPCCode();
+            msg = GetIPCMessageFromCode(null_msg.GetIPCCode(), socket);
+            ok_read = msg->DataFromSocket();
+        }
+    });
 
-    case IPC_REQUEST:
-        msg = new wxIPCMessageRequest(socket);
-        break;
+    if ( ok_read )
+        return msg;
 
-    case IPC_POKE:
-        msg = new wxIPCMessagePoke(socket, this);
-        break;
-
-    case IPC_ADVISE_START:
-        msg = new wxIPCMessageAdviseStart(socket);
-        break;
-
-    case IPC_ADVISE:
-        msg = new wxIPCMessageAdvise(socket, this);
-        break;
-
-    case IPC_ADVISE_STOP:
-        msg = new wxIPCMessageAdviseStop(socket);
-        break;
-
-    case IPC_REQUEST_REPLY:
-        msg = new wxIPCMessageRequestReply(socket, this);
-        break;
-
-    case IPC_FAIL:
-        msg = new wxIPCMessageFail(socket);
-        break;
-
-    case IPC_CONNECT:
-        msg = new wxIPCMessageConnect(socket);
-        break;
-
-    case IPC_DISCONNECT:
-        msg = new wxIPCMessageDisconnect(socket);
-        break;
-
-    default:
-        // faulty message indicates data misalignment
-        null_msg->SetError(wxSOCKET_IOERR);
-        return null_msg;
-    }
-
-    if (!msg->DataFromSocket())
-    {
-        null_msg->SetError(msg->GetError());
-        delete msg;
-        return null_msg;
-    }
-
-    delete null_msg;
-    return msg;
+    // failure
+    delete msg;
+    return new wxIPCMessageNull(socket);
 };
 
 // Writes this message object to the socket.
 bool wxTCPEventHandler::WriteMessageToSocket(wxIPCMessageBase& msg)
 {
-    // Serialize all socket I/O: wxSocketBase is not safe for concurrent use
-    // from multiple threads on the same connection.
-    wxCRIT_SECT_LOCKER(lock, gs_critical_io);
+    bool ok_write = false;
+    RunOnMainThread( [&] {
+        // See ReadMessageFromSocket(): gs_critical_io is taken inside the
+        // marshalled work so it is never held across the worker->main handoff.
+        wxCRIT_SECT_LOCKER(lock, gs_critical_io);
+        ok_write = msg.WriteIPCCode() && msg.DataToSocket();
+    });
 
-    return msg.WriteIPCCode() && msg.DataToSocket();
+    return ok_write;
 };
 
 // We determine if there is more data waiting in the socket buffer for read.
@@ -1795,18 +1972,21 @@ bool wxTCPEventHandler::WriteMessageToSocket(wxIPCMessageBase& msg)
 // IPCCode.
 bool wxTCPEventHandler::PeekAtMessageInSocket(wxSocketBase* socket)
 {
-    // Serialize all socket I/O: wxSocketBase is not safe for concurrent use
-    // from multiple threads on the same connection.
-    wxCRIT_SECT_LOCKER(lock, gs_critical_io);
-
     if ( !socket || !socket->IsOk() )
         return false;
 
     wxUint32 code_with_header = 0;
+    bool enough = false;
 
-    socket->Peek(reinterpret_cast<char *>(&code_with_header), 4);
+    RunOnMainThread( [&] {
+        // See ReadMessageFromSocket(): gs_critical_io is taken inside the
+        // marshalled work so it is never held across the worker->main handoff.
+        wxCRIT_SECT_LOCKER(lock, gs_critical_io);
+        socket->Peek(reinterpret_cast<char *>(&code_with_header), 4);
+        enough = socket->LastCount() == 4;
+    });
 
-    return socket->LastCount() == 4;
+    return enough;
 }
 
 char* wxTCPEventHandler::GetBufPtr(size_t size)

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -64,11 +64,12 @@ namespace
 // wxIPC protocol!)
 enum IPCCode
 {
+    IPC_NULL            = 0,
     IPC_EXECUTE         = 1,
     IPC_REQUEST         = 2,
     IPC_POKE            = 3,
     IPC_ADVISE_START    = 4,
-    IPC_ADVISE_REQUEST  = 5,
+    IPC_ADVISE_REQUEST  = 5, // not used
     IPC_ADVISE          = 6,
     IPC_ADVISE_STOP     = 7,
     IPC_REQUEST_REPLY   = 8,
@@ -90,6 +91,10 @@ const wxUint32 IPCCodeHeader=0x439d9600;
     #include <sys/types.h>
     #include <sys/stat.h>
 #endif // __UNIX_LIKE__
+
+#define wxNO_RETURN_MESSAGE nullptr
+
+const long wxIPCTimeout = 10; // socket timeout, in seconds
 
 
 // For IPC returning a char* buffer. wxWidgets docs say that the user is not

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -47,6 +47,13 @@
 class wxIPCMessageBase;
 
 // --------------------------------------------------------------------------
+// Global variables
+// --------------------------------------------------------------------------
+
+wxCRIT_SECT_DECLARE_MEMBER(gs_critical_read);
+wxCRIT_SECT_DECLARE_MEMBER(gs_critical_write);
+
+// --------------------------------------------------------------------------
 // macros and constants
 // --------------------------------------------------------------------------
 
@@ -132,6 +139,9 @@ public:
 private:
     void HandleDisconnect(wxTCPConnection *connection);
 
+    wxIPCMessageBase* ReadMessageFromSocket(wxSocketBase *socket);
+    bool WriteMessageToSocket(wxIPCMessageBase& msg);
+    bool PeekAtMessageInSocket(wxSocketBase *socket);
 
     char* GetBufPtr(size_t size);
 
@@ -1464,6 +1474,107 @@ void wxTCPEventHandler::Server_OnRequest(wxSocketEvent &event)
 
     delete streams;
     sock->Destroy();
+// Reads a single message from the socket. Returns wxIPCMessageNull when no
+// message was read.  The returned message must be freed by the caller.
+wxIPCMessageBase* wxTCPEventHandler::ReadMessageFromSocket(wxSocketBase* socket)
+{
+    // ensure that we read from the socket without any read call from another
+    // thread
+    wxCRIT_SECT_LOCKER(lock, gs_critical_read);
+
+    wxIPCMessageNull* null_msg = new wxIPCMessageNull(socket);
+    if ( !null_msg->ReadIPCCode() )
+        return null_msg;
+
+    // ptr to returned message when successful
+    wxIPCMessageBase *msg = nullptr;
+
+    switch ( null_msg->GetIPCCode() )
+    {
+    case IPC_EXECUTE:
+        msg = new wxIPCMessageExecute(socket, this);
+        break;
+
+    case IPC_REQUEST:
+        msg = new wxIPCMessageRequest(socket);
+        break;
+
+    case IPC_POKE:
+        msg = new wxIPCMessagePoke(socket, this);
+        break;
+
+    case IPC_ADVISE_START:
+        msg = new wxIPCMessageAdviseStart(socket);
+        break;
+
+    case IPC_ADVISE:
+        msg = new wxIPCMessageAdvise(socket, this);
+        break;
+
+    case IPC_ADVISE_STOP:
+        msg = new wxIPCMessageAdviseStop(socket);
+        break;
+
+    case IPC_REQUEST_REPLY:
+        msg = new wxIPCMessageRequestReply(socket, this);
+        break;
+
+    case IPC_FAIL:
+        msg = new wxIPCMessageFail(socket);
+        break;
+
+    case IPC_CONNECT:
+        msg = new wxIPCMessageConnect(socket);
+        break;
+
+    case IPC_DISCONNECT:
+        msg = new wxIPCMessageDisconnect(socket);
+        break;
+
+    default:
+        // faulty message indicates data misalignment
+        null_msg->SetError(wxSOCKET_IOERR);
+        return null_msg;
+    }
+
+    if (!msg->DataFromSocket())
+    {
+        null_msg->SetError(msg->GetError());
+        delete msg;
+        return null_msg;
+    }
+
+    delete null_msg;
+    return msg;
+};
+
+// Writes this message object to the socket.
+bool wxTCPEventHandler::WriteMessageToSocket(wxIPCMessageBase& msg)
+{
+    // ensure that we write to the socket without any write call from another
+    // thread
+    wxCRIT_SECT_LOCKER(lock, gs_critical_write);
+
+    return msg.WriteIPCCode() && msg.DataToSocket();
+};
+
+// We determine if there is more data waiting in the socket buffer for read.
+// Return true if there are enough bytes there for the IPCCodeHeader and
+// IPCCode.
+bool wxTCPEventHandler::PeekAtMessageInSocket(wxSocketBase* socket)
+{
+    wxCRIT_SECT_LOCKER(lock, gs_critical_read);
+
+    if ( !socket || !socket->IsOk() )
+        return false;
+
+    wxUint32 code_with_header = 0;
+
+    socket->Peek(reinterpret_cast<char *>(&code_with_header), 4);
+
+    return socket->LastCount() == 4;
+}
+
 }
 
 #endif // wxUSE_SOCKETS && wxUSE_IPC

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -51,6 +51,8 @@
 #include "wx/socket.h"
 #include "wx/thread.h"
 
+#include "wx/private/make_unique.h"
+
 class wxIPCMessageBase;
 
 // --------------------------------------------------------------------------
@@ -115,7 +117,7 @@ constexpr int MAX_MSG_BUFFERS = 2048;
 // ----------------------------------------------------------------------------
 
 // get the address object for the given server name, the caller must delete it
-static wxSockAddress *
+static std::unique_ptr<wxSockAddress>
 GetAddressFromName(const wxString& serverName,
                    const wxString& host = wxEmptyString)
 {
@@ -125,14 +127,14 @@ GetAddressFromName(const wxString& serverName,
     // socket instead of AF_INET one
     if ( serverName.Find(wxT('/')) != wxNOT_FOUND )
     {
-        wxUNIXaddress *addr = new wxUNIXaddress;
+        auto addr = std::make_unique<wxUNIXaddress>();
         addr->Filename(serverName);
 
         return addr;
     }
 #endif // Unix/!Unix
     {
-        wxIPV4address *addr = new wxIPV4address;
+        auto addr = std::make_unique<wxIPV4address>();
         addr->Service(serverName);
         if ( !host.empty() )
         {
@@ -1048,7 +1050,7 @@ wxConnectionBase *wxTCPClient::MakeConnection(const wxString& host,
                                               const wxString& serverName,
                                               const wxString& topic)
 {
-    wxSockAddress *addr = GetAddressFromName(serverName, host);
+    auto addr = GetAddressFromName(serverName, host);
     if ( !addr )
         return nullptr;
 
@@ -1063,7 +1065,6 @@ wxConnectionBase *wxTCPClient::MakeConnection(const wxString& host,
     client->SetTimeout(wxIPCTimeout);
 
     bool ok = client->Connect(*addr);
-    delete addr;
 
 
     if ( ok )
@@ -1143,7 +1144,7 @@ bool wxTCPServer::Create(const wxString& serverName)
         m_server = nullptr;
     }
 
-    wxSockAddress *addr = GetAddressFromName(serverName);
+    auto addr = GetAddressFromName(serverName);
     if ( !addr )
         return false;
 
@@ -1156,8 +1157,6 @@ bool wxTCPServer::Create(const wxString& serverName)
         int rc = remove(serverName.fn_str());
         if ( rc < 0 && errno != ENOENT )
         {
-            delete addr;
-
             return false;
         }
 
@@ -1186,8 +1185,6 @@ bool wxTCPServer::Create(const wxString& serverName)
         m_filename = serverName;
     }
 #endif // __UNIX_LIKE__
-
-    delete addr;
 
     if (!m_server->IsOk())
     {

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -136,7 +136,8 @@ public:
     void Client_OnRequest(wxSocketEvent& event);
     void Server_OnRequest(wxSocketEvent& event);
 
-private:
+    bool ExecuteMessage(wxIPCMessageBase* msg, wxSocketBase *socket);
+    void SendFailMessage(const wxString& reason, wxSocketBase* socket);
     void HandleDisconnect(wxTCPConnection *connection);
 
     wxIPCMessageBase* ReadMessageFromSocket(wxSocketBase *socket);
@@ -1298,33 +1299,196 @@ void wxTCPEventHandler::Client_OnRequest(wxSocketEvent &event)
             }
 
 
+// Process a single wxIPCMessage from the socket. Returns true if processing
+// can continue, or false if processing should stop, usually because a
+// disconnect was received.
+bool wxTCPEventHandler::ExecuteMessage(wxIPCMessageBase* msg, wxSocketBase *socket)
+{
+    if ( !msg || !msg->IsOk() )
+        return false;
 
+    wxTCPConnection * const connection = GetConnection(socket);
+    if ( !connection || !connection->GetConnected() )
+        return false; // socket is being deleted
 
+    wxString errmsg;
 
-
-
-
-
-
-
-
-
-
-            break;
-
-
-            break;
-
-            break;
-    }
-
-
-
-
-
+    switch ( msg->GetIPCCode() )
     {
+    case IPC_EXECUTE:
+    {
+        wxIPCMessageExecute* msg_execute =
+            wxDynamicCast(msg, wxIPCMessageExecute);
+
+        if ( msg_execute )
+            connection->OnExecute(connection->m_topic,
+                                  msg_execute->GetReadData(),
+                                  msg_execute->GetSize(),
+                                  msg_execute->GetIPCFormat());
+        else
+            errmsg = "No data read for IPC Execute";
+    }
+    break;
+
+    case IPC_ADVISE:
+    {
+        wxIPCMessageAdvise* msg_advise =
+            wxDynamicCast(msg, wxIPCMessageAdvise);
+
+        if ( msg_advise )
+            connection->OnAdvise(connection->m_topic,
+                                 msg_advise->GetItem(),
+                                 msg_advise->GetReadData(),
+                                 msg_advise->GetSize(),
+                                 msg_advise->GetIPCFormat());
+        else
+            errmsg = "No data read for IPC Advise";
+    }
+    break;
+
+    case IPC_ADVISE_START:
+    {
+        wxIPCMessageAdviseStart* msg_advise_start =
+            wxDynamicCast(msg, wxIPCMessageAdviseStart);
+
+        if ( !msg_advise_start )
+        {
+            errmsg = "No data read for IPC Advise Start";
+            break;
+        }
+
+        if ( connection->OnStartAdvise(connection->m_topic,
+                                       msg_advise_start->GetItem()) )
+        {
+            // reply to confirm
+            wxIPCMessageAdviseStart reply(socket,
+                                          msg_advise_start->GetItem());
+            if ( !WriteMessageToSocket(reply) )
+                errmsg = "Failed to confirm IPC StartAdvise";
+        }
+        else
+        {
+            errmsg = "IPC StartAdvise refused by peer";
+        }
+
+    }
+    break;
+
+    case IPC_ADVISE_STOP:
+    {
+        wxIPCMessageAdviseStop* msg_advise_stop =
+            wxDynamicCast(msg, wxIPCMessageAdviseStop);
+
+        if ( !msg_advise_stop )
+        {
+            errmsg = "No data read for IPC Advise Stop";
+            break;
+        }
+
+        if ( connection->OnStopAdvise(connection->m_topic, msg_advise_stop->GetItem()) )
+        {
+            // reply to confirm
+            wxIPCMessageAdviseStop reply(socket, msg_advise_stop->GetItem());
+            if ( !WriteMessageToSocket(reply) )
+                errmsg = "Failed to confirm IPC StopAdvise";
+        }
+        else
+        {
+            errmsg = "IPC StopAdvise refused by peer";
+        }
+
+    }
+    break;
+
+    case IPC_POKE:
+    {
+        wxIPCMessagePoke* msg_poke =
+            wxDynamicCast(msg, wxIPCMessagePoke);
+
+        if ( msg_poke )
+            connection->OnPoke(connection->m_topic,
+                               msg_poke->GetItem(),
+                               msg_poke->GetReadData(),
+                               msg_poke->GetSize(),
+                               msg_poke->GetIPCFormat());
+        else
+            errmsg = "No data read for IPC Poke";
+    }
+    break;
+
+    case IPC_REQUEST:
+    {
+        wxIPCMessageRequest* msg_request =
+            wxDynamicCast(msg, wxIPCMessageRequest);
+
+        if ( !msg_request )
+        {
+            errmsg = "No data read for IPC Request";
+            break;
+        }
+
+        size_t user_size = wxNO_LEN;
+        const void *user_data = connection->OnRequest(connection->m_topic,
+                                                      msg->GetItem(),
+                                                      &user_size,
+                                                      msg->GetIPCFormat());
+        if ( !user_data )
+        {
+            SendFailMessage("No reply data for request.", socket);
+            break;
+        }
+
+        wxIPCMessageRequestReply msg_reply(socket,
+                                           user_data,
+                                           user_size,
+                                           msg->GetItem(),
+                                           msg->GetIPCFormat());
+
+        if ( !WriteMessageToSocket(msg_reply) )
+            errmsg = "Reply failed for IPC Request";
+    }
+    break;
+
+    case IPC_DISCONNECT:
+        HandleDisconnect(connection);
+        return false;
+
+    case IPC_FAIL:
+    {
+        wxIPCMessageFail* msg_fail =
+            wxDynamicCast(msg, wxIPCMessageFail);
+
+        if ( msg_fail )
+            wxLogDebug("Unexpected IPC_FAIL received: " + msg_fail->GetItem());
+        else
+            wxLogDebug("Unexpected IPC_FAIL, and data read failed.");
+
+        return false;
     }
 
+    // Silence unused-enum warnings from the compiler. These should never be
+    // received in this method.
+    case IPC_ADVISE_REQUEST:
+    case IPC_REQUEST_REPLY:
+    case IPC_CONNECT:
+    case IPC_MAX:
+        wxLogDebug("Invalid IPC code %d received", msg->GetIPCCode());
+        return false;
+
+    default:
+        wxLogDebug("Unknown message code %d received. IPC data may be misaligned",
+                   msg);
+        return false;
+    }
+
+    if ( !errmsg.IsEmpty() )
+    {
+        wxLogDebug(errmsg);
+        SendFailMessage(errmsg, socket);
+    }
+
+    return true;
+}
 
     {
 

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -102,7 +102,7 @@ constexpr wxUint32 IPCCodeHeader = 0x439d9600;
 
 constexpr auto wxNO_RETURN_MESSAGE = nullptr;
 
-constexpr long wxIPCTimeout = 10; // socket timeout, in seconds
+constexpr long wxIPCTimeout = 5; // socket timeout, in seconds
 
 
 // For IPC returning a char* buffer. wxWidgets docs say that the user is not

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -340,7 +340,6 @@ public:
     {
         Init(socket);
     }
-    virtual ~wxIPCMessageBase() {};
 
     bool IsOk() const { return m_ipc_code != IPC_NULL; }
 

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -7,6 +7,8 @@
 //                                  (callbacks deprecated)    Mar 2000
 //              Vadim Zeitlin (added support for Unix sockets) Apr 2002
 //                            (use buffering, many fixes/cleanup) Oct 2008
+//              JP Mattia (use messages, fix reporting of errors
+//                         and use in multithreading) Sep 2024
 // Created:     1993
 // Copyright:   (c) Julian Smart 1993
 //              (c) Guilhem Lavaux 1997, 1998
@@ -26,7 +28,7 @@
 #include "wx/wxprec.h"
 
 
-#if wxUSE_SOCKETS && wxUSE_IPC && wxUSE_STREAMS
+#if wxUSE_SOCKETS && wxUSE_IPC
 
 #include "wx/sckipc.h"
 
@@ -170,189 +172,62 @@ wxTCPEventHandler *wxTCPEventHandlerModule::ms_handler = nullptr;
 // wxIPCSocketStreams
 // --------------------------------------------------------------------------
 
-#define USE_BUFFER
-
-// this class contains the various (related) streams used by wxTCPConnection
-// and also provides a way to read from the socket stream directly
-//
-// for writing to the stream use the IPCOutput class below
-class wxIPCSocketStreams
 {
 public:
-    // ctor initializes all the streams on top of the given socket
-    //
-    // note that we use a bigger than default buffer size which matches the
-    // typical Ethernet MTU (minus TCP header overhead)
-    wxIPCSocketStreams(wxSocketBase& sock)
-        : m_socketStream(sock),
-#ifdef USE_BUFFER
-          m_bufferedOut(m_socketStream, 1448),
-#else
-          m_bufferedOut(m_socketStream),
-#endif
-          m_dataIn(m_socketStream),
-          m_dataOut(m_bufferedOut)
     {
     }
 
-    // expose the IO methods needed by IPC code (notice that writing is only
-    // done via IPCOutput)
 
-    // flush output
-    void Flush()
     {
-#ifdef USE_BUFFER
-        m_bufferedOut.Sync();
-#endif
     }
 
-    // simple wrappers around the functions with the same name in
-    // wxDataInputStream
-    wxUint8 Read8()
     {
-        Flush();
-        return m_dataIn.Read8();
     }
 
-    wxUint32 Read32()
     {
-        Flush();
-        return m_dataIn.Read32();
     }
 
-    wxString ReadString()
     {
-        Flush();
-        return m_dataIn.ReadString();
     }
 
-    // read arbitrary (size-prepended) data
-    //
-    // connection parameter is needed to call its GetBufferAtLeast() method
-    void *ReadData(wxConnectionBase *conn, size_t *size)
     {
-        Flush();
 
-        wxCHECK_MSG( conn, nullptr, "null connection parameter" );
-        wxCHECK_MSG( size, nullptr, "null size parameter" );
 
-        *size = Read32();
-        if ( !*size )
-        {
-            wxLogDebug("IPC: data unexpectedly has zero size");
-            return nullptr;
-        }
 
-        void * const data = conn->GetBufferAtLeast(*size);
-        wxCHECK_MSG( data, nullptr, "IPC buffer allocation failed" );
 
-        // We should always read exactly the provided number of bytes,
-        // otherwise something is wrong and we must return an error.
-        auto const read = m_socketStream.Read(data, *size).LastRead();
-        if ( read != *size )
-        {
-            wxLogDebug("IPC: got %zu bytes (expected %zu)", read, *size);
-            return nullptr;
-        }
 
-        return data;
     }
 
-    // same as above but for data preceded by the format
-    void *
-    ReadFormatData(wxConnectionBase *conn, wxIPCFormat *format, size_t *size)
     {
-        wxCHECK_MSG( format, nullptr, "null format parameter" );
 
-        *format = static_cast<wxIPCFormat>(Read8());
 
-        return ReadData(conn, size);
     }
 
 
-    // these methods are only used by IPCOutput and not directly
-    wxDataOutputStream& GetDataOut() { return m_dataOut; }
-    wxOutputStream& GetUnformattedOut() { return m_bufferedOut; }
 
-private:
-    // this is the low-level underlying stream using the connection socket
-    wxSocketStream m_socketStream;
 
-    // the buffered stream is used to avoid writing all pieces of an IPC
-    // request to the socket one by one but to instead do it all at once when
-    // we're done with it
-#ifdef USE_BUFFER
-    wxBufferedOutputStream m_bufferedOut;
-#else
-    wxOutputStream& m_bufferedOut;
-#endif
 
-    // finally the data streams are used to be able to write typed data into
-    // the above streams easily
-    wxDataInputStream  m_dataIn;
-    wxDataOutputStream m_dataOut;
-
-    wxDECLARE_NO_COPY_CLASS(wxIPCSocketStreams);
 };
 
-namespace
-{
 
-// an object of this class should be instantiated on the stack to write to the
-// underlying socket stream
-//
-// this class is intentionally separated from wxIPCSocketStreams to ensure that
-// Flush() is always called
-class IPCOutput
 {
 public:
-    // construct an object associated with the given streams (which must have
-    // life time greater than ours as we keep a reference to it)
-    IPCOutput(wxIPCSocketStreams *streams)
-        : m_streams(*streams)
     {
-        wxASSERT_MSG( streams, "null streams pointer" );
     }
 
-    // dtor calls Flush() really sending the IPC data to the network
-    ~IPCOutput() { m_streams.Flush(); }
-
-
-    // write a byte
-    void Write8(wxUint8 i)
     {
-        m_streams.GetDataOut().Write8(i);
     }
 
-    // write the reply code and a string
-    void Write(IPCCode code, const wxString& str)
     {
-        Write8(code);
-        m_streams.GetDataOut().WriteString(str);
     }
 
-    // write the reply code, a string and a format in this order
-    void Write(IPCCode code, const wxString& str, wxIPCFormat format)
     {
-        Write(code, str);
-        Write8(format);
     }
 
-    // write arbitrary data
-    void WriteData(const void *data, size_t size)
     {
-        m_streams.GetDataOut().Write32(size);
-        m_streams.GetUnformattedOut().Write(data, size);
     }
 
-
-private:
-    wxIPCSocketStreams& m_streams;
-
-    wxDECLARE_NO_COPY_CLASS(IPCOutput);
 };
-
-} // anonymous namespace
 
 // ==========================================================================
 // implementation
@@ -937,4 +812,4 @@ void wxTCPEventHandler::Server_OnRequest(wxSocketEvent &event)
     sock->Destroy();
 }
 
-#endif // wxUSE_SOCKETS && wxUSE_IPC && wxUSE_STREAMS
+#endif // wxUSE_SOCKETS && wxUSE_IPC

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1641,20 +1641,24 @@ bool wxTCPEventHandler::FindMessage(IPCCode code,
 
         if ( msg && msg->GetIPCCode() == code )
         {
-            // The correct message has been found, but there may still be
-            // messages waiting in the socket data buffer. Place an event in
-            // the socket event queue so that they will be read out later.
-            if ( PeekAtMessageInSocket(socket) )
+            // The correct message has been found, but more messages may follow
+            // it: either already buffered in the socket, or arriving just after
+            // this read. This read happened off the main event loop (a worker
+            // thread calling Request()/Advise() here), so the socket's own
+            // wxSOCKET_INPUT notification for the trailing data may already have
+            // been consumed and never reach the main loop. Unconditionally
+            // re-post a wxSOCKET_INPUT event so the main event loop is always
+            // nudged to re-scan this socket and drain any remaining messages
+            // (e.g. Advise notifications). A spurious event is harmless: the
+            // handler simply peeks, finds nothing, and returns.
+            if (socket && socket->GetEventHandler())
             {
-                if (socket && socket->GetEventHandler())
-                {
-                    wxSocketEvent event(wxID_ANY);
-                    event.m_event = wxSOCKET_INPUT;
-                    event.m_clientData = socket->GetClientData();
-                    event.SetEventObject(socket);
+                wxSocketEvent event(wxID_ANY);
+                event.m_event = wxSOCKET_INPUT;
+                event.m_clientData = socket->GetClientData();
+                event.SetEventObject(socket);
 
-                    socket->GetEventHandler()->AddPendingEvent(event);
-                }
+                socket->GetEventHandler()->AddPendingEvent(event);
             }
 
             if (return_msgptr)

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -233,6 +233,7 @@ public:
     wxIPCMessageBase* GetIPCMessageFromCode(IPCCode code, wxSocketBase* socket);
 
     void PostSocketInputEvent(wxSocketBase* socket);
+
 private:
     wxTCPConnection* GetConnection(wxSocketBase* socket);
 
@@ -252,7 +253,9 @@ private:
     std::unordered_set<wxSocketBase*> m_socketsBeingRead;
 
     bool IsReadingSocket(wxSocketBase* socket) const
-        { return m_socketsBeingRead.count(socket) != 0; }
+    {
+        return m_socketsBeingRead.count(socket) != 0;
+    }
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxTCPEventHandler);
@@ -273,13 +276,22 @@ namespace
 class MainThreadReadGuard
 {
 public:
+    // First argument is always wxTCPEventHandler::m_socketsBeingRead.
     MainThreadReadGuard(std::unordered_set<wxSocketBase*>& set, wxSocketBase* socket)
-        : m_set(set), m_socket(socket) { m_set.insert(m_socket); }
-    ~MainThreadReadGuard() { m_set.erase(m_socket); }
+        : m_set(set), m_socket(socket)
+    {
+        m_set.insert(m_socket);
+    }
+
+    ~MainThreadReadGuard()
+    {
+        m_set.erase(m_socket);
+    }
 
 private:
     std::unordered_set<wxSocketBase*>& m_set;
     wxSocketBase* const m_socket;
+
     wxDECLARE_NO_COPY_CLASS(MainThreadReadGuard);
 };
 
@@ -329,22 +341,22 @@ class wxIPCMessageBase : public wxObject
 public:
     wxIPCMessageBase(wxSocketBase* socket = nullptr,
                      wxTCPEventHandler* handler = nullptr)
-        : m_write_data(nullptr), m_handler(handler)
+        : m_writeData(nullptr), m_handler(handler)
     {
         Init(socket);
     }
 
     wxIPCMessageBase(wxSocketBase* socket, const void* data)
-        : m_write_data(data), m_handler(nullptr)
+        : m_writeData(data), m_handler(nullptr)
     {
         Init(socket);
     }
 
-    bool IsOk() const { return m_ipc_code != IPC_NULL; }
+    bool IsOk() const { return m_ipcCode != IPC_NULL; }
 
     // Accessors for the base object
-    IPCCode GetIPCCode() const { return m_ipc_code; }
-    void SetIPCCode(IPCCode ipc_code) { m_ipc_code = ipc_code; }
+    IPCCode GetIPCCode() const { return m_ipcCode; }
+    void SetIPCCode(IPCCode ipc_code) { m_ipcCode = ipc_code; }
 
     wxSocketBase* GetSocket() const { return m_socket; }
     void SetSocket(wxSocketBase* socket) { m_socket = socket; }
@@ -353,11 +365,11 @@ public:
     void SetError(wxSocketError error) { m_error = error; }
 
     // These accessors are here to avoid repetition in the derived objects.
-    wxIPCFormat GetIPCFormat() const { return m_ipc_format; }
-    void SetIPCFormat(wxIPCFormat ipc_format) { m_ipc_format = ipc_format; }
+    wxIPCFormat GetIPCFormat() const { return m_ipcFormat; }
+    void SetIPCFormat(wxIPCFormat ipc_format) { m_ipcFormat = ipc_format; }
 
-    const void* GetReadData() const { return m_read_data; }
-    void SetReadData(void *data) { m_read_data = data; }
+    const void* GetReadData() const { return m_readData; }
+    void SetReadData(void *data) { m_readData = data; }
 
     size_t GetSize() const { return m_size; }
     void SetSize(size_t size) { m_size = size; }
@@ -384,7 +396,8 @@ protected:
 
     bool VerifyValidSocket()
     {
-        if (m_socket && m_socket->IsOk() && m_socket->IsConnected() ) return true;
+        if (m_socket && m_socket->IsOk() && m_socket->IsConnected() )
+            return true;
 
         SetError(wxSOCKET_INVSOCK);
         return false;
@@ -436,7 +449,7 @@ protected:
         if ( !VerifyValidSocket() )
             return false;
 
-        m_socket->Read(reinterpret_cast<char *>(&m_ipc_format), 1);
+        m_socket->Read(reinterpret_cast<char *>(&m_ipcFormat), 1);
 
         return VerifyLastReadCount(1);
     }
@@ -487,7 +500,7 @@ protected:
         if (!Write32(m_size))
             return false;
 
-        return WriteData(m_write_data, m_size);
+        return WriteData(m_writeData, m_size);
     }
 
     bool WriteIPCCode()
@@ -501,7 +514,7 @@ protected:
         if ( !VerifyValidSocket() )
             return false;
 
-        m_socket->Write(reinterpret_cast<char *>(&m_ipc_format), 1);
+        m_socket->Write(reinterpret_cast<char *>(&m_ipcFormat), 1);
 
         return VerifyLastWriteCount(1);
     }
@@ -527,21 +540,21 @@ protected:
         return true;
     }
 
-    IPCCode m_ipc_code;
+    IPCCode m_ipcCode;
 
     wxSocketBase* m_socket;
     wxSocketError m_error;
 
     // Members used in most of the derived messages
     wxUint32 m_size;
-    wxIPCFormat m_ipc_format;
+    wxIPCFormat m_ipcFormat;
     wxString m_item;
 
     // immutable pointer to data from connection object
-    const void* m_write_data;
+    const void* m_writeData;
 
     // pointer to data read from socket
-    void* m_read_data;
+    void* m_readData;
 
     wxTCPEventHandler *m_handler;
 
@@ -553,7 +566,7 @@ protected:
 
 // Reads a 32-bit word to get the desired buffer m_size from the socket, allocates
 // a buffer of that size, then read m_size bytes worth of data from the socket
-// into m_read_data.
+// into m_readData.
 bool wxIPCMessageBase::ReadSizeAndData()
 {
     if (!Read32(m_size))
@@ -561,9 +574,9 @@ bool wxIPCMessageBase::ReadSizeAndData()
 
     wxCHECK_MSG( m_handler, false, "No handler for read allocation");
 
-    m_read_data = m_handler->GetBufPtr(m_size);
+    m_readData = m_handler->GetBufPtr(m_size);
 
-    m_socket->Read(m_read_data, m_size);
+    m_socket->Read(m_readData, m_size);
     return VerifyLastReadCount(m_size);
 }
 

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1029,6 +1029,27 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageDisconnect,wxIPCMessageBase);
 wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageFail,wxIPCMessageBase);
 wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageNull,wxIPCMessageBase);
 
+namespace
+{
+
+// Cast a message read from the socket to its concrete type after its IPC code
+// has been checked.
+//
+// The concrete type of a message is uniquely determined by its IPC code (see
+// GetIPCMessageFromCode(), the only place where the messages read from the
+// socket are created), so the cast cannot fail and a static_cast is enough;
+// still verify the invariant in debug builds.
+template <typename T>
+T* wxIPCMessageCast(wxIPCMessageBase* msg)
+{
+    wxASSERT_MSG( wxDynamicCast(msg, T),
+                  "IPC message type doesn't correspond to its IPC code" );
+
+    return static_cast<T*>(msg);
+}
+
+} // anonymous namespace
+
 // --------------------------------------------------------------------------
 // wxTCPClient
 // --------------------------------------------------------------------------
@@ -1102,17 +1123,16 @@ wxConnectionBase *wxTCPClient::MakeConnection(const wxString& host,
             }
             else
             {
-                delete connection;
+                delete connectionBase;
                 // and fall through to delete everything else
             }
         }
         else if ( msg_reply->GetIPCCode() == IPC_FAIL )
         {
-            wxIPCMessageFail* msg_fail =
-                wxDynamicCast(msg_reply, wxIPCMessageFail);
-
-            if (msg_fail)
-                wxLogDebug("FailMessage received: " + msg_fail->GetItem());
+            // The cast is done inside the macro argument so that no unused
+            // variable is left behind when wxLogDebug() expands to nothing.
+            wxLogDebug("FailMessage received: " +
+                       wxIPCMessageCast<wxIPCMessageFail>(msg_reply)->GetItem());
         }
     }
 
@@ -1460,41 +1480,35 @@ void wxTCPEventHandler::OnSocketConnection(wxSocketEvent &event)
 
     if ( msg->GetIPCCode() == IPC_CONNECT )
     {
-        wxIPCMessageConnect* msg_conn = (wxIPCMessageConnect*) msg;
+        wxIPCMessageConnect* msg_conn = wxIPCMessageCast<wxIPCMessageConnect>(msg);
 
-        if ( msg_conn )
+        wxString topic = msg_conn->GetTopic();
+
+        auto* const connectionBase = ipcserv->OnAcceptConnection(topic);
+
+        if ( auto* const new_connection = wxDynamicCast(connectionBase, wxTCPConnection) )
         {
-            if (wxDynamicCast(msg, wxIPCMessageConnect))
+            // Acknowledge success
+            wxIPCMessageConnect msg_reply(sock, topic);
+
+            if ( WriteMessageToSocket(msg_reply) )
             {
-                wxString topic = msg_conn->GetTopic();
+                new_connection->m_topic = topic;
+                new_connection->m_sock = sock;
+                new_connection->m_handler = &wxTCPEventHandlerModule::GetHandler();
 
-                auto* const connectionBase = ipcserv->OnAcceptConnection(topic);
-
-                if ( auto* const new_connection = wxDynamicCast(connectionBase, wxTCPConnection) )
-                {
-                    // Acknowledge success
-                    wxIPCMessageConnect msg_reply(sock, topic);
-
-                    if ( WriteMessageToSocket(msg_reply) )
-                    {
-                        new_connection->m_topic = topic;
-                        new_connection->m_sock = sock;
-                        new_connection->m_handler = &wxTCPEventHandlerModule::GetHandler();
-
-                        sock->SetTimeout(wxIPCTimeout);
-                        sock->SetEventHandler(wxTCPEventHandlerModule::GetHandler(),
-                                              _SOCKET_INPUT_ID);
-                        sock->SetClientData(new_connection);
-                        RegisterConnectionSocket(sock);
-                        sock->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
-                        sock->Notify(true);
-                        return;
-                    }
-                }
-
-                delete connectionBase;
+                sock->SetTimeout(wxIPCTimeout);
+                sock->SetEventHandler(wxTCPEventHandlerModule::GetHandler(),
+                                      _SOCKET_INPUT_ID);
+                sock->SetClientData(new_connection);
+                RegisterConnectionSocket(sock);
+                sock->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
+                sock->Notify(true);
+                return;
             }
         }
+
+        delete connectionBase;
     }
 
     SendFailMessage("IPC CONNECT failed to create valid connection", sock);
@@ -1520,44 +1534,32 @@ bool wxTCPEventHandler::ProcessMessage(wxIPCMessageBase* msg, wxSocketBase *sock
     case IPC_EXECUTE:
     {
         wxIPCMessageExecute* msg_execute =
-            wxDynamicCast(msg, wxIPCMessageExecute);
+            wxIPCMessageCast<wxIPCMessageExecute>(msg);
 
-        if ( msg_execute )
-            connection->OnExecute(connection->m_topic,
-                                  msg_execute->GetReadData(),
-                                  msg_execute->GetSize(),
-                                  msg_execute->GetIPCFormat());
-        else
-            errmsg = "No data read for IPC Execute";
+        connection->OnExecute(connection->m_topic,
+                              msg_execute->GetReadData(),
+                              msg_execute->GetSize(),
+                              msg_execute->GetIPCFormat());
     }
     break;
 
     case IPC_ADVISE:
     {
         wxIPCMessageAdvise* msg_advise =
-            wxDynamicCast(msg, wxIPCMessageAdvise);
+            wxIPCMessageCast<wxIPCMessageAdvise>(msg);
 
-        if ( msg_advise )
-            connection->OnAdvise(connection->m_topic,
-                                 msg_advise->GetItem(),
-                                 msg_advise->GetReadData(),
-                                 msg_advise->GetSize(),
-                                 msg_advise->GetIPCFormat());
-        else
-            errmsg = "No data read for IPC Advise";
+        connection->OnAdvise(connection->m_topic,
+                             msg_advise->GetItem(),
+                             msg_advise->GetReadData(),
+                             msg_advise->GetSize(),
+                             msg_advise->GetIPCFormat());
     }
     break;
 
     case IPC_ADVISE_START:
     {
         wxIPCMessageAdviseStart* msg_advise_start =
-            wxDynamicCast(msg, wxIPCMessageAdviseStart);
-
-        if ( !msg_advise_start )
-        {
-            errmsg = "No data read for IPC Advise Start";
-            break;
-        }
+            wxIPCMessageCast<wxIPCMessageAdviseStart>(msg);
 
         if ( connection->OnStartAdvise(connection->m_topic,
                                        msg_advise_start->GetItem()) )
@@ -1579,13 +1581,7 @@ bool wxTCPEventHandler::ProcessMessage(wxIPCMessageBase* msg, wxSocketBase *sock
     case IPC_ADVISE_STOP:
     {
         wxIPCMessageAdviseStop* msg_advise_stop =
-            wxDynamicCast(msg, wxIPCMessageAdviseStop);
-
-        if ( !msg_advise_stop )
-        {
-            errmsg = "No data read for IPC Advise Stop";
-            break;
-        }
+            wxIPCMessageCast<wxIPCMessageAdviseStop>(msg);
 
         if ( connection->OnStopAdvise(connection->m_topic, msg_advise_stop->GetItem()) )
         {
@@ -1605,30 +1601,18 @@ bool wxTCPEventHandler::ProcessMessage(wxIPCMessageBase* msg, wxSocketBase *sock
     case IPC_POKE:
     {
         wxIPCMessagePoke* msg_poke =
-            wxDynamicCast(msg, wxIPCMessagePoke);
+            wxIPCMessageCast<wxIPCMessagePoke>(msg);
 
-        if ( msg_poke )
-            connection->OnPoke(connection->m_topic,
-                               msg_poke->GetItem(),
-                               msg_poke->GetReadData(),
-                               msg_poke->GetSize(),
-                               msg_poke->GetIPCFormat());
-        else
-            errmsg = "No data read for IPC Poke";
+        connection->OnPoke(connection->m_topic,
+                           msg_poke->GetItem(),
+                           msg_poke->GetReadData(),
+                           msg_poke->GetSize(),
+                           msg_poke->GetIPCFormat());
     }
     break;
 
     case IPC_REQUEST:
     {
-        wxIPCMessageRequest* msg_request =
-            wxDynamicCast(msg, wxIPCMessageRequest);
-
-        if ( !msg_request )
-        {
-            errmsg = "No data read for IPC Request";
-            break;
-        }
-
         size_t user_size = wxNO_LEN;
         const void *user_data = connection->OnRequest(connection->m_topic,
                                                       msg->GetItem(),
@@ -1657,13 +1641,10 @@ bool wxTCPEventHandler::ProcessMessage(wxIPCMessageBase* msg, wxSocketBase *sock
 
     case IPC_FAIL:
     {
-        wxIPCMessageFail* msg_fail =
-            wxDynamicCast(msg, wxIPCMessageFail);
-
-        if ( msg_fail )
-            wxLogDebug("Unexpected IPC_FAIL received: " + msg_fail->GetItem());
-        else
-            wxLogDebug("Unexpected IPC_FAIL, and data read failed.");
+        // The cast is done inside the macro argument so that no unused
+        // variable is left behind when wxLogDebug() expands to nothing.
+        wxLogDebug("Unexpected IPC_FAIL received: " +
+                   wxIPCMessageCast<wxIPCMessageFail>(msg)->GetItem());
 
         return false;
     }

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -42,6 +42,8 @@
 #include <stdio.h>
 #include <errno.h>
 
+#include <set>
+
 #include "wx/socket.h"
 
 class wxIPCMessageBase;
@@ -175,6 +177,18 @@ public:
 
     char* GetBufPtr(size_t size);
 
+    // This event handler is a process-wide singleton shared by every IPC
+    // connection (client and server) and it lives until the program exits.
+    // Socket events are queued on it and may still be pending after the socket
+    // they refer to has been destroyed: dispatching such a stale event would
+    // dereference a dangling wxSocketBase pointer. To guard against this we
+    // keep the set of sockets that currently have a live connection and ignore
+    // events for any socket which is not in it. The check compares only
+    // pointer values, so it is safe even if the socket has already been freed.
+    void RegisterConnectionSocket(wxSocketBase* socket);
+    void UnregisterConnectionSocket(wxSocketBase* socket);
+    bool IsConnectionSocket(wxSocketBase* socket);
+
     wxCRIT_SECT_DECLARE_MEMBER(m_cs_process_msgs);
 
 private:
@@ -184,6 +198,9 @@ private:
 
     char* m_bufferList[MAX_MSG_BUFFERS];
     int m_nextAvailable;
+
+    wxCRIT_SECT_DECLARE_MEMBER(m_cs_connection_sockets);
+    std::set<wxSocketBase*> m_connectionSockets;
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxTCPEventHandler);
@@ -1003,6 +1020,7 @@ wxConnectionBase *wxTCPClient::MakeConnection(const wxString& host,
 
                     client->SetEventHandler(*handler, _CLIENT_ONREQUEST_ID);
                     client->SetClientData(connection);
+                    handler->RegisterConnectionSocket(client);
                     client->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
                     client->Notify(true);
                     return connection;
@@ -1159,6 +1177,8 @@ wxTCPConnection::~wxTCPConnection()
 
     if ( m_sock )
     {
+        if ( m_handler )
+            m_handler->UnregisterConnectionSocket(m_sock);
         m_sock->SetClientData(nullptr);
         m_sock->Destroy();
     }
@@ -1299,6 +1319,16 @@ wxEND_EVENT_TABLE()
 void wxTCPEventHandler::Client_OnRequest(wxSocketEvent &event)
 {
     wxSocketBase *sock = event.GetSocket();
+
+    // This handler is a shared, process-lifetime singleton, so it may receive
+    // a socket event that was queued before its socket was destroyed (e.g. a
+    // wxSOCKET_LOST generated as a connection is being torn down). Such an
+    // event must be ignored without touching the socket, as it now points to
+    // freed memory. IsConnectionSocket() only compares the pointer value and
+    // never dereferences it, so it is safe to call here.
+    if ( !IsConnectionSocket(sock) )
+        return;
+
     wxTCPConnection * connection = GetConnection(sock);
 
     // This socket is being deleted
@@ -1389,6 +1419,7 @@ void wxTCPEventHandler::Server_OnRequest(wxSocketEvent &event)
                             sock->SetEventHandler(wxTCPEventHandlerModule::GetHandler(),
                                                   _CLIENT_ONREQUEST_ID);
                             sock->SetClientData(new_connection);
+                            RegisterConnectionSocket(sock);
                             sock->SetNotify(wxSOCKET_INPUT_FLAG | wxSOCKET_LOST_FLAG);
                             sock->Notify(true);
                             return;
@@ -1654,6 +1685,7 @@ void wxTCPEventHandler::SendFailMessage(const wxString& reason, wxSocketBase* so
 void wxTCPEventHandler::HandleDisconnect(wxTCPConnection *connection)
 {
     // connection was closed (either gracefully or not): destroy everything
+    UnregisterConnectionSocket(connection->m_sock);
     connection->m_sock->Notify(false);
     connection->m_sock->Close();
 
@@ -1790,6 +1822,24 @@ wxTCPConnection* wxTCPEventHandler::GetConnection(wxSocketBase* socket)
         return nullptr;
 
     return static_cast<wxTCPConnection *>(socket->GetClientData());
+}
+
+void wxTCPEventHandler::RegisterConnectionSocket(wxSocketBase* socket)
+{
+    wxCRIT_SECT_LOCKER(lock, m_cs_connection_sockets);
+    m_connectionSockets.insert(socket);
+}
+
+void wxTCPEventHandler::UnregisterConnectionSocket(wxSocketBase* socket)
+{
+    wxCRIT_SECT_LOCKER(lock, m_cs_connection_sockets);
+    m_connectionSockets.erase(socket);
+}
+
+bool wxTCPEventHandler::IsConnectionSocket(wxSocketBase* socket)
+{
+    wxCRIT_SECT_LOCKER(lock, m_cs_connection_sockets);
+    return m_connectionSockets.find(socket) != m_connectionSockets.end();
 }
 
 #endif // wxUSE_SOCKETS && wxUSE_IPC

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -576,23 +576,14 @@ bool wxIPCMessageBase::ReadString(wxString& str)
 
     if ( len > 0 )
     {
-
-#if wxUSE_UNICODE
         wxCharBuffer buf(len);
         if ( !buf || !ReadData(buf.data(), len) )
             return false;
-#else
-        wxStringBuffer buf(str, len);
-        if ( !buf || !ReadData(buf,len) )
-            return false;
-#endif
 
         if ( !VerifyLastReadCount(len))
             return false;
 
-#if wxUSE_UNICODE
-        str = wxConvUTF8.cMB2WC(buf.data(), len, nullptr);
-#endif
+        str = wxString::FromUTF8(buf.data(), len);
     }
 
     return true;
@@ -600,13 +591,8 @@ bool wxIPCMessageBase::ReadString(wxString& str)
 
 bool wxIPCMessageBase::WriteString(const wxString& str)
 {
-#if wxUSE_UNICODE
-    const wxWX2MBbuf buf = str.mb_str(wxConvUTF8);
+    const wxScopedCharBuffer& buf = str.utf8_str();
     size_t len = buf.length();
-#else
-    const wxWX2MBbuf buf = str.mb_str();
-    size_t len = str.size();
-#endif
 
     if (len > 0)
         return Write32(len) && WriteData(buf, len);

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -560,9 +560,7 @@ bool wxIPCMessageBase::ReadSizeAndData()
     if (!Read32(m_size))
         return false;
 
-    wxASSERT_MSG( m_handler, "No handler for read allocation");
-    if ( !m_handler )
-        return false;
+    wxCHECK_MSG( m_handler, false, "No handler for read allocation");
 
     m_read_data = m_handler->GetBufPtr(m_size);
 

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1139,11 +1139,7 @@ wxConnectionBase *wxTCPClient::OnMakeConnection()
 // wxTCPServer
 // --------------------------------------------------------------------------
 
-wxTCPServer::wxTCPServer()
-    : wxServerBase()
-{
-    m_server = nullptr;
-}
+wxTCPServer::wxTCPServer() = default;
 
 bool wxTCPServer::Create(const wxString& serverName)
 {

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -132,6 +132,9 @@ public:
 private:
     void HandleDisconnect(wxTCPConnection *connection);
 
+
+    char* GetBufPtr(size_t size);
+
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxTCPEventHandler);
 };
@@ -408,6 +411,70 @@ protected:
     wxDECLARE_NO_COPY_CLASS(wxIPCMessageBase);
     wxDECLARE_CLASS(wxIPCMessageBase);
 };
+
+// Reads a 32-bit size from the socket, allocates a buffer of that size, then
+// read nbytes worth of data from the socket into m_read_data.
+bool wxIPCMessageBase::ReadSizeAndData()
+{
+    if (!Read32(m_size))
+        return false;
+
+    wxASSERT_MSG( m_handler, "No handler for read allocation");
+    if ( !m_handler )
+        return false;
+
+    m_read_data = m_handler->GetBufPtr(m_size);
+
+    m_socket->Read(m_read_data, m_size);
+    return VerifyLastReadCount(m_size);
+}
+
+bool wxIPCMessageBase::ReadString(wxString& str)
+{
+    wxUint32 len = 0;
+    if ( !Read32(len) )
+        return false;
+
+    if ( len > 0 )
+    {
+
+#if wxUSE_UNICODE
+        wxCharBuffer buf(len);
+        if ( !buf || !ReadData(buf.data(), len) )
+            return false;
+#else
+        wxStringBuffer buf(str, len);
+        if ( !buf || !ReadData(buf,len) )
+            return false;
+#endif
+
+        if ( !VerifyLastReadCount(len))
+            return false;
+
+#if wxUSE_UNICODE
+        str = wxConvUTF8.cMB2WC(buf.data(), len, nullptr);
+#endif
+    }
+
+    return true;
+}
+
+bool wxIPCMessageBase::WriteString(const wxString& str)
+{
+#if wxUSE_UNICODE
+    const wxWX2MBbuf buf = str.mb_str(wxConvUTF8);
+    size_t len = buf.length();
+#else
+    const wxWX2MBbuf buf = str.mb_str();
+    size_t len = str.size();
+#endif
+
+    if (len > 0)
+        return Write32(len) && WriteData(buf, len);
+    else
+        return Write32(len);
+}
+
 
 // ==========================================================================
 // wxIPCMessages

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -36,7 +36,10 @@
     #include "wx/log.h"
     #include "wx/event.h"
     #include "wx/module.h"
+    #include "wx/app.h"
 #endif
+
+#include "wx/evtloop.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -1700,6 +1703,25 @@ bool wxTCPEventHandler::SendAndGetReply(wxIPCMessageBase& send_msg,
         return SendAndGetReply_WorkerThread(send_msg, expected_code, return_msgptr);
 }
 
+namespace
+{
+
+// RAII guard that leaves an already-entered critical section on destruction
+// (the inverse of wxCRIT_SECT_LOCKER, which enters on construction). Used when
+// the section was acquired with TryEnter() in a custom wait loop.
+class CritSectLeaver
+{
+public:
+    explicit CritSectLeaver(wxCriticalSection& cs) : m_cs(cs) {}
+    ~CritSectLeaver() { m_cs.Leave(); }
+
+private:
+    wxCriticalSection& m_cs;
+    wxDECLARE_NO_COPY_CLASS(CritSectLeaver);
+};
+
+} // anonymous namespace
+
 // Take over socket processing from OnSocketInput until we find the
 // return message.
 bool wxTCPEventHandler::SendAndGetReply_MainThread(wxIPCMessageBase& send_msg,
@@ -1707,7 +1729,29 @@ bool wxTCPEventHandler::SendAndGetReply_MainThread(wxIPCMessageBase& send_msg,
                                                    wxSocketBase* socket,
                                                    wxIPCMessageBase** return_msgptr)
 {
-    wxCRIT_SECT_LOCKER(find_message_lock, m_cs_awaiting_reply);
+    // A worker thread may have triggered m_cs_awaiting_reply while parked in
+    // RunOnMainThread(), waiting for *this* (the main) thread to run its
+    // marshalled socket I/O. Blocking on the lock here would stop us pumping the
+    // event loop and deadlock. So acquire it without blocking the loop: spin on
+    // TryEnter(), pumping pending events (the worker's RunOnMainThread() jobs)
+    // and socket I/O (its reply) between attempts so the worker can finish and
+    // release the lock.
+    while ( !m_cs_awaiting_reply.TryEnter() )
+    {
+        wxEventLoopBase* const loop = wxEventLoopBase::GetActive();
+        if ( !loop )
+        {
+            // No event loop to pump, so no worker can be waiting on us; the only
+            // safe thing left is to block until the lock is free.
+            m_cs_awaiting_reply.Enter();
+            break;
+        }
+
+        if ( wxTheApp )
+            wxTheApp->ProcessPendingEvents();
+        loop->DispatchTimeout(1);
+    }
+    CritSectLeaver find_message_lock(m_cs_awaiting_reply);
 
     wxCRIT_SECT_LOCKER(socket_processing_lock, m_cs_socket_processing);
 

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -214,7 +214,7 @@ public:
 
     // The handoff objects between a worker thread blocked in SendAndGetReply()
     // and the main thread's OnSocketInput(). Only one reply is ever pending at a
-    // time, which is guaranteed by m_cs_awaiting_reply.
+    // time, which is serialized by m_cs_awaiting_reply.
     wxMutex m_replyMutex;
     wxCondition m_replyCond{m_replyMutex};
     struct PendingReply
@@ -1057,6 +1057,14 @@ wxConnectionBase *wxTCPClient::MakeConnection(const wxString& host,
         return nullptr;
 
     wxSocketClient * const client = new wxSocketClient(wxSOCKET_WAITALL);
+
+    // Bound the connection attempt (the TCP connect and the topic handshake
+    // that follows) by the IPC timeout instead of leaving it at the socket's
+    // long default: without this, connecting to a listener that is not yet
+    // ready to complete the handshake blocks for the default timeout (ten
+    // minutes) rather than failing promptly so the caller can retry. The
+    // per-connection socket timeout is set to the same value once connected.
+    client->SetTimeout(wxIPCTimeout);
 
     bool ok = client->Connect(*addr);
     delete addr;

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -137,6 +137,10 @@ public:
     void Server_OnRequest(wxSocketEvent& event);
 
     bool ExecuteMessage(wxIPCMessageBase* msg, wxSocketBase *socket);
+    bool FindMessage(IPCCode code,
+                     wxSocketBase* socket,
+                     wxIPCMessageBase** msgptr);
+
     void SendFailMessage(const wxString& reason, wxSocketBase* socket);
     void HandleDisconnect(wxTCPConnection *connection);
 
@@ -1490,14 +1494,50 @@ bool wxTCPEventHandler::ExecuteMessage(wxIPCMessageBase* msg, wxSocketBase *sock
     return true;
 }
 
+// Find a message with IPCCode code. Returns true when a valid message with
+// the matching IPCCode is found.  If msgptr is non-null, then the message is
+// also returned and the caller is responsible for deleting the returned
+// message.
+bool wxTCPEventHandler::FindMessage(IPCCode code,
+                                    wxSocketBase* socket,
+                                    wxIPCMessageBase** return_msgptr)
+{
+    while ( GetConnection(socket) )
     {
+        wxIPCMessageBase* msg = ReadMessageFromSocket(socket);
 
+        if ( msg && msg->GetIPCCode() == code )
         {
+            // The correct message has been found, but there may still be
+            // messages waiting in the socket data buffer. Place an event in
+            // the socket event queue so that they will be read out later.
 
+            if (socket && socket->GetEventHandler())
             {
+                wxSocketEvent event(wxID_ANY);
+                event.m_event = wxSOCKET_INPUT;
+                event.m_clientData = socket->GetClientData();
+                event.SetEventObject(socket);
+
+                socket->GetEventHandler()->AddPendingEvent(event);
             }
+
+            if (return_msgptr)
+                *return_msgptr = msg;
+            else
+                delete msg;
+
+            return true;
         }
 
+        // Not the correct msg to be returned.
+        wxIPCMessageBaseLocker lock(msg);
+        if (!ExecuteMessage(msg, socket) )
+            return false;
+    };
+
+    return false;
+}
 
 // Reads a single message from the socket. Returns wxIPCMessageNull when no
 // message was read.  The returned message must be freed by the caller.

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -409,36 +409,380 @@ protected:
     wxDECLARE_CLASS(wxIPCMessageBase);
 };
 
-    }
+// ==========================================================================
+// wxIPCMessages
+// ==========================================================================
 
+class wxIPCMessageExecute : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageExecute(wxSocketBase* socket = nullptr,
+                        wxTCPEventHandler* handler = nullptr)
+        : wxIPCMessageBase(socket, handler)
     {
-
-
+        SetIPCCode(IPC_EXECUTE);
     }
 
+    wxIPCMessageExecute(wxSocketBase* socket,
+                        const void* data,
+                        size_t size,
+                        wxIPCFormat format)
+        : wxIPCMessageBase(socket, data)
+    {
+        SetIPCCode(IPC_EXECUTE);
+        SetSize((wxUint32) size);
+        SetIPCFormat(format);
+    }
 
+protected:
+    bool DataToSocket() override
+    {
+        return WriteIPCFormat() && WriteSizeAndData();
+    }
 
+    bool DataFromSocket() override
+    {
+        return ReadIPCFormat() && ReadSizeAndData();
+    }
 
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageExecute);
+};
 
+class wxIPCMessageRequest : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageRequest(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_REQUEST);
+        SetIPCFormat(wxIPC_INVALID);
+    }
+
+    wxIPCMessageRequest(wxSocketBase* socket,
+                        const wxString& item,
+                        wxIPCFormat format)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_REQUEST);
+        SetItem(item);
+        SetIPCFormat(format);
+    }
+
+protected:
+    bool DataToSocket() override
+    {
+        return WriteIPCFormat() && WriteString(m_item);
+    }
+
+    bool DataFromSocket() override
+    {
+        return ReadIPCFormat() && ReadString(m_item);
+    }
+
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageRequest);
+};
+
+class wxIPCMessageRequestReply : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageRequestReply(wxSocketBase* socket = nullptr,
+                             wxTCPEventHandler* handler = nullptr)
+        : wxIPCMessageBase(socket, handler)
+    {
+        SetIPCCode(IPC_REQUEST_REPLY);
+    }
+
+    wxIPCMessageRequestReply(wxSocketBase* socket,
+                             const void* user_data,
+                             size_t user_size,
+                             const wxString& item,
+                             wxIPCFormat format)
+        : wxIPCMessageBase(socket, user_data)
+    {
+        SetIPCCode(IPC_REQUEST_REPLY);
+        SetItem(item);
+        SetIPCFormat(format);
+
+        wxUint32 len = user_size;
+        if ( user_size == wxNO_LEN )
+        {
+            switch ( format )
+            {
+            case wxIPC_TEXT:
+            case wxIPC_UTF8TEXT:
+                len = strlen((const char *)user_data) + 1;  // includes final NUL
+                break;
+            case wxIPC_UNICODETEXT:
+                len = (wcslen((const wchar_t *)user_data) + 1) * sizeof(wchar_t);  // includes final NUL
+                break;
+            default:
+                len = 0;
+            }
+        }
+        SetSize(len);
+    }
+
+protected:
+    bool DataToSocket() override
+    {
+        return WriteIPCFormat() && WriteString(m_item) && WriteSizeAndData();
+    }
+
+    bool DataFromSocket() override
+    {
+        return ReadIPCFormat() && ReadString(m_item) && ReadSizeAndData();
+    }
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageRequestReply);
+};
+
+class wxIPCMessagePoke : public wxIPCMessageBase
+{
+public:
+    wxIPCMessagePoke(wxSocketBase* socket = nullptr,
+                     wxTCPEventHandler* handler = nullptr)
+        : wxIPCMessageBase(socket, handler)
+    {
+        SetIPCCode(IPC_POKE);
+    }
+
+    wxIPCMessagePoke(wxSocketBase* socket,
+                     const wxString& item,
+                     const void* data,
+                     size_t size,
+                     wxIPCFormat format)
+        : wxIPCMessageBase(socket, data)
+    {
+        SetIPCCode(IPC_POKE);
+        SetItem(item);
+        SetIPCFormat(format);
+        SetSize(size);
+    }
+
+protected:
+    bool DataToSocket() override
+    {
+        return WriteIPCFormat() && WriteString(m_item) && WriteSizeAndData();
+    }
+
+    bool DataFromSocket() override
+    {
+        return ReadIPCFormat() && ReadString(m_item) && ReadSizeAndData();
+    }
+
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessagePoke);
+};
+
+class wxIPCMessageAdviseStart : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageAdviseStart(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_ADVISE_START);
+    }
+
+    wxIPCMessageAdviseStart(wxSocketBase* socket, const wxString& item)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_ADVISE_START);
+        SetItem(item);
+    }
+
+protected:
+    bool DataToSocket() override
+    {
+        return WriteString(m_item);
+    }
+
+    bool DataFromSocket() override
+    {
+        return ReadString(m_item);
+    }
+
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageAdviseStart);
+};
+
+class wxIPCMessageAdviseStop : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageAdviseStop(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_ADVISE_STOP);
+    }
+
+    wxIPCMessageAdviseStop(wxSocketBase* socket, const wxString& item)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_ADVISE_STOP);
+        SetItem(item);
+    }
+
+protected:
+    bool DataToSocket() override
+    {
+        return WriteString(m_item);
+    }
+
+    bool DataFromSocket() override
+    {
+        return ReadString(m_item);
+    }
+
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageAdviseStop);
+};
+
+class wxIPCMessageAdvise : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageAdvise(wxSocketBase* socket = nullptr,
+                       wxTCPEventHandler* handler = nullptr)
+        : wxIPCMessageBase(socket, handler)
+    {
+        SetIPCCode(IPC_ADVISE);
+    }
+
+    wxIPCMessageAdvise(wxSocketBase* socket,
+                       const wxString& item,
+                       const void* data,
+                       size_t size,
+                       wxIPCFormat format)
+        : wxIPCMessageBase(socket, data)
+    {
+        SetIPCCode(IPC_ADVISE);
+        SetItem(item);
+        SetIPCFormat(format);
+        SetSize(size);
+    }
+
+protected:
+    bool DataToSocket() override
+    {
+        return WriteIPCFormat() && WriteString(m_item) && WriteSizeAndData();
+    }
+
+    bool DataFromSocket() override
+    {
+        return ReadIPCFormat() && ReadString(m_item) && ReadSizeAndData();
+    }
+
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageAdvise);
+};
+
+// Member var item to be used for failure reason (for debug)
+class wxIPCMessageFail : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageFail(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_FAIL);
+    }
+
+    wxIPCMessageFail(wxSocketBase* socket, const wxString& item)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_FAIL);
+        SetItem(item);
+    }
+
+protected:
+    bool DataToSocket() override
+    {
+        return WriteString(m_item);
+    }
+
+    bool DataFromSocket() override
+    {
+        return ReadString(m_item);
+    }
+
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageFail);
+};
+
+// Message returned when socket fails to read an wxIPCMessage
+class wxIPCMessageNull : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageNull(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_NULL);
+    }
+
+protected:
+    bool DataToSocket() override
+    {
+        return false;
+    }
+
+    bool DataFromSocket() override
+    {
+        return false;
+    }
+
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageNull);
+};
+
+class wxIPCMessageConnect : public wxIPCMessageBase
+{
+public:
+    wxIPCMessageConnect(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_CONNECT);
+    }
+
+    wxIPCMessageConnect(wxSocketBase* socket, const wxString& topic)
+        : wxIPCMessageBase(socket)
+    {
+        SetIPCCode(IPC_CONNECT);
+        SetTopic(topic);
+    }
+
+    wxString GetTopic() const { return m_topic; }
+    void SetTopic(const wxString& topic) { m_topic = topic; }
+
+protected:
+    bool DataToSocket() override
+    {
+        return WriteString(m_topic);
+    }
+
+    bool DataFromSocket() override
+    {
+        bool b = ReadString(m_topic);
+        return b;
+    }
+
+    wxString m_topic;
+
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageConnect);
 };
 
 
+class wxIPCMessageDisconnect : public wxIPCMessageBase
 {
 public:
+    wxIPCMessageDisconnect(wxSocketBase* socket = nullptr)
+        : wxIPCMessageBase(socket)
     {
+        SetIPCCode(IPC_DISCONNECT);
     }
 
+protected:
+    bool DataToSocket() override
     {
+        return true;
     }
 
+    bool DataFromSocket() override
     {
+        return true;
     }
 
-    {
-    }
-
-    {
-    }
+    wxDECLARE_DYNAMIC_CLASS(wxIPCMessageDisconnect);
+};
 
 };
 
@@ -449,6 +793,21 @@ public:
 wxIMPLEMENT_DYNAMIC_CLASS(wxTCPServer, wxServerBase);
 wxIMPLEMENT_DYNAMIC_CLASS(wxTCPClient, wxClientBase);
 wxIMPLEMENT_CLASS(wxTCPConnection, wxConnectionBase);
+
+wxIMPLEMENT_CLASS(wxIPCMessageBase,wxObject);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageExecute,wxIPCMessageBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageRequest,wxIPCMessageBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageRequestReply,wxIPCMessageBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessagePoke,wxIPCMessageBase);
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageAdviseStart,wxIPCMessageBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageAdviseStop,wxIPCMessageBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageAdvise,wxIPCMessageBase);
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageConnect,wxIPCMessageBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageDisconnect,wxIPCMessageBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageFail,wxIPCMessageBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxIPCMessageNull,wxIPCMessageBase);
 
 // --------------------------------------------------------------------------
 // wxTCPClient

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -91,6 +91,14 @@ const wxUint32 IPCCodeHeader=0x439d9600;
     #include <sys/stat.h>
 #endif // __UNIX_LIKE__
 
+
+// For IPC returning a char* buffer. wxWidgets docs say that the user is not
+// supposed to free the memory.  Each buffer pointer is assigned to a list
+// sequentially, and the buffer memory is not freed until MAX_MSG_BUFFERS have
+// been assigned.
+#define MAX_MSG_BUFFERS 2048
+
+
 // ----------------------------------------------------------------------------
 // private functions
 // ----------------------------------------------------------------------------
@@ -125,13 +133,26 @@ GetAddressFromName(const wxString& serverName,
 }
 
 // --------------------------------------------------------------------------
-// wxTCPEventHandler stuff (private class)
+// wxTCPEventHandler declaration (private class)
 // --------------------------------------------------------------------------
 
 class wxTCPEventHandler : public wxEvtHandler
 {
 public:
-    wxTCPEventHandler() : wxEvtHandler() { }
+    wxTCPEventHandler() : wxEvtHandler()
+    {
+        for (int i = 0; i < MAX_MSG_BUFFERS; i++)
+            m_bufferList[i] = nullptr;
+
+        m_nextAvailable = 0;
+    }
+
+    ~wxTCPEventHandler()
+    {
+        for (int i = 0; i < MAX_MSG_BUFFERS; i++)
+            if (m_bufferList[i])
+                delete[] m_bufferList[i];
+    }
 
     void Client_OnRequest(wxSocketEvent& event);
     void Server_OnRequest(wxSocketEvent& event);
@@ -152,6 +173,11 @@ public:
 
 private:
     wxTCPConnection* GetConnection(wxSocketBase* socket);
+
+    wxCRIT_SECT_DECLARE_MEMBER(m_cs_assign_buffer);
+
+    char* m_bufferList[MAX_MSG_BUFFERS];
+    int m_nextAvailable;
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxTCPEventHandler);
@@ -1708,6 +1734,19 @@ bool wxTCPEventHandler::PeekAtMessageInSocket(wxSocketBase* socket)
     return socket->LastCount() == 4;
 }
 
+char* wxTCPEventHandler::GetBufPtr(size_t size)
+{
+    wxCRIT_SECT_LOCKER(lock, m_cs_assign_buffer);
+
+    if (m_bufferList[m_nextAvailable] != nullptr)
+        delete[] m_bufferList[m_nextAvailable];  // Free the memory from the last use
+
+    char* ptr = new char[size];
+
+    m_bufferList[m_nextAvailable] = ptr;
+    m_nextAvailable = (m_nextAvailable + 1) % MAX_MSG_BUFFERS;
+
+    return ptr;
 }
 
 wxTCPConnection* wxTCPEventHandler::GetConnection(wxSocketBase* socket)

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -1318,14 +1318,18 @@ wxEND_EVENT_TABLE()
 
 void wxTCPEventHandler::Client_OnRequest(wxSocketEvent &event)
 {
-    wxSocketBase *sock = event.GetSocket();
-
     // This handler is a shared, process-lifetime singleton, so it may receive
     // a socket event that was queued before its socket was destroyed (e.g. a
     // wxSOCKET_LOST generated as a connection is being torn down). Such an
     // event must be ignored without touching the socket, as it now points to
-    // freed memory. IsConnectionSocket() only compares the pointer value and
-    // never dereferences it, so it is safe to call here.
+    // freed memory. Even obtaining the typed pointer via GetSocket() performs a
+    // checked downcast (wxObject* -> wxSocketBase*), which is undefined behavior
+    // on a freed object and trips UBSAN's vptr check, so use reinterpret_cast
+    // (not vptr-instrumented) purely for the registry pointer-value lookup
+    // below. IsConnectionSocket() only compares the pointer value and never
+    // dereferences it, so it is safe to call here.
+    wxSocketBase *sock =
+        reinterpret_cast<wxSocketBase *>(event.GetEventObject());
     if ( !IsConnectionSocket(sock) )
         return;
 

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -44,6 +44,8 @@
 
 #include "wx/socket.h"
 
+class wxIPCMessageBase;
+
 // --------------------------------------------------------------------------
 // macros and constants
 // --------------------------------------------------------------------------
@@ -68,6 +70,11 @@ enum IPCCode
     IPC_DISCONNECT      = 11,
     IPC_MAX
 };
+
+// A random header, which is used to detect a loss-of-sync on the IPC
+// data stream. The header is 24-bits, and the IPCCode above is sent in the
+// last 8 bits.
+const wxUint32 IPCCodeHeader=0x439d9600;
 
 } // anonymous namespace
 
@@ -169,32 +176,238 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxTCPEventHandlerModule, wxModule);
 wxTCPEventHandler *wxTCPEventHandlerModule::ms_handler = nullptr;
 
 // --------------------------------------------------------------------------
-// wxIPCSocketStreams
+// wxIPCMessageBase
 // --------------------------------------------------------------------------
 
+// This class and its derivatives manage the reading and writing of data from
+// the socket.
+class wxIPCMessageBase : public wxObject
 {
 public:
+    wxIPCMessageBase(wxSocketBase* socket = nullptr,
+                     wxTCPEventHandler* handler = nullptr)
+        : m_write_data(nullptr), m_handler(handler)
     {
+        Init(socket);
     }
 
-
+    wxIPCMessageBase(wxSocketBase* socket, const void* data)
+        : m_write_data(data), m_handler(nullptr)
     {
+        Init(socket);
+    }
+    virtual ~wxIPCMessageBase() {};
+
+    bool IsOk() const { return m_ipc_code != IPC_NULL; }
+
+    // Accessors for the base object
+    IPCCode GetIPCCode() const { return m_ipc_code; }
+    void SetIPCCode(IPCCode ipc_code) { m_ipc_code = ipc_code; }
+
+    wxSocketBase* GetSocket() const { return m_socket; }
+    void SetSocket(wxSocketBase* socket) { m_socket = socket; }
+
+    wxSocketError GetError() const { return m_error; }
+    void SetError(wxSocketError error) { m_error = error; }
+
+    // These accessors are here to avoid repetition in the derived objects.
+    wxIPCFormat GetIPCFormat() const { return m_ipc_format; }
+    void SetIPCFormat(wxIPCFormat ipc_format) { m_ipc_format = ipc_format; }
+
+    const void* GetReadData() const { return m_read_data; }
+    void SetReadData(void *data) { m_read_data = data; }
+
+    size_t GetSize() const { return m_size; }
+    void SetSize(size_t size) { m_size = size; }
+
+    wxString GetItem() const { return m_item; }
+    void SetItem(const wxString& item) { m_item = item; }
+
+protected:
+    void Init(wxSocketBase* socket)
+    {
+        SetIPCCode(IPC_NULL);
+        SetSocket(socket);
+        SetError(wxSOCKET_NOERROR);
+
+        SetIPCFormat(wxIPC_INVALID);
+        SetReadData(nullptr);
+        SetSize(0);
     }
 
+    virtual bool DataFromSocket() = 0;
+    virtual bool DataToSocket() = 0;
+
+    // primitives for read/write to socket
+
+    bool VerifyValidSocket()
     {
+        if (m_socket && m_socket->IsOk() && m_socket->IsConnected() ) return true;
+
+        SetError(wxSOCKET_INVSOCK);
+        return false;
     }
 
+    bool Read32(wxUint32& word)
     {
+        word = 0;
+
+        if ( !VerifyValidSocket() )
+            return false;
+
+        m_socket->Read(reinterpret_cast<char *>(&word), 4);
+
+        return VerifyLastReadCount(4);
     }
 
+    // Reads nbytes of data from the socket into a pre-allocated buffer
+    bool ReadData(void* buffer, wxUint32& nbytes)
     {
+        if ( !VerifyValidSocket() )
+            return false;
+
+        m_socket->Read(buffer, nbytes);
+
+        return VerifyLastReadCount(nbytes);
     }
 
+    bool ReadSizeAndData();
+    bool ReadIPCCode()
     {
+        wxUint32 code_with_header;
+        if (!Read32(code_with_header))
+            return false;
 
+        if ((code_with_header & 0xFFFFFF00) != IPCCodeHeader)
+        {
+            // The expected data is misaligned, which is bad.
+            SetError(wxSOCKET_IOERR);
+            return false;
+        }
 
+        SetIPCCode(static_cast<IPCCode>(code_with_header & 0xFF));
+        return true;
+    }
 
+    bool ReadIPCFormat()
+    {
+        if ( !VerifyValidSocket() )
+            return false;
 
+        m_socket->Read(reinterpret_cast<char *>(&m_ipc_format), 1);
+
+        return VerifyLastReadCount(1);
+    }
+
+    bool ReadString(wxString& str);
+    bool VerifyLastReadCount(wxUint32 nbytes)
+    {
+        if ( !VerifyValidSocket() )
+            return false;
+
+        if (m_socket->Error())
+        {
+            SetError(m_socket->LastError());
+            return false;
+        }
+
+        if (m_socket->LastReadCount() != nbytes)
+        {
+            // The expected data is misaligned, which is bad.
+            SetError(wxSOCKET_IOERR);
+            return false;
+        }
+        return true;
+    }
+
+    bool Write32(wxUint32 word)
+    {
+        if ( !VerifyValidSocket() )
+            return false;
+
+        m_socket->Write(reinterpret_cast<char *>(&word), 4);
+
+        return VerifyLastWriteCount(4);
+    }
+
+    bool WriteData(const void* data, wxUint32 nbytes)
+    {
+        if ( !VerifyValidSocket() )
+            return false;
+
+        m_socket->Write(data, nbytes);
+
+        return VerifyLastWriteCount(nbytes);
+    }
+
+    bool WriteSizeAndData()
+    {
+        if (!Write32(m_size))
+            return false;
+
+        return WriteData(m_write_data, m_size);
+    }
+
+    bool WriteIPCCode()
+    {
+        wxUint32 code_with_header = IPCCodeHeader | GetIPCCode();
+        return Write32(code_with_header);
+    }
+
+    bool WriteIPCFormat()
+    {
+        if ( !VerifyValidSocket() )
+            return false;
+
+        m_socket->Write(reinterpret_cast<char *>(&m_ipc_format), 1);
+
+        return VerifyLastWriteCount(1);
+    }
+
+    bool WriteString(const wxString& str);
+
+    bool VerifyLastWriteCount(wxUint32 nbytes)
+    {
+        if ( !VerifyValidSocket() )
+            return false;
+
+        if (m_socket->Error())
+        {
+            SetError(m_socket->LastError());
+            return false;
+        }
+
+        if (m_socket->LastWriteCount() != nbytes)
+        {
+            SetError(wxSOCKET_IOERR);
+            return false;
+        }
+        return true;
+    }
+
+    IPCCode m_ipc_code;
+
+    wxSocketBase* m_socket;
+    wxSocketError m_error;
+
+    // Members used in most of the derived messages
+    wxUint32 m_size;
+    wxIPCFormat m_ipc_format;
+    wxString m_item;
+
+    // immutable pointer to data from connection object
+    const void* m_write_data;
+
+    // pointer to data read from socket
+    void* m_read_data;
+
+    wxTCPEventHandler *m_handler;
+
+    friend wxTCPEventHandler;
+
+    wxDECLARE_NO_COPY_CLASS(wxIPCMessageBase);
+    wxDECLARE_CLASS(wxIPCMessageBase);
+};
 
     }
 

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -45,8 +45,8 @@
 #include <stdio.h>
 #include <errno.h>
 
-#include <set>
 #include <functional>
+#include <unordered_set>
 
 #include "wx/socket.h"
 #include "wx/thread.h"
@@ -243,14 +243,15 @@ private:
     int m_nextAvailable;
 
     wxCRIT_SECT_DECLARE_MEMBER(m_cs_connection_sockets);
-    std::set<wxSocketBase*> m_connectionSockets;
+    std::unordered_set<wxSocketBase*> m_connectionSockets;
 
     // Sockets the main thread is currently reading. A WAITALL Read/Peek pumps the
     // event loop while it waits, so on MSW the GUI message pump can re-dispatch a
     // wxSOCKET_INPUT for a socket we are already reading; OnSocketInput() consults
     // this set and bails to avoid a re-entrant read (which trips wxSocketReadGuard,
     // "read reentrancy?"). All reads run on the main thread, so this needs no lock.
-    std::set<wxSocketBase*> m_socketsBeingRead;
+    std::unordered_set<wxSocketBase*> m_socketsBeingRead;
+
     bool IsReadingSocket(wxSocketBase* socket) const
         { return m_socketsBeingRead.count(socket) != 0; }
 
@@ -273,12 +274,12 @@ namespace
 class MainThreadReadGuard
 {
 public:
-    MainThreadReadGuard(std::set<wxSocketBase*>& set, wxSocketBase* socket)
+    MainThreadReadGuard(std::unordered_set<wxSocketBase*>& set, wxSocketBase* socket)
         : m_set(set), m_socket(socket) { m_set.insert(m_socket); }
     ~MainThreadReadGuard() { m_set.erase(m_socket); }
 
 private:
-    std::set<wxSocketBase*>& m_set;
+    std::unordered_set<wxSocketBase*>& m_set;
     wxSocketBase* const m_socket;
     wxDECLARE_NO_COPY_CLASS(MainThreadReadGuard);
 };

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -150,6 +150,9 @@ public:
 
     char* GetBufPtr(size_t size);
 
+private:
+    wxTCPConnection* GetConnection(wxSocketBase* socket);
+
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxTCPEventHandler);
 };
@@ -1596,6 +1599,14 @@ bool wxTCPEventHandler::FindMessage(IPCCode code,
     return false;
 }
 
+void wxTCPEventHandler::SendFailMessage(const wxString& reason, wxSocketBase* socket)
+{
+    wxIPCMessageFail msg(socket, reason);
+
+    if (!WriteMessageToSocket(msg) )
+        wxLogDebug("Failed to send IPC_FAIL message: " + reason);
+}
+
 // Reads a single message from the socket. Returns wxIPCMessageNull when no
 // message was read.  The returned message must be freed by the caller.
 wxIPCMessageBase* wxTCPEventHandler::ReadMessageFromSocket(wxSocketBase* socket)
@@ -1697,6 +1708,14 @@ bool wxTCPEventHandler::PeekAtMessageInSocket(wxSocketBase* socket)
     return socket->LastCount() == 4;
 }
 
+}
+
+wxTCPConnection* wxTCPEventHandler::GetConnection(wxSocketBase* socket)
+{
+    if ( !socket || !socket->IsOk() )
+        return nullptr;
+
+    return static_cast<wxTCPConnection *>(socket->GetClientData());
 }
 
 #endif // wxUSE_SOCKETS && wxUSE_IPC

--- a/src/msw/sockmsw.cpp
+++ b/src/msw/sockmsw.cpp
@@ -295,6 +295,13 @@ wxSocketError wxSocketImplMSW::GetLastError() const
         case WSAENOTSOCK:
             return wxSOCKET_INVSOCK;
 
+        // Trying to read or peek on the socket when there
+        // is no data waiting will result in ERROR_ACCESS_DENIED
+        // and/or WSAECONNABORTED. We return wxSOCKET_WOULDBLOCK
+        // so the caller can keep trying.
+        case ERROR_ACCESS_DENIED:
+        case WSAECONNABORTED:
+
         case WSAEWOULDBLOCK:
             return wxSOCKET_WOULDBLOCK;
 

--- a/src/msw/sockmsw.cpp
+++ b/src/msw/sockmsw.cpp
@@ -182,22 +182,6 @@ LRESULT CALLBACK wxSocket_Internal_WinProc(HWND hWnd,
         switch ( WSAGETSELECTEVENT(lParam) )
         {
             case FD_READ:
-                // We may get a FD_READ notification even when there is no data
-                // to read on the socket, in particular this happens on socket
-                // creation when we seem to always get FD_CONNECT, FD_WRITE and
-                // FD_READ notifications all at once (but it doesn't happen
-                // only then). Ignore such dummy notifications.
-                {
-                    fd_set fds;
-                    wxTimeVal_t tv = { 0, 0 };
-
-                    wxFD_ZERO(&fds);
-                    wxFD_SET(socket->m_fd, &fds);
-
-                    if ( select(socket->m_fd + 1, &fds, nullptr, nullptr, &tv) != 1 )
-                        return 0;
-                }
-
                 event = wxSOCKET_INPUT;
                 break;
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -102,6 +102,7 @@ TEST_OBJECTS =  \
 	test_pathlist.o \
 	test_typeinfotest.o \
 	test_ipc.o \
+	test_ipc_test_server.o \
 	test_socket.o \
 	test_webrequest.o \
 	test_regextest.o \
@@ -162,7 +163,7 @@ TEST_GUI_CXXFLAGS = $(__test_gui_PCH_INC) $(WX_CPPFLAGS) -D__WX$(TOOLKIT)__ \
 	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
 	$(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) -I$(srcdir) $(__DLLFLAG_p) \
 	-I$(srcdir)/../samples $(WX_CXXFLAGS) $(SAMPLES_CXXFLAGS) $(CATCH2_CFLAGS) \
-	$(CPPFLAGS) $(CXXFLAGS)
+	-DTEST_HAS_IPC_SERVER $(CPPFLAGS) $(CXXFLAGS)
 TEST_GUI_OBJECTS =  \
 	$(__test_gui___win32rc) \
 	test_gui_asserthelper.o \
@@ -265,6 +266,8 @@ TEST_GUI_OBJECTS =  \
 	test_gui_settings.o \
 	test_gui_textwrap.o \
 	test_gui_socket.o \
+	test_gui_ipc.o \
+	test_gui_ipc_test_server.o \
 	test_gui_tlw.o \
 	test_gui_dataview.o \
 	test_gui_rowheightcachetest.o \
@@ -291,6 +294,7 @@ TEST_ALLHEADERS_OBJECTS =  \
 	test_allheaders_testableframe.o
 TEST_ALLHEADERS_ODEP = \
 	$(_____pch_testprec_test_allheaders_testprec_h_gch___depname)
+
 
 ### Conditionally set variables: ###
 
@@ -562,7 +566,7 @@ test$(EXEEXT): $(TEST_OBJECTS) $(__test___win32rc)
 @COND_USE_PCH_1@./.pch/testprec_test_allheaders/testprec.h.gch: 
 @COND_USE_PCH_1@	$(BK_MAKE_PCH) ./.pch/testprec_test_allheaders/testprec.h.gch testprec.h $(CXX) $(TEST_ALLHEADERS_CXXFLAGS)
 
-data: 
+data:
 	@mkdir -p .
 	@for f in testdata.conf horse.svg; do \
 	if test ! -f ./$$f -a ! -d ./$$f ; \
@@ -650,7 +654,7 @@ test_test_rc.o: $(srcdir)/../tests/test.rc $(TEST_ODEP)
 	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9)  $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(srcdir) $(__DLLFLAG_p_9) --define wxUSE_GUI=0 --include-dir $(top_srcdir)/samples $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include
 
 test_test.o: $(srcdir)/test.cpp $(TEST_ODEP)
-	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/test.cpp
+	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) -DTEST_HAS_IPC_SERVER $(srcdir)/test.cpp
 
 test_anytest.o: $(srcdir)/any/anytest.cpp $(TEST_ODEP)
 	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/any/anytest.cpp
@@ -780,6 +784,9 @@ test_typeinfotest.o: $(srcdir)/misc/typeinfotest.cpp $(TEST_ODEP)
 
 test_ipc.o: $(srcdir)/net/ipc.cpp $(TEST_ODEP)
 	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/net/ipc.cpp
+
+test_ipc_test_server.o: $(srcdir)/net/ipc_test_server.cpp $(TEST_ODEP)
+	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/net/ipc_test_server.cpp
 
 test_socket.o: $(srcdir)/net/socket.cpp $(TEST_ODEP)
 	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/net/socket.cpp
@@ -1224,6 +1231,12 @@ test_gui_textwrap.o: $(srcdir)/misc/textwrap.cpp $(TEST_GUI_ODEP)
 
 test_gui_socket.o: $(srcdir)/net/socket.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/net/socket.cpp
+
+test_gui_ipc.o: $(srcdir)/net/ipc.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/net/ipc.cpp
+
+test_gui_ipc_test_server.o: $(srcdir)/net/ipc_test_server.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/net/ipc_test_server.cpp
 
 test_gui_tlw.o: $(srcdir)/persistence/tlw.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/persistence/tlw.cpp

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -54,8 +54,8 @@ LIBDIRNAME = $(wx_top_builddir)/lib
 TEST_CXXFLAGS = $(__test_PCH_INC) $(WX_CPPFLAGS) -D__WX$(TOOLKIT)__ \
 	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
 	$(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) -I$(srcdir) $(__DLLFLAG_p) \
-	-DwxUSE_GUI=0 $(WX_CXXFLAGS) $(SAMPLES_CXXFLAGS) $(CATCH2_CFLAGS) \
-	$(CPPFLAGS) $(CXXFLAGS)
+	-DwxUSE_GUI=0 -DTEST_HAS_IPC_SERVER $(WX_CXXFLAGS) $(SAMPLES_CXXFLAGS) \
+	$(CATCH2_CFLAGS) $(CPPFLAGS) $(CXXFLAGS)
 TEST_OBJECTS =  \
 	$(__test___win32rc) \
 	test_test.o \
@@ -162,8 +162,8 @@ TEST_DRAWING_ODEP = \
 TEST_GUI_CXXFLAGS = $(__test_gui_PCH_INC) $(WX_CPPFLAGS) -D__WX$(TOOLKIT)__ \
 	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
 	$(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) -I$(srcdir) $(__DLLFLAG_p) \
-	-I$(srcdir)/../samples $(WX_CXXFLAGS) $(SAMPLES_CXXFLAGS) $(CATCH2_CFLAGS) \
-	-DTEST_HAS_IPC_SERVER $(CPPFLAGS) $(CXXFLAGS)
+	-I$(srcdir)/../samples -DTEST_HAS_IPC_SERVER $(WX_CXXFLAGS) \
+	$(SAMPLES_CXXFLAGS) $(CATCH2_CFLAGS) $(CPPFLAGS) $(CXXFLAGS)
 TEST_GUI_OBJECTS =  \
 	$(__test_gui___win32rc) \
 	test_gui_asserthelper.o \
@@ -295,7 +295,6 @@ TEST_ALLHEADERS_OBJECTS =  \
 TEST_ALLHEADERS_ODEP = \
 	$(_____pch_testprec_test_allheaders_testprec_h_gch___depname)
 
-
 ### Conditionally set variables: ###
 
 @COND_DEPS_TRACKING_0@CXXC = $(CXX)
@@ -310,12 +309,12 @@ TEST_ALLHEADERS_ODEP = \
 @COND_MONOLITHIC_1@	$(EXTRALIBS_XML) $(EXTRALIBS_GUI)
 @COND_MONOLITHIC_0@EXTRALIBS_FOR_GUI = $(EXTRALIBS_GUI)
 @COND_MONOLITHIC_1@EXTRALIBS_FOR_GUI = 
-@COND_PLATFORM_WIN32_1@__test___win32rc = test_test_rc.o
 @COND_GCC_PCH_1@__test_PCH_INC = -I./.pch/testprec_test
 @COND_ICC_PCH_1@__test_PCH_INC = $(ICC_PCH_USE_SWITCH) \
 @COND_ICC_PCH_1@	./.pch/testprec_test/testprec.h.gch
 @COND_USE_PCH_1@_____pch_testprec_test_testprec_h_gch___depname \
 @COND_USE_PCH_1@	= ./.pch/testprec_test/testprec.h.gch
+@COND_PLATFORM_WIN32_1@__test___win32rc = test_test_rc.o
 @COND_MONOLITHIC_1@__LIB_PNG_IF_MONO_p = $(__LIB_PNG_p)
 @COND_USE_GUI_1@__test_drawing___depname = test_drawing$(EXEEXT)
 @COND_PLATFORM_WIN32_1@__test_drawing___win32rc = test_drawing_test_rc.o
@@ -343,12 +342,12 @@ TEST_ALLHEADERS_ODEP = \
 @COND_TOOLKIT_OSX_COCOA@	= $(__test_gui_app_Contents_PkgInfo___depname)
 @COND_TOOLKIT_OSX_IPHONE@____test_gui_BUNDLE_TGT_REF_DEP \
 @COND_TOOLKIT_OSX_IPHONE@	= $(__test_gui_app_Contents_PkgInfo___depname)
-@COND_PLATFORM_WIN32_1@__test_gui___win32rc = test_gui_test_rc.o
 @COND_GCC_PCH_1@__test_gui_PCH_INC = -I./.pch/testprec_test_gui
 @COND_ICC_PCH_1@__test_gui_PCH_INC = $(ICC_PCH_USE_SWITCH) \
 @COND_ICC_PCH_1@	./.pch/testprec_test_gui/testprec.h.gch
 @COND_USE_PCH_1@_____pch_testprec_test_gui_testprec_h_gch___depname \
 @COND_USE_PCH_1@	= ./.pch/testprec_test_gui/testprec.h.gch
+@COND_PLATFORM_WIN32_1@__test_gui___win32rc = test_gui_test_rc.o
 COND_MONOLITHIC_0___WXLIB_AUI_p = \
 	-lwx_$(PORTNAME)$(WXUNIVNAME)u$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_aui-$(WX_RELEASE)$(HOST_SUFFIX)
 @COND_MONOLITHIC_0@__WXLIB_AUI_p = $(COND_MONOLITHIC_0___WXLIB_AUI_p)
@@ -566,7 +565,7 @@ test$(EXEEXT): $(TEST_OBJECTS) $(__test___win32rc)
 @COND_USE_PCH_1@./.pch/testprec_test_allheaders/testprec.h.gch: 
 @COND_USE_PCH_1@	$(BK_MAKE_PCH) ./.pch/testprec_test_allheaders/testprec.h.gch testprec.h $(CXX) $(TEST_ALLHEADERS_CXXFLAGS)
 
-data:
+data: 
 	@mkdir -p .
 	@for f in testdata.conf horse.svg; do \
 	if test ! -f ./$$f -a ! -d ./$$f ; \
@@ -651,10 +650,10 @@ xart-dothraki:
 	done
 
 test_test_rc.o: $(srcdir)/../tests/test.rc $(TEST_ODEP)
-	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9)  $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(srcdir) $(__DLLFLAG_p_9) --define wxUSE_GUI=0 --include-dir $(top_srcdir)/samples $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include
+	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9)  $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(srcdir) $(__DLLFLAG_p_9) --define wxUSE_GUI=0 --include-dir $(top_srcdir)/samples $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include --define TEST_HAS_IPC_SERVER
 
 test_test.o: $(srcdir)/test.cpp $(TEST_ODEP)
-	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) -DTEST_HAS_IPC_SERVER $(srcdir)/test.cpp
+	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/test.cpp
 
 test_anytest.o: $(srcdir)/any/anytest.cpp $(TEST_ODEP)
 	$(CXXC) -c -o $@ $(TEST_CXXFLAGS) $(srcdir)/any/anytest.cpp
@@ -930,7 +929,7 @@ test_drawing_fonttest.o: $(srcdir)/drawing/fonttest.cpp $(TEST_DRAWING_ODEP)
 	$(CXXC) -c -o $@ $(TEST_DRAWING_CXXFLAGS) $(srcdir)/drawing/fonttest.cpp
 
 test_gui_test_rc.o: $(srcdir)/../tests/test.rc $(TEST_GUI_ODEP)
-	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9)  $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(srcdir) $(__DLLFLAG_p_9) $(__WIN32_DPI_MANIFEST_p) --include-dir $(srcdir)/../samples $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include --include-dir $(top_srcdir)/samples $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include
+	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9)  $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(srcdir) $(__DLLFLAG_p_9) $(__WIN32_DPI_MANIFEST_p) --include-dir $(srcdir)/../samples $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include --include-dir $(top_srcdir)/samples $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include --define TEST_HAS_IPC_SERVER
 
 test_gui_asserthelper.o: $(srcdir)/asserthelper.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/asserthelper.cpp

--- a/tests/descrip.mms
+++ b/tests/descrip.mms
@@ -97,6 +97,7 @@ TEST_OBJECTS =  \
 	test_typeinfotest.obj
 
 TEST_OBJECTS1=test_ipc.obj,\
+	test_ipc_test_server.obj,\
 	test_socket.obj,\
 	test_regextest.obj,\
 	test_wxregextest.obj,\
@@ -374,10 +375,13 @@ test_pathlist.obj : [.misc]pathlist.cpp
 test_typeinfotest.obj : [.misc]typeinfotest.cpp 
 	$(CXXC) /object=[]$@ $(TEST_CXXFLAGS) [.misc]typeinfotest.cpp
 
-test_ipc.obj : [.net]ipc.cpp 
+test_ipc.obj : [.net]ipc.cpp
 	$(CXXC) /object=[]$@ $(TEST_CXXFLAGS) [.net]ipc.cpp
 
-test_socket.obj : [.net]socket.cpp 
+test_ipc_test_server.obj : [.net]ipc_test_server.cpp
+	$(CXXC) /object=[]$@ $(TEST_CXXFLAGS) [.net]ipc_test_server.cpp
+
+test_socket.obj : [.net]socket.cpp
 	$(CXXC) /object=[]$@ $(TEST_CXXFLAGS)/warn=(disable=REFTEMPORARY)\
 	[.net]socket.cpp
 

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -25,11 +25,11 @@ TEST_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) -D__WXMSW__ \
 	$(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) \
 	-I$(SETUPHDIR) -I.\..\include $(____CAIRO_INCLUDEDIR_FILENAMES) -W -Wall -I. \
 	$(__DLLFLAG_p) -DwxUSE_GUI=0 -I.\..\3rdparty\catch\single_include \
-	$(__RTTIFLAG) $(__EXCEPTIONSFLAG) -Wno-ctor-dtor-privacy $(CPPFLAGS) \
-	$(CXXFLAGS)
+	-DTEST_HAS_IPC_SERVER $(__RTTIFLAG) $(__EXCEPTIONSFLAG) \
+	-Wno-ctor-dtor-privacy $(CPPFLAGS) $(CXXFLAGS)
 TEST_OBJECTS =  \
-	$(OBJS)\test_test_rc.o \
 	$(OBJS)\test_dummy.o \
+	$(OBJS)\test_test_rc.o \
 	$(OBJS)\test_test.o \
 	$(OBJS)\test_anytest.o \
 	$(OBJS)\test_archivetest.o \
@@ -136,11 +136,11 @@ TEST_GUI_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) \
 	$(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) \
 	-I$(SETUPHDIR) -I.\..\include $(____CAIRO_INCLUDEDIR_FILENAMES) -W -Wall -I. \
 	$(__DLLFLAG_p) -I.\..\samples -DNOPCH -I.\..\3rdparty\catch\single_include \
-	$(__RTTIFLAG) $(__EXCEPTIONSFLAG) -Wno-ctor-dtor-privacy \
-	-DTEST_HAS_IPC_SERVER $(CPPFLAGS) $(CXXFLAGS)
+	-DTEST_HAS_IPC_SERVER $(__RTTIFLAG) $(__EXCEPTIONSFLAG) \
+	-Wno-ctor-dtor-privacy $(CPPFLAGS) $(CXXFLAGS)
 TEST_GUI_OBJECTS =  \
-	$(OBJS)\test_gui_test_rc.o \
 	$(OBJS)\test_gui_dummy.o \
+	$(OBJS)\test_gui_test_rc.o \
 	$(OBJS)\test_gui_asserthelper.o \
 	$(OBJS)\test_gui_test.o \
 	$(OBJS)\test_gui_testableframe.o \
@@ -581,14 +581,14 @@ xart-dothraki:
 	if not exist $(OBJS)\intl\xart-dothraki mkdir $(OBJS)\intl\xart-dothraki
 	for %%f in (internat.po internat.mo) do if not exist $(OBJS)\intl\xart-dothraki\%%f copy .\intl\xart-dothraki\%%f $(OBJS)\intl\xart-dothraki
 
-$(OBJS)\test_test_rc.o: ./../tests/test.rc
-	$(WINDRES) -i$< -o$@    --define __WXMSW__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9) $(__NDEBUG_DEFINE_p_9) $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(SETUPHDIR) --include-dir ./../include $(__CAIRO_INCLUDEDIR_p) --include-dir . $(__DLLFLAG_p_9) --define wxUSE_GUI=0 --include-dir ./../samples --include-dir ./../3rdparty/catch/single_include
-
 $(OBJS)\test_dummy.o: ./dummy.cpp
 	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
 
+$(OBJS)\test_test_rc.o: ./../tests/test.rc
+	$(WINDRES) -i$< -o$@    --define __WXMSW__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9) $(__NDEBUG_DEFINE_p_9) $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(SETUPHDIR) --include-dir ./../include $(__CAIRO_INCLUDEDIR_p) --include-dir . $(__DLLFLAG_p_9) --define wxUSE_GUI=0 --include-dir ./../samples --include-dir ./../3rdparty/catch/single_include --define TEST_HAS_IPC_SERVER
+
 $(OBJS)\test_test.o: ./test.cpp
-	$(CXX) -c -o $@ $(TEST_CXXFLAGS) -DTEST_HAS_IPC_SERVER $(CPPDEPS) $<
+	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_anytest.o: ./any/anytest.cpp
 	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
@@ -866,11 +866,11 @@ $(OBJS)\test_drawing_basictest.o: ./drawing/basictest.cpp
 $(OBJS)\test_drawing_fonttest.o: ./drawing/fonttest.cpp
 	$(CXX) -c -o $@ $(TEST_DRAWING_CXXFLAGS) $(CPPDEPS) $<
 
-$(OBJS)\test_gui_test_rc.o: ./../tests/test.rc
-	$(WINDRES) -i$< -o$@    --define __WXMSW__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9) $(__NDEBUG_DEFINE_p_9) $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(SETUPHDIR) --include-dir ./../include $(__CAIRO_INCLUDEDIR_p) --include-dir . $(__DLLFLAG_p_9) --define wxUSE_DPI_AWARE_MANIFEST=$(USE_DPI_AWARE_MANIFEST) --include-dir ./../samples --define NOPCH --include-dir ./../samples --include-dir ./../3rdparty/catch/single_include
-
 $(OBJS)\test_gui_dummy.o: ./dummy.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_test_rc.o: ./../tests/test.rc
+	$(WINDRES) -i$< -o$@    --define __WXMSW__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9) $(__NDEBUG_DEFINE_p_9) $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) --include-dir $(SETUPHDIR) --include-dir ./../include $(__CAIRO_INCLUDEDIR_p) --include-dir . $(__DLLFLAG_p_9) --define wxUSE_DPI_AWARE_MANIFEST=$(USE_DPI_AWARE_MANIFEST) --include-dir ./../samples --define NOPCH --include-dir ./../samples --include-dir ./../3rdparty/catch/single_include --define TEST_HAS_IPC_SERVER
 
 $(OBJS)\test_gui_asserthelper.o: ./asserthelper.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -74,6 +74,7 @@ TEST_OBJECTS =  \
 	$(OBJS)\test_pathlist.o \
 	$(OBJS)\test_typeinfotest.o \
 	$(OBJS)\test_ipc.o \
+	$(OBJS)\test_ipc_test_server.o \
 	$(OBJS)\test_socket.o \
 	$(OBJS)\test_webrequest.o \
 	$(OBJS)\test_regextest.o \
@@ -135,8 +136,8 @@ TEST_GUI_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) \
 	$(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) \
 	-I$(SETUPHDIR) -I.\..\include $(____CAIRO_INCLUDEDIR_FILENAMES) -W -Wall -I. \
 	$(__DLLFLAG_p) -I.\..\samples -DNOPCH -I.\..\3rdparty\catch\single_include \
-	$(__RTTIFLAG) $(__EXCEPTIONSFLAG) -Wno-ctor-dtor-privacy $(CPPFLAGS) \
-	$(CXXFLAGS)
+	$(__RTTIFLAG) $(__EXCEPTIONSFLAG) -Wno-ctor-dtor-privacy \
+	-DTEST_HAS_IPC_SERVER $(CPPFLAGS) $(CXXFLAGS)
 TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_test_rc.o \
 	$(OBJS)\test_gui_dummy.o \
@@ -240,6 +241,8 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_settings.o \
 	$(OBJS)\test_gui_textwrap.o \
 	$(OBJS)\test_gui_socket.o \
+	$(OBJS)\test_gui_ipc.o \
+	$(OBJS)\test_gui_ipc_test_server.o \
 	$(OBJS)\test_gui_tlw.o \
 	$(OBJS)\test_gui_dataview.o \
 	$(OBJS)\test_gui_rowheightcachetest.o \
@@ -585,7 +588,7 @@ $(OBJS)\test_dummy.o: ./dummy.cpp
 	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_test.o: ./test.cpp
-	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
+	$(CXX) -c -o $@ $(TEST_CXXFLAGS) -DTEST_HAS_IPC_SERVER $(CPPDEPS) $<
 
 $(OBJS)\test_anytest.o: ./any/anytest.cpp
 	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
@@ -714,6 +717,9 @@ $(OBJS)\test_typeinfotest.o: ./misc/typeinfotest.cpp
 	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_ipc.o: ./net/ipc.cpp
+	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_ipc_test_server.o: ./net/ipc_test_server.cpp
 	$(CXX) -c -o $@ $(TEST_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_socket.o: ./net/socket.cpp
@@ -1164,6 +1170,12 @@ $(OBJS)\test_gui_textwrap.o: ./misc/textwrap.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_socket.o: ./net/socket.cpp
+	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_ipc.o: ./net/ipc.cpp
+	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_ipc_test_server.o: ./net/ipc_test_server.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_tlw.o: ./persistence/tlw.cpp

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -27,8 +27,9 @@ TEST_CXXFLAGS = /M$(__RUNTIME_LIBS_10)$(__DEBUGRUNTIME) /DWIN32 $(__DEBUGINFO) \
 	$(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) \
 	/I$(SETUPHDIR) /I.\..\include $(____CAIRO_INCLUDEDIR_FILENAMES) /W4 /I. \
 	$(__DLLFLAG_p) /D_CONSOLE /DwxUSE_GUI=0 \
-	/I.\..\3rdparty\catch\single_include $(__RTTIFLAG) $(__EXCEPTIONSFLAG) \
-	/Yu"testprec.h" /Fp"$(OBJS)\testprec_test.pch" $(CPPFLAGS) $(CXXFLAGS)
+	/I.\..\3rdparty\catch\single_include /DTEST_HAS_IPC_SERVER $(__RTTIFLAG) \
+	$(__EXCEPTIONSFLAG) /Yu"testprec.h" /Fp"$(OBJS)\testprec_test.pch" \
+	$(CPPFLAGS) $(CXXFLAGS)
 TEST_OBJECTS =  \
 	$(OBJS)\test_dummy.obj \
 	$(OBJS)\test_test.obj \
@@ -149,9 +150,8 @@ TEST_GUI_CXXFLAGS = /M$(__RUNTIME_LIBS_44)$(__DEBUGRUNTIME) /DWIN32 \
 	$(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) \
 	/I$(SETUPHDIR) /I.\..\include $(____CAIRO_INCLUDEDIR_FILENAMES) /W4 /I. \
 	$(__DLLFLAG_p) /I.\..\samples /DNOPCH /I.\..\3rdparty\catch\single_include \
-	/D_CONSOLE $(__RTTIFLAG) $(__EXCEPTIONSFLAG) /Yu"testprec.h" \
-	/Fp"$(OBJS)\testprec_test_gui.pch" -DTEST_HAS_IPC_SERVER $(CPPFLAGS) \
-	$(CXXFLAGS)
+	/D_CONSOLE /DTEST_HAS_IPC_SERVER $(__RTTIFLAG) $(__EXCEPTIONSFLAG) \
+	/Yu"testprec.h" /Fp"$(OBJS)\testprec_test_gui.pch" $(CPPFLAGS) $(CXXFLAGS)
 TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_dummy.obj \
 	$(OBJS)\test_gui_asserthelper.obj \
@@ -870,14 +870,14 @@ xart-dothraki:
 	if not exist $(OBJS)\intl\xart-dothraki mkdir $(OBJS)\intl\xart-dothraki
 	for %f in (internat.po internat.mo) do if not exist $(OBJS)\intl\xart-dothraki\%f copy .\intl\xart-dothraki\%f $(OBJS)\intl\xart-dothraki
 
-$(OBJS)\test_test.res: .\..\tests\test.rc
-	rc /fo$@  /d WIN32 $(____DEBUGRUNTIME_2) /d _CRT_SECURE_NO_DEPRECATE=1 /d _CRT_NON_CONFORMING_SWPRINTFS=1 /d _SCL_SECURE_NO_WARNINGS=1 $(__NO_VC_CRTDBG_p_9)  $(__TARGET_CPU_COMPFLAG_p_9) /d __WXMSW__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9) $(__NDEBUG_DEFINE_p_9) $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) /i $(SETUPHDIR) /i .\..\include $(____CAIRO_INCLUDEDIR_FILENAMES_2) /i . $(__DLLFLAG_p_9) /d _CONSOLE /d wxUSE_GUI=0 /i .\..\samples /i .\..\3rdparty\catch\single_include .\..\tests\test.rc
-
 $(OBJS)\test_dummy.obj: .\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) /Yctestprec.h .\dummy.cpp
 
+$(OBJS)\test_test.res: .\..\tests\test.rc
+	rc /fo$@  /d WIN32 $(____DEBUGRUNTIME_2) /d _CRT_SECURE_NO_DEPRECATE=1 /d _CRT_NON_CONFORMING_SWPRINTFS=1 /d _SCL_SECURE_NO_WARNINGS=1 $(__NO_VC_CRTDBG_p_9)  $(__TARGET_CPU_COMPFLAG_p_9) /d __WXMSW__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9) $(__NDEBUG_DEFINE_p_9) $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) /i $(SETUPHDIR) /i .\..\include $(____CAIRO_INCLUDEDIR_FILENAMES_2) /i . $(__DLLFLAG_p_9) /d _CONSOLE /d wxUSE_GUI=0 /i .\..\samples /i .\..\3rdparty\catch\single_include /d TEST_HAS_IPC_SERVER .\..\tests\test.rc
+
 $(OBJS)\test_test.obj: .\test.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) /DTEST_HAS_IPC_SERVER .\test.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\test.cpp
 
 $(OBJS)\test_anytest.obj: .\any\anytest.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\any\anytest.cpp
@@ -1159,7 +1159,7 @@ $(OBJS)\test_gui_dummy.obj: .\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) /Yctestprec.h .\dummy.cpp
 
 $(OBJS)\test_gui_test.res: .\..\tests\test.rc
-	rc /fo$@  /d WIN32 $(____DEBUGRUNTIME_2) /d _CRT_SECURE_NO_DEPRECATE=1 /d _CRT_NON_CONFORMING_SWPRINTFS=1 /d _SCL_SECURE_NO_WARNINGS=1 $(__NO_VC_CRTDBG_p_9)  $(__TARGET_CPU_COMPFLAG_p_9) /d __WXMSW__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9) $(__NDEBUG_DEFINE_p_9) $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) /i $(SETUPHDIR) /i .\..\include $(____CAIRO_INCLUDEDIR_FILENAMES_2) /i . $(__DLLFLAG_p_9)  /i .\..\samples /d NOPCH /i .\..\samples /i .\..\3rdparty\catch\single_include /d _CONSOLE .\..\tests\test.rc
+	rc /fo$@  /d WIN32 $(____DEBUGRUNTIME_2) /d _CRT_SECURE_NO_DEPRECATE=1 /d _CRT_NON_CONFORMING_SWPRINTFS=1 /d _SCL_SECURE_NO_WARNINGS=1 $(__NO_VC_CRTDBG_p_9)  $(__TARGET_CPU_COMPFLAG_p_9) /d __WXMSW__ $(__WXUNIV_DEFINE_p_9) $(__DEBUG_DEFINE_p_9) $(__NDEBUG_DEFINE_p_9) $(__EXCEPTIONS_DEFINE_p_9) $(__RTTI_DEFINE_p_9) $(__THREAD_DEFINE_p_9) /i $(SETUPHDIR) /i .\..\include $(____CAIRO_INCLUDEDIR_FILENAMES_2) /i . $(__DLLFLAG_p_9)  /i .\..\samples /d NOPCH /i .\..\samples /i .\..\3rdparty\catch\single_include /d _CONSOLE /d TEST_HAS_IPC_SERVER .\..\tests\test.rc
 
 $(OBJS)\test_gui_asserthelper.obj: .\asserthelper.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\asserthelper.cpp

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -75,6 +75,7 @@ TEST_OBJECTS =  \
 	$(OBJS)\test_pathlist.obj \
 	$(OBJS)\test_typeinfotest.obj \
 	$(OBJS)\test_ipc.obj \
+	$(OBJS)\test_ipc_test_server.obj \
 	$(OBJS)\test_socket.obj \
 	$(OBJS)\test_webrequest.obj \
 	$(OBJS)\test_regextest.obj \
@@ -149,7 +150,8 @@ TEST_GUI_CXXFLAGS = /M$(__RUNTIME_LIBS_44)$(__DEBUGRUNTIME) /DWIN32 \
 	/I$(SETUPHDIR) /I.\..\include $(____CAIRO_INCLUDEDIR_FILENAMES) /W4 /I. \
 	$(__DLLFLAG_p) /I.\..\samples /DNOPCH /I.\..\3rdparty\catch\single_include \
 	/D_CONSOLE $(__RTTIFLAG) $(__EXCEPTIONSFLAG) /Yu"testprec.h" \
-	/Fp"$(OBJS)\testprec_test_gui.pch" $(CPPFLAGS) $(CXXFLAGS)
+	/Fp"$(OBJS)\testprec_test_gui.pch" -DTEST_HAS_IPC_SERVER $(CPPFLAGS) \
+	$(CXXFLAGS)
 TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_dummy.obj \
 	$(OBJS)\test_gui_asserthelper.obj \
@@ -252,6 +254,8 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_settings.obj \
 	$(OBJS)\test_gui_textwrap.obj \
 	$(OBJS)\test_gui_socket.obj \
+	$(OBJS)\test_gui_ipc.obj \
+	$(OBJS)\test_gui_ipc_test_server.obj \
 	$(OBJS)\test_gui_tlw.obj \
 	$(OBJS)\test_gui_dataview.obj \
 	$(OBJS)\test_gui_rowheightcachetest.obj \
@@ -873,7 +877,7 @@ $(OBJS)\test_dummy.obj: .\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) /Yctestprec.h .\dummy.cpp
 
 $(OBJS)\test_test.obj: .\test.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\test.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) /DTEST_HAS_IPC_SERVER .\test.cpp
 
 $(OBJS)\test_anytest.obj: .\any\anytest.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\any\anytest.cpp
@@ -1003,6 +1007,9 @@ $(OBJS)\test_typeinfotest.obj: .\misc\typeinfotest.cpp
 
 $(OBJS)\test_ipc.obj: .\net\ipc.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\net\ipc.cpp
+
+$(OBJS)\test_ipc_test_server.obj: .\net\ipc_test_server.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\net\ipc_test_server.cpp
 
 $(OBJS)\test_socket.obj: .\net\socket.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_CXXFLAGS) .\net\socket.cpp
@@ -1453,6 +1460,12 @@ $(OBJS)\test_gui_textwrap.obj: .\misc\textwrap.cpp
 
 $(OBJS)\test_gui_socket.obj: .\net\socket.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\net\socket.cpp
+
+$(OBJS)\test_gui_ipc.obj: .\net\ipc.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\net\ipc.cpp
+
+$(OBJS)\test_gui_ipc_test_server.obj: .\net\ipc_test_server.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\net\ipc_test_server.cpp
 
 $(OBJS)\test_gui_tlw.obj: .\persistence\tlw.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\persistence\tlw.cpp

--- a/tests/net/ipc.cpp
+++ b/tests/net/ipc.cpp
@@ -459,15 +459,6 @@ private:
 // connect attempt is time-bounded (wxIPCTimeout, see wxTCPClient::MakeConnection)
 // so a not-yet-ready server fails the attempt promptly and the readiness poll
 // below retries, rather than blocking on the socket's long default timeout.)
-// The re-exec'd server process is much slower to become ready under
-// sanitizers (instrumented startup plus full toolkit init), so use a longer
-// readiness bound there to avoid a spurious REQUIRE(serverReady) failure.
-#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__) || \
-    WX_HAS_CLANG_FEATURE(address_sanitizer) || WX_HAS_CLANG_FEATURE(thread_sanitizer)
-static constexpr int gs_serverReadyTimeoutMs = 120000;
-#else
-static constexpr int gs_serverReadyTimeoutMs = 30000;
-#endif
 
 class IPCFixture
 {
@@ -536,7 +527,10 @@ public:
         // not-yet-ready server fails promptly and we retry rather than blocking.
         bool serverReady = false;
         wxStopWatch sw;
-        while ( !serverReady && sw.Time() < gs_serverReadyTimeoutMs )
+
+        // Make the timeout big enough to give the server the time to start up
+        // even when sanitizers are enabled (which makes startup much slower).
+        while ( !serverReady && sw.Time() < 120000 )
         {
             if ( gs_client->Connect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) )
             {

--- a/tests/net/ipc.cpp
+++ b/tests/net/ipc.cpp
@@ -3,50 +3,72 @@
 // Purpose:     IPC classes unit tests
 // Author:      Vadim Zeitlin
 // Copyright:   (c) 2008 Vadim Zeitlin
+// Modified by: JP Mattia, 2024
 // Licence:     wxWindows licence
 ///////////////////////////////////////////////////////////////////////////////
 
-// For compilers that support precompilation, includes "wx/wx.h".
-// and "wx/cppunit.h"
 #include "testprec.h"
 
 
-// FIXME: this tests currently sometimes hangs in Connect() for unknown reason
-//        and this prevents buildbot builds from working so disabling it, but
-//        the real problem needs to be fixed, of course
-#if 0
+// The IPC tests use a single test binary: the server is started by re-executing
+// the same test program with WX_IPC_TEST_SERVER set (see ipc_test_server.cpp).
+// The client runs in the main Catch2 process. Catch2 cannot run checks in the
+// server process, so the client queries the server for state and verifies it
+// here.
+//
+// This test requires wxUSE_THREADS==1 since it runs the test server concurrently
+// with the client. One build configuration is excluded: wxQt.
+//
+// wxQt is excluded because of a bug in wxQt found during our testing:
+// wxIPC worker threads marshal their socket I/O to the main thread via
+// CallAfter(), but a cross-thread CallAfter() is not reliably processed by the
+// wxQt event loop. wxQtEventLoopBase::WakeUp() wakes the loop without posting a
+// Qt event, so the idle handler that runs pending events is never scheduled, and
+// server-pushed Advise() notifications stall. That is a wxQt event-loop bug, not
+// a wxIPC bug; it is fixed separately on branch
+// jpmattia/wxQT-CallAfter-wxWakeUpIdle, which will be a separate PR.
+//
+#if wxUSE_THREADS && !defined(__WXQT__)
 
-// this test needs threads as it runs the test server in a secondary thread
-#if wxUSE_THREADS
-
-// for all others, include the necessary headers
 #ifndef WX_PRECOMP
     #include "wx/app.h"
-#endif
+#endif // WX_PRECOMP
+
+#include "ipc_setup_test.h"
+#include "ipc_test_server.h"
 
 #include "wx/ipc.h"
 #include "wx/thread.h"
+#include "wx/utils.h"
+#include "wx/evtloop.h"
+#include "wx/stopwatch.h"
 
-#define wxUSE_SOCKETS_FOR_IPC (!wxUSE_DDE_FOR_IPC)
+#include <atomic>
+#include <memory>
 
-namespace
-{
+// forward decl
+class IPCTestClient;
 
-const char *IPC_TEST_PORT = "4242";
-const char *IPC_TEST_TOPIC = "IPC TEST";
+// When g_showMessageTiming is set to true, Advise() and RequestReply()
+// messages will be printed when they arrive. This shows how the IPC messages
+// arrive and whether they interleave.
+bool g_showMessageTiming = false;
 
-} // anonymous namespace
+// Output for g_showMessageTiming uses std::cout, so we can get a sense of the
+// raw arrival times.
+#include <iostream>
 
-// ----------------------------------------------------------------------------
-// test connection class used by IPCTestServer
-// ----------------------------------------------------------------------------
-
+// Test connection class used by the client.
 class IPCTestConnection : public wxConnection
 {
 public:
-    IPCTestConnection() { }
+    explicit IPCTestConnection(IPCTestClient* client)
+    {
+        m_client = client;
+        ResetThreadTrackers();
+    }
 
-    virtual bool OnExec(const wxString& topic, const wxString& data)
+    virtual bool OnExec(const wxString& topic, const wxString& data) override
     {
         if ( topic != IPC_TEST_TOPIC )
             return false;
@@ -54,93 +76,141 @@ public:
         return data == "Date";
     }
 
+    virtual bool OnAdvise(const wxString& topic,
+                          const wxString& item,
+                          const void* data,
+                          size_t size,
+                          wxIPCFormat format) override
+    {
+        if ( topic != IPC_TEST_TOPIC )
+            return false;
+
+        CHECK( format == wxIPC_TEXT );
+
+        wxString s(static_cast<const char*>(data), size);
+
+        if ( item == "SimpleAdvise test" )
+        {
+            if ( s == "OK SimpleAdvise" )
+                m_adviseComplete = true;
+            else
+                m_generalError << "SimpleAdvise: unexpected payload: " << s << '\n';
+        }
+
+        else if ( item == "MultiAdvise test" ||
+                  item == "MultiAdvise MultiThread test" ||
+                  item == "MultiAdvise MultiThread test with simultaneous Requests" )
+        {
+            HandleThreadAdviseCounting(s);
+
+            if ( m_threadAdviseLastVal[0] == MESSAGE_ITERATIONS &&
+                 m_threadAdviseLastVal[1] == MESSAGE_ITERATIONS &&
+                 m_threadAdviseLastVal[2] == MESSAGE_ITERATIONS )
+            {
+                m_adviseComplete = true;
+            }
+        }
+
+        else
+        {
+            m_generalError << "Unknown Advise item: " << item << wxString('\n');
+        }
+
+        return true;
+    }
+
+
+    virtual bool OnDisconnect() override;
+
 private:
+
+    void ResetThreadTrackers()
+    {
+        m_generalError.clear();
+
+        m_adviseComplete = false;
+
+        for ( auto& val : m_threadAdviseLastVal )
+            val = 0;
+    }
+
+    void HandleThreadAdviseCounting(const wxString& adviseString);
+
+    wxCRIT_SECT_DECLARE_MEMBER(m_csAssignBuffer);
+
+    IPCTestClient* m_client;
+
+public:
+    bool  m_adviseComplete;
+
+    int m_threadAdviseLastVal[3];
+
+    wxString m_generalError;
+
     wxDECLARE_NO_COPY_CLASS(IPCTestConnection);
 };
 
-// ----------------------------------------------------------------------------
-// event dispatching thread class
-// ----------------------------------------------------------------------------
-
-class EventThread : public wxThread
+// Helper for the MultiAdvise thread tests. Repeated Advise's of the form
+// "MultiAdvise thread <threadNumber N> <serial_number>" are received during
+// the test. Track the serial number in the appropriate
+// m_threadAdviseLastVal[N] element for CHECKing at the end of the test.
+void IPCTestConnection::HandleThreadAdviseCounting(const wxString& adviseString)
 {
-public:
-    EventThread()
-        : wxThread(wxTHREAD_JOINABLE)
+    wxCRIT_SECT_LOCKER(lock, m_csAssignBuffer);
+
+    wxString info;
+    adviseString.StartsWith("MultiAdvise thread", &info);
+
+    int threadNumber = wxAtoi(info.Left(2));
+    int counterValue = wxAtoi(info.Mid(3));
+    int lastval = INT_MIN; // default to causing an error below
+
+    bool err = false;
+    wxString errString;
+
+    if ( g_showMessageTiming )
+        std::cout << adviseString << '\n' << std::flush;
+
+
+    switch (threadNumber)
     {
-        Create();
-        Run();
+        case 0:
+            errString =
+                "Error: MultiAdvise thread number could not be converted.\n";
+            err = true;
+            break;
+
+        case 1:
+        case 2:
+        case 3:
+            lastval = m_threadAdviseLastVal[threadNumber - 1];
+            m_threadAdviseLastVal[threadNumber - 1] = counterValue;
+            break;
+
+        default:
+            errString =
+                "Error: MultiAdvise thread number must be 1, 2, or 3.\n";
+            err = true;
     }
 
-protected:
-    virtual void *Entry()
+    if ( lastval != counterValue -1 )
     {
-        wxTheApp->MainLoop();
-
-        return nullptr;
+        // Concatenate to any other error:
+        errString +=
+            "Error: Misordered count in thread " +
+            wxString::Format("%d - expected %d, received %d\n",
+                             threadNumber, lastval + 1, counterValue);
+        err = true;
     }
 
-    wxDECLARE_NO_COPY_CLASS(EventThread);
-};
-
-// ----------------------------------------------------------------------------
-// test server class
-// ----------------------------------------------------------------------------
-
-class IPCTestServer : public wxServer
-{
-public:
-    IPCTestServer()
+    if ( err )
     {
-        m_conn = nullptr;
-
-#if wxUSE_SOCKETS_FOR_IPC
-        // we must call this from the main thread
-        wxSocketBase::Initialize();
-#endif // wxUSE_SOCKETS_FOR_IPC
-
-        // we need event dispatching to work for IPC server to work
-        m_thread = new EventThread;
-
-        Create(IPC_TEST_PORT);
+        m_generalError += errString;
     }
+}
 
-    virtual ~IPCTestServer()
-    {
-        wxTheApp->ExitMainLoop();
-
-        m_thread->Wait();
-        delete m_thread;
-
-        delete m_conn;
-
-#if wxUSE_SOCKETS_FOR_IPC
-        wxSocketBase::Shutdown();
-#endif // wxUSE_SOCKETS_FOR_IPC
-    }
-
-    virtual wxConnectionBase *OnAcceptConnection(const wxString& topic)
-    {
-        if ( topic != IPC_TEST_TOPIC )
-            return nullptr;
-
-        m_conn = new IPCTestConnection;
-        return m_conn;
-    }
-
-private:
-    EventThread *m_thread;
-    IPCTestConnection *m_conn;
-
-    wxDECLARE_NO_COPY_CLASS(IPCTestServer);
-};
-
-static IPCTestServer *gs_server = nullptr;
-
-// ----------------------------------------------------------------------------
-// test client class
-// ----------------------------------------------------------------------------
-
+// The actual client is pretty thin, most of the work is done in the
+// connection class.
 class IPCTestClient : public wxClient
 {
 public:
@@ -157,7 +227,7 @@ public:
     bool
     Connect(const wxString& host, const wxString& service, const wxString& topic)
     {
-        m_conn = MakeConnection(host, service, topic);
+        m_conn = (IPCTestConnection*) MakeConnection(host, service, topic);
 
         return m_conn != nullptr;
     }
@@ -166,96 +236,792 @@ public:
     {
         if ( m_conn )
         {
+            m_conn->Disconnect();
             delete m_conn;
             m_conn = nullptr;
         }
     }
 
-    wxConnectionBase& GetConn() const
+    wxConnectionBase* OnMakeConnection() override
     {
-        CPPUNIT_ASSERT( m_conn );
+        return new IPCTestConnection(this);
+    }
+
+    IPCTestConnection& GetConn() const
+    {
+        REQUIRE( m_conn );
 
         return *m_conn;
     }
 
-private:
-    wxConnectionBase *m_conn;
+    IPCTestConnection* m_conn;
 
     wxDECLARE_NO_COPY_CLASS(IPCTestClient);
 };
 
-static IPCTestClient *gs_client = nullptr;
+static IPCTestClient* gs_client = nullptr;
+static wxEventLoop* gs_clientLoop = nullptr;
 
-// ----------------------------------------------------------------------------
-// the test code itself
-// ----------------------------------------------------------------------------
+static bool PumpConnect(const wxString& host,
+                        const wxString& service,
+                        const wxString& topic)
+{
+    return gs_client->Connect(host, service, topic);
+}
 
-class IPCTestCase : public CppUnit::TestCase
+void IPCClientDispatch(unsigned long timeoutMs)
+{
+    if ( !gs_clientLoop )
+        return;
+
+    // The client loop is already active for the lifetime of IPCFixture, so do
+    // NOT re-activate it per call: that writes ms_activeLoop and races the
+    // worker threads reading it via CallAfter() -> WakeUpIdle().
+
+    // Run any queued CallAfter() work first: worker threads marshal their IPC
+    // socket I/O to the main thread via wxTCPEventHandler::RunOnMainThread(),
+    // which posts async method-call events. DispatchTimeout() only services FD
+    // (socket) events, so without this the marshaled jobs would never run.
+    if ( wxTheApp )
+        wxTheApp->ProcessPendingEvents();
+
+    gs_clientLoop->DispatchTimeout(timeoutMs);
+}
+
+static void PumpDispatch()
+{
+    IPCClientDispatch(10);
+}
+
+static void DrainPendingIPCEvents()
+{
+    if ( gs_clientLoop )
+    {
+        // No per-call activation: the client loop is already active via IPCFixture
+        // (and DispatchTimeout()/Pending() act on the loop object directly).
+        for ( int i = 0; i < 100; ++i )
+        {
+            if ( !gs_clientLoop->Pending() )
+                break;
+
+            gs_clientLoop->DispatchTimeout(10);
+        }
+    }
+
+    if ( wxTheApp )
+    {
+        for ( int i = 0; i < 100; ++i )
+        {
+            if ( !wxTheApp->Pending() )
+                break;
+
+            wxTheApp->ProcessPendingEvents();
+        }
+    }
+}
+
+bool IPCTestConnection::OnDisconnect()
+{
+    m_client->m_conn = nullptr;
+    return wxConnection::OnDisconnect();
+}
+
+// MultiRequestThread sends repeated Request()'s, each with a serial number,
+// so that we can verify the repeated messages are sent and received correctly
+// and in order.
+class MultiRequestThread : public wxThread
 {
 public:
-    IPCTestCase() { }
 
-private:
-    CPPUNIT_TEST_SUITE( IPCTestCase );
-        CPPUNIT_TEST( Connect );
-        CPPUNIT_TEST( Execute );
-        CPPUNIT_TEST( Disconnect );
-    CPPUNIT_TEST_SUITE_END();
+    // label: A header to be put on the string sent to the server.
+    // It should be of the form "MultiRequest thread N", where N
+    // is "1", "2", or "3".
+    MultiRequestThread(const wxString& label )
+        : wxThread(wxTHREAD_JOINABLE)
+    {
+        m_label = label;
 
-    void Connect();
-    void Execute();
-    void Disconnect();
+        // Resolve the connection on the main thread. GetConn() uses
+        // REQUIRE(), a Catch2 macro that is not thread-safe, so it
+        // must not run on the worker thread in Entry(). The
+        // connection is stable for our lifetime, so caching the
+        // pointer is safe.
+        m_conn = &gs_client->GetConn();
 
-    wxDECLARE_NO_COPY_CLASS(IPCTestCase);
+        Create();
+    }
+
+protected:
+    virtual void* Entry() override
+    {
+        IPCTestConnection& conn = *m_conn;
+
+        for (size_t n=1; n < MESSAGE_ITERATIONS + 1; n++)
+        {
+            wxString s = m_label + wxString::Format(" %zu", n);
+            size_t size = 0;
+            const char* data = (const char*) conn.Request(s, &size, wxIPC_PRIVATE);
+
+            // Catch2 macros are not thread safe, so we check explicitly and
+            // store any deviation from the expected result.
+            if ( wxString(data) != "OK: " + s )
+            {
+                m_error += "MultiRequestThread error: expected \"OK: " + s;
+                m_error += ", received " + wxString(data);
+                m_error += '\n';
+            }
+
+            if ( g_showMessageTiming )
+                std::cout << wxString(data) << '\n' << std::flush;
+
+            // Space out the requests, to test any race conditions with
+            // incoming messages, like Advise()
+            wxMilliSleep(50);
+        }
+
+        return nullptr;
+    }
+
+public:
+    wxString m_label;
+    wxString m_error;
+    IPCTestConnection* m_conn = nullptr;
+
+    wxDECLARE_NO_COPY_CLASS(MultiRequestThread);
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION( IPCTestCase );
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( IPCTestCase, "IPCTestCase" );
-
-void IPCTestCase::Connect()
+// A deadlock cannot be detected from the main thread, because the main thread
+// is precisely what gets stuck. This watchdog runs on its own thread and aborts
+// the process with a diagnostic if the test does not signal completion in time,
+// turning an otherwise indefinite hang into a clear, bounded failure.
+class DeadlockWatchdog : public wxThread
 {
-    gs_server = new IPCTestServer;
-    gs_client = new IPCTestClient;
+public:
+    explicit DeadlockWatchdog(int timeoutMs, const wxString& what = "the IPC test")
+        : wxThread(wxTHREAD_JOINABLE), m_timeoutMs(timeoutMs), m_what(what) {}
 
-    // connecting to the wrong port should fail
-    CPPUNIT_ASSERT( !gs_client->Connect("localhost", "2424", IPC_TEST_TOPIC) );
+    // Called by the test once it has completed normally.
+    void Done() { m_done.store(true); }
 
-    // connecting using an unsupported topic should fail (unless the server
-    // expects a ROT-13'd topic name...)
-    CPPUNIT_ASSERT( !gs_client->Connect("localhost", IPC_TEST_PORT, "VCP GRFG") );
-
-    // connecting to the right port on the right topic should succeed
-    CPPUNIT_ASSERT( gs_client->Connect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
-}
-
-void IPCTestCase::Execute()
-{
-    wxConnectionBase& conn = gs_client->GetConn();
-
-    const wxString s("Date");
-    CPPUNIT_ASSERT( conn.Execute(s) );
-    CPPUNIT_ASSERT( conn.Execute(s.mb_str(), s.length() + 1) );
-
-    char bytes[] = { 1, 2, 3 };
-    CPPUNIT_ASSERT( conn.Execute(bytes, WXSIZEOF(bytes)) );
-}
-
-void IPCTestCase::Disconnect()
-{
-    if ( gs_client )
+protected:
+    void* Entry() override
     {
-        gs_client->Disconnect();
+        const int step = 50;
+        for ( int waited = 0; waited < m_timeoutMs; waited += step )
+        {
+            if ( m_done.load() )
+                return nullptr;
+            wxMilliSleep(step);
+        }
+
+        std::cerr << "\nIPC WATCHDOG: " << m_what
+                  << " did not complete within " << m_timeoutMs
+                  << " ms; aborting to avoid a CI hang.\n" << std::flush;
+        abort();
+    }
+
+    const int m_timeoutMs;
+    const wxString m_what;
+    std::atomic<bool> m_done{false};
+
+    wxDECLARE_NO_COPY_CLASS(DeadlockWatchdog);
+};
+
+// RAII wrapper that runs a DeadlockWatchdog for its whole lifetime. Used as the
+// first member of IPCFixture so a watchdog covers the entire fixture (setup,
+// test body, and teardown): if any of them blocks, e.g. a socket Connect()
+// that never returns under an environment where the test server can't run, as
+// on the Wine-based wxMSW cross-builds. The watchdog aborts with a diagnostic
+// after the timeout instead of letting CI hang until its multi-hour job cap.
+class FixtureWatchdog
+{
+public:
+    FixtureWatchdog(int timeoutMs, const wxString& what)
+        : m_watchdog(timeoutMs, what) { m_watchdog.Run(); }
+    ~FixtureWatchdog() { m_watchdog.Done(); m_watchdog.Wait(); }
+
+private:
+    DeadlockWatchdog m_watchdog;
+    wxDECLARE_NO_COPY_CLASS(FixtureWatchdog);
+};
+
+// IPCFixture starts a fresh IPC server for each test, connects a client to it,
+// and shuts the server down again in the destructor, so no IPC server process
+// is ever alive between tests, or during the unrelated GUI control tests that
+// run in the same test_gui binary.
+//
+// (A previous version shared one long-lived server across all IPC tests to dodge
+// an intermittent Wine Connect() hang caused by rapidly restarting the localhost
+// listener. But that left the server (a second GUI process on the one Xvfb
+// display) alive for the rest of the run, where it stole window-from-point and
+// focus from the client and failed ~30 non-IPC GUI tests, guifuncs/treectrl/
+// listbase/etc. The hang is now prevented at its source instead: the client's
+// connect attempt is time-bounded (wxIPCTimeout, see wxTCPClient::MakeConnection)
+// so a not-yet-ready server fails the attempt promptly and the readiness poll
+// below retries, rather than blocking on the socket's long default timeout.)
+class IPCFixture
+{
+    // Declared first so it is constructed first and destroyed last: the watchdog
+    // then covers the whole fixture lifetime (setup, test body, teardown).
+    FixtureWatchdog m_watchdog{180000, "an IPC test (setup, body, or teardown)"};
+    std::unique_ptr<wxEventLoop> m_clientLoop{new wxEventLoop};
+    std::unique_ptr<wxEventLoopActivator> m_loopActivator;
+    IPCServerThread m_server;
+
+public:
+    IPCFixture()
+    {
+#if wxUSE_SOCKETS_FOR_IPC
+        wxSocketBase::Initialize();
+#endif // wxUSE_SOCKETS_FOR_IPC
+
+        DrainPendingIPCEvents();
+
+        gs_clientLoop = m_clientLoop.get();
+
+        // Activate the client loop once for the lifetime of this fixture so its
+        // worker threads see a stable wxEventLoopBase::ms_activeLoop. Activating
+        // per IPCClientDispatch() call would write ms_activeLoop and race the
+        // workers' CallAfter() -> WakeUpIdle() -> GetActive() reads.
+        m_loopActivator.reset(new wxEventLoopActivator(m_clientLoop.get()));
+
+        gs_client = new IPCTestClient;
+
+        REQUIRE( m_server.Start() );
+
+        // Wait until the freshly-launched server is ready to accept a
+        // connection: the re-exec'd server process can take a while to come up
+        // (well over a second under sanitizers, or as a GUI process doing full
+        // toolkit init). Poll with a throwaway connection until one succeeds,
+        // then drop it so the test starts from a clean state. The bound is
+        // wall-clock based, not iteration based: in a GUI event loop
+        // IPCClientDispatch() returns at once (idle events), so a fixed
+        // iteration count would expire before a GUI server is listening. Each
+        // Connect() attempt is itself time-bounded (see the class comment), so a
+        // not-yet-ready server fails promptly and we retry rather than blocking.
+        bool serverReady = false;
+        wxStopWatch sw;
+        while ( !serverReady && sw.Time() < 30000 )   // up to 30s
+        {
+            if ( gs_client->Connect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) )
+            {
+                gs_client->Disconnect();
+                serverReady = true;
+            }
+            else
+            {
+                // Pace the retries: a refused Connect() returns at once, and
+                // IPCClientDispatch() also returns immediately when idle, so
+                // without a sleep this loop spins hundreds of connect attempts
+                // (each creating and destroying a socket) while the server comes
+                // up, enough churn to exhaust resources over a whole run of
+                // per-test servers. Sleep briefly so we poll ~20x/second instead.
+                IPCClientDispatch(50);
+                wxMilliSleep(50);
+            }
+        }
+        REQUIRE( serverReady );
+    }
+
+    ~IPCFixture()
+    {
+        // Ask the server to shut down cleanly, then wait for the child to exit.
+        // This runs while the client loop is still active, so the server's
+        // wxProcess::OnTerminate() is dispatched before its handler is destroyed
+        // (see PumpForProcessExit() in the server launcher).
+        if ( gs_client )
+        {
+            if ( !gs_client->m_conn )
+                PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC);
+
+            if ( gs_client->m_conn )
+            {
+                const wxString s("shutdown");
+                gs_client->GetConn().Execute(s);
+                wxMilliSleep(100);
+            }
+        }
+
+        m_server.WaitForExit();
+
+        DrainPendingIPCEvents();
+
+        if ( gs_client )
+            gs_client->Disconnect();
+
+        DrainPendingIPCEvents();
+
+        m_loopActivator.reset(); // restore the previously-active loop, once
+        gs_clientLoop = nullptr;
+        m_clientLoop.reset();
+
         delete gs_client;
         gs_client = nullptr;
-    }
 
-    if ( gs_server )
-    {
-        delete gs_server;
-        gs_server = nullptr;
+#if wxUSE_SOCKETS_FOR_IPC
+        wxSocketBase::Shutdown();
+#endif // wxUSE_SOCKETS_FOR_IPC
+
+        if ( g_showMessageTiming )
+            std::cout << "teardown complete\n" << std::flush;
     }
+};
+
+// Test the basics of Connect()
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::Connect", "[net][ipc][single_command]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test Connect\n" << std::flush;
+
+    // connecting to the wrong port should fail
+    CHECK( !PumpConnect("localhost", "2424", IPC_TEST_TOPIC) );
+
+    // connecting with the wrong topic should fail
+    CHECK( !PumpConnect("localhost", IPC_TEST_PORT, "VCP GRFG") );
+
+    // Connecting to the right port on the right topic should succeed.
+    REQUIRE( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
 }
 
-#endif // wxUSE_THREADS
+// Test the basics of Request(): A Request() goes out and it should result in
+// a reply from the server.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::SingleRequest", "[net][ipc][single_command]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test SingleRequest\n" << std::flush;
 
-#endif // !__WINDOWS__
+    // If the connection itself failed there is no point in probing
+    // the server, and it distinguishes a connect failure from a
+    // Request() failure below.
+    REQUIRE( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+
+    IPCTestConnection& conn = gs_client->GetConn();
+
+    const wxString s("ping");
+    size_t size = 0;
+    const char* data = (char*) conn.Request( s, &size, wxIPC_PRIVATE);
+
+    // Guard against a null return before constructing a wxString from it:
+    // a failed Request() must report cleanly instead of dereferencing null
+    // (this was an information-free SIGSEGV on wxMSW). size is logged to help
+    // diagnose why the very first post-connect Request would fail.
+    INFO( "Request() returned size=" << size );
+    REQUIRE( data != nullptr );
+
+    // Make sure that Request() works, because we use it to probe the
+    // state of the server for the remaining tests.
+    REQUIRE( wxString(data) == "pong"  );
+}
+
+// Test the basics of Execute(). The Execute() goes out: Note that a return
+// value of "true" means simply that the message was transmitted. We follow
+// the Execute with a Request() to verify that the server received the Execute
+// correctly.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::SingleExecute", "[net][ipc][single_command]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test Execute\n" << std::flush;
+
+    CHECK( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+
+    IPCTestConnection& conn = gs_client->GetConn();
+
+    wxString s("Date");
+    CHECK( conn.Execute(s) );
+
+    // Get the last execute from the server side.
+    size_t size = 0;
+    const wxString lastExecuteQuery("last_execute");
+
+    char* data = (char*) conn.Request(lastExecuteQuery, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == s );
+
+
+    s = "another execution command!";
+    CHECK( conn.Execute(s.mb_str(), s.length() + 1) );
+
+    data = (char*) conn.Request(lastExecuteQuery, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == s );
+}
+
+// Send multiple requests to the server. Each request has a serial number, and
+// this test verifies that the replies have the correct serial in the reply
+// message. After the serial requests are done, the client queries the server
+// and verifies the server received the requests error-free.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::RequestThread", "[net][ipc][multi_command]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test Single Thread Of Requests\n" << std::flush;
+
+    CHECK( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+
+    MultiRequestThread thread1("MultiRequest thread 1");
+    thread1.Run();
+    WaitForThreadWithDispatch(thread1);
+
+    INFO( thread1.m_error );
+    CHECK( thread1.m_error.empty() );
+
+    // Make sure the server got all the requests in the correct order.
+    IPCTestConnection& conn = gs_client->GetConn();
+
+    size_t size = 0;
+    wxString query("get_thread1_request_counter");
+
+    char* data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == MESSAGE_ITERATIONS_STRING );
+
+    size = 0;
+    query = "get_error_string";
+    data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+
+    INFO( wxString(data) );
+    CHECK( wxString(data).empty() );
+}
+
+// Send multiple requests to the server via three concurrent threads. Each
+// reply is verified to make sure that the request corresponds to the correct
+// thread and has the correctly ordered serial number. After the request
+// threads are finished, the client queries the server and verifies the server
+// received the requests error-free.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::RequestMultiThread", "[net][ipc][multi_thread]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test Requests with Multiple Threads\n"
+                  << std::flush;
+
+    CHECK( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+
+    MultiRequestThread thread1("MultiRequest thread 1");
+    MultiRequestThread thread2("MultiRequest thread 2");
+    MultiRequestThread thread3("MultiRequest thread 3");
+
+    thread1.Run();
+    thread2.Run();
+    thread3.Run();
+
+    WaitForThreadWithDispatch(thread1);
+    WaitForThreadWithDispatch(thread2);
+    WaitForThreadWithDispatch(thread3);
+
+    INFO( thread1.m_error );
+    CHECK( thread1.m_error.empty() );
+
+    INFO( thread2.m_error );
+    CHECK( thread2.m_error.empty() );
+
+    INFO( thread3.m_error );
+    CHECK( thread3.m_error.empty() );
+
+    // Make sure the server got all the requests in the correct order.
+    IPCTestConnection& conn = gs_client->GetConn();
+
+    size_t size = 0;
+    wxString query = "get_thread1_request_counter";
+
+    char* data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == MESSAGE_ITERATIONS_STRING );
+
+    size = 0;
+    query = "get_thread2_request_counter";
+
+    data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == MESSAGE_ITERATIONS_STRING );
+
+    size = 0;
+    query = "get_thread3_request_counter";
+
+    data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == MESSAGE_ITERATIONS_STRING );
+
+    size = 0;
+    query = "get_error_string";
+    data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+
+    INFO( wxString(data) );
+    CHECK( wxString(data).empty() );
+}
+
+// Test the basics of Advise(). First, send a StartAdvise(), then wait for the
+// server to send a single Advise(). When that is received, StopAdvise() is
+// sent.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::SingleAdvise", "[net][ipc][single_command]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test Advise as single command\n" << std::flush;
+
+    CHECK( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+
+    IPCTestConnection& conn = gs_client->GetConn();
+    wxString item = "SimpleAdvise test";
+
+    CHECK( conn.StartAdvise(item) );
+
+    // Wait a maximum of 2 seconds for completion. The bound is wall-clock based,
+    // not iteration based: under a GUI event loop PumpDispatch() returns at once
+    // (idle events), so a fixed iteration count would expire almost immediately,
+    // before the server's advise arrives.
+    wxStopWatch sw;
+    while ( sw.Time() < 2000 && !conn.m_adviseComplete )
+    {
+        PumpDispatch();
+    }
+
+    CHECK( conn.StopAdvise(item) );
+    CHECK( conn.m_adviseComplete );
+
+    // Make sure the server didn't record an error
+    wxString query = "get_error_string";
+    size_t size = 0;
+
+    char* data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+
+    INFO( wxString(data) );
+    CHECK( wxString(data).empty() );
+}
+
+// Instruct the server to send a series of Advise() items to the client. Each
+// Advise() is verified to make sure that the Advise() arrives in order by
+// checking its serial number. Also verifies that the server encountered no
+// errors during the Advise() calls.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::AdviseThread", "[net][ipc][multi_command]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test Single Thread Of Advise()'s\n" << std::flush;
+
+    CHECK( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+
+    IPCTestConnection& conn = gs_client->GetConn();
+    wxString item = "MultiAdvise test";
+
+    CHECK( conn.StartAdvise(item) );
+
+    // Wait a maximum of 20 seconds for completion (wall-clock bounded; see the
+    // note in IPC::SingleAdvise about GUI event loops and PumpDispatch()).
+    wxStopWatch sw;
+    while ( sw.Time() < 20000 &&
+            conn.m_threadAdviseLastVal[0] != MESSAGE_ITERATIONS )
+    {
+        PumpDispatch();
+    }
+
+    CHECK( conn.StopAdvise(item) );
+
+    // Verify the results of the test.
+    CHECK( conn.m_threadAdviseLastVal[0] == MESSAGE_ITERATIONS );
+
+    INFO( conn.m_generalError );
+    CHECK( conn.m_generalError.empty() );
+
+    // Make sure the server didn't record an error
+    wxString query = "get_error_string";
+    size_t size = 0;
+
+    char* data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+
+    INFO( wxString(data) );
+    CHECK( wxString(data).empty() );
+}
+
+// Instruct the server to send a series of Advise() items to the client via
+// three concurrent threads. Each Advise() is verified to make sure that the
+// Advise() arrives in order within its thread number. Also verifies that
+// the server encountered no errors during the Advise() calls.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::AdviseMultiThread", "[net][ipc][multi_thread]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test MultipleThreadsOfMultiAdvise\n" << std::flush;
+
+    CHECK( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+
+    IPCTestConnection& conn = gs_client->GetConn();
+    wxString item = "MultiAdvise MultiThread test";
+
+    CHECK( conn.StartAdvise(item) );
+
+    // Wait a maximum of 20 seconds for completion (wall-clock bounded; see the
+    // note in IPC::SingleAdvise about GUI event loops and PumpDispatch()).
+    wxStopWatch sw;
+    while ( sw.Time() < 20000 )
+    {
+        PumpDispatch();
+
+        if ( conn.m_threadAdviseLastVal[0] == MESSAGE_ITERATIONS &&
+             conn.m_threadAdviseLastVal[1] == MESSAGE_ITERATIONS &&
+             conn.m_threadAdviseLastVal[2] == MESSAGE_ITERATIONS)
+        {
+            break;
+        }
+    }
+
+    CHECK( conn.StopAdvise(item) );
+
+    CHECK( conn.m_threadAdviseLastVal[0] == MESSAGE_ITERATIONS );
+    CHECK( conn.m_threadAdviseLastVal[1] == MESSAGE_ITERATIONS );
+    CHECK( conn.m_threadAdviseLastVal[2] == MESSAGE_ITERATIONS );
+
+    INFO( conn.m_generalError );
+    CHECK( conn.m_generalError.empty() );
+
+    // Make sure the server didn't record an error
+    wxString query = "get_error_string";
+    size_t size = 0;
+
+    char* data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+
+    INFO( wxString(data) );
+    CHECK( wxString(data).empty() );
+}
+
+// Run three concurrent threads in the client sending Requests() to the
+// server, and simultaneously run three concurrent threads in the server
+// sending Advise() information to the client. Verify that all messages are
+// serial and correspond to the correct thread. Lastly, verify that the server
+// encountered no errors during this test.
+//
+// By setting g_showMessageTiming to "true", the ordering of the Requests
+// and Advise's can be seen. Different systems may need to change the delay
+// wxMilliSleep in the client and server threads to make the interleave happen
+// properly, which is a stringent test of race conditions that might be present
+// in wxIPC.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::AdviseAndRequestMultiThread", "[net][ipc][multi_thread]")
+{
+    if ( g_showMessageTiming )
+        std::cout << "Running test MultiAdvise MultiThreads test with simultaneous MultiRequests MultiThreads\n" << std::flush;
+
+    CHECK( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+    IPCTestConnection& conn = gs_client->GetConn();
+
+    MultiRequestThread thread1("MultiRequest thread 1");
+    MultiRequestThread thread2("MultiRequest thread 2");
+    MultiRequestThread thread3("MultiRequest thread 3");
+
+    // start local and remote threads as close to simultaneously as possible
+    wxString item = "MultiAdvise MultiThread test with simultaneous Requests";
+
+    CHECK( conn.StartAdvise(item) ); // starts 3 advise threads on the server
+
+    thread1.Run();
+    thread2.Run();
+    thread3.Run();
+
+    // Phase 1: Request() threads process interleaved Advise() via FindMessage().
+    // Do not PumpDispatch() here: main-thread dispatch races worker Request().
+    WaitForThreadWithDispatch(thread1);
+    WaitForThreadWithDispatch(thread2);
+    WaitForThreadWithDispatch(thread3);
+
+    // Phase 2: dispatch any remaining Advise() notifications on the main thread.
+    // Wall-clock bounded; see the note in IPC::SingleAdvise about GUI event loops.
+    wxStopWatch sw;
+    while ( sw.Time() < 20000 )
+    {
+        PumpDispatch();
+
+        if ( conn.m_threadAdviseLastVal[0] == MESSAGE_ITERATIONS &&
+             conn.m_threadAdviseLastVal[1] == MESSAGE_ITERATIONS &&
+             conn.m_threadAdviseLastVal[2] == MESSAGE_ITERATIONS )
+        {
+            break;
+        }
+    }
+
+    CHECK( conn.StopAdvise(item) );
+
+    // Everything is done, check that all the advise messages were
+    // correctly received.
+
+    CHECK( conn.m_threadAdviseLastVal[0] == MESSAGE_ITERATIONS );
+    CHECK( conn.m_threadAdviseLastVal[1] == MESSAGE_ITERATIONS );
+    CHECK( conn.m_threadAdviseLastVal[2] == MESSAGE_ITERATIONS );
+
+    INFO( conn.m_generalError );
+    CHECK( conn.m_generalError.empty() );
+
+
+    // Also make sure all the request messages were correctly received on
+    // the server side. The client side was already validated in the
+    // MultiRequestThread.
+    size_t size = 0;
+    wxString query = "get_thread1_request_counter";
+
+    char* data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == MESSAGE_ITERATIONS_STRING );
+
+    size = 0;
+    query = "get_thread2_request_counter";
+
+    data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == MESSAGE_ITERATIONS_STRING );
+
+    size = 0;
+    query = "get_thread3_request_counter";
+
+    data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+    CHECK( wxString(data) == MESSAGE_ITERATIONS_STRING );
+
+    size = 0;
+    query = "get_error_string";
+    data = (char*) conn.Request(query, &size, wxIPC_PRIVATE);
+
+    INFO( wxString(data) );
+    CHECK( wxString(data).empty() );
+}
+
+// Exercises the case where a Request() is issued on the main thread while a
+// worker thread is also issuing Request()s on the same connection, which was
+// a source of several problems.
+//
+// When this test fails, the watchdog bounds the time-to-failure; the test should
+// complete near-instantly if main-thread and worker-thread Request()s are
+// properly serialized.
+TEST_CASE_METHOD(IPCFixture,
+                 "IPC::ConcurrentMainAndWorkerRequest", "[net][ipc][multi_command]")
+{
+    CHECK( PumpConnect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) );
+    IPCTestConnection& conn = gs_client->GetConn();
+
+    // Generous timeout: the test completes in ~1-2s when healthy, so the
+    // watchdog only ever fires on a *permanent* deadlock (which never recovers).
+    // A large value avoids spurious aborts on slow/loaded CI runners or under
+    // sanitizers, at no cost to the passing case.
+    DeadlockWatchdog watchdog(30000,
+        "concurrent main- and worker-thread Request() on the same connection");
+    watchdog.Run();
+
+    MultiRequestThread worker("MultiRequest thread 1");
+    worker.Run();
+
+    // Hammer the connection from the main thread while the worker does the same
+    // from its thread. Pump between requests so that, absent the deadlock, the
+    // worker's marshalled socket I/O can run on the main thread.
+    while ( worker.IsRunning() )
+    {
+        size_t size = 0;
+        const char* pong = (const char*) conn.Request("ping", &size, wxIPC_PRIVATE);
+
+        CHECK( pong != nullptr );
+        if ( pong )
+            CHECK( wxString(pong) == "pong" );
+
+        IPCClientDispatch(5);
+    }
+
+    worker.Wait();
+    watchdog.Done();
+    watchdog.Wait();
+
+    INFO( worker.m_error );
+    CHECK( worker.m_error.empty() );
+}
+
+#endif // wxUSE_THREADS && !__WXQT__

--- a/tests/net/ipc.cpp
+++ b/tests/net/ipc.cpp
@@ -459,6 +459,16 @@ private:
 // connect attempt is time-bounded (wxIPCTimeout, see wxTCPClient::MakeConnection)
 // so a not-yet-ready server fails the attempt promptly and the readiness poll
 // below retries, rather than blocking on the socket's long default timeout.)
+// The re-exec'd server process is much slower to become ready under
+// sanitizers (instrumented startup plus full toolkit init), so use a longer
+// readiness bound there to avoid a spurious REQUIRE(serverReady) failure.
+#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__) || \
+    WX_HAS_CLANG_FEATURE(address_sanitizer) || WX_HAS_CLANG_FEATURE(thread_sanitizer)
+static constexpr int gs_serverReadyTimeoutMs = 120000;
+#else
+static constexpr int gs_serverReadyTimeoutMs = 30000;
+#endif
+
 class IPCFixture
 {
     // Declared first so it is constructed first and destroyed last: the watchdog
@@ -478,6 +488,31 @@ public:
         DrainPendingIPCEvents();
 
         gs_clientLoop = m_clientLoop.get();
+
+        // The constructor can still throw below (a REQUIRE() fails, or the
+        // server never becomes ready). If it does, this object never becomes
+        // alive, so ~IPCFixture() will not run to clear the globals set here --
+        // yet our members are still destroyed during unwinding, which would
+        // leave gs_clientLoop dangling at a freed wxEventLoop and leak gs_client.
+        // A later fixture's DrainPendingIPCEvents() would then dereference that
+        // freed loop (a use-after-free). This guard undoes the global state on
+        // any early exit and is dismissed only once construction fully succeeds.
+        struct CtorGuard
+        {
+            bool dismiss = false;
+            ~CtorGuard()
+            {
+                if ( dismiss )
+                    return;
+
+                gs_clientLoop = nullptr;
+                delete gs_client;
+                gs_client = nullptr;
+#if wxUSE_SOCKETS_FOR_IPC
+                wxSocketBase::Shutdown();
+#endif // wxUSE_SOCKETS_FOR_IPC
+            }
+        } ctorGuard;
 
         // Activate the client loop once for the lifetime of this fixture so its
         // worker threads see a stable wxEventLoopBase::ms_activeLoop. Activating
@@ -501,7 +536,7 @@ public:
         // not-yet-ready server fails promptly and we retry rather than blocking.
         bool serverReady = false;
         wxStopWatch sw;
-        while ( !serverReady && sw.Time() < 30000 )   // up to 30s
+        while ( !serverReady && sw.Time() < gs_serverReadyTimeoutMs )
         {
             if ( gs_client->Connect("localhost", IPC_TEST_PORT, IPC_TEST_TOPIC) )
             {
@@ -521,6 +556,8 @@ public:
             }
         }
         REQUIRE( serverReady );
+
+        ctorGuard.dismiss = true;
     }
 
     ~IPCFixture()

--- a/tests/net/ipc_setup_test.h
+++ b/tests/net/ipc_setup_test.h
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/net/ipc_setup_test.h
+// Purpose:     IPC classes unit tests
+// Author:      Vadim Zeitlin
+// Copyright:   (c) 2008
+// Modified by: JP Mattia, 2024
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_TESTS_NET_IPC_H_
+#define _WX_TESTS_NET_IPC_H_
+
+// This test was written for sockets
+#define wxUSE_SOCKETS_FOR_IPC 1
+#define wxUSE_DDE_FOR_IPC     0
+
+#define IPC_TEST_PORT  "4242"
+#define IPC_TEST_TOPIC "IPC TEST"
+
+// Many IPC issues show up only after several iterations, and
+// MESSAGE_ITERATIONS sets the number of iterations. The value of 20 is chosen
+// as a compromise between exposing race conditions vs slowing down the
+// overall automated test process.
+//
+// For stress-testing: if the number of MESSAGE_ITERATIONS is set much beyond
+// 200, then the client-side wait bounds should likely also be increased.
+// Search for "Wait a maximum" in ipc.cpp to find those values. (The server
+// side needs no adjustment: it paces each Advise() and otherwise waits for
+// completion, so it scales with the iteration count on its own.)
+#define MESSAGE_ITERATIONS 20
+#define MESSAGE_ITERATIONS_STRING  wxString::Format("%d",MESSAGE_ITERATIONS)
+
+#endif // _WX_TESTS_NET_IPC_H_

--- a/tests/net/ipc_test_server.cpp
+++ b/tests/net/ipc_test_server.cpp
@@ -1,0 +1,717 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/net/ipc_test_server.cpp
+// Purpose:     IPC test server for unit tests
+// Authors:     Vadim Zeitlin, JP Mattia
+// Copyright:   (c) 2024
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#include "testprec.h"
+
+// Match the guard in tests/net/ipc.cpp
+
+#if wxUSE_THREADS && !defined(__WXQT__)
+
+#ifndef WX_PRECOMP
+    #include "wx/app.h"
+#endif
+
+#include "ipc_test_server.h"
+#include "ipc_setup_test.h"
+
+#include "wx/ipc.h"
+#include "wx/thread.h"
+#include "wx/evtloop.h"
+#include "wx/vector.h"
+#include "wx/process.h"
+#include "wx/timer.h"
+#include "wx/filename.h"
+#include "wx/stdpaths.h"
+
+#include "wx/private/make_unique.h"
+
+#ifdef __UNIX__
+    #include <unistd.h>
+#endif
+
+#define MAX_MSG_BUFFERS 2048
+
+class IPCServerTestServer;
+
+class IPCServerConnection : public wxConnection
+{
+public:
+    explicit IPCServerConnection(IPCServerTestServer* server)
+    {
+        m_server = server;
+        ResetThreadTrackers();
+
+        for ( auto& buf : m_bufferList )
+            buf = nullptr;
+
+        m_nextAvailable = 0;
+    }
+
+    ~IPCServerConnection()
+    {
+        m_adviseActive = false;
+        WaitForAdviseWorkers();
+
+        for ( auto& buf : m_bufferList )
+            delete[] buf;
+    }
+
+    virtual bool OnExec(const wxString& topic, const wxString& data) override;
+    virtual bool OnDisconnect() override;
+
+    virtual const void* OnRequest(const wxString& topic,
+                                  const wxString& item,
+                                  size_t* size,
+                                  wxIPCFormat format) override;
+
+    virtual bool OnStartAdvise(const wxString& topic,
+                               const wxString& item) override;
+
+    virtual bool OnStopAdvise(const wxString& topic,
+                              const wxString& item) override;
+
+private:
+    wxString HandleThreadRequestCounting(const wxString& item);
+    void ResetThreadTrackers();
+    void StartAdviseWorker(wxThread* thread);
+    void WaitForAdviseWorkers();
+
+    char* GetBufPtr(size_t size)
+    {
+        wxCRIT_SECT_LOCKER(lock, m_csAssignBuffer);
+
+        delete[] m_bufferList[m_nextAvailable];
+
+        char* ptr = new char[size];
+
+        m_bufferList[m_nextAvailable] = ptr;
+        m_nextAvailable = (m_nextAvailable + 1) % MAX_MSG_BUFFERS;
+
+        return ptr;
+    }
+
+    wxCRIT_SECT_DECLARE_MEMBER(m_csAssignBuffer);
+
+    IPCServerTestServer* m_server;
+
+    char* m_bufferList[MAX_MSG_BUFFERS];
+    int m_nextAvailable;
+
+    wxString m_lastExecute;
+
+    int m_threadRequestLastVal[3];
+
+public:
+    bool m_adviseActive;
+    wxString m_generalError;
+
+    bool m_waitForFirstRequest;
+    bool m_firstRequestReceived;
+
+    wxVector<wxThread*> m_adviseThreads;
+
+    wxDECLARE_NO_COPY_CLASS(IPCServerConnection);
+};
+
+class SingleAdviseThread : public wxThread
+{
+public:
+    SingleAdviseThread(IPCServerTestServer* server, const wxString& item)
+        : wxThread(wxTHREAD_JOINABLE),
+          m_server(server),
+          m_item(item)
+    {
+        Create();
+    }
+
+protected:
+    virtual void* Entry() override;
+
+    IPCServerTestServer* m_server;
+    wxString m_item;
+
+    wxDECLARE_NO_COPY_CLASS(SingleAdviseThread);
+};
+
+class MultiAdviseThread : public wxThread
+{
+public:
+    MultiAdviseThread(IPCServerTestServer* server,
+                      const wxString& item,
+                      const wxString& label)
+        : wxThread(wxTHREAD_JOINABLE),
+          m_server(server),
+          m_item(item),
+          m_label(label)
+    {
+        Create();
+    }
+
+protected:
+    virtual void* Entry() override;
+
+    IPCServerTestServer* m_server;
+    wxString m_item, m_label;
+
+    wxDECLARE_NO_COPY_CLASS(MultiAdviseThread);
+};
+
+class IPCServerTestServer : public wxServer
+{
+public:
+    IPCServerTestServer() = default;
+
+    virtual ~IPCServerTestServer()
+    {
+        delete m_conn;
+    }
+
+    virtual wxConnectionBase* OnAcceptConnection(const wxString& topic) override
+    {
+        if ( topic != IPC_TEST_TOPIC )
+            return nullptr;
+
+        m_conn = new IPCServerConnection(this);
+        return m_conn;
+    }
+
+    void Shutdown()
+    {
+        if ( m_conn )
+            m_conn->Disconnect();
+    }
+
+    IPCServerConnection& GetConn()
+    {
+        if ( !m_conn )
+        {
+            m_conn = new IPCServerConnection(this);
+            m_conn->m_generalError = "Invalid connection in GetConn()";
+        }
+
+        return *m_conn;
+    }
+
+    IPCServerConnection* m_conn = nullptr;
+
+    wxDECLARE_NO_COPY_CLASS(IPCServerTestServer);
+};
+
+bool IPCServerConnection::OnExec(const wxString& topic, const wxString& data)
+{
+    if ( topic != IPC_TEST_TOPIC )
+        return false;
+
+    if ( data == "shutdown" )
+    {
+        m_adviseActive = false;
+        WaitForAdviseWorkers();
+        m_server->Shutdown();
+        if ( wxEventLoopBase::GetActive() )
+            wxEventLoopBase::GetActive()->ScheduleExit(0);
+        else
+            _exit(0);
+        return true;
+    }
+
+    m_lastExecute = data;
+    return true;
+}
+
+bool IPCServerConnection::OnDisconnect()
+{
+    // Clear the server's current-connection pointer only if *this* connection is
+    // still the current one. Connections can briefly overlap, e.g. the fixture
+    // probes server readiness with a throwaway connect/disconnect, and that
+    // probe's disconnect can be processed after the real connection has already
+    // been accepted and stored. Nulling unconditionally there would discard the
+    // live connection, after which GetConn() fabricates an unconnected one and
+    // server-side Advise() fails. (Surfaced under the GUI event loop, where the
+    // overlap is more likely.)
+    if ( m_server->m_conn == this )
+        m_server->m_conn = nullptr;
+    return wxConnection::OnDisconnect();
+}
+
+const void* IPCServerConnection::OnRequest(const wxString& topic,
+                                         const wxString& item,
+                                         size_t* size,
+                                         wxIPCFormat format)
+{
+    *size = 0;
+
+    if ( topic != IPC_TEST_TOPIC )
+        return nullptr;
+
+    m_firstRequestReceived = true;
+
+    wxString s;
+
+    if ( item == "ping" )
+    {
+        if ( format != wxIPC_PRIVATE )
+            return nullptr;
+
+        s = "pong";
+    }
+    else if ( item == "last_execute" )
+    {
+        s = m_lastExecute;
+    }
+    else if ( item.StartsWith("MultiRequest thread") )
+    {
+        s = HandleThreadRequestCounting(item);
+    }
+    else if ( item == "get_thread1_request_counter")
+    {
+        s = wxString::Format("%d", m_threadRequestLastVal[0]);
+    }
+    else if ( item == "get_thread2_request_counter")
+    {
+        s = wxString::Format("%d", m_threadRequestLastVal[1]);
+    }
+    else if ( item == "get_thread3_request_counter")
+    {
+        s = wxString::Format("%d", m_threadRequestLastVal[2]);
+    }
+    else if ( item == "get_error_string")
+    {
+        s = m_generalError;
+    }
+    else
+    {
+        s = "Error: Unknown request - " + item;
+        m_generalError += s;
+    }
+
+    *size = strlen(s.mb_str()) + 1;
+    char* ret = GetBufPtr(*size);
+    strncpy(ret, s.mb_str(), *size);
+    return ret;
+}
+
+wxString IPCServerConnection::HandleThreadRequestCounting(const wxString& item)
+{
+    wxString info;
+    item.StartsWith("MultiRequest thread", &info);
+
+    int threadNumber = wxAtoi(info.Left(2));
+    int counterValue = wxAtoi(info.Mid(3));
+    int lastval = -2;
+
+    bool err = false;
+    wxString errString;
+
+    switch (threadNumber)
+    {
+        case 0:
+            errString =
+                "Error: MultiRequest thread number could not be converted.\n";
+            err = true;
+            break;
+
+        case 1:
+        case 2:
+        case 3:
+            lastval = m_threadRequestLastVal[threadNumber - 1];
+            m_threadRequestLastVal[threadNumber - 1] = counterValue;
+            break;
+
+        default:
+            errString =
+                "Error: MultiRequest thread number must be 1, 2, or 3.\n";
+            err = true;
+    }
+
+    if ( lastval !=  counterValue -1 )
+    {
+        errString +=
+            "Error: Misordered count in thread " +
+            wxString::Format("%d - expected %d, received %d\n",
+                             threadNumber, lastval + 1, counterValue);
+        err = true;
+    }
+
+    if ( err )
+    {
+        m_generalError += errString;
+        return errString;
+    }
+
+    return "OK: " + item;
+}
+
+void IPCServerConnection::ResetThreadTrackers()
+{
+    m_generalError.clear();
+
+    for ( auto& val : m_threadRequestLastVal )
+        val = 0;
+
+    m_adviseActive = false;
+
+    m_waitForFirstRequest = false;
+    m_firstRequestReceived = false;
+}
+
+void IPCServerConnection::StartAdviseWorker(wxThread* thread)
+{
+    thread->Run();
+    m_adviseThreads.push_back(thread);
+}
+
+void IPCServerConnection::WaitForAdviseWorkers()
+{
+    for ( wxThread* thread : m_adviseThreads )
+    {
+        if ( thread->IsRunning() )
+            thread->Wait();
+
+        delete thread;
+    }
+
+    m_adviseThreads.clear();
+}
+
+bool IPCServerConnection::OnStartAdvise(const wxString& topic,
+                                      const wxString& item)
+{
+    if ( topic != IPC_TEST_TOPIC )
+        return false;
+
+    WaitForAdviseWorkers();
+
+    m_adviseActive = true;
+
+    if ( item == "SimpleAdvise test" )
+    {
+        StartAdviseWorker(new SingleAdviseThread(m_server, item));
+    }
+    else if ( item.StartsWith("MultiAdvise test") )
+    {
+        StartAdviseWorker(
+            new MultiAdviseThread(m_server, item, "MultiAdvise thread 1"));
+    }
+    else if ( item.StartsWith("MultiAdvise MultiThread test") )
+    {
+        StartAdviseWorker(
+            new MultiAdviseThread(m_server, item, "MultiAdvise thread 1"));
+        StartAdviseWorker(
+            new MultiAdviseThread(m_server, item, "MultiAdvise thread 2"));
+        StartAdviseWorker(
+            new MultiAdviseThread(m_server, item, "MultiAdvise thread 3"));
+    }
+    else if ( item.StartsWith("MultiAdvise MultiThread test with simultaneous Requests") )
+    {
+        m_waitForFirstRequest = true;
+
+        StartAdviseWorker(
+            new MultiAdviseThread(m_server, item, "MultiAdvise thread 1"));
+        StartAdviseWorker(
+            new MultiAdviseThread(m_server, item, "MultiAdvise thread 2"));
+        StartAdviseWorker(
+            new MultiAdviseThread(m_server, item, "MultiAdvise thread 3"));
+    }
+    else
+    {
+        m_generalError += "Unknown StartAdvise item\n";
+        m_adviseActive = false;
+    }
+
+    return m_adviseActive;
+}
+
+bool IPCServerConnection::OnStopAdvise(const wxString& topic,
+                                     const wxString& WXUNUSED(item))
+{
+    if ( topic != IPC_TEST_TOPIC )
+        return false;
+
+    m_adviseActive = false;
+
+    return true;
+}
+
+void* SingleAdviseThread::Entry()
+{
+    wxMilliSleep(50);
+
+    IPCServerConnection& conn = m_server->GetConn();
+    if ( !conn.m_adviseActive )
+        conn.m_generalError = "Advise() call without StartAdvise()\n";
+
+    wxString s = "OK SimpleAdvise";
+    size_t size = strlen(s.mb_str());
+
+    if ( !conn.Advise(m_item, s.mb_str(), size, wxIPC_TEXT) )
+        conn.m_generalError = "Advise() call returned false";
+
+    return nullptr;
+}
+
+void* MultiAdviseThread::Entry()
+{
+    IPCServerConnection& conn = m_server->GetConn();
+
+    if ( !conn.m_adviseActive )
+        conn.m_generalError = "Advise() call without StartAdvise()\n";
+
+    if ( conn.m_waitForFirstRequest )
+    {
+        while ( !conn.m_firstRequestReceived )
+            wxMilliSleep(50);
+    }
+
+    for ( size_t n = 1; n < MESSAGE_ITERATIONS + 1; n++ )
+    {
+        if ( !conn.m_adviseActive )
+            break;
+
+        wxMilliSleep(50);
+
+        wxString s = m_label + wxString::Format(" %zu", n);
+        size_t size = strlen(s.mb_str());
+
+        if ( !conn.Advise(m_item, s.mb_str(), size, wxIPC_TEXT) )
+        {
+            conn.m_generalError
+                += wxString::Format(m_label +
+                                    "Advise() call returned false: %zu", n);
+        }
+    }
+
+    return nullptr;
+}
+
+// ============================================================================
+// In-process server context (server child process entry point)
+// ============================================================================
+
+class IPCServerContext
+{
+public:
+    IPCServerContext()
+        : m_server(std::make_unique<IPCServerTestServer>())
+    {
+    }
+
+    ~IPCServerContext()
+    {
+        Stop();
+    }
+
+    bool Start()
+    {
+        wxEventLoopActivator activate(&m_loop);
+
+        if ( !m_server->Create(IPC_TEST_PORT) )
+            return false;
+
+        m_started = true;
+        return true;
+    }
+
+    void RunUntilStopped()
+    {
+        wxEventLoopActivator activate(&m_loop);
+        m_loop.Run();
+    }
+
+    void Stop()
+    {
+        if ( !m_started )
+            return;
+
+        m_server->Shutdown();
+        m_started = false;
+    }
+
+private:
+    std::unique_ptr<IPCServerTestServer> m_server;
+    wxEventLoop m_loop;
+    bool m_started = false;
+
+    wxDECLARE_NO_COPY_CLASS(IPCServerContext);
+};
+
+void RunIPCServerUntilStopped()
+{
+#if wxUSE_SOCKETS
+    wxSocketBase::Initialize();
+#endif
+
+    IPCServerContext ctx;
+
+    if ( !ctx.Start() )
+        _exit(1);
+
+    ctx.RunUntilStopped();
+}
+
+// ============================================================================
+// IPCServerThread: launch server via same test binary (no separate executable)
+// ============================================================================
+
+class IPCServerProcess : public wxProcess
+{
+public:
+    IPCServerProcess() { m_finished = false; }
+
+    virtual void OnTerminate(int pid, int status) override
+    {
+        wxUnusedVar(status);
+        wxUnusedVar(pid);
+        m_finished = true;
+    }
+
+    bool IsFinished() const { return m_finished; }
+
+    bool m_finished;
+};
+
+struct IPCServerLaunchState
+{
+    std::unique_ptr<IPCServerProcess> process;
+    wxString command;
+    long pid = 0;
+
+    IPCServerLaunchState() : process(std::make_unique<IPCServerProcess>()) {}
+};
+
+// Pump the real event loop so async wxExecute() can deliver its process-exit
+// notification (on MSW, a wxWM_PROC_TERMINATED window message handled by
+// wxExecuteWindowCbk, which calls wxProcess::OnTerminate()). The IPC client's
+// IPCClientDispatch() can't be used here: during end-of-run teardown the client
+// loop is already gone (gs_clientLoop == nullptr) so it no-ops, and the exit
+// notification would otherwise be delivered only later, after we've destroyed
+// the IPCServerProcess handler, making wxExecuteWindowCbk dereference a freed
+// wxProcess. Dispatching here lets OnTerminate() run (and wxExecute free its
+// per-process data) while the handler is still alive.
+static void PumpForProcessExit(unsigned long timeoutMs)
+{
+    if ( wxEventLoopBase* const active = wxEventLoopBase::GetActive() )
+    {
+        active->DispatchTimeout(timeoutMs);
+    }
+    else
+    {
+        wxEventLoop loop;
+        wxEventLoopActivator activate(&loop);
+        loop.DispatchTimeout(timeoutMs);
+    }
+}
+
+class IPCServerLauncher : public wxTimer
+{
+public:
+    IPCServerLauncher(IPCServerLaunchState* state)
+        : m_state(state)
+    {
+        wxFileName fn(wxStandardPaths::Get().GetExecutablePath());
+        m_state->command = fn.GetFullPath();
+    }
+
+    bool DoStart()
+    {
+        if ( m_state->pid )
+            DoStop();
+
+        wxEventLoop loop;
+        Bind(wxEVT_TIMER, &IPCServerLauncher::OnTimer, this);
+        StartOnce(10);
+        loop.Run();
+
+        return m_state->pid != 0;
+    }
+
+    void OnTimer(wxTimerEvent& WXUNUSED(event))
+    {
+        wxSetEnv("WX_IPC_TEST_SERVER", "1");
+
+        // Pass the environment to the child explicitly. Relying on wxExecute()
+        // to inherit a variable set via wxSetEnv() works for the console "test"
+        // but not for the wxGTK GUI "test_gui": there the re-executed child did
+        // not see WX_IPC_TEST_SERVER and ran the whole test suite instead of the
+        // IPC server. Building the env map and handing it to wxExecute() makes
+        // the hand-off reliable in both programs.
+        wxExecuteEnv execEnv;
+        wxGetEnvMap(&execEnv.env);
+        execEnv.env["WX_IPC_TEST_SERVER"] = "1";
+
+        m_state->pid = wxExecute(m_state->command,
+                                 wxEXEC_ASYNC,
+                                 m_state->process.get(),
+                                 &execEnv);
+
+        if ( wxEventLoop::GetActive() )
+            wxEventLoop::GetActive()->Exit();
+    }
+
+    void DoStop()
+    {
+        if ( m_state->pid && !m_state->process->IsFinished() )
+        {
+            wxKill(m_state->pid, wxSIGTERM);
+            // Pump the real loop (not IPCClientDispatch) so the child's exit
+            // notification reaches wxProcess::OnTerminate() before the handler
+            // is destroyed; see PumpForProcessExit().
+            for ( int i = 0; i < 250 && !m_state->process->IsFinished(); ++i )
+            {
+                PumpForProcessExit(20);
+                wxMilliSleep(20);
+            }
+        }
+
+        m_state->pid = 0;
+        wxUnsetEnv("WX_IPC_TEST_SERVER");
+    }
+
+    void WaitUntilFinished()
+    {
+        for ( int i = 0; i < 100 && !m_state->process->IsFinished(); ++i )
+        {
+            PumpForProcessExit(20);
+            wxMilliSleep(20);
+        }
+    }
+
+    IPCServerLaunchState* m_state;
+};
+
+struct IPCServerThread::Private
+{
+    IPCServerLaunchState state;
+};
+
+IPCServerThread::IPCServerThread()
+    : m_priv(std::make_unique<Private>())
+{
+}
+
+IPCServerThread::~IPCServerThread()
+{
+    WaitForExit();
+}
+
+bool IPCServerThread::Start()
+{
+    IPCServerLauncher launcher(&m_priv->state);
+    return launcher.DoStart();
+}
+
+void IPCServerThread::WaitForExit()
+{
+    if ( !m_priv->state.pid )
+        return;
+
+    IPCServerLauncher launcher(&m_priv->state);
+    launcher.WaitUntilFinished();
+    launcher.DoStop();
+}
+
+#endif // wxUSE_THREADS && !__WXQT__

--- a/tests/net/ipc_test_server.cpp
+++ b/tests/net/ipc_test_server.cpp
@@ -369,8 +369,9 @@ void IPCServerConnection::WaitForAdviseWorkers()
 {
     for ( wxThread* thread : m_adviseThreads )
     {
-        if ( thread->IsRunning() )
-            thread->Wait();
+        // Wait() even if the thread has already finished: a joinable thread
+        // must always be joined to release its resources.
+        thread->Wait();
 
         delete thread;
     }

--- a/tests/net/ipc_test_server.h
+++ b/tests/net/ipc_test_server.h
@@ -1,0 +1,62 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/net/ipc_test_server.h
+// Purpose:     IPC test server (in-process on Windows, same-binary subprocess
+//              on Unix where wxSocket IPC requires main-thread event dispatch)
+// Author:      JP Mattia
+// Copyright:   (c) 2024
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_TESTS_NET_IPC_TEST_SERVER_H_
+#define _WX_TESTS_NET_IPC_TEST_SERVER_H_
+
+#include "wx/evtloop.h"
+#include "wx/thread.h"
+
+// Match the guard in tests/net/ipc.cpp and ipc_test_server.cpp: the IPC test is
+// excluded from wxQt, so its declarations must be too.
+#if wxUSE_THREADS && !defined(__WXQT__)
+
+#include <memory>
+
+// Starts the IPC test server and blocks until it is listening (or failed).
+// Stops the server in WaitForExit().
+class IPCServerThread
+{
+public:
+    IPCServerThread();
+    ~IPCServerThread();
+
+    bool Start();
+    void WaitForExit();
+
+private:
+    struct Private;
+    std::unique_ptr<Private> m_priv;
+
+    wxDECLARE_NO_COPY_CLASS(IPCServerThread);
+};
+
+// Called from tests/test.cpp when WX_IPC_TEST_SERVER is set in the environment.
+void RunIPCServerUntilStopped();
+
+// Dispatch client-side socket events (implemented in ipc.cpp).
+void IPCClientDispatch(unsigned long timeoutMs = 10);
+
+// Wait for a joinable thread to finish while pumping the client event loop.
+// Worker threads marshal their IPC socket I/O to the main thread (see
+// wxTCPEventHandler::RunOnMainThread), so we must keep dispatching here for those
+// marshaled jobs to run; otherwise the worker blocks forever. This is safe now
+// that workers no longer touch the socket themselves (which is what previously
+// made re-entrant dispatch corrupt the connection).
+inline void WaitForThreadWithDispatch(wxThread& thread)
+{
+    while ( thread.IsRunning() )
+        IPCClientDispatch(10);
+
+    thread.Wait();
+}
+
+#endif // wxUSE_THREADS && !__WXQT__
+
+#endif // _WX_TESTS_NET_IPC_TEST_SERVER_H_

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -34,6 +34,7 @@
 
     <exe id="test" template="wx_sample_console,wx_test"
                    template_append="wx_append_base">
+        <cxxflags>-DTEST_HAS_IPC_SERVER</cxxflags>
         <sources>
             test.cpp
             any/anytest.cpp
@@ -79,6 +80,7 @@
             misc/pathlist.cpp
             misc/typeinfotest.cpp
             net/ipc.cpp
+            net/ipc_test_server.cpp
             net/socket.cpp
             net/webrequest.cpp
             regex/regextest.cpp
@@ -164,6 +166,9 @@
 
         <!-- link against GUI libraries, but be a console app: -->
         <app-type>console</app-type>
+
+        <!-- needed by the duplicated net/ipc.cpp test below -->
+        <cxxflags>-DTEST_HAS_IPC_SERVER</cxxflags>
 
         <sources>
             asserthelper.cpp
@@ -276,11 +281,13 @@
             misc/settings.cpp
             misc/textwrap.cpp
             <!--
-                This one is intentionally duplicated here (it is also part of
-                non-GUI test) as sockets behave differently in console and GUI
-                applications.
+                These are intentionally duplicated here (they are also part of
+                the non-GUI test) as sockets and IPC behave differently in
+                console and GUI applications.
              -->
             net/socket.cpp
+            net/ipc.cpp
+            net/ipc_test_server.cpp
             persistence/tlw.cpp
             persistence/dataview.cpp
             rowheightcache/rowheightcachetest.cpp

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -34,7 +34,7 @@
 
     <exe id="test" template="wx_sample_console,wx_test"
                    template_append="wx_append_base">
-        <cxxflags>-DTEST_HAS_IPC_SERVER</cxxflags>
+        <define>TEST_HAS_IPC_SERVER</define>
         <sources>
             test.cpp
             any/anytest.cpp
@@ -168,7 +168,7 @@
         <app-type>console</app-type>
 
         <!-- needed by the duplicated net/ipc.cpp test below -->
-        <cxxflags>-DTEST_HAS_IPC_SERVER</cxxflags>
+        <define>TEST_HAS_IPC_SERVER</define>
 
         <sources>
             asserthelper.cpp

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -668,21 +668,8 @@ TestApp::TestApp()
 #endif // wxUSE_GUI
 }
 
-// Init
-//
-bool TestApp::OnInit()
+static void ShowTestInformation()
 {
-#if wxUSE_GUI
-    if ( !IsGUIEnabled() )
-    {
-        wxFputs(wxASCII_STR("Not running tests because GUI is disabled.\n"), stderr);
-        return true;
-    }
-#endif // wxUSE_GUI
-
-    // Hack: don't call TestAppBase::OnInit() to let CATCH handle command line.
-
-    // Output some important information about the test environment.
 #if wxUSE_GUI
     cout << "Test program for wxWidgets GUI features\n"
 #else
@@ -715,6 +702,24 @@ bool TestApp::OnInit()
 
     cout << " as " << wxGetUserId()
          << std::endl;
+}
+
+// Init
+//
+bool TestApp::OnInit()
+{
+#if wxUSE_GUI
+    if ( !IsGUIEnabled() )
+    {
+        wxFputs(wxASCII_STR("Not running tests because GUI is disabled.\n"), stderr);
+        return true;
+    }
+#endif // wxUSE_GUI
+
+    // Hack: don't call TestAppBase::OnInit() to let CATCH handle command line.
+
+    // Output some important information about the test environment.
+    ShowTestInformation();
 
     // Optionally allow executing the tests in the locale specified by the
     // standard environment variable, this is especially useful to use UTF-8

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -69,6 +69,11 @@ std::string wxTheCurrentTestClass, wxTheCurrentTestMethod;
     {
         return wxGetEnv("WX_IPC_TEST_SERVER", nullptr);
     }
+#else // not using IPC test server
+    static bool ShouldRunTestIPCServer()
+    {
+        return false;
+    }
 #endif
 
 using namespace std;
@@ -718,8 +723,10 @@ bool TestApp::OnInit()
 
     // Hack: don't call TestAppBase::OnInit() to let CATCH handle command line.
 
-    // Output some important information about the test environment.
-    ShowTestInformation();
+    // Output some important information about the test environment unless
+    // we're running as a helper IPC server process.
+    if ( !ShouldRunTestIPCServer() )
+        ShowTestInformation();
 
     // Optionally allow executing the tests in the locale specified by the
     // standard environment variable, this is especially useful to use UTF-8

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -55,6 +55,14 @@ std::string wxTheCurrentTestClass, wxTheCurrentTestMethod;
 #include "wx/socket.h"
 #include "wx/evtloop.h"
 
+// __WXQT__ guard: see the longer note in tests/net/ipc.cpp. The IPC test (and
+// its server) is excluded from wxQt (cross-thread CallAfter() not processed by
+// the wxQt event loop, fixed separately on branch
+// jpmattia/wxQT-CallAfter-wxWakeUpIdle).
+#if wxUSE_THREADS && defined(TEST_HAS_IPC_SERVER) && !defined(__WXQT__)
+    #include "net/ipc_test_server.h"
+#endif
+
 using namespace std;
 
 // ----------------------------------------------------------------------------
@@ -340,6 +348,22 @@ public:
 
     virtual int OnRun() override
     {
+#if wxUSE_THREADS && defined(TEST_HAS_IPC_SERVER) && !defined(__WXQT__)
+        // The IPC test re-executes this same binary as its server (with
+        // WX_IPC_TEST_SERVER set), so test_gui must run the server here too,
+        // exactly as the console test does in the non-GUI OnRun() below. See the
+        // note there and tests/net/ipc.cpp for the wxQt exclusion.
+        if ( wxGetEnv("WX_IPC_TEST_SERVER", nullptr) )
+        {
+            // Suppress the idle-driven test runner: RunIPCServerUntilStopped()
+            // spins its own event loop, and our OnIdle() would otherwise fire
+            // there and run the whole test suite inside the server process.
+            m_runTests = false;
+            RunIPCServerUntilStopped();
+            return 0;
+        }
+#endif // wxUSE_THREADS && TEST_HAS_IPC_SERVER && !__WXQT__
+
         if ( !IsGUIEnabled() )
             return 0;
 
@@ -351,6 +375,18 @@ public:
 #else // !wxUSE_GUI
     virtual int OnRun() override
     {
+#if wxUSE_THREADS && defined(TEST_HAS_IPC_SERVER) && !defined(__WXQT__)
+        // The IPC test starts its server by re-executing this same binary with
+        // WX_IPC_TEST_SERVER set and then running a bare event loop here. The IPC
+        // sources and TEST_HAS_IPC_SERVER are built into both the console "test"
+        // and "test_gui" programs, so the GUI OnRun() above has the same hook.
+        if ( wxGetEnv("WX_IPC_TEST_SERVER", nullptr) )
+        {
+            RunIPCServerUntilStopped();
+            return 0;
+        }
+#endif // wxUSE_THREADS && TEST_HAS_IPC_SERVER && !__WXQT__
+
         return RunTests();
     }
 #endif // wxUSE_GUI/!wxUSE_GUI

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -60,7 +60,15 @@ std::string wxTheCurrentTestClass, wxTheCurrentTestMethod;
 // the wxQt event loop, fixed separately on branch
 // jpmattia/wxQT-CallAfter-wxWakeUpIdle).
 #if wxUSE_THREADS && defined(TEST_HAS_IPC_SERVER) && !defined(__WXQT__)
+    #define wxHAS_TEST_IPC_SERVER
+
     #include "net/ipc_test_server.h"
+
+    // Return true if the test should run in the special "IPC server" mode.
+    static bool ShouldRunTestIPCServer()
+    {
+        return wxGetEnv("WX_IPC_TEST_SERVER", nullptr);
+    }
 #endif
 
 using namespace std;
@@ -348,12 +356,12 @@ public:
 
     virtual int OnRun() override
     {
-#if wxUSE_THREADS && defined(TEST_HAS_IPC_SERVER) && !defined(__WXQT__)
+#ifdef wxHAS_TEST_IPC_SERVER
         // The IPC test re-executes this same binary as its server (with
         // WX_IPC_TEST_SERVER set), so test_gui must run the server here too,
         // exactly as the console test does in the non-GUI OnRun() below. See the
         // note there and tests/net/ipc.cpp for the wxQt exclusion.
-        if ( wxGetEnv("WX_IPC_TEST_SERVER", nullptr) )
+        if ( ShouldRunTestIPCServer() )
         {
             // Suppress the idle-driven test runner: RunIPCServerUntilStopped()
             // spins its own event loop, and our OnIdle() would otherwise fire
@@ -362,7 +370,7 @@ public:
             RunIPCServerUntilStopped();
             return 0;
         }
-#endif // wxUSE_THREADS && TEST_HAS_IPC_SERVER && !__WXQT__
+#endif // wxHAS_TEST_IPC_SERVER
 
         if ( !IsGUIEnabled() )
             return 0;
@@ -375,17 +383,17 @@ public:
 #else // !wxUSE_GUI
     virtual int OnRun() override
     {
-#if wxUSE_THREADS && defined(TEST_HAS_IPC_SERVER) && !defined(__WXQT__)
+#ifdef wxHAS_TEST_IPC_SERVER
         // The IPC test starts its server by re-executing this same binary with
         // WX_IPC_TEST_SERVER set and then running a bare event loop here. The IPC
         // sources and TEST_HAS_IPC_SERVER are built into both the console "test"
         // and "test_gui" programs, so the GUI OnRun() above has the same hook.
-        if ( wxGetEnv("WX_IPC_TEST_SERVER", nullptr) )
+        if ( ShouldRunTestIPCServer() )
         {
             RunIPCServerUntilStopped();
             return 0;
         }
-#endif // wxUSE_THREADS && TEST_HAS_IPC_SERVER && !__WXQT__
+#endif // wxHAS_TEST_IPC_SERVER
 
         return RunTests();
     }

--- a/tests/test.vcxproj
+++ b/tests/test.vcxproj
@@ -972,6 +972,7 @@
     <ClCompile Include="misc\pathlist.cpp" />
     <ClCompile Include="misc\typeinfotest.cpp" />
     <ClCompile Include="net\ipc.cpp" />
+    <ClCompile Include="net\ipc_test_server.cpp" />
     <ClCompile Include="net\socket.cpp" />
     <ClCompile Include="net\webrequest.cpp" />
     <ClCompile Include="regex\regextest.cpp" />
@@ -1002,7 +1003,9 @@
     <ClCompile Include="strings\vararg.cpp" />
     <ClCompile Include="strings\vsnprintf.cpp" />
     <ClCompile Include="strings\hexconv.cpp" />
-    <ClCompile Include="test.cpp" />
+    <ClCompile Include="test.cpp">
+      <PreprocessorDefinitions>TEST_HAS_IPC_SERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="textfile\textfiletest.cpp" />
     <ClCompile Include="thread\atomic.cpp" />
     <ClCompile Include="thread\misc.cpp" />

--- a/tests/test.vcxproj.filters
+++ b/tests/test.vcxproj.filters
@@ -124,6 +124,9 @@
     <ClCompile Include="net\ipc.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="net\ipc_test_server.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="streams\largefile.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/tests/test_gui.vcxproj
+++ b/tests/test_gui.vcxproj
@@ -1024,13 +1024,17 @@
     <ClCompile Include="misc\selstoretest.cpp" />
     <ClCompile Include="misc\settings.cpp" />
     <ClCompile Include="misc\textwrap.cpp" />
+    <ClCompile Include="net\ipc.cpp" />
+    <ClCompile Include="net\ipc_test_server.cpp" />
     <ClCompile Include="net\socket.cpp" />
     <ClCompile Include="persistence\tlw.cpp" />
     <ClCompile Include="persistence\dataview.cpp" />
     <ClCompile Include="sizers\boxsizer.cpp" />
     <ClCompile Include="sizers\gridsizer.cpp" />
     <ClCompile Include="sizers\wrapsizer.cpp" />
-    <ClCompile Include="test.cpp" />
+    <ClCompile Include="test.cpp">
+      <PreprocessorDefinitions>TEST_HAS_IPC_SERVER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Include="testableframe.cpp" />
     <ClCompile Include="toplevel\toplevel.cpp" />
     <ClCompile Include="validators\valnum.cpp" />

--- a/tests/test_gui.vcxproj.filters
+++ b/tests/test_gui.vcxproj.filters
@@ -233,6 +233,12 @@
     <ClCompile Include="controls\slidertest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="net\ipc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="net\ipc_test_server.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="net\socket.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
This PR addresses several of the IPC issues raised in #24639. It is a substantial rewrite of sckipc.cpp, so my attempt at writing "atomic commits" may fall short. It may be more productive to look at the entire file, along with the individual commit messages and these notes:

1. `wxIPCMessageBase` largely replaces `IPCStreams`. `IPCStreams` was burying errors, and was not detecting loss of data sync.  Both of these issues are fixed with `wxIPCMessageBase`.

2. For each `IPCCode`, there is a message derived from `wxIPCMessageBase`. The derived message has methods `DataFromSocket()` and `DataToSocket()`, which simplifies verifying the symmetry in reading and writing.

3. Reading and writing messages to the socket are guarded by critical sections, which ensures that a message is read or written to the socket without interruption (and therefore corruption) from another thread.

4. When the socket sends notification, there are potentially multiple messages waiting. The previous implementation would not process more than one message per notification. To fix this, the new `Client_OnRequest` implements a read-and-execute loop, which continues until there is no data left in the socket. A critical section ensures that `Client_OnRequest` is alone in receiving messages, and locks out others like `Request()` to avoid race conditions.

5. When a method expects a reply (such as `wxConnection::Request()`), a critical section prevents any new request until the current request is answered, which ensures that the reply correctly matches the request. Any non-requested messages sent before the reply (eg IPC_ADVISE) are processed, and the read loop continues until the desired reply type is found.

6. In the issue thread for [#24639](https://github.com/wxWidgets/wxWidgets/issues/24639), it was mentioned that `ERROR_ACCESS_DENIED` (5) and/or `WSAECONNABORTED` (10053) were being triggered on the socket for wxMSW. I've determined these errors result from attempting to read (or peek) on a socket which has no data waiting. Microsoft, in its infinite wisdom, has determined that trying to read data on a socket that has no data deserves both `ERROR_ACCESS_DENIED` and `WSAECONNABORTED`, which sound much more dramatic than just reading (or peeking) on the socket with no queued data.  As such, I've moved those errors into the category of `wxSOCKET_WOULDBLOCK`, rather than `wxSOCKET_IOERR`; Otherwise, the communication drops at the first attempted read of an empty socket.

7. sockmsw.cpp was also filtering out some `FD_READ` notifications, and this was causing some hangs in the IPC reads. That filter has been eliminated. A side effect is that notifications from sockmsw.cpp will now sometimes be notifying when the socket does not have queued data waiting. I confess I do not understand why an `FD_READ` notification is sent in such circumstances, but again, who am I to question the infinite wisdom of Microsoft.
   
8. Data returned from something like `wxConnection::Request()` had a potential issue if the caller tried to use the data after another `wxConnection::Request()` had been received.  There was only one buffer, and the new request-reply would overwrite the first returned data.  The new design creates an array, so that data and the allocations have a lifetime greater than one call.

I have tested the changes successfully with both the ipc sample as well as our company's new windows-service + client. Our service+client has loops which are sending `Advise()` and `Request()` back and forth with greater speed than the ipc sample. (Testing with our service also uncovered issue #24856.)

This PR strikes me as a large change, so let me know of any questions and any recommendations as to how to best proceed.
