### PR TITLE
wxMSW: Toolbar checked item bg color fix for dark mode

### DIFF
--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1694,6 +1694,7 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                 nmtbcd->clrTextHighlight = wxColourToRGB(GetForegroundColour());
                 nmtbcd->clrHighlightHotTrack = wxSysColourToRGB(wxSYS_COLOUR_HOTLIGHT);
 
+                // draw custom checked button background
                 if (nmtbcd->nmcd.uItemState & CDIS_CHECKED) {
                     wxColor color = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT).ChangeLightness(110);
                     HBRUSH br = CreateSolidBrush(wxColourToRGB(color));

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1694,6 +1694,15 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                 nmtbcd->clrTextHighlight = wxColourToRGB(GetForegroundColour());
                 nmtbcd->clrHighlightHotTrack = wxSysColourToRGB(wxSYS_COLOUR_HOTLIGHT);
 
+                if (nmtbcd->nmcd.uItemState & CDIS_CHECKED) {
+                    wxColor color = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT).ChangeLightness(110);
+                    HBRUSH br = CreateSolidBrush(wxColourToRGB(color));
+                    FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, br);
+                    DeleteObject(br);
+                    *result = CDRF_DODEFAULT | TBCDRF_USECDCOLORS | TBCDRF_HILITEHOTTRACK | TBCDRF_NOBACKGROUND;
+                    return true;
+                }
+
                 *result = CDRF_DODEFAULT | TBCDRF_USECDCOLORS | TBCDRF_HILITEHOTTRACK;
                 return true;
         }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1700,7 +1700,7 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                     HBRUSH br = CreateSolidBrush(wxColourToRGB(color));
                     FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, br);
                     DeleteObject(br);
-                    *result = CDRF_DODEFAULT | TBCDRF_USECDCOLORS | TBCDRF_HILITEHOTTRACK | TBCDRF_NOBACKGROUND;
+                    *result = CDRF_DODEFAULT | TBCDRF_USECDCOLORS | TBCDRF_HILITEHOTTRACK | TBCDRF_NOBACKGROUND | CDRF_NOTIFYPOSTPAINT;
                     return true;
                 }
 

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1695,11 +1695,11 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                 nmtbcd->clrHighlightHotTrack = wxSysColourToRGB(wxSYS_COLOUR_HOTLIGHT);
 
                 // draw custom checked button background
-                if ((nmtbcd->nmcd.uItemState & (CDIS_CHECKED|CDIS_HOT)) == CDIS_CHECKED) {
-                    wxColor color = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT).ChangeLightness(110);
-                    HBRUSH br = CreateSolidBrush(wxColourToRGB(color));
-                    FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, br);
-                    DeleteObject(br);
+                if ( (nmtbcd->nmcd.uItemState & (CDIS_CHECKED | CDIS_HOT)) == CDIS_CHECKED )
+                {
+                    const wxColor color = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT).ChangeLightness(110);
+                    AutoHBRUSH br(wxColourToRGB(color));
+                    ::FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, br);
                     *result = CDRF_DODEFAULT | TBCDRF_USECDCOLORS | TBCDRF_HILITEHOTTRACK | TBCDRF_NOBACKGROUND | CDRF_NOTIFYPOSTPAINT;
                     return true;
                 }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1695,7 +1695,7 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                 nmtbcd->clrHighlightHotTrack = wxSysColourToRGB(wxSYS_COLOUR_HOTLIGHT);
 
                 // draw custom checked button background
-                if (nmtbcd->nmcd.uItemState & CDIS_CHECKED) {
+                if ((nmtbcd->nmcd.uItemState & (CDIS_CHECKED|CDIS_HOT)) == CDIS_CHECKED) {
                     wxColor color = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT).ChangeLightness(110);
                     HBRUSH br = CreateSolidBrush(wxColourToRGB(color));
                     FillRect(nmtbcd->nmcd.hdc, &nmtbcd->nmcd.rc, br);


### PR DESCRIPTION
In dark mode and MSW, a checked toolbar item always has this light blue background color as you can see here:

![image](https://github.com/user-attachments/assets/b4ad6711-4447-4934-be34-2f57990feefd)

This pull request fixes this and the new color better fits the dark design, as you can see here:

![image](https://github.com/user-attachments/assets/12c77e94-a12a-4f86-9973-a9da21a6775f)

The flag `CDRF_NOTIFYPOSTPAINT` is actually not required for this change, but but you accept another pull request (#24901) that fixes the dark dropdown arrow issue in dark theme, then it is required.


