### PR TITLE
Support multiple HTTP headers with same name

### DIFF
--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -30,6 +30,8 @@ public:
 
     wxString GetHeader(const wxString& name) const override;
 
+    std::vector<wxString> GetAllHeaderValues(const wxString& name) const override;
+
     int GetStatus() const override;
 
     wxString GetStatusText() const override;

--- a/include/wx/osx/private/webrequest_urlsession.h
+++ b/include/wx/osx/private/webrequest_urlsession.h
@@ -61,6 +61,8 @@ public:
 
     wxString GetHeader(const wxString& name) const override;
 
+    std::vector<wxString> GetAllHeaderValues(const wxString& name) const override;
+
     int GetStatus() const override;
 
     wxString GetStatusText() const override;

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -220,6 +220,8 @@ public:
 
     virtual wxString GetHeader(const wxString& name) const = 0;
 
+    virtual std::vector<wxString> GetAllHeaderValues(const wxString& name) const = 0;
+
     virtual wxString GetMimeType() const;
 
     virtual wxString GetContentType() const;

--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -16,10 +16,11 @@
 
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 class WXDLLIMPEXP_FWD_BASE wxURI;
 
-using wxWebRequestHeaderMap = std::unordered_map<wxString, wxString>;
+using wxWebRequestHeaderMap = std::unordered_map<wxString, std::vector<wxString>>;
 
 // Trace mask used for the messages in wxWebRequest code.
 #define wxTRACE_WEBREQUEST "webrequest"
@@ -62,7 +63,15 @@ public:
     virtual ~wxWebRequestImpl() = default;
 
     void SetHeader(const wxString& name, const wxString& value)
-    { m_headers[name] = value; }
+    {
+        if (value.empty())
+            m_headers.erase(name);
+        else
+            m_headers[name] = { value };
+    }
+
+    void AddHeader(const wxString& name, const wxString& value)
+        { m_headers[name].push_back(value); }
 
     void SetMethod(const wxString& method) { m_method = method; }
 
@@ -321,8 +330,16 @@ public:
     bool SetBaseURL(const wxString& url);
     const wxURI* GetBaseURL() const;
 
+    void SetCommonHeader(const wxString& name, const wxString& value)
+    {
+        if (value.empty())
+            m_headers.erase(name);
+        else
+            m_headers[name] = { value };
+    }
+
     void AddCommonHeader(const wxString& name, const wxString& value)
-        { m_headers[name] = value; }
+        { m_headers[name].push_back(value); }
 
     void SetTempDir(const wxString& dir) { m_tempDir = dir; }
 

--- a/include/wx/private/webrequest_curl.h
+++ b/include/wx/private/webrequest_curl.h
@@ -131,6 +131,8 @@ public:
 
     wxString GetHeader(const wxString& name) const override;
 
+    std::vector<wxString> GetAllHeaderValues(const wxString& name) const override;
+
     int GetStatus() const override;
 
     wxString GetStatusText() const override { return m_statusText; }

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -104,6 +104,8 @@ public:
 
     wxString GetHeader(const wxString& name) const;
 
+    std::vector<wxString> GetAllHeaderValues(const wxString& name) const;
+
     wxString GetMimeType() const;
 
     wxString GetContentType() const;

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -198,6 +198,8 @@ public:
 
     void SetHeader(const wxString& name, const wxString& value);
 
+    void AddHeader(const wxString& name, const wxString& value);
+
     void SetMethod(const wxString& method);
 
     void SetData(const wxString& text, const wxString& contentType, const wxMBConv& conv = wxConvUTF8);

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -320,9 +320,29 @@ public:
         @param name
             Name of the header
         @param value
-            String value of the header. An empty string will remove the header.
+            String value of the header. An empty string will remove all headers
+            with the same name.
+
+        @see AddHeader()
     */
     void SetHeader(const wxString& name, const wxString& value);
+
+    /**
+        Adds a request header which will be sent to the server by this request.
+
+        The header will be added even if a header with the same name has been
+        set before.
+
+        @param name
+            Name of the header
+        @param value
+            String value of the header.
+
+        @since 3.3.0
+
+        @see SetHeader()
+    */
+    void AddHeader(const wxString& name, const wxString& value);
 
     /**
         Set <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html">common</a>
@@ -737,9 +757,29 @@ public:
         @param name
             Name of the header
         @param value
-            String value of the header. An empty string will remove the header.
+            String value of the header. An empty string will remove all headers
+            with the same name.
+
+        @see AddHeader()
     */
     void SetHeader(const wxString& name, const wxString& value);
+
+    /**
+        Adds a request header which will be sent to the server by this request.
+
+        The header will be added even if a header with the same name has been
+        set before.
+
+        @param name
+            Name of the header
+        @param value
+            String value of the header.
+
+        @since 3.3.0
+
+        @see SetHeader()
+    */
+    void AddHeader(const wxString& name, const wxString& value);
 
     /**
         Set <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html">common</a>
@@ -1022,6 +1062,8 @@ public:
         could not be found.
 
         @param name Name of the header field
+
+        @see GetAllHeaderValues()
     */
     wxString GetHeader(const wxString& name) const;
 
@@ -1228,16 +1270,35 @@ public:
 
     /**
         Sets a request header in every wxWebRequest created from this session
-        after is has been set.
+        after it has been set.
 
         A good example for a session-wide request header is the @c User-Agent
         header.
 
-        Calling this function with the same header name again replaces the
-        previously used value.
+        Calling this function with the same header name again replaces all
+        previously added headers with that name.
+
+        @param name Name of the header
+        @param value String value of the header. An empty string will remove
+            all headers with the same name.
+
+        @see AddCommonHeader()
+
+        @since 3.3.0
+    */
+    void SetCommonHeader(const wxString& name, const wxString& value);
+
+    /**
+        Adds a request header to every wxWebRequest created from this session
+        after it has been added.
+
+        Calling this function with the same header name again adds another
+        header with the same name.
 
         @param name Name of the header
         @param value String value of the header
+
+        @see SetCommonHeader()
     */
     void AddCommonHeader(const wxString& name, const wxString& value);
 

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -338,6 +338,11 @@ public:
         @param value
             String value of the header.
 
+        @note
+            The URLSession backend does not support multiple headers with the
+            same name. The last added header with a given name is used as a
+            fallback.
+
         @since 3.3.0
 
         @see SetHeader()
@@ -775,6 +780,11 @@ public:
         @param value
             String value of the header.
 
+        @note
+            The URLSession backend does not support multiple headers with the
+            same name. The last added header with a given name is used as a
+            fallback.
+
         @since 3.3.0
 
         @see SetHeader()
@@ -1073,6 +1083,11 @@ public:
 
         @param name Name of the header fields
 
+        @note
+            The URLSession backend does not support multiple headers with the
+            same name. The last added header with a given name is used as a
+            fallback.
+
         @since 3.3.0
 
         @see GetHeader()
@@ -1297,6 +1312,11 @@ public:
 
         @param name Name of the header
         @param value String value of the header
+
+        @note
+            The URLSession backend does not support multiple headers with the
+            same name. The last added header with a given name is used as a
+            fallback.
 
         @see SetCommonHeader()
     */

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -1026,6 +1026,18 @@ public:
     wxString GetHeader(const wxString& name) const;
 
     /**
+        Returns all values of response headers with the same name or an empty
+        vector if the header could not be found at all.
+
+        @param name Name of the header fields
+
+        @since 3.3.0
+
+        @see GetHeader()
+    */
+    std::vector<wxString> GetAllHeaderValues(const wxString& name) const;
+
+    /**
         Get the length of returned data if available.
 
         Returns the value specified in the @c Content-Length response header

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -321,7 +321,7 @@ SplitParameters(const wxString& s, wxWebRequestHeaderMap& parameters)
         }
         pvalue.Trim();
         if ( !pname.empty() )
-            parameters[pname] = pvalue;
+            parameters[pname] = { pvalue };
         if ( it != end )
             ++it;
     }
@@ -418,6 +418,13 @@ void wxWebRequestBase::SetHeader(const wxString& name, const wxString& value)
     wxCHECK_IMPL_VOID();
 
     m_impl->SetHeader(name, value);
+}
+
+void wxWebRequestBase::AddHeader(const wxString& name, const wxString& value)
+{
+    wxCHECK_IMPL_VOID();
+
+    m_impl->AddHeader(name, value);
 }
 
 void wxWebRequestBase::SetMethod(const wxString& method)
@@ -702,10 +709,10 @@ wxString wxWebResponseImpl::GetSuggestedFileName() const
     wxString contentDisp = GetHeader("Content-Disposition");
     wxWebRequestHeaderMap params;
     const wxString disp = wxPrivate::SplitParameters(contentDisp, params);
-    if ( disp == "attachment" )
+    if ( disp == "attachment" && !params["filename"].empty())
     {
         // Parse as filename to filter potential path names
-        wxFileName fn(params["filename"]);
+        wxFileName fn(params["filename"].back());
         suggestedFilename = fn.GetFullName();
     }
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -843,6 +843,13 @@ wxString wxWebResponse::GetHeader(const wxString& name) const
     return m_impl->GetHeader(name);
 }
 
+std::vector<wxString> wxWebResponse::GetAllHeaderValues(const wxString& name) const
+{
+    wxCHECK_IMPL( std::vector<wxString>() );
+
+    return m_impl->GetAllHeaderValues(name);
+}
+
 wxString wxWebResponse::GetMimeType() const
 {
     wxCHECK_IMPL( wxString() );

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -709,7 +709,7 @@ wxString wxWebResponseImpl::GetSuggestedFileName() const
     wxString contentDisp = GetHeader("Content-Disposition");
     wxWebRequestHeaderMap params;
     const wxString disp = wxPrivate::SplitParameters(contentDisp, params);
-    if ( disp == "attachment" && !params["filename"].empty())
+    if ( disp == "attachment" && !params["filename"].empty() )
     {
         // Parse as filename to filter potential path names
         wxFileName fn(params["filename"].back());

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -222,7 +222,7 @@ size_t wxWebResponseCURL::CURLOnHeader(const char * buffer, size_t size)
         wxString hdrValue;
         wxString hdrName = hdr.BeforeFirst(':', &hdrValue).Strip(wxString::trailing);
         hdrName.MakeUpper();
-        m_headers[hdrName] = hdrValue.Strip(wxString::leading);
+        m_headers[hdrName].push_back(hdrValue.Strip(wxString::leading));
     }
 
     return size;
@@ -270,15 +270,20 @@ wxString wxWebResponseCURL::GetURL() const
 wxString wxWebResponseCURL::GetHeader(const wxString& name) const
 {
     wxWebRequestHeaderMap::const_iterator it = m_headers.find(name.Upper());
-    if ( it != m_headers.end() )
-        return it->second;
-    else
-        return wxString();
+    if ( it != m_headers.end() && !it->second.empty() )
+        return it->second.back();
+
+    return wxString();
 }
 
-std::vector<wxString> wxWebResponseCURL::GetAllHeaderValues(const wxString& WXUNUSED(name)) const
+std::vector<wxString> wxWebResponseCURL::GetAllHeaderValues(const wxString& name) const
 {
     std::vector<wxString> result;
+
+    wxWebRequestHeaderMap::const_iterator it = m_headers.find(name.Upper());
+    if ( it != m_headers.end() )
+        result = it->second;
+
     return result;
 }
 
@@ -451,10 +456,13 @@ wxWebRequest::Result wxWebRequestCURL::DoFinishPrepare()
     for ( wxWebRequestHeaderMap::const_iterator it = m_headers.begin();
         it != m_headers.end(); ++it )
     {
-        // TODO: We need to implement RFC 2047 encoding here instead of blindly
-        //       sending UTF-8 which is against the standard.
-        wxString hdrStr = wxString::Format("%s: %s", it->first, it->second);
-        m_headerList = curl_slist_append(m_headerList, hdrStr.utf8_str());
+        for ( const wxString& value : it->second )
+        {
+            // TODO: We need to implement RFC 2047 encoding here instead of blindly
+            //       sending UTF-8 which is against the standard.
+            wxString hdrStr = wxString::Format("%s: %s", it->first, value);
+            m_headerList = curl_slist_append(m_headerList, hdrStr.utf8_str());
+        }
     }
     wxCURLSetOpt(m_handle, CURLOPT_HTTPHEADER, m_headerList);
 

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -276,6 +276,12 @@ wxString wxWebResponseCURL::GetHeader(const wxString& name) const
         return wxString();
 }
 
+std::vector<wxString> wxWebResponseCURL::GetAllHeaderValues(const wxString& WXUNUSED(name)) const
+{
+    std::vector<wxString> result;
+    return result;
+}
+
 int wxWebResponseCURL::GetStatus() const
 {
     long status = 0;

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -194,6 +194,7 @@ static std::vector<wxString> wxWinHTTPQueryAllHeaderStrings(HINTERNET hRequest, 
     while ( ::GetLastError() != ERROR_WINHTTP_HEADER_NOT_FOUND )
     {
         DWORD bufferLen = 0;
+        DWORD currentIndex = nextIndex;
         wxWinHTTP::WinHttpQueryHeaders(hRequest, dwInfoLevel, pwszName, nullptr, &bufferLen, &nextIndex);
         if ( ::GetLastError() == ERROR_INSUFFICIENT_BUFFER )
         {
@@ -212,6 +213,9 @@ static std::vector<wxString> wxWinHTTPQueryAllHeaderStrings(HINTERNET hRequest, 
                 result.push_back(resBuf);
             }
         }
+
+        if ( nextIndex <= currentIndex )
+            break;
     }
 
     return result;

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -769,7 +769,8 @@ wxWebRequest::Result wxWebRequestWinHTTP::SendRequest()
           header != m_headers.end();
           ++header )
     {
-        allHeaders.append(wxString::Format("%s: %s\n", header->first, header->second));
+        for ( const wxString& value : header->second )
+            allHeaders.append(wxString::Format("%s: %s\n", header->first, value));
     }
 
     if ( m_dataSize )
@@ -1011,7 +1012,7 @@ bool wxWebSessionWinHTTP::Open()
 
     m_handle = wxWinHTTP::WinHttpOpen
                  (
-                    GetHeaders().find("User-Agent")->second.wc_str(),
+                    GetHeaders().find("User-Agent")->second.back().wc_str(),
                     accessType,
                     proxyName,
                     WINHTTP_NO_PROXY_BYPASS,

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -190,8 +190,10 @@ wxWebRequestURLSession::DoPrepare(void (^completionHandler)(NSData*, NSURLRespon
     // Set request headers
     for (wxWebRequestHeaderMap::const_iterator it = m_headers.begin(); it != m_headers.end(); ++it)
     {
-        [req setValue:wxCFStringRef(it->second).AsNSString() forHTTPHeaderField:
-         wxCFStringRef(it->first).AsNSString()];
+        // TODO: URLSession does not support multiple headers with the same name.
+        //       Fall back to last header with given name.
+        [req setValue:wxCFStringRef(it->second.back()).AsNSString() forHTTPHeaderField:
+        wxCFStringRef(it->first).AsNSString()];
     }
 
     if (m_dataSize)
@@ -434,10 +436,11 @@ wxString wxWebResponseURLSession::GetHeader(const wxString& name) const
         return wxString();
 }
 
-std::vector<wxString> wxWebResponseURLSession::GetAllHeaderValues(const wxString& WXUNUSED(name)) const
+std::vector<wxString> wxWebResponseURLSession::GetAllHeaderValues(const wxString& name) const
 {
-    std::vector<wxString> result;
-    return result;
+    // TODO: URLSession does not support multiple headers with the same name.
+    //       Fall back to last header with given name.
+    return { GetHeader(name) };
 }
 
 int wxWebResponseURLSession::GetStatus() const

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -434,6 +434,12 @@ wxString wxWebResponseURLSession::GetHeader(const wxString& name) const
         return wxString();
 }
 
+std::vector<wxString> wxWebResponseURLSession::GetAllHeaderValues(const wxString& WXUNUSED(name)) const
+{
+    std::vector<wxString> result;
+    return result;
+}
+
 int wxWebResponseURLSession::GetStatus() const
 {
     NSHTTPURLResponse* httpResp = (NSHTTPURLResponse*) m_task.response;

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -182,10 +182,14 @@ protected:
 
         // There may, or not, be a space after it.
         // And the value may be returned in an array.
-        while ( wxIsspace(response[pos]) || response[pos] == '[' )
+        while ( wxIsspace(response[pos]) ||
+                response[pos] == '"' ||
+                response[pos] == '[' )
+        {
             ++pos;
+        }
 
-        wxString actualValue = response.substr(++pos, value.size());
+        wxString actualValue = response.substr(pos, value.size());
         REQUIRE( actualValue == value );
     }
 
@@ -460,17 +464,12 @@ TEST_CASE_METHOD(RequestFixture,
         return;
 
     Create("headers");
-    request.AddHeader("Greeting", "Hello");
-    request.AddHeader("Greeting", "wxWidgets!");
+    request.SetHeader("One", "1");
+    request.AddHeader("Two", "2");
     Run();
 
-#if wxUSE_WEBREQUEST_URLSESSION
-    // Only the last header of a given name is sent by the URLSession backend.
-    CheckExpectedJSON( request.GetResponse().AsString(), "Greeting", "wxWidgets!" );
-#else
-    // The httpbin service joins multiple headers with the same name using commas.
-    CheckExpectedJSON( request.GetResponse().AsString(), "Greeting", "Hello,wxWidgets!" );
-#endif
+    CheckExpectedJSON( request.GetResponse().AsString(), "One", "1" );
+    CheckExpectedJSON( request.GetResponse().AsString(), "Two", "2" );
 }
 
 TEST_CASE_METHOD(RequestFixture,

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -442,8 +442,15 @@ TEST_CASE_METHOD(RequestFixture,
     Create("response-headers?freeform=wxWidgets&freeform=works!");
     Run();
     std::vector<wxString> headers = request.GetResponse().GetAllHeaderValues("freeform");
+
+#if wxUSE_WEBREQUEST_URLSESSION
+    // The httpbin service concatenates the given parameters.
+    REQUIRE( headers.size() == 1 );
+    CHECK( headers[0] == "wxWidgets, works!" );
+#else
     REQUIRE( headers.size() == 2 );
     CHECK( (headers[0] == "wxWidgets" && headers[1] == "works!") );
+#endif
 }
 
 TEST_CASE_METHOD(RequestFixture,
@@ -457,8 +464,13 @@ TEST_CASE_METHOD(RequestFixture,
     request.AddHeader("Greeting", "wxWidgets!");
     Run();
 
+#if wxUSE_WEBREQUEST_URLSESSION
+    // Only the last header of a given name is sent by the URLSession backend.
+    CheckExpectedJSON( request.GetResponse().AsString(), "Greeting", "wxWidgets!" );
+#else
     // The httpbin service joins multiple headers with the same name using commas.
     CheckExpectedJSON( request.GetResponse().AsString(), "Greeting", "Hello,wxWidgets!" );
+#endif
 }
 
 TEST_CASE_METHOD(RequestFixture,

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -183,10 +183,10 @@ protected:
         // There may, or not, be a space after it.
         // And the value may be returned in an array.
         while ( wxIsspace(response[pos]) || response[pos] == '[' )
-            pos++;
+            ++pos;
 
-        wxString expectedValue = wxString::Format("\"%s\"", value);
-        REQUIRE( response.compare(pos, expectedValue.size(), expectedValue) == 0 );
+        wxString actualValue = response.substr(++pos, value.size());
+        REQUIRE( actualValue == value );
     }
 
     // Special helper for "manual" tests taking the URL from the environment.

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -1174,7 +1174,7 @@ TEST_CASE_METHOD(SyncRequestFixture,
     DumpResponse(request.GetResponse());
 }
 
-using wxWebRequestHeaderMap = std::unordered_map<wxString, wxString>;
+using wxWebRequestHeaderMap = std::unordered_map<wxString, std::vector<wxString>>;
 
 namespace wxPrivate
 {
@@ -1192,7 +1192,8 @@ TEST_CASE("WebRequestUtils", "[net][webrequest]")
     value = wxPrivate::SplitParameters(header, params);
     CHECK( value == "multipart/mixed" );
     CHECK( params.size() == 1 );
-    CHECK( params["boundary"] == "MIME_boundary_01234567" );
+    REQUIRE( !params["boundary"].empty() );
+    CHECK( params["boundary"].back() == "MIME_boundary_01234567" );
 }
 
 // This is not a real test, run it to see the version of the library used.

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -447,6 +447,21 @@ TEST_CASE_METHOD(RequestFixture,
 }
 
 TEST_CASE_METHOD(RequestFixture,
+    "WebRequest::Headers", "[net][webrequest][headers]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    Create("headers");
+    request.AddHeader("Greeting", "Hello");
+    request.AddHeader("Greeting", "wxWidgets!");
+    Run();
+
+    // The httpbin service joins multiple headers with the same name using commas.
+    CheckExpectedJSON( request.GetResponse().AsString(), "Greeting", "Hello,wxWidgets!" );
+}
+
+TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Get::Param", "[net][webrequest][get]")
 {
     if ( !InitBaseURL() )

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -165,27 +165,28 @@ protected:
 
     virtual wxWebRequestBase& GetRequest() = 0;
 
-    // Check that the response is a JSON object containing a key "pi" with the
+    // Check that the response is a JSON object containing a specific key with the
     // expected value.
-    void CheckExpectedJSON(const wxString& response)
+    void CheckExpectedJSON(const wxString& response, const wxString& key,
+                           const wxString& value)
     {
         // We ought to really parse the returned JSON object, but to keep things as
         // simple as possible for now we just treat it as a string.
         INFO("Response: " << response);
 
-        const char* expectedKey = "\"pi\":";
+        wxString expectedKey = wxString::Format("\"%s\":", key);
         size_t pos = response.find(expectedKey);
         REQUIRE( pos != wxString::npos );
 
-        pos += strlen(expectedKey);
+        pos += expectedKey.size();
 
         // There may, or not, be a space after it.
         // And the value may be returned in an array.
         while ( wxIsspace(response[pos]) || response[pos] == '[' )
             pos++;
 
-        const char* expectedValue = "\"3.14159265358979323\"";
-        REQUIRE( response.compare(pos, strlen(expectedValue), expectedValue) == 0 );
+        wxString expectedValue = wxString::Format("\"%s\"", value);
+        REQUIRE( response.compare(pos, expectedValue.size(), expectedValue) == 0 );
     }
 
     // Special helper for "manual" tests taking the URL from the environment.
@@ -451,10 +452,13 @@ TEST_CASE_METHOD(RequestFixture,
     if ( !InitBaseURL() )
         return;
 
-    Create("get?pi=3.14159265358979323");
+    wxString key = "pi";
+    wxString value = "3.14159265358979323";
+
+    Create(wxString::Format("get?%s=%s", key, value));
     Run();
 
-    CheckExpectedJSON( request.GetResponse().AsString() );
+    CheckExpectedJSON( request.GetResponse().AsString(), key, value );
 }
 
 TEST_CASE_METHOD(RequestFixture,
@@ -879,9 +883,12 @@ TEST_CASE_METHOD(SyncRequestFixture,
     if ( !InitBaseURL() )
         return;
 
-    REQUIRE( Execute("get?pi=3.14159265358979323") );
+    wxString key = "pi";
+    wxString value = "3.14159265358979323";
 
-    CheckExpectedJSON( response.AsString() );
+    REQUIRE( Execute(wxString::Format("get?%s=%s", key, value)) );
+
+    CheckExpectedJSON( response.AsString(), key, value );
 }
 
 TEST_CASE_METHOD(SyncRequestFixture,

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -433,6 +433,19 @@ TEST_CASE_METHOD(RequestFixture,
 }
 
 TEST_CASE_METHOD(RequestFixture,
+    "WebRequest::Get::AllHeaderValues", "[net][webrequest][get]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    Create("response-headers?freeform=wxWidgets&freeform=works!");
+    Run();
+    std::vector<wxString> headers = request.GetResponse().GetAllHeaderValues("freeform");
+    REQUIRE( headers.size() == 2 );
+    CHECK( (headers[0] == "wxWidgets" && headers[1] == "works!") );
+}
+
+TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Get::Param", "[net][webrequest][get]")
 {
     if ( !InitBaseURL() )


### PR DESCRIPTION
This is a draft. It is currently missing the implementation for macOS resp. URLSession.

Closes #24878.