### PR TITLE
Cleanup and reorder wrapcdlg.h includes

### DIFF
--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -392,7 +392,6 @@ wx_option(wxUSE_TREELISTCTRL "use wxTreeListCtrl class")
 # common dialogs
 # ---------------------------------------------------------------------------
 
-wx_option(wxUSE_COMMON_DIALOGS "use all common dialogs")
 wx_option(wxUSE_ABOUTDLG "use wxAboutBox")
 wx_option(wxUSE_CHOICEDLG "use wxChoiceDialog")
 wx_option(wxUSE_COLOURDLG "use wxColourDialog")

--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -445,8 +445,6 @@
 #endif
 
 
-#cmakedefine01 wxUSE_COMMON_DIALOGS
-
 #cmakedefine01 wxUSE_BUSYINFO
 
 #cmakedefine01 wxUSE_CHOICEDLG

--- a/docs/doxygen/mainpages/const_wxusedef.h
+++ b/docs/doxygen/mainpages/const_wxusedef.h
@@ -308,7 +308,6 @@ library:
 @itemdef{wxUSE_ACCESSIBILITY, Enable accessibility support}
 @itemdef{wxUSE_ACTIVEX, Use wxActiveXContainer and related classes.}
 @itemdef{wxUSE_COMBOCTRL_POPUP_ANIMATION, See wx/msw/combo.h file.}
-@itemdef{wxUSE_COMMON_DIALOGS, Enable use of windows common dialogs from header commdlg.h; example PRINTDLG.}
 @itemdef{wxUSE_CRASHREPORT, Use wxCrashReport class.}
 @itemdef{wxUSE_DATEPICKCTRL_GENERIC, Use generic wxDatePickerCtrl implementation in addition to the native one.}
 @itemdef{wxUSE_DC_CACHEING, cache temporary wxDC objects.}

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -1184,14 +1184,6 @@
 // common dialogs
 // ----------------------------------------------------------------------------
 
-// Use common dialogs (e.g. file selector, printer dialog). Switching this off
-// also switches off the printing architecture and interactive wxPrinterDC.
-//
-// Default is 1
-//
-// Recommended setting: 1
-#define wxUSE_COMMON_DIALOGS 1
-
 // wxBusyInfo displays window with message when app is busy. Works in same way
 // as wxBusyCursor
 #define wxUSE_BUSYINFO      1

--- a/include/wx/gtk/setup.h
+++ b/include/wx/gtk/setup.h
@@ -1184,14 +1184,6 @@
 // common dialogs
 // ----------------------------------------------------------------------------
 
-// Use common dialogs (e.g. file selector, printer dialog). Switching this off
-// also switches off the printing architecture and interactive wxPrinterDC.
-//
-// Default is 1
-//
-// Recommended setting: 1
-#define wxUSE_COMMON_DIALOGS 1
-
 // wxBusyInfo displays window with message when app is busy. Works in same way
 // as wxBusyCursor
 #define wxUSE_BUSYINFO      1

--- a/include/wx/msw/setup.h
+++ b/include/wx/msw/setup.h
@@ -1184,14 +1184,6 @@
 // common dialogs
 // ----------------------------------------------------------------------------
 
-// Use common dialogs (e.g. file selector, printer dialog). Switching this off
-// also switches off the printing architecture and interactive wxPrinterDC.
-//
-// Default is 1
-//
-// Recommended setting: 1
-#define wxUSE_COMMON_DIALOGS 1
-
 // wxBusyInfo displays window with message when app is busy. Works in same way
 // as wxBusyCursor
 #define wxUSE_BUSYINFO      1

--- a/include/wx/msw/wrapcdlg.h
+++ b/include/wx/msw/wrapcdlg.h
@@ -14,12 +14,10 @@
 
 #include "wx/msw/wrapwin.h"
 #include "wx/msw/private.h"
+
+#include <commdlg.h>
+
 #include "wx/msw/missing.h"
-
-#if wxUSE_COMMON_DIALOGS
-    #include <commdlg.h>
-#endif
-
 #include "wx/msw/winundef.h"
 
 #endif // _WX_MSW_WRAPCDLG_H_

--- a/include/wx/osx/setup.h
+++ b/include/wx/osx/setup.h
@@ -1191,14 +1191,6 @@
 // common dialogs
 // ----------------------------------------------------------------------------
 
-// Use common dialogs (e.g. file selector, printer dialog). Switching this off
-// also switches off the printing architecture and interactive wxPrinterDC.
-//
-// Default is 1
-//
-// Recommended setting: 1
-#define wxUSE_COMMON_DIALOGS 1
-
 // wxBusyInfo displays window with message when app is busy. Works in same way
 // as wxBusyCursor
 #define wxUSE_BUSYINFO      1

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -1180,14 +1180,6 @@
 // common dialogs
 // ----------------------------------------------------------------------------
 
-// Use common dialogs (e.g. file selector, printer dialog). Switching this off
-// also switches off the printing architecture and interactive wxPrinterDC.
-//
-// Default is 1
-//
-// Recommended setting: 1
-#define wxUSE_COMMON_DIALOGS 1
-
 // wxBusyInfo displays window with message when app is busy. Works in same way
 // as wxBusyCursor
 #define wxUSE_BUSYINFO      1

--- a/include/wx/univ/setup.h
+++ b/include/wx/univ/setup.h
@@ -1184,14 +1184,6 @@
 // common dialogs
 // ----------------------------------------------------------------------------
 
-// Use common dialogs (e.g. file selector, printer dialog). Switching this off
-// also switches off the printing architecture and interactive wxPrinterDC.
-//
-// Default is 1
-//
-// Recommended setting: 1
-#define wxUSE_COMMON_DIALOGS 1
-
 // wxBusyInfo displays window with message when app is busy. Works in same way
 // as wxBusyCursor
 #define wxUSE_BUSYINFO      1

--- a/setup.h.in
+++ b/setup.h.in
@@ -448,8 +448,6 @@
 #endif
 
 
-#define wxUSE_COMMON_DIALOGS 0
-
 #define wxUSE_BUSYINFO      0
 
 #define wxUSE_CHOICEDLG     0

--- a/setup.h_vms
+++ b/setup.h_vms
@@ -501,8 +501,6 @@ typedef pid_t GPid;
 #define wxUSE_AUTOID_MANAGEMENT 0
 #endif
 
-#define wxUSE_COMMON_DIALOGS 1
-
 #define wxUSE_BUSYINFO      1
 
 #define wxUSE_CHOICEDLG     1

--- a/src/common/cmndata.cpp
+++ b/src/common/cmndata.cpp
@@ -24,9 +24,6 @@
 #include "wx/cmndata.h"
 
 #ifndef WX_PRECOMP
-    #if defined(__WXMSW__)
-        #include "wx/msw/wrapcdlg.h"
-    #endif // MSW
     #include <stdio.h>
     #include "wx/string.h"
     #include "wx/utils.h"

--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -16,9 +16,6 @@
 #include "wx/dcprint.h"
 
 #ifndef WX_PRECOMP
-    #if defined(__WXMSW__)
-        #include "wx/msw/wrapcdlg.h"
-    #endif // MSW
     #include "wx/utils.h"
     #include "wx/dc.h"
     #include "wx/app.h"
@@ -63,12 +60,6 @@
 #include "wx/generic/prntdlgg.h"
 #include "wx/dcps.h"
 #endif
-
-#ifdef __WXMSW__
-    #ifndef __WIN32__
-        #include <print.h>
-    #endif
-#endif // __WXMSW__
 
 // The value traditionally used as the default max page number and meaning
 // "infinitely many". It should probably be documented and exposed, but for now

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -20,7 +20,7 @@
 
 
 #ifndef WX_PRECOMP
-    #include "wx/msw/wrapcdlg.h"
+    #include "wx/msw/private.h"
     #include "wx/image.h"
     #include "wx/window.h"
     #include "wx/utils.h"

--- a/src/msw/dcprint.cpp
+++ b/src/msw/dcprint.cpp
@@ -74,69 +74,6 @@ wxIMPLEMENT_ABSTRACT_CLASS(wxPrinterDCImpl, wxMSWDCImpl);
 // wxPrinterDC construction
 // ----------------------------------------------------------------------------
 
-#if 0
-// This form is deprecated
-wxPrinterDC::wxPrinterDC(const wxString& driver_name,
-                         const wxString& device_name,
-                         const wxString& file,
-                         bool interactive,
-                         wxPrintOrientation orientation)
-{
-    m_isInteractive = interactive;
-
-    if ( !file.empty() )
-        m_printData.SetFilename(file);
-
-#if wxUSE_COMMON_DIALOGS
-    if ( interactive )
-    {
-        PRINTDLG pd;
-
-        pd.lStructSize = sizeof( PRINTDLG );
-        pd.hwndOwner = (HWND) nullptr;
-        pd.hDevMode = (HANDLE)nullptr;
-        pd.hDevNames = (HANDLE)nullptr;
-        pd.Flags = PD_RETURNDC | PD_NOSELECTION | PD_NOPAGENUMS;
-        pd.nFromPage = 0;
-        pd.nToPage = 0;
-        pd.nMinPage = 0;
-        pd.nMaxPage = 0;
-        pd.nCopies = 1;
-        pd.hInstance = (HINSTANCE)nullptr;
-
-        m_ok = PrintDlg( &pd ) != 0;
-        if ( m_ok )
-        {
-            m_hDC = (WXHDC) pd.hDC;
-        }
-    }
-    else
-#endif // wxUSE_COMMON_DIALOGS
-    {
-        if ( !driver_name.empty() && !device_name.empty() && !file.empty() )
-        {
-            m_hDC = (WXHDC) CreateDC(driver_name.t_str(),
-                                     device_name.t_str(),
-                                     file.fn_str(),
-                                     nullptr);
-        }
-        else // we don't have all parameters, ask the user
-        {
-            wxPrintData printData;
-            printData.SetOrientation(orientation);
-            m_hDC = wxGetPrinterDC(printData);
-        }
-
-        m_ok = m_hDC ? true: false;
-
-        // as we created it, we must delete it as well
-        m_bOwnsDC = true;
-    }
-
-    Init();
-}
-#endif
-
 wxPrinterDCImpl::wxPrinterDCImpl( wxPrinterDC *owner, const wxPrintData& printData ) :
     wxMSWDCImpl( owner )
     , m_printData(printData)

--- a/src/msw/dialog.cpp
+++ b/src/msw/dialog.cpp
@@ -23,7 +23,6 @@
 #include "wx/modalhook.h"
 
 #ifndef WX_PRECOMP
-    #include "wx/msw/wrapcdlg.h"
     #include "wx/utils.h"
     #include "wx/frame.h"
     #include "wx/app.h"

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -24,8 +24,6 @@
 #include "wx/filedlg.h"
 
 #ifndef WX_PRECOMP
-    #include "wx/msw/wrapcdlg.h"
-    #include "wx/msw/missing.h"
     #include "wx/utils.h"
     #include "wx/msgdlg.h"
     #include "wx/filefn.h"
@@ -44,6 +42,8 @@
 #include "wx/tokenzr.h"
 #include "wx/modalhook.h"
 
+#include "wx/msw/wrapshl.h"
+#include "wx/msw/wrapcdlg.h"
 #include "wx/msw/private/dpiaware.h"
 #include "wx/msw/private/filedialog.h"
 
@@ -59,8 +59,6 @@
     #include "wx/radiobut.h"
     #include "wx/stattext.h"
     #include "wx/textctrl.h"
-
-    #include "wx/msw/wrapshl.h"
 
     #include "wx/msw/private/cotaskmemptr.h"
 #endif // wxUSE_IFILEOPENDIALOG

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -15,7 +15,7 @@
 #if wxUSE_GRAPHICS_GDIPLUS
 
 #ifndef WX_PRECOMP
-    #include "wx/msw/wrapcdlg.h"
+    #include "wx/msw/private.h"
     #include "wx/image.h"
     #include "wx/window.h"
     #include "wx/utils.h"
@@ -42,11 +42,6 @@
 #include "wx/dcgraph.h"
 #include "wx/rawbmp.h"
 
-#include "wx/msw/private.h" // needs to be before #include <commdlg.h>
-
-#if wxUSE_COMMON_DIALOGS
-#include <commdlg.h>
-#endif
 #include <float.h> // for FLT_MAX, FLT_MIN
 
 #ifdef _MSC_VER

--- a/src/msw/printwin.cpp
+++ b/src/msw/printwin.cpp
@@ -24,7 +24,6 @@
 #if wxUSE_PRINTING_ARCHITECTURE && (!defined(__WXUNIVERSAL__) || !wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW)
 
 #ifndef WX_PRECOMP
-    #include "wx/msw/wrapcdlg.h"
     #include "wx/window.h"
     #include "wx/msw/private.h"
     #include "wx/utils.h"


### PR DESCRIPTION
Include wrappers in a specific order so missing.h does not cause macro redefinition warnings.
When wrapcdlg.h/<commdlg.h> is not needed, include wx/msw/private.h instead.

fixes https://github.com/wxWidgets/wxWidgets/issues/24851

And remove unused `wxUSE_COMMON_DIALOGS` option