### PR TITLE
Run macOS CI builds using macos-14 GitHub image

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -66,11 +66,11 @@ jobs:
             runner: ubuntu-22.04
             cmake_generator: Unix Makefiles
             cmake_samples: ALL
-          - name: macOS 12 wxOSX
-            runner: macos-12
+          - name: macOS 14 wxOSX
+            runner: macos-14
             cmake_generator: Xcode
-          - name: macOS 12 wxIOS
-            runner: macos-12
+          - name: macOS 14 wxIOS
+            runner: macos-14
             cmake_generator: Xcode
             cmake_defines: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_FIND_ROOT_PATH=/usr/local -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
             cmake_samples: OFF

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -94,12 +94,12 @@ jobs:
           runner: self-hosted
           arch: arm64
           configure_flags: --with-cxx=14 --enable-universal_binary=arm64,x86_64 --disable-shared --disable-debug --enable-optimise
-        - name: wxMac macOS 12
-          runner: macos-12
+        - name: wxMac macOS 14
+          runner: macos-14
           arch: x86_64
           configure_flags: --disable-sys-libs
         - name: wxiOS
-          runner: macos-12
+          runner: macos-14
           arch: x86_64
           configure_flags: --with-osx_iphone --enable-monolithic  --disable-sys-libs --host=i686-apple-darwin_sim --build=x86_64-apple-darwin17.7.0
           configure_env: PKG_CONFIG_LIBDIR=/dev/null


### PR DESCRIPTION
"macos-12" one is deprecated and will be removed soon.