### PR TITLE
Backport wxWARN_UNUSED into 3.2, along with removing unused variables

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -406,11 +406,11 @@ more details.
         this symbol is only honoured by wxWidgets 3.2 (since 3.2.5) but not by
         the future versions of the library.}
 @itemdef{wxNO_UNUSED_VARIABLES,
-	this symbol is not defined by wxWidgets itself, but can be defined by
-	the applications using the library to opt-in enabling the @c wxWARN_UNUSED
-	attribute, and use it for selected wxWidgets classes to allow warnings
-	for unused instances. This symbol only has effect in wxWidgets 3.2
-	(since 3.2.7); it is no longer needed with 3.3.0 and later.}
+        this symbol is not defined by wxWidgets itself, but can be defined by
+        the applications using the library to opt-in enabling the @c wxWARN_UNUSED
+        attribute, and use it for selected wxWidgets classes to allow warnings
+        for unused instances. This symbol only has effect in wxWidgets 3.2
+        (since 3.2.7); it is no longer needed with 3.3.0 and later.}
 @itemdef{WXMAKINGDLL_XXX,
         used internally and defined when building the
         library @c XXX as a DLL; when a monolithic wxWidgets build is used only a

--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -405,6 +405,12 @@ more details.
         fix such problems, by explicitly selecting the wanted conversion, as
         this symbol is only honoured by wxWidgets 3.2 (since 3.2.5) but not by
         the future versions of the library.}
+@itemdef{wxNO_UNUSED_VARIABLES,
+	this symbol is not defined by wxWidgets itself, but can be defined by
+	the applications using the library to opt-in enabling the @c wxWARN_UNUSED
+	attribute, and use it for selected wxWidgets classes to allow warnings
+	for unused instances. This symbol only has effect in wxWidgets 3.2
+	(since 3.2.7); it is no longer needed with 3.3.0 and later.}
 @itemdef{WXMAKINGDLL_XXX,
         used internally and defined when building the
         library @c XXX as a DLL; when a monolithic wxWidgets build is used only a

--- a/include/wx/arrstr.h
+++ b/include/wx/arrstr.h
@@ -75,7 +75,7 @@ typedef int (wxCMPFUNC_CONV *CMPFUNCwxString)(wxString*, wxString*);
 WX_DEFINE_USER_EXPORTED_TYPEARRAY(wxString, wxArrayStringBase,
                                   wxARRAY_DUMMY_BASE, WXDLLIMPEXP_BASE);
 
-class WXDLLIMPEXP_BASE wxArrayString : public wxArrayStringBase
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxArrayString : public wxArrayStringBase
 {
 public:
     // type of function used by wxArrayString::Sort()
@@ -161,7 +161,7 @@ private:
 #include <iterator>
 #include "wx/afterstd.h"
 
-class WXDLLIMPEXP_BASE wxArrayString
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxArrayString
 {
 public:
   // type of function used by wxArrayString::Sort()

--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -125,7 +125,7 @@ extern WXDLLIMPEXP_DATA_BASE(const wxDateTime) wxDefaultDateTime;
 // wxDateTime represents an absolute moment in the time
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_BASE wxDateTime
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxDateTime
 {
 public:
     // types

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -342,11 +342,14 @@ typedef short int WXTYPE;
 #endif
 
 /* wxWARN_UNUSED is used as an attribute to a class, stating that unused instances
-   should be warned about (in case such warnings are enabled in the first place) */
+   should be warned about (in case such warnings are enabled in the first place)
+   In 3.2.x this is an opt-in feature enabled by defining wxNO_UNUSED_VARIABLES. */
 
-#ifdef __has_cpp_attribute
-    #if __has_cpp_attribute(warn_unused)
-        #define wxWARN_UNUSED __attribute__((warn_unused))
+#if defined(wxNO_UNUSED_VARIABLES) || defined(WXBUILDING)
+    #ifdef __has_cpp_attribute
+        #if __has_cpp_attribute(warn_unused)
+            #define wxWARN_UNUSED __attribute__((warn_unused))
+        #endif
     #endif
 #endif
 #ifndef wxWARN_UNUSED

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -341,6 +341,18 @@ typedef short int WXTYPE;
     #define wxFALLTHROUGH ((void)0)
 #endif
 
+/* wxWARN_UNUSED is used as an attribute to a class, stating that unused instances
+   should be warned about (in case such warnings are enabled in the first place) */
+
+#ifdef __has_cpp_attribute
+    #if __has_cpp_attribute(warn_unused)
+        #define wxWARN_UNUSED __attribute__((warn_unused))
+    #endif
+#endif
+#ifndef wxWARN_UNUSED
+    #define wxWARN_UNUSED
+#endif
+
 /* these macros are obsolete, use the standard C++ casts directly now */
 #define wx_static_cast(t, x) static_cast<t>(x)
 #define wx_const_cast(t, x) const_cast<t>(x)

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -279,7 +279,7 @@ enum wxEllipsizeMode
 // wxSize
 // ---------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxSize
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxSize
 {
 public:
     // members are public for compatibility, don't use them directly.
@@ -456,7 +456,7 @@ inline wxSize operator*(double i, const wxSize& s)
 // Point classes: with real or integer coordinates
 // ---------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxRealPoint
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxRealPoint
 {
 public:
     double x;
@@ -574,7 +574,7 @@ inline wxRealPoint operator*(double i, const wxRealPoint& s)
 // wxPoint: 2D point with integer coordinates
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxPoint
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxPoint
 {
 public:
     int x, y;
@@ -730,7 +730,7 @@ WX_DECLARE_LIST_WITH_DECL(wxPoint, wxPointList, class WXDLLIMPEXP_CORE);
 // wxRect
 // ---------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxRect
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxRect
 {
 public:
     wxRect()

--- a/include/wx/generic/colour.h
+++ b/include/wx/generic/colour.h
@@ -14,7 +14,7 @@
 #include "wx/object.h"
 
 // Colour
-class WXDLLIMPEXP_CORE wxColour: public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour: public wxColourBase
 {
 public:
     // constructors

--- a/include/wx/gtk/colour.h
+++ b/include/wx/gtk/colour.h
@@ -17,7 +17,7 @@ typedef struct _GdkRGBA GdkRGBA;
 // wxColour
 //-----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxColour : public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour : public wxColourBase
 {
 public:
     // constructors

--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -103,7 +103,7 @@
 
 #if wxUSE_LONGLONG_NATIVE
 
-class WXDLLIMPEXP_BASE wxLongLongNative
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxLongLongNative
 {
 public:
     // ctors
@@ -344,7 +344,7 @@ private:
 };
 
 
-class WXDLLIMPEXP_BASE wxULongLongNative
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxULongLongNative
 {
 public:
     // ctors
@@ -573,7 +573,7 @@ wxLongLongNative& wxLongLongNative::operator=(const wxULongLongNative &ll)
 
 #if wxUSE_LONGLONG_WX
 
-class WXDLLIMPEXP_BASE wxLongLongWx
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxLongLongWx
 {
 public:
     // ctors
@@ -815,7 +815,7 @@ private:
 };
 
 
-class WXDLLIMPEXP_BASE wxULongLongWx
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxULongLongWx
 {
 public:
     // ctors

--- a/include/wx/msw/colour.h
+++ b/include/wx/msw/colour.h
@@ -17,7 +17,7 @@
 // Colour
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxColour : public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour : public wxColourBase
 {
 public:
     // constructors

--- a/include/wx/osx/core/colour.h
+++ b/include/wx/osx/core/colour.h
@@ -19,7 +19,7 @@
 struct RGBColor;
 
 // Colour
-class WXDLLIMPEXP_CORE wxColour: public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour: public wxColourBase
 {
 public:
     // constructors

--- a/include/wx/qt/colour.h
+++ b/include/wx/qt/colour.h
@@ -12,7 +12,7 @@
 
 class QColor;
 
-class WXDLLIMPEXP_CORE wxColour : public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour : public wxColourBase
 {
 public:
     DEFINE_STD_WXCOLOUR_CONSTRUCTORS

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -298,7 +298,7 @@ private:
 };
 #endif // wxUSE_UNICODE_UTF8
 
-class WXDLLIMPEXP_BASE wxString
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxString
 {
   // NB: special care was taken in arranging the member functions in such order
   //     that all inline functions can be effectively inlined, verify that all

--- a/include/wx/tokenzr.h
+++ b/include/wx/tokenzr.h
@@ -37,7 +37,7 @@ enum wxStringTokenizerMode
 // wxStringTokenizer: replaces infamous strtok() and has some other features
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_BASE wxStringTokenizer : public wxObject
+class WXDLLIMPEXP_BASE wxWARN_UNUSED wxStringTokenizer : public wxObject
 {
 public:
     // ctors and initializers

--- a/include/wx/x11/colour.h
+++ b/include/wx/x11/colour.h
@@ -32,7 +32,7 @@ class WXDLLIMPEXP_FWD_CORE wxColour;
 // wxColour
 //-----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxColour : public wxColourBase
+class WXDLLIMPEXP_CORE wxWARN_UNUSED wxColour : public wxColourBase
 {
 public:
     // constructors

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1863,6 +1863,16 @@ template <typename T> void wxDELETEA(T*& array);
 #define wxSUPPRESS_GCC_PRIVATE_DTOR_WARNING(name)
 
 /**
+    Expands to the "warn_unused" attribute (also known as [[gnu::warn_unused]])
+    on compilers supporting it (GCC and Clang), otherwise to nothing.
+
+    @header{wx/defs.h}
+
+    @since 3.3.0
+*/
+#define wxWARN_UNUSED __attribute__((warn_unused))
+
+/**
     Swaps the contents of two variables.
 
     This is similar to std::swap() but can be used even on the platforms where

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1866,9 +1866,12 @@ template <typename T> void wxDELETEA(T*& array);
     Expands to the "warn_unused" attribute (also known as [[gnu::warn_unused]])
     on compilers supporting it (GCC and Clang), otherwise to nothing.
 
+    @note This is an opt-in feature, and wxNO_UNUSED_VARIABLES must be
+    defined to enable it. In 3.3.0 and later, it is enabled by default.
+
     @header{wx/defs.h}
 
-    @since 3.3.0
+    @since 3.2.7 (opt-in), 3.3.0
 */
 #define wxWARN_UNUSED __attribute__((warn_unused))
 

--- a/samples/fswatcher/fswatcher.cpp
+++ b/samples/fswatcher/fswatcher.cpp
@@ -481,7 +481,7 @@ void MyFrame::OnFileSystemEvent(wxFileSystemWatcherEvent& event)
         bool found(false);
         for (size_t n = m_filesList->GetItemCount(); n > 0; --n)
         {
-            wxString path, foo = m_filesList->GetItemText(n-1);
+            wxString path;
             if ((!m_filesList->GetItemText(n-1).StartsWith("Dir:  ", &path)) &&
                 (!m_filesList->GetItemText(n-1).StartsWith("Tree: ", &path)))
             {

--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -558,7 +558,6 @@ void MyFrame::OnTestLocaleAvail(wxCommandEvent& WXUNUSED(event))
     {
         wxLayoutDirection layout = uiLocale.GetLayoutDirection();
         wxString strLayout = (layout == wxLayout_RightToLeft) ? "RTL" : "LTR";
-        wxString strLocale = uiLocale.GetLocalizedName(wxLOCALE_NAME_LOCALE, wxLOCALE_FORM_NATIVE);
         wxLogMessage(_("Locale \"%s\" is available.\nIdentifier: %s; Layout: %s\nEnglish name: %s\nLocalized name: %s"),
                      s_locale, uiLocale.GetName(), strLayout,
                      uiLocale.GetLocalizedName(wxLOCALE_NAME_LOCALE, wxLOCALE_FORM_ENGLISH),

--- a/samples/propgrid/propgrid.cpp
+++ b/samples/propgrid/propgrid.cpp
@@ -2761,7 +2761,7 @@ void FormMain::OnColourScheme( wxCommandEvent& event )
         m_pPropGridManager->Freeze();
         m_pPropGridManager->GetGrid()->SetMarginColour( my_grey_1 );
         m_pPropGridManager->GetGrid()->SetCaptionBackgroundColour( my_grey_1 );
-        m_pPropGridManager->GetGrid()->SetLineColour( my_grey_1 );
+        m_pPropGridManager->GetGrid()->SetLineColour( my_grey_2 );
         m_pPropGridManager->Thaw();
     }
     else if ( id == ID_COLOURSCHEME4 )

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2515,8 +2515,6 @@ void wxAuiToolBar::OnEraseBackground(wxEraseEvent& WXUNUSED(evt))
 
 void wxAuiToolBar::OnLeftDown(wxMouseEvent& evt)
 {
-    wxRect cli_rect(wxPoint(0,0), GetClientSize());
-
     if (m_gripperSizerItem)
     {
         wxRect gripper_rect = m_gripperSizerItem->GetRect();

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -515,7 +515,6 @@ wxBitmapBundle wxBitmapBundle::FromFiles(const wxString& path, const wxString& f
     wxVector<wxBitmap> bitmaps;
 
     wxFileName fn(path, filename, extension);
-    wxString ext = extension.Lower();
 
     for ( int dpiFactor = 1 ; dpiFactor <= 2 ; ++dpiFactor)
     {

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -393,7 +393,7 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
     tmTimeOnly.tm_year = 76;
     tmTimeOnly.tm_isdst = 0;        // no DST, we adjust for tz ourselves
 
-    wxString tmp, res, fmt;
+    wxString res, fmt;
     for ( wxString::const_iterator p = format.begin(); p != format.end(); ++p )
     {
         if ( *p != wxT('%') )
@@ -1043,7 +1043,6 @@ wxDateTime::ParseFormat(const wxString& date,
     wxCHECK_MSG( !format.empty(), false, "format can't be empty" );
     wxCHECK_MSG( endParse, false, "end iterator pointer must be specified" );
 
-    wxString str;
     unsigned long num;
 
     // what fields have we found?

--- a/src/common/http.cpp
+++ b/src/common/http.cpp
@@ -247,7 +247,6 @@ void wxHTTP::SendHeaders()
 bool wxHTTP::ParseHeaders()
 {
     wxString line;
-    wxStringTokenizer tokenzr;
 
     ClearHeaders();
     ClearCookies();

--- a/src/common/http.cpp
+++ b/src/common/http.cpp
@@ -486,8 +486,6 @@ wxInputStream *wxHTTP::GetInputStream(const wxString& path)
 {
     wxHTTPStream *inp_stream;
 
-    wxString new_path;
-
     m_lastError = wxPROTO_CONNERR;  // all following returns share this type of error
     if (!m_addr)
         return NULL;

--- a/src/common/mimecmn.cpp
+++ b/src/common/mimecmn.cpp
@@ -217,7 +217,6 @@ wxString wxFileType::ExpandCommand(const wxString& command,
                     {
                         const wxChar *pEnd = wxStrchr(pc, wxT('}'));
                         if ( pEnd == NULL ) {
-                            wxString mimetype;
                             wxLogWarning(_("Unmatched '{' in an entry for mime type %s."),
                                          params.GetMimeType().c_str());
                             str << wxT("%{");

--- a/src/common/variant.cpp
+++ b/src/common/variant.cpp
@@ -2068,7 +2068,6 @@ bool wxVariantDataList::Write(wxString& str) const
         wxVariant* var = node->GetData();
         if (node != m_value.GetFirst())
           str += wxT(" ");
-        wxString str1;
         str += var->MakeString();
         node = node->GetNext();
     }

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -411,7 +411,6 @@ wxGridSelection::DeselectBlock(const wxGridBlockCoords& block,
 void wxGridSelection::ClearSelection()
 {
     size_t n;
-    wxRect r;
     wxGridCellCoords coords1, coords2;
 
     // deselect all blocks and update the screen

--- a/src/html/helpdata.cpp
+++ b/src/html/helpdata.cpp
@@ -276,7 +276,6 @@ bool wxHtmlHelpData::LoadMSProject(wxHtmlBookRecord *book, wxFileSystem& fsys,
     wxFSFile *f;
     wxHtmlFilterHTML filter;
     wxString buf;
-    wxString string;
 
     HP_Parser parser;
     HP_TagHandler *handler = new HP_TagHandler(book);
@@ -648,7 +647,6 @@ bool wxHtmlHelpData::AddBook(const wxString& book)
     wxFileSystem fsys;
 
     wxString title = _("noname"),
-             safetitle,
              start,
              contents,
              index,

--- a/src/html/helpwnd.cpp
+++ b/src/html/helpwnd.cpp
@@ -1068,7 +1068,6 @@ void wxHtmlHelpWindow::RefreshLists()
 void wxHtmlHelpWindow::ReadCustomization(wxConfigBase *cfg, const wxString& path)
 {
     wxString oldpath;
-    wxString tmp;
 
     if (!path.empty())
     {
@@ -1126,7 +1125,6 @@ void wxHtmlHelpWindow::ReadCustomization(wxConfigBase *cfg, const wxString& path
 void wxHtmlHelpWindow::WriteCustomization(wxConfigBase *cfg, const wxString& path)
 {
     wxString oldpath;
-    wxString tmp;
 
     if (!path.empty())
     {

--- a/src/html/m_image.cpp
+++ b/src/html/m_image.cpp
@@ -77,7 +77,7 @@ class wxHtmlImageMapAreaCell : public wxHtmlCell
 wxHtmlImageMapAreaCell::wxHtmlImageMapAreaCell( wxHtmlImageMapAreaCell::celltype t, wxString &incoords, double pixel_scale )
 {
     int i;
-    wxString x = incoords, y;
+    wxString x = incoords;
 
     type = t;
     while ((i = x.Find( ',' )) != wxNOT_FOUND)

--- a/src/msw/volume.cpp
+++ b/src/msw/volume.cpp
@@ -363,15 +363,12 @@ static bool BuildRemoteList(wxArrayString& list, NETRESOURCE* pResSrc,
         for (ssize_t iMounted = mounted.GetCount()-1; iMounted >= 0 && iList >= 0; iMounted--)
         {
             int compare;
-            wxString all(list[iList]);
-            wxString mount(mounted[iMounted]);
 
             while (compare =
                      wxStricmp(list[iList].c_str(), mounted[iMounted].c_str()),
                    compare > 0 && iList >= 0)
             {
                 iList--;
-                all = list[iList];
             }
 
 

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -955,7 +955,6 @@ void wxWebViewIE::ClearSelection()
     if(document)
     {
         wxCOMPtr<IHTMLSelectionObject> selection;
-        wxString selected;
         HRESULT hr = document->get_selection(&selection);
         if(SUCCEEDED(hr))
         {

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -10121,7 +10121,6 @@ bool wxRichTextTable::Draw(wxDC& dc, wxRichTextDrawingContext& context, const wx
                     wxRichTextCell* cell = GetCell(row, col);
                     if (cell && cell->IsShown() && !cell->GetRange().IsOutside(range))
                     {
-                        wxRect childRect(cell->GetPosition(), cell->GetCachedSize());
                         wxRichTextAttr attr(cell->GetAttributes());
                         cell->AdjustAttributes(attr, context);
                         if (row != 0)
@@ -10399,8 +10398,6 @@ bool wxRichTextTable::Layout(wxDC& dc, wxRichTextDrawingContext& context, const 
     wxArrayInt spanningWidths, spanningWidthsSpanLengths;
     spanningWidths.Add(0, m_colCount);
     spanningWidthsSpanLengths.Add(0, m_colCount);
-
-    wxSize tableSize(tableWidth, 0);
 
     int i, j, k;
 
@@ -12787,7 +12784,6 @@ bool wxRichTextImage::Draw(wxDC& dc, wxRichTextDrawingContext& context, const wx
 
     DrawBoxAttributes(dc, GetBuffer(), attr, wxRect(position, GetCachedSize()));
 
-    wxSize imageSize(m_imageCache.GetWidth(), m_imageCache.GetHeight());
     wxRect marginRect, borderRect, contentRect, paddingRect, outlineRect;
     marginRect = wxRect(position, GetCachedSize()); // outer rectangle, will calculate contentRect
     GetBoxRects(dc, GetBuffer(), attr, marginRect, borderRect, contentRect, paddingRect, outlineRect);

--- a/src/richtext/richtextxml.cpp
+++ b/src/richtext/richtextxml.cpp
@@ -1954,7 +1954,6 @@ void wxRichTextXMLHelper::OutputIndentation(wxOutputStream& stream, int indent)
 void wxRichTextXMLHelper::OutputStringEnt(wxOutputStream& stream, const wxString& str,
                             wxMBConv *convMem, wxMBConv *convFile)
 {
-    wxString buf;
     size_t i, last, len;
     wxChar c;
 

--- a/src/unix/mimetype.cpp
+++ b/src/unix/mimetype.cpp
@@ -317,7 +317,7 @@ size_t wxFileTypeImpl::GetAllCommands(wxArrayString *verbs,
                                   wxArrayString *commands,
                                   const wxFileType::MessageParameters& params) const
 {
-    wxString vrb, cmd, sTmp;
+    wxString vrb, cmd;
     size_t count = 0;
     wxMimeTypeCommands * sPairs;
 
@@ -951,7 +951,7 @@ wxFileType * wxMimeTypesManagerImpl::GetFileTypeFromMimeType(const wxString& mim
 
 wxString wxMimeTypesManagerImpl::GetCommand(const wxString & verb, size_t nIndex) const
 {
-    wxString command, testcmd, sV, sTmp;
+    wxString command, sV, sTmp;
     sV = verb + wxT("=");
 
     // list of verb = command pairs for this mimetype

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -904,11 +904,10 @@ long wxExecute(const char* const* argv, int flags, wxProcess* process,
 const wxChar* wxGetHomeDir( wxString *home  )
 {
     *home = wxGetUserHome();
-    wxString tmp;
     if ( home->empty() )
         *home = wxT("/");
 #ifdef __VMS
-    tmp = *home;
+    wxString tmp = *home;
     if ( tmp.Last() != wxT(']'))
         if ( tmp.Last() != wxT('/')) *home << wxT('/');
 #endif

--- a/tests/config/config.cpp
+++ b/tests/config/config.cpp
@@ -144,10 +144,10 @@ size_t ReadValues(const wxConfig& config, bool has_values)
     size_t read = 0;
     bool r;
 
-    wxString string1 = config.Read("string1", "abc");
+    config.Read("string1", "abc");
     read++;
 
-    wxString string2 = config.Read("string2", wxString("def"));
+    config.Read("string2", wxString("def"));
     read++;
 
     wxString string3;

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -1262,9 +1262,9 @@ TEST_CASE_METHOD(GridTestCase, "Grid::CellFormatting", "[grid]")
 
     CHECK(m_grid->GetCellBackgroundColour(0, 0) == back);
 
-    back = m_grid->GetDefaultCellTextColour();
+    text = m_grid->GetDefaultCellTextColour();
 
-    CHECK(m_grid->GetCellTextColour(0, 0) == back);
+    CHECK(m_grid->GetCellTextColour(0, 0) == text);
 
 #if WXWIN_COMPATIBILITY_2_8
     m_grid->SetCellAlignment(wxALIGN_CENTRE, 0, 0);

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -250,7 +250,6 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
 #endif // __WXMSW__ || __WXOSX__
         {
             const wxColour clrFg(*wxCYAN);
-            const wxColour clrBg(*wxGREEN);
             const unsigned char alpha = 92;
 
 #if defined(__WXMSW__) || defined(__WXOSX__)
@@ -328,7 +327,6 @@ TEST_CASE("BitmapTestCase::ToImage", "[bitmap][image][convertto]")
 #endif // __WXMSW__ || __WXOSX__
         {
             const wxColour clrFg(*wxCYAN);
-            const wxColour clrBg(*wxGREEN);
             const unsigned char alpha = 92;
 #if defined(__WXMSW__) || defined(__WXOSX__)
             // premultiplied values

--- a/tests/graphics/graphbitmap.cpp
+++ b/tests/graphics/graphbitmap.cpp
@@ -98,7 +98,6 @@ wxBitmap CreateBitmapRGBA(int w, int h, bool withMask)
 #endif // __WXMSW__ || __WXOSX__
     {
         const wxColour clrFg(*wxCYAN);
-        const wxColour clrBg(*wxGREEN);
         const unsigned char alpha = 51;
 
 #if defined(__WXMSW__) || defined(__WXOSX__)

--- a/tests/strings/stdstrings.cpp
+++ b/tests/strings/stdstrings.cpp
@@ -235,7 +235,7 @@ TEST_CASE("StdString::AssignOp", "[stdstring]")
 
 TEST_CASE("StdString::Compare", "[stdstring]")
 {
-    wxString s1, s2, s3, s4, s5, s6, s7, s8;
+    wxString s1, s2, s3, s4, s5, s6;
 
     s1 = wxT("abcdefgh");
     s2 = wxT("abcdefgh");
@@ -257,14 +257,12 @@ TEST_CASE("StdString::Compare", "[stdstring]")
 
 TEST_CASE("StdString::Erase", "[stdstring]")
 {
-    wxString s1, s2, s3, s4, s5, s6, s7;
+    wxString s1, s2, s3, s4, s7;
 
     s1 = wxT("abcdefgh");
     s2 = wxT("abcdefgh");
     s3 = wxT("abc");
     s4 = wxT("abcdefghi");
-    s5 = wxT("aaa");
-    s6 = wxT("zzz");
     s7 = wxT("zabcdefg");
 
     s1.erase(1, 1);

--- a/tests/strings/tokenizer.cpp
+++ b/tests/strings/tokenizer.cpp
@@ -275,15 +275,15 @@ void TokenizerTestCase::CopyObj()
     wxStringTokenizer tkzSrc(wxT("first:second:third:fourth"), wxT(":"));
     while ( tkzSrc.HasMoreTokens() )
     {
-        wxString tokenSrc = tkzSrc.GetNextToken();
+        tkzSrc.GetNextToken();
         wxStringTokenizer tkz = tkzSrc;
 
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetPosition(), tkz.GetPosition() );
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetString(), tkz.GetString() );
 
         // Change the state of both objects and compare again...
-        tokenSrc = tkzSrc.GetNextToken();
-        wxString token = tkz.GetNextToken();
+        tkzSrc.GetNextToken();
+        tkz.GetNextToken();
 
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetPosition(), tkz.GetPosition() );
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetString(), tkz.GetString() );
@@ -297,15 +297,15 @@ void TokenizerTestCase::AssignObj()
     wxStringTokenizer tkz;
     while ( tkzSrc.HasMoreTokens() )
     {
-        wxString tokenSrc = tkzSrc.GetNextToken();
+        tkzSrc.GetNextToken();
         tkz = tkzSrc;
 
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetPosition(), tkz.GetPosition() );
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetString(), tkz.GetString() );
 
         // Change the state of both objects and compare again...
-        tokenSrc = tkzSrc.GetNextToken();
-        wxString token = tkz.GetNextToken();
+        tkzSrc.GetNextToken();
+        tkz.GetNextToken();
 
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetPosition(), tkz.GetPosition() );
         CPPUNIT_ASSERT_EQUAL( tkzSrc.GetString(), tkz.GetString() );

--- a/tests/strings/vsnprintf.cpp
+++ b/tests/strings/vsnprintf.cpp
@@ -519,7 +519,6 @@ TEST_CASE_METHOD(VsnprintfTestCase, "Vsnprintf::GlibcMisc1", "[vsnprintf]")
 TEST_CASE_METHOD(VsnprintfTestCase, "Vsnprintf::GlibcMisc2", "[vsnprintf]")
 {
     int prec;
-    wxString test_format;
 
     prec = 0;
     CMP("3", "%.*g", prec, 3.3);


### PR DESCRIPTION
Backport #24833 and #24873 into 3.2 branch.

This is introduced as an opt-in feature in 3.2, to avoid potentially breaking compilation of projects that use `-Werror=unused*`.

`wxWARN_UNUSED` is defined as nothing, unless `wxNO_UNUSED_VARIABLES` is defined by the user.

`wxWARN_UNUSED` is also automatically opted-in when `WXBUILDING` is defined. If this is seen as a risk, I'm not against not doing so.

`wxNO_UNUSED_VARIABLES` as a name is IMHO rather awkward for enabling something, but couldn't come up with something better that would begin with `wxNO_`.