### PR TITLE
Deprecate `wxScreenDC` even more and remove macOS implementation

### DIFF
--- a/docs/doxygen/mainpages/cat_classes.h
+++ b/docs/doxygen/mainpages/cat_classes.h
@@ -292,11 +292,13 @@ Related Overviews: @ref overview_dc
 @li wxBufferedPaintDC: A helper device context for double buffered drawing
     inside @b OnPaint().
 @li wxClientDC: A device context to access the client area outside
-    @b OnPaint() events
+    @b OnPaint() events (doesn't work on many modern systems, deprecated).
 @li wxPaintDC: A device context to access the client area inside @b OnPaint()
     events
-@li wxWindowDC: A device context to access the non-client area
-@li wxScreenDC: A device context to access the entire screen
+@li wxWindowDC: A device context to access the non-client area (Windows-only,
+    deprecated).
+@li wxScreenDC: A device context to access the entire screen (doesn't work on
+    many modern systems, deprecated).
 @li wxDC: The device context base class
 @li wxMemoryDC: A device context for drawing into bitmaps
 @li wxMetafileDC: A device context for drawing into metafiles

--- a/include/wx/dcscreen.h
+++ b/include/wx/dcscreen.h
@@ -13,6 +13,7 @@
 #include "wx/defs.h"
 #include "wx/dc.h"
 
+// This class is obsolete and doesn't work, don't use it.
 class WXDLLIMPEXP_CORE wxScreenDC : public wxDC
 {
 public:

--- a/interface/wx/dcclient.h
+++ b/interface/wx/dcclient.h
@@ -24,7 +24,7 @@
     @library{wxcore}
     @category{dc}
 
-    @see wxDC, wxClientDC, wxMemoryDC, wxWindowDC, wxScreenDC
+    @see wxDC, wxMemoryDC
 */
 class wxPaintDC : public wxClientDC
 {
@@ -66,7 +66,7 @@ public:
     @library{wxcore}
     @category{dc}
 
-    @see wxDC, wxMemoryDC, wxPaintDC, wxWindowDC, wxScreenDC
+    @see wxDC, wxMemoryDC, wxPaintDC, wxWindowDC
 */
 class wxClientDC : public wxWindowDC
 {
@@ -120,7 +120,7 @@ public:
     @library{wxcore}
     @category{dc}
 
-    @see wxDC, wxMemoryDC, wxPaintDC, wxClientDC, wxScreenDC
+    @see wxDC, wxMemoryDC, wxPaintDC, wxClientDC
 */
 class wxWindowDC : public wxDC
 {

--- a/interface/wx/dcscreen.h
+++ b/interface/wx/dcscreen.h
@@ -12,6 +12,8 @@
 
     Please don't use this class in the new code, as it doesn't work on modern
     systems any longer and using it is not guaranteed to have any effect at all.
+    Use wxDisplay for getting information about the screen and wxOverlay for
+    temporarily drawing over a window.
 
     A wxScreenDC can be used to paint on the screen. This should normally be
     constructed as a temporary stack object; don't store a wxScreenDC object.

--- a/interface/wx/dragimag.h
+++ b/interface/wx/dragimag.h
@@ -15,6 +15,9 @@
     platforms, wxGenericDragImage is used. Applications may also prefer to use
     wxGenericDragImage on Windows, too.
 
+    @note wxGenericDragImage implementation uses wxScreenDC and so doesn't work
+    on the platforms where wxScreenDC doesn't work, e.g. modern macOS versions.
+
     To use this class, when you wish to start dragging an image, create a
     wxDragImage object and store it somewhere you can access it as the drag
     progresses. Call BeginDrag() to start, and EndDrag() to stop the drag. To

--- a/samples/dragimag/dragimag.cpp
+++ b/samples/dragimag/dragimag.cpp
@@ -398,23 +398,6 @@ bool MyApp::OnInit()
         }
     }
 
-#if 0
-    // Under GTK, this demonstrates that
-    // wxScreenDC only gets the root window content.
-    // We need to be able to copy the overall content
-    // for full-screen dragging to work.
-    int w, h;
-    wxDisplaySize(& w, & h);
-    wxBitmap bitmap(w, h);
-
-    wxScreenDC dc;
-    wxMemoryDC memDC;
-    memDC.SelectObject(bitmap);
-    memDC.Blit(0, 0, w, h, & dc, 0, 0);
-    memDC.SelectObject(wxNullBitmap);
-    m_background = bitmap;
-#endif
-
     frame->Show( true );
 
     return true;

--- a/samples/help/doc/wx34.htm
+++ b/samples/help/doc/wx34.htm
@@ -496,8 +496,6 @@
 
 <A HREF="wxwin271.htm#wxstaticboxsizer"><B>wxStaticBoxSizer</B></A><BR>
 
-<A HREF="wxwin272.htm#wxscreendc"><B>wxScreenDC</B></A><BR>
-
 <A HREF="wxwin273.htm#wxscrollbar"><B>wxScrollBar</B></A><BR>
 
 <A HREF="wxwin274.htm#wxscrollwinevent"><B>wxScrollWinEvent</B></A><BR>

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -38,7 +38,6 @@
     #include "wx/statusbr.h"
     #include "wx/toolbar.h"
     #include "wx/dcclient.h"
-    #include "wx/dcscreen.h"
     #include "wx/scrolbar.h"
     #include "wx/layout.h"
     #include "wx/sizer.h"
@@ -2905,7 +2904,7 @@ static wxSize GetDPIHelper(const wxWindowBase* w)
     if ( w )
         dpi = w->GetDPI();
     if ( !dpi.x || !dpi.y )
-        dpi = wxScreenDC().GetPPI();
+        dpi = wxDisplay().GetPPI();
     if ( !dpi.x || !dpi.y )
         dpi = wxDisplay::GetStdPPI();
 

--- a/src/generic/sashwin.cpp
+++ b/src/generic/sashwin.cpp
@@ -114,8 +114,6 @@ void wxSashWindow::OnMouseEvent(wxMouseEvent& event)
                              !wxDynamicCast(parent, wxFrame))
               parent = parent->GetParent();
 
-            wxScreenDC::StartDrawingOnTop(parent);
-
             // We don't say we're dragging yet; we leave that
             // decision for the Dragging() branch, to ensure
             // the user has dragged a little bit.
@@ -149,7 +147,6 @@ void wxSashWindow::OnMouseEvent(wxMouseEvent& event)
             ReleaseMouse();
         m_mouseCaptured = false;
 
-        wxScreenDC::EndDrawingOnTop();
         m_dragMode = wxSASH_DRAG_NONE;
         m_draggingEdge = wxSASH_NONE;
     }
@@ -163,10 +160,6 @@ void wxSashWindow::OnMouseEvent(wxMouseEvent& event)
 
         // Erase old tracker
         DrawSashTracker(m_draggingEdge, m_oldX, m_oldY);
-
-        // End drawing on top (frees the window used for drawing
-        // over the screen)
-        wxScreenDC::EndDrawingOnTop();
 
         int w, h;
         GetSize(&w, &h);

--- a/src/osx/carbon/dcscreen.cpp
+++ b/src/osx/carbon/dcscreen.cpp
@@ -17,10 +17,6 @@
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxScreenDCImpl, wxWindowDCImpl);
 
-// TODO : for the Screenshot use case, which doesn't work in Quartz
-// we should do a GetAsBitmap using something like
-// http://www.cocoabuilder.com/archive/message/cocoa/2005/8/13/144256
-
 // Create a DC representing the whole screen
 wxScreenDCImpl::wxScreenDCImpl( wxDC *owner ) :
    wxWindowDCImpl( owner )
@@ -41,45 +37,13 @@ wxScreenDCImpl::~wxScreenDCImpl()
     wxDELETE(m_graphicContext);
 }
 
-#if wxOSX_USE_IPHONE
-// Apple has allowed usage of this API as of 15th Dec 2009w
-extern CGImageRef UIGetScreenImage();
-#endif
-
-// TODO Switch to CGWindowListCreateImage for 10.5 and above
-
 wxBitmap wxScreenDCImpl::DoGetAsBitmap(const wxRect *subrect) const
 {
     wxRect rect = subrect ? *subrect : wxRect(0, 0, m_width, m_height);
 
     wxBitmap bmp(rect.GetSize(), 32);
 
-#if !wxOSX_USE_IPHONE
-    CGRect srcRect = CGRectMake(rect.x, rect.y, rect.width, rect.height);
+    // TODO: Implement this using ScreenCaptureKit.
 
-    CGContextRef context = (CGContextRef)bmp.GetHBITMAP();
-
-    CGContextSaveGState(context);
-
-    CGContextTranslateCTM( context, 0,  m_height );
-    CGContextScaleCTM( context, 1, -1 );
-
-    if ( subrect )
-        srcRect = CGRectOffset( srcRect, -subrect->x, -subrect->y ) ;
-
-    CGImageRef image = nullptr;
-    
-    image = CGDisplayCreateImage(kCGDirectMainDisplay);
-
-    wxASSERT_MSG(image, wxT("wxScreenDC::GetAsBitmap - unable to get screenshot."));
-
-    CGContextDrawImage(context, srcRect, image);
-
-    CGImageRelease(image);
-
-    CGContextRestoreGState(context);
-#else
-    // TODO implement using UIGetScreenImage, CGImageCreateWithImageInRect, CGContextDrawImage
-#endif
     return bmp;
 }


### PR DESCRIPTION
@csomor This is a bit brutal, but I don't know how to do compile/run-time tests there and it just doesn't seem worth it, so if you don't terribly mind, I'd like to merge this to at least fix compilation, as this is certainly going to affect more and more people.