### PR TITLE
Fix height of wxOwnerDrawnComboBox popup at different DPI

### DIFF
--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -116,7 +116,7 @@ wxCONSTRUCTOR_5( wxComboBox, wxWindow*, Parent, wxWindowID, Id, \
 
 #define BMP_BUTTON_MARGIN                       4
 
-#define DEFAULT_POPUP_HEIGHT                    400
+#define DEFAULT_POPUP_ITEMS                     21
 
 #define DEFAULT_TEXT_INDENT                     3
 
@@ -2159,8 +2159,13 @@ void wxComboCtrlBase::ShowPopup()
 
     wxASSERT( !m_popup || m_popup == popup ); // Consistency check.
 
+    int heightPopup = m_heightPopup;
+    if (heightPopup <= 0)
+        // estimated height for a row containig text
+        heightPopup = DEFAULT_POPUP_ITEMS * (GetCharHeight() + FromDIP(4));
+
     wxSize adjustedSize = m_popupInterface->GetAdjustedSize(widthPopup,
-                                                            m_heightPopup<=0?DEFAULT_POPUP_HEIGHT:m_heightPopup,
+                                                            heightPopup,
                                                             maxHeightPopup);
 
     popup->SetSize(adjustedSize);

--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -809,7 +809,7 @@ void wxVListBoxComboPopup::CalcWidths()
 
 wxSize wxVListBoxComboPopup::GetAdjustedSize( int minWidth, int prefHeight, int maxHeight )
 {
-    int height = 250;
+    int height = FromDIP(250);
 
     maxHeight -= 2;  // Must take borders into account
 
@@ -841,7 +841,7 @@ wxSize wxVListBoxComboPopup::GetAdjustedSize( int minWidth, int prefHeight, int 
         }
     }
     else
-        height = 50;
+        height = FromDIP(50);
 
     CalcWidths();
 

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1378,6 +1378,8 @@ void wxPropertyGrid::OnDPIChanged(wxDPIChangedEvent &event)
     CalculateFontAndBitmapStuff(m_vspacing);
     Refresh();
 
+    RefreshProperty(GetSelection());
+
     event.Skip();
 }
 


### PR DESCRIPTION
Don't use a hard-coded height of 400px but estimate the height of 21 rows containing text (the orignal 400px at default DPI resulted in 21 items).
The actual height of a row depends on it's content and (custom) OnGetRowHeight implementation and is not known, and can also be different per row.
Also make the height DPI aware when no preferred height is given, and when the popup is empty.

Fixes https://github.com/wxWidgets/wxWidgets/issues/24850

And fix wxPropGrid editor appearance after a DPI change. 
The height of the propgrid item being edited does not correctly adjust to the new DPI, so recreate the control(s).
<img src="https://github.com/user-attachments/assets/a9e881bf-bdae-4f07-bfaa-fc05d9321795">

