### PR TITLE
wxQt: Add support for wxTextCtrl::SearchText

### DIFF
--- a/include/wx/qt/textctrl.h
+++ b/include/wx/qt/textctrl.h
@@ -85,6 +85,8 @@ public:
 
     virtual void SetMaxLength(unsigned long len) override;
 
+    virtual wxTextSearchResult SearchText(const wxTextSearch& search) const override;
+
 protected:
     virtual wxSize DoGetBestSize() const override;
 

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -48,6 +48,7 @@ public:
     virtual wxTextCtrlHitTestResult HitTest(const wxPoint& pt, long *pos) const = 0;
     virtual void WriteText( const wxString &text ) = 0;
     virtual void SetMaxLength(unsigned long len) = 0;
+    virtual wxTextSearchResult SearchText(const wxTextSearch& search) const = 0;
     virtual void MarkDirty() = 0;
     virtual void DiscardEdits() = 0;
     virtual void blockSignals(bool block) = 0;
@@ -291,6 +292,44 @@ public:
         wxMISSING_IMPLEMENTATION("not implemented for multiline control");
     }
 
+    virtual wxTextSearchResult SearchText(const wxTextSearch& search) const override
+    {
+        // set up the flags
+        QTextDocument::FindFlags options;
+
+        if ( search.m_direction == wxTextSearch::Direction::Up )
+        {
+            options |= QTextDocument::FindBackward;
+        }
+        if ( search.m_wholeWord )
+        {
+            options |= QTextDocument::FindWholeWords;
+        }
+        if ( search.m_matchCase )
+        {
+            options |= QTextDocument::FindCaseSensitively;
+        }
+
+        const auto searchValue = wxQtConvertString(search.m_searchValue);
+        const auto startPos = search.m_startingPosition != -1
+                            ? search.m_startingPosition // user-provided start
+                            : (search.m_direction == wxTextSearch::Direction::Down) ?
+                                // if going down, then start from 0; otherwise, start from end
+                                0 : m_edit->document()->characterCount()-1;
+
+        const auto cursor = m_edit->document()->find(searchValue, startPos, options);
+
+        wxTextSearchResult result;
+
+        if ( !cursor.isNull() )
+        {
+            result.m_start = cursor.selectionStart();
+            result.m_end = cursor.selectionEnd();
+        }
+
+        return result;
+    }
+
     virtual void MarkDirty() override
     {
         return m_edit->setWindowModified( true );
@@ -473,6 +512,11 @@ public:
         }
 
         m_edit->setMaxLength(len);
+    }
+
+    virtual wxTextSearchResult SearchText(const wxTextSearch& WXUNUSED(search)) const override
+    {
+        return {};
     }
 
     virtual void MarkDirty() override
@@ -901,6 +945,11 @@ void wxTextCtrl::DoSetValue( const wxString &text, int flags )
         if ( flags & SetValue_SendEvent )
             SendTextUpdatedEventIfAllowed();
     }
+}
+
+wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
+{
+    return m_qtEdit->SearchText(search);
 }
 
 #endif // wxUSE_TEXTCTRL

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1487,7 +1487,7 @@ TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 }
 #endif
 
-#ifdef __WXMSW__
+#if defined(__WXMSW__) || defined(__WXQT__)
 TEST_CASE("wxTextCtrl::SearchText", "[wxTextCtrl][search]")
 {
     wxWindow* const parent = wxTheApp->GetTopWindow();


### PR DESCRIPTION
Some notes:
- Implemented for multi-line control only.
- A rebase to master is needed if #24897 get merged before this.
