### PR TITLE
autoconf fixes for gcc 14 on Solaris

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -269,7 +269,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <sys/types.h>
  not big endian
 #endif])], ac_cv_c_bigendian=yes, ac_cv_c_bigendian=no)])
 if test $ac_cv_c_bigendian = unknown; then
-AC_RUN_IFELSE([AC_LANG_SOURCE([[main () {
+AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]],[[
   /* Are we little or big endian?  From Harbison&Steele.  */
   union
   {
@@ -278,7 +278,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[main () {
   } u;
   u.l = 1;
   exit (u.c[sizeof (long) - 1] == 1);
-}]])], [ac_cv_c_bigendian=no], [ac_cv_c_bigendian=yes], [ac_cv_c_bigendian=unknown])
+]])], [ac_cv_c_bigendian=no], [ac_cv_c_bigendian=yes], [ac_cv_c_bigendian=unknown])
 fi])
 if test $ac_cv_c_bigendian = unknown; then
   AC_MSG_WARN([Assuming little-endian target machine - this may be overridden by adding the line "ac_cv_c_bigendian=${ac_cv_c_bigendian='yes'}" to config.cache file])

--- a/configure
+++ b/configure
@@ -35642,6 +35642,9 @@ else
 
                 #include <sys/ioctl.h>
                 #include <sys/soundcard.h>
+                #ifdef HAVE_UNISTD_H
+                # include <unistd.h> /* needed for ioctl() on Solaris */
+                #endif
 
 int
 main ()
@@ -35664,6 +35667,9 @@ else
 
                         #include <sys/ioctl.h>
                         #include <sys/soundcard.h>
+                        #ifdef HAVE_UNISTD_H
+                        # include <unistd.h> /* needed for ioctl() on Solaris */
+                        #endif
 
 int
 main ()

--- a/configure
+++ b/configure
@@ -24397,7 +24397,11 @@ if test "$cross_compiling" = yes; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-main () {
+#include <stdlib.h>
+int
+main (void)
+{
+
   /* Are we little or big endian?  From Harbison&Steele.  */
   union
   {
@@ -24406,6 +24410,9 @@ main () {
   } u;
   u.l = 1;
   exit (u.c[sizeof (long) - 1] == 1);
+
+  ;
+  return 0;
 }
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -5093,6 +5093,9 @@ if test "$USE_UNIX" = 1 ; then
         AC_LINK_IFELSE([AC_LANG_PROGRAM([
                 #include <sys/ioctl.h>
                 #include <sys/soundcard.h>
+                #ifdef HAVE_UNISTD_H
+                # include <unistd.h> /* needed for ioctl() on Solaris */
+                #endif
             ],
             [
                 ioctl(0, SNDCTL_DSP_SPEED, 0);
@@ -5104,6 +5107,9 @@ if test "$USE_UNIX" = 1 ; then
                 AC_LINK_IFELSE([AC_LANG_PROGRAM([
                         #include <sys/ioctl.h>
                         #include <sys/soundcard.h>
+                        #ifdef HAVE_UNISTD_H
+                        # include <unistd.h> /* needed for ioctl() on Solaris */
+                        #endif
                     ],
                     [
                         ioctl(0, SNDCTL_DSP_SPEED, 0);


### PR DESCRIPTION
This fixes two autoconf checks that currently produce the wrong results when run with gcc 14 on Solaris 11.4 as they trigger errors in gcc 14 that were only warnings in previous gcc versions.

The first issue causes the configure script to incorrectly decide that x86 systems are big endian instead of little.  The second one causes it to determine that the OSS ioctl SNDCTL_DSP_SPEED is not supported on Solaris 11 when it is.