### PR TITLE
wxQt: Fix wxEVT_{ENTER,LEAVE}_WINDOW events generation

### DIFF
--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -251,6 +251,7 @@ TEST_GUI_OBJECTS =  \
 	test_gui_windowtest.o \
 	test_gui_dialogtest.o \
 	test_gui_clone.o \
+	test_gui_enterleave.o \
 	test_gui_evtlooptest.o \
 	test_gui_propagation.o \
 	test_gui_keyboard.o \
@@ -1164,6 +1165,9 @@ test_gui_dialogtest.o: $(srcdir)/controls/dialogtest.cpp $(TEST_GUI_ODEP)
 
 test_gui_clone.o: $(srcdir)/events/clone.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/events/clone.cpp
+
+test_gui_enterleave.o: $(srcdir)/events/enterleave.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/events/enterleave.cpp
 
 test_gui_evtlooptest.o: $(srcdir)/events/evtlooptest.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/events/evtlooptest.cpp

--- a/tests/events/enterleave.cpp
+++ b/tests/events/enterleave.cpp
@@ -1,0 +1,156 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/events/enterleave.cpp
+// Purpose:     Test wxEVT_ENTER_WINDOW and wxEVT_LEAVE_WINDOW events
+// Author:      Ali Kettab
+// Created:     2024-10-16
+// Copyright:   (c) 2024 wxWidgets team
+///////////////////////////////////////////////////////////////////////////////
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+#include "testprec.h"
+
+
+#ifndef WX_PRECOMP
+    #include "wx/app.h"
+    #include "wx/button.h"
+    #include "wx/panel.h"
+    #include "wx/textctrl.h"
+    #include "wx/window.h"
+#endif // WX_PRECOMP
+
+#include "wx/uiaction.h"
+
+#include "asserthelper.h"
+#include "testableframe.h"
+#include "waitfor.h"
+
+// ----------------------------------------------------------------------------
+// tests themselves
+// ----------------------------------------------------------------------------
+
+#if wxUSE_UIACTIONSIMULATOR
+
+TEST_CASE("EnterLeaveEvents", "[wxEvent][enter-leave]")
+{
+    if ( !EnableUITests() )
+    {
+        WARN("Skipping wxEVT_{ENTER,LEAVE}_WINDOW tests: wxUIActionSimulator not available");
+        return;
+    }
+
+    std::unique_ptr<wxPanel>
+        panel(new wxPanel(wxTheApp->GetTopWindow(), wxID_ANY));
+    auto button = new wxButton(panel.get(), wxID_ANY, "button", {50, 50});
+    auto textctrl = new wxTextCtrl(panel.get(), wxID_ANY, "", {160, 50});
+
+    EventCounter enter(panel.get(), wxEVT_ENTER_WINDOW);
+    EventCounter leave(panel.get(), wxEVT_LEAVE_WINDOW);
+
+    // Wait for the first paint event to be sure that panel really
+    // has its final size.
+    WaitForPaint waitForPaint(panel.get());
+    panel->SendSizeEventToParent();
+    waitForPaint.YieldUntilPainted();
+
+    wxUIActionSimulator sim;
+
+    SECTION("Without mouse capture")
+    {
+        sim.MouseMove(panel->GetScreenPosition() + wxPoint(5, 5));
+        wxYield();
+
+        CHECK( enter.GetCount() == 1 );
+        CHECK( leave.GetCount() == 0 );
+
+        enter.Clear();
+
+        sim.MouseMove(button->GetScreenPosition() + wxPoint(5, 5));
+        wxYield();
+
+        // The parent window (panel) should receive wxEVT_LEAVE_WINDOW event
+        // when mouse enters the child window (button)
+        CHECK( enter.GetCount() == 0 );
+        CHECK( leave.GetCount() == 1 );
+
+        leave.Clear();
+
+        sim.MouseMove(panel->GetScreenPosition() + wxPoint(5, 5));
+        wxYield();
+
+        // Now it (panel) should receive wxEVT_ENTER_WINDOW event when
+        // the mouse leaves the button and enters the panel again.
+        CHECK( enter.GetCount() == 1 );
+        CHECK( leave.GetCount() == 0 );
+    }
+
+    SECTION("With (implicit) mouse capture")
+    {
+        // Just to be sure that the button is really shown
+        EventCounter clicked(button, wxEVT_BUTTON);
+
+        sim.MouseMove(button->GetScreenPosition() + wxPoint(5, 5));
+        wxYield();
+
+        sim.MouseClick();
+        wxYield();
+
+        CHECK( clicked.GetCount() == 1 );
+
+        enter.Clear();
+        leave.Clear();
+
+        sim.MouseDown();
+        wxYield();
+
+#if defined(__WXGTK__) && !defined(__WXGTK3__)
+        if ( IsAutomaticTest() )
+        {
+            WARN("Skipping tests known to fail under GitHub Actions");
+            return;
+        }
+#endif
+        sim.MouseMove(button->GetScreenPosition() + wxPoint(10, 5));
+        wxYield();
+
+        // Holding the mouse button down (initiated on the button) and then
+        // hovering over the panel should not generate any events (enter/leave)
+        // Additionally, entering and leaving another child (textctrl) while the
+        // mouse is still held down should also not generate any events.
+
+        sim.MouseMove(panel->GetScreenPosition() + wxPoint(5, 5));
+        wxYield();
+
+        CHECK( enter.GetCount() == 0 );
+        CHECK( leave.GetCount() == 0 );
+
+        sim.MouseMove(textctrl->GetScreenPosition() + wxPoint(5, 5));
+        wxYield();
+
+        CHECK( enter.GetCount() == 0 );
+        CHECK( leave.GetCount() == 0 );
+
+        sim.MouseMove(panel->GetScreenPosition() + wxPoint(5, 5));
+        wxYield();
+
+        CHECK( enter.GetCount() == 0 );
+        CHECK( leave.GetCount() == 0 );
+
+        sim.MouseUp();
+        wxYield();
+
+        // wxGTK behaves differently here, as it does not generate a
+        // wxEVT_ENTER_WINDOW event when we release the mouse button.
+
+    #ifndef __WXGTK__
+        CHECK( enter.GetCount() == 1 );
+    #else
+        CHECK( enter.GetCount() == 0 );
+    #endif
+        CHECK( leave.GetCount() == 0 );
+    }
+}
+
+#endif // wxUSE_UIACTIONSIMULATOR

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -224,6 +224,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_windowtest.o \
 	$(OBJS)\test_gui_dialogtest.o \
 	$(OBJS)\test_gui_clone.o \
+	$(OBJS)\test_gui_enterleave.o \
 	$(OBJS)\test_gui_evtlooptest.o \
 	$(OBJS)\test_gui_propagation.o \
 	$(OBJS)\test_gui_keyboard.o \
@@ -1107,6 +1108,9 @@ $(OBJS)\test_gui_dialogtest.o: ./controls/dialogtest.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_clone.o: ./events/clone.cpp
+	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_enterleave.o: ./events/enterleave.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_evtlooptest.o: ./events/evtlooptest.cpp

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -239,6 +239,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_windowtest.obj \
 	$(OBJS)\test_gui_dialogtest.obj \
 	$(OBJS)\test_gui_clone.obj \
+	$(OBJS)\test_gui_enterleave.obj \
 	$(OBJS)\test_gui_evtlooptest.obj \
 	$(OBJS)\test_gui_propagation.obj \
 	$(OBJS)\test_gui_keyboard.obj \
@@ -1409,6 +1410,9 @@ $(OBJS)\test_gui_dialogtest.obj: .\controls\dialogtest.cpp
 
 $(OBJS)\test_gui_clone.obj: .\events\clone.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\events\clone.cpp
+
+$(OBJS)\test_gui_enterleave.obj: .\events\enterleave.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\events\enterleave.cpp
 
 $(OBJS)\test_gui_evtlooptest.obj: .\events\evtlooptest.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\events\evtlooptest.cpp

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -261,6 +261,7 @@
             controls/windowtest.cpp
             controls/dialogtest.cpp
             events/clone.cpp
+            events/enterleave.cpp
             <!--
                 Duplicate this file here to test GUI event loops too.
              -->


### PR DESCRIPTION
Quoting Qt docs:

- enterEvent() is called when the mouse enters the widget's screen space. (This excludes screen space owned by any of the widget's children.)
- leaveEvent() is called when the mouse leaves the widget's screen space. If the mouse enters a child widget it will not cause a leaveEvent().

Which contradicts what wx docs says:

For the wxEVT_ENTER_WINDOW and wxEVT_LEAVE_WINDOW events purposes, the mouse is considered to be inside the window if it is in the window client area and not inside one of its children. In other words, the parent window receives wxEVT_LEAVE_WINDOW event not only when the mouse leaves the window entirely but also when it enters one of its children.