### PR TITLE
Add GTK+ support for wxTextCtrl::SearchText

### DIFF
--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -105,6 +105,8 @@ public:
     virtual wxTextProofOptions GetProofCheckOptions() const override;
 #endif // wxUSE_SPELLCHECK && __WXGTK3__
 
+    virtual wxTextSearchResult SearchText(const wxTextSearch& search) const override;
+
     // GTK-specific functions
 
     // Get the underlying text buffer for multi-line controls.

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -105,7 +105,9 @@ public:
     virtual wxTextProofOptions GetProofCheckOptions() const override;
 #endif // wxUSE_SPELLCHECK && __WXGTK3__
 
+#ifdef __WXGTK3__
     virtual wxTextSearchResult SearchText(const wxTextSearch& search) const override;
+#endif // __WXGTK3__
 
     // GTK-specific functions
 

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1813,7 +1813,7 @@ public:
         The range of the match will be returned as a wxTextSearchResult, which will
         contain -1 values if no match was found.
 
-        This is currently only implemented under wxMSW.
+        This is currently only implemented under wxMSW and wxGTK.
 
         @since 3.3.0
 

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1813,11 +1813,11 @@ public:
         The range of the match will be returned as a wxTextSearchResult, which will
         contain -1 values if no match was found.
 
-        This is currently only implemented under wxMSW and wxGTK.
+        This is currently only implemented under wxMSW and wxGTK3.
 
         @since 3.3.0
 
-        @onlyfor{wxmsw}
+        @onlyfor{wxmsw,wxgtk}
     */
     wxTextSearchResult SearchText(const wxTextSearch& search) const;
 

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -2074,6 +2074,7 @@ bool wxTextCtrl::GetStyle(long position, wxTextAttr& style)
     return true;
 }
 
+#ifdef __WXGTK3__
 wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
 {
     const GtkTextSearchFlags flags = static_cast<GtkTextSearchFlags>(
@@ -2168,6 +2169,7 @@ wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
         return wxTextSearchResult();
     }
 }
+#endif // __WXGTK3__
 
 void wxTextCtrl::DoApplyWidgetStyle(GtkRcStyle *style)
 {

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1234,7 +1234,7 @@ wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
     }
     else
     {
-        // will search from the start of the selection and upward
+        // will search from the end (or user-provided position) and go upward
         // to the start of the text
         findText.chrg.cpMax = 0;
     }

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1470,11 +1470,7 @@ TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 
     std::unique_ptr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_RICH2 | wxTE_MULTILINE));
 
-    text->SetRTFValue(R"({\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
-{\colortbl ;\red192\green80\blue77;}
-{\*\generator Riched20 10.0.22621}\viewkind4\uc1
- \pard\sa200\sl276\slmult1\b\i\f0\fs22\lang9 wxWidg\'e9ts \cf1\i0 3.3\cf0\b0\par
-})");
+    text->SetRTFValue("{\\rtf1\\ansi\\ansicpg1252\\deff0\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}{\\colortbl ;\\red192\\green80\\blue77;}{\\*\\generator Riched20 10.0.22621}\\viewkind4\\uc1 \\pard\\sa200\\sl276\\slmult1\\b\\i\\f0\\fs22\\lang9 wxWidg\\'e9ts \\cf1\\i0 3.3\\cf0\\b0\\par}");
     // test getting the main text, including an extended ASCII character
     wxString result = text->GetValue();
 

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1477,11 +1477,11 @@ TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 })");
     // test getting the main text, including an extended ASCII character
     wxString result = text->GetValue();
-    CHECK(result.find(L"wxWidgéts") != wxString::npos);
+    CHECK(result.find(L"wxWidg\x00E9ts") != wxString::npos);
     CHECK(result.find(L"3.3") != wxString::npos);
 
     result = text->GetRTFValue();
-    // 'é' will be encoded, just see if parts of the content are in there
+    // 'e' with acute will be encoded, just see if parts of the content are in there
     CHECK(result.find(L"wxWidg") != wxString::npos);
     CHECK(result.find(L"3.3") != wxString::npos);
 }

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1477,7 +1477,9 @@ TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 })");
     // test getting the main text, including an extended ASCII character
     wxString result = text->GetValue();
-    CHECK(result.find(L"wxWidg\x00E9") != wxString::npos);
+
+    auto foundPos = result.find(L"wxWidg");
+    CHECK(result[foundPos + 6] == 233); // e with acute
     CHECK(result.find(L"3.3") != wxString::npos);
 
     result = text->GetRTFValue();

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1470,18 +1470,21 @@ TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 
     std::unique_ptr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_RICH2 | wxTE_MULTILINE));
 
-    text->SetRTFValue("{\\rtf1\\ansi\\ansicpg1252\\deff0\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}{\\colortbl ;\\red192\\green80\\blue77;}{\\*\\generator Riched20 10.0.22621}\\viewkind4\\uc1 \\pard\\sa200\\sl276\\slmult1\\b\\i\\f0\\fs22\\lang9 wxWidg\\'e9ts \\cf1\\i0 3.3\\cf0\\b0\\par}");
-    // test getting the main text, including an extended ASCII character
-    wxString result = text->GetValue();
+    if (text->IsRTFSupported())
+    {
+        text->SetRTFValue("{\\rtf1\\ansi\\ansicpg1252\\deff0\\nouicompat\\deflang1033{\\fonttbl{\\f0\\fnil\\fcharset0 Calibri;}}{\\colortbl ;\\red192\\green80\\blue77;}{\\*\\generator Riched20 10.0.22621}\\viewkind4\\uc1 \\pard\\sa200\\sl276\\slmult1\\b\\i\\f0\\fs22\\lang9 wxWidg\\'e9ts \\cf1\\i0 3.3\\cf0\\b0\\par}");
+        // test getting the main text, including an extended ASCII character
+        wxString result = text->GetValue();
 
-    auto foundPos = result.find(L"wxWidg");
-    CHECK(result[foundPos + 6] == 233); // e with acute
-    CHECK(result.find(L"3.3") != wxString::npos);
+        auto foundPos = result.find(L"wxWidg");
+        CHECK(result[foundPos + 6] == 233); // e with acute
+        CHECK(result.find(L"3.3") != wxString::npos);
 
-    result = text->GetRTFValue();
-    // 'e' with acute will be encoded, just see if parts of the content are in there
-    CHECK(result.find(L"wxWidg") != wxString::npos);
-    CHECK(result.find(L"3.3") != wxString::npos);
+        result = text->GetRTFValue();
+        // 'e' with acute will be encoded, just see if parts of the content are in there
+        CHECK(result.find(L"wxWidg") != wxString::npos);
+        CHECK(result.find(L"3.3") != wxString::npos);
+    }
 }
 #endif
 

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1463,7 +1463,7 @@ TEST_CASE("wxTextCtrl::EventsOnCreate", "[wxTextCtrl][event]")
     CHECK( updated.GetCount() == 1 );
 }
 
-#ifdef __WXOSX__
+#ifdef wxHAS_TEXTCTRL_RTF
 TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 {
     wxWindow* const parent = wxTheApp->GetTopWindow();
@@ -1487,7 +1487,7 @@ TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 }
 #endif
 
-#ifdef __WXMSW__
+#if defined(__WXMSW__) || defined(__WXGTK__)
 TEST_CASE("wxTextCtrl::SearchText", "[wxTextCtrl][search]")
 {
     wxWindow* const parent = wxTheApp->GetTopWindow();
@@ -1556,6 +1556,10 @@ And there is a mispeled word)");
     // no more matches going down
     results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(results.m_start + 1));
     CHECK_FALSE(results);
+
+    // bad start position
+    results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Down).MatchCase().MatchWholeWord().Start(2000));
+    CHECK_FALSE(results); // started past the length of the control
 
     // go up from the end
     results = text->SearchText(wxTextSearch(L"very").SearchDirection(wxTextSearch::Direction::Up).MatchCase().MatchWholeWord());

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1477,7 +1477,7 @@ TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 })");
     // test getting the main text, including an extended ASCII character
     wxString result = text->GetValue();
-    CHECK(result.find(L"wxWidg\x00E9ts") != wxString::npos);
+    CHECK(result.find(L"wxWidg\x00E9") != wxString::npos);
     CHECK(result.find(L"3.3") != wxString::npos);
 
     result = text->GetRTFValue();

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1487,7 +1487,7 @@ TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 }
 #endif
 
-#if defined(__WXMSW__) || defined(__WXGTK__)
+#if defined(__WXMSW__) || defined(__WXGTK3__)
 TEST_CASE("wxTextCtrl::SearchText", "[wxTextCtrl][search]")
 {
     wxWindow* const parent = wxTheApp->GetTopWindow();


### PR DESCRIPTION
Also, fix comment in MSW version of function and add another edge test case.
Include MSW test cases for (unrelated) RTF functions.