### PR TITLE
Add the wxWARN_UNUSED attribute to more classes

### DIFF
--- a/include/wx/arrstr.h
+++ b/include/wx/arrstr.h
@@ -65,7 +65,7 @@ inline int wxCMPFUNC_CONV wxNaturalStringSortDescending(const wxString& s1, cons
 
 typedef int (wxCMPFUNC_CONV *CMPFUNCwxString)(wxString*, wxString*);
 
-class WXDLLIMPEXP_BASE wxArrayString : public wxBaseArray<wxString>
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxArrayString : public wxBaseArray<wxString>
 {
 public:
     // type of function used by wxArrayString::Sort()
@@ -155,7 +155,7 @@ private:
 #include <iterator>
 #include "wx/afterstd.h"
 
-class WXDLLIMPEXP_BASE wxArrayString
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxArrayString
 {
 public:
   // type of function used by wxArrayString::Sort()

--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -126,7 +126,7 @@ extern WXDLLIMPEXP_DATA_BASE(const wxDateTime) wxDefaultDateTime;
 // wxDateTime represents an absolute moment in the time
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_BASE wxDateTime
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxDateTime
 {
 public:
     // types

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -270,7 +270,7 @@ enum wxEllipsizeMode
 // wxSize
 // ---------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxSize
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxSize
 {
 public:
     // members are public for compatibility, don't use them directly.
@@ -450,7 +450,7 @@ public:
 // Point classes: with real or integer coordinates
 // ---------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxRealPoint
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxRealPoint
 {
 public:
     double x;
@@ -600,7 +600,7 @@ public:
 // wxPoint: 2D point with integer coordinates
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxPoint
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxPoint
 {
 public:
     int x, y;
@@ -766,7 +766,7 @@ WX_DECLARE_LIST_WITH_DECL(wxPoint, wxPointList, class WXDLLIMPEXP_CORE);
 // wxRect
 // ---------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxRect
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxRect
 {
 public:
     wxRect()

--- a/include/wx/generic/colour.h
+++ b/include/wx/generic/colour.h
@@ -13,7 +13,7 @@
 #include "wx/object.h"
 
 // Colour
-class WXDLLIMPEXP_CORE wxColour: public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour: public wxColourBase
 {
 public:
     // constructors

--- a/include/wx/gtk/colour.h
+++ b/include/wx/gtk/colour.h
@@ -17,7 +17,7 @@ typedef struct _GdkRGBA GdkRGBA;
 // wxColour
 //-----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxColour : public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour : public wxColourBase
 {
 public:
     // constructors

--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -102,7 +102,7 @@
 
 #if wxUSE_LONGLONG_NATIVE
 
-class WXDLLIMPEXP_BASE wxLongLongNative
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxLongLongNative
 {
 public:
     // ctors
@@ -356,7 +356,7 @@ private:
 };
 
 
-class WXDLLIMPEXP_BASE wxULongLongNative
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxULongLongNative
 {
 public:
     // ctors
@@ -598,7 +598,7 @@ wxLongLongNative& wxLongLongNative::operator=(const wxULongLongNative &ll)
 
 #if wxUSE_LONGLONG_WX
 
-class WXDLLIMPEXP_BASE wxLongLongWx
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxLongLongWx
 {
 public:
     // ctors
@@ -860,7 +860,7 @@ private:
 };
 
 
-class WXDLLIMPEXP_BASE wxULongLongWx
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxULongLongWx
 {
 public:
     // ctors

--- a/include/wx/msw/colour.h
+++ b/include/wx/msw/colour.h
@@ -16,7 +16,7 @@
 // Colour
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxColour : public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour : public wxColourBase
 {
 public:
     // constructors

--- a/include/wx/osx/core/colour.h
+++ b/include/wx/osx/core/colour.h
@@ -18,7 +18,7 @@
 struct RGBColor;
 
 // Colour
-class WXDLLIMPEXP_CORE wxColour: public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour: public wxColourBase
 {
 public:
     // constructors

--- a/include/wx/qt/colour.h
+++ b/include/wx/qt/colour.h
@@ -12,7 +12,7 @@
 
 class QColor;
 
-class WXDLLIMPEXP_CORE wxColour : public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour : public wxColourBase
 {
 public:
     DEFINE_STD_WXCOLOUR_CONSTRUCTORS

--- a/include/wx/tokenzr.h
+++ b/include/wx/tokenzr.h
@@ -37,7 +37,7 @@ enum wxStringTokenizerMode
 // wxStringTokenizer: replaces infamous strtok() and has some other features
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_BASE wxStringTokenizer : public wxObject
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxStringTokenizer : public wxObject
 {
 public:
     // ctors and initializers

--- a/include/wx/x11/colour.h
+++ b/include/wx/x11/colour.h
@@ -31,7 +31,7 @@ class WXDLLIMPEXP_FWD_CORE wxColour;
 // wxColour
 //-----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxColour : public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour : public wxColourBase
 {
 public:
     // constructors

--- a/samples/propgrid/propgrid.cpp
+++ b/samples/propgrid/propgrid.cpp
@@ -2787,7 +2787,7 @@ void FormMain::OnColourScheme( wxCommandEvent& event )
         m_propGridManager->Freeze();
         m_propGridManager->GetGrid()->SetMarginColour( my_grey_1 );
         m_propGridManager->GetGrid()->SetCaptionBackgroundColour( my_grey_1 );
-        m_propGridManager->GetGrid()->SetLineColour( my_grey_1 );
+        m_propGridManager->GetGrid()->SetLineColour( my_grey_2 );
         m_propGridManager->Thaw();
     }
     else if ( id == ID_COLOURSCHEME4 )

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2549,8 +2549,6 @@ void wxAuiToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
 
 void wxAuiToolBar::OnLeftDown(wxMouseEvent& evt)
 {
-    wxRect cli_rect(wxPoint(0,0), GetClientSize());
-
     if (m_gripperSizerItem)
     {
         wxRect gripper_rect = m_gripperSizerItem->GetRect();

--- a/src/common/http.cpp
+++ b/src/common/http.cpp
@@ -242,7 +242,6 @@ void wxHTTP::SendHeaders()
 bool wxHTTP::ParseHeaders()
 {
     wxString line;
-    wxStringTokenizer tokenzr;
 
     ClearHeaders();
     ClearCookies();

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -423,7 +423,6 @@ wxGridSelection::DeselectBlock(const wxGridBlockCoords& block,
 void wxGridSelection::ClearSelection()
 {
     size_t n;
-    wxRect r;
     wxGridCellCoords coords1, coords2;
 
     if ( m_grid->UsesOverlaySelection() )

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -10116,7 +10116,6 @@ bool wxRichTextTable::Draw(wxDC& dc, wxRichTextDrawingContext& context, const wx
                     wxRichTextCell* cell = GetCell(row, col);
                     if (cell && cell->IsShown() && !cell->GetRange().IsOutside(range))
                     {
-                        wxRect childRect(cell->GetPosition(), cell->GetCachedSize());
                         wxRichTextAttr attr(cell->GetAttributes());
                         cell->AdjustAttributes(attr, context);
                         if (row != 0)
@@ -10394,8 +10393,6 @@ bool wxRichTextTable::Layout(wxReadOnlyDC& dc, wxRichTextDrawingContext& context
     wxArrayInt spanningWidths, spanningWidthsSpanLengths;
     spanningWidths.Add(0, m_colCount);
     spanningWidthsSpanLengths.Add(0, m_colCount);
-
-    wxSize tableSize(tableWidth, 0);
 
     int i, j, k;
 
@@ -12782,7 +12779,6 @@ bool wxRichTextImage::Draw(wxDC& dc, wxRichTextDrawingContext& context, const wx
 
     DrawBoxAttributes(dc, GetBuffer(), attr, wxRect(position, GetCachedSize()));
 
-    wxSize imageSize(m_imageCache.GetWidth(), m_imageCache.GetHeight());
     wxRect marginRect, borderRect, contentRect, paddingRect, outlineRect;
     marginRect = wxRect(position, GetCachedSize()); // outer rectangle, will calculate contentRect
     GetBoxRects(dc, GetBuffer(), attr, marginRect, borderRect, contentRect, paddingRect, outlineRect);

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -1420,9 +1420,9 @@ TEST_CASE_METHOD(GridTestCase, "Grid::CellFormatting", "[grid]")
 
     CHECK(m_grid->GetCellBackgroundColour(0, 0) == back);
 
-    back = m_grid->GetDefaultCellTextColour();
+    text = m_grid->GetDefaultCellTextColour();
 
-    CHECK(m_grid->GetCellTextColour(0, 0) == back);
+    CHECK(m_grid->GetCellTextColour(0, 0) == text);
 
     m_grid->SetCellAlignment(0, 0, wxALIGN_LEFT, wxALIGN_BOTTOM);
     m_grid->GetCellAlignment(0, 0, &cellhoriz, &cellvert);

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -411,7 +411,6 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
 #endif // __WXMSW__ || __WXOSX__
         {
             const wxColour clrFg(*wxCYAN);
-            const wxColour clrBg(*wxGREEN);
             const unsigned char alpha = 92;
 
 #ifdef wxHAS_PREMULTIPLIED_ALPHA
@@ -489,7 +488,6 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
 #endif // __WXMSW__ || __WXOSX__
         {
             const wxColour clrFg(*wxCYAN);
-            const wxColour clrBg(*wxGREEN);
             const unsigned char alpha = 92;
 #ifdef wxHAS_PREMULTIPLIED_ALPHA
             // premultiplied values

--- a/tests/graphics/graphbitmap.cpp
+++ b/tests/graphics/graphbitmap.cpp
@@ -98,7 +98,6 @@ wxBitmap CreateBitmapRGBA(int w, int h, bool withMask)
 #endif // __WXMSW__ || __WXOSX__
     {
         const wxColour clrFg(*wxCYAN);
-        const wxColour clrBg(*wxGREEN);
         const unsigned char alpha = 51;
 
 #ifdef wxHAS_PREMULTIPLIED_ALPHA


### PR DESCRIPTION
Here is the new `wxWARN_UNUSED` attribute added to some other commonly used classes, besides `wxString`. Not all of these classes have any unused instances in wx's own code base.

The classes affected by this PR are:
```
wxColour
wxStringTokenizer
wxSize, wxRect, wxPoint, wxRealPoint
wxLongLong, wxULongLong
wxArrayString
wxDateTime
```

The changes are in multiple commits to make cherry-picking or dropping easier. Some squashing may be appropriate.