### PR TITLE
wxMSW: Fix for dark drop down icon in dark mode

### DIFF
--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1707,7 +1707,7 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                     ::SendMessage(GetHwnd(), TB_GETITEMDROPDOWNRECT, (WPARAM)itemIndex, (LPARAM)&ddrc);
 
                     if (nmtbcd->nmcd.uItemState & CDIS_HOT) {
-                        HBRUSH bgBrush = CreateSolidBrush(wxColourToRGB(GetBackgroundColour().ChangeLightness(110)));
+                        AutoHBRUSH bgBrush(wxColourToRGB(GetBackgroundColour().ChangeLightness(110)));
                         ::FillRect(nmtbcd->nmcd.hdc, &ddrc, bgBrush);
                         DeleteObject(bgBrush);
                     }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1726,7 +1726,7 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                     };
 
                     AutoHBRUSH fgBrush(wxColourToRGB(GetForegroundColour()));
-                    HPEN hPen = CreatePen(PS_SOLID, 1, wxColourToRGB(GetForegroundColour()));
+                    AutoHPEN hPen(wxColourToRGB(GetForegroundColour()));
                     SelectObject(nmtbcd->nmcd.hdc, hPen);
                     SelectObject(nmtbcd->nmcd.hdc, fgBrush);
                     Polygon(nmtbcd->nmcd.hdc, ptsArrow, 3);

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1686,7 +1686,8 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                 *result = CDRF_NOTIFYITEMDRAW;
                 return true;
 
-            case CDDS_ITEMPREPAINT: {
+            case CDDS_ITEMPREPAINT:
+            {
                 // If we get here, we must have returned CDRF_NOTIFYITEMDRAW
                 // from above, so we're using the dark mode and need to
                 // customize the colours for it.
@@ -1700,28 +1701,33 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                 return true;
             }
 
-            case CDDS_ITEMPOSTPAINT: {
+            case CDDS_ITEMPOSTPAINT:
+            {
                 // custom draw the drop-down arrow here, as it is always black
                 WinStruct<TBBUTTONINFO> bi;
                 bi.dwMask = TBIF_STYLE | TBIF_COMMAND;
                 int itemIndex = (int) ::SendMessage(GetHwnd(), TB_GETBUTTONINFO, (WPARAM)nmtbcd->nmcd.dwItemSpec, (LPARAM)&bi);
-                if (itemIndex >= 0 && bi.fsStyle & TBSTYLE_DROPDOWN) {
+                if (itemIndex >= 0 && bi.fsStyle & TBSTYLE_DROPDOWN)
+                {
                     RECT ddrc = { 0 };
                     ::SendMessage(GetHwnd(), TB_GETITEMDROPDOWNRECT, (WPARAM)itemIndex, (LPARAM)&ddrc);
 
                     wxColour colBg = m_hasBgCol ? GetBackgroundColour() : wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);
-                    if (nmtbcd->nmcd.uItemState & CDIS_HOT) {
+                    if (nmtbcd->nmcd.uItemState & CDIS_HOT)
+                    {
                         AutoHBRUSH bgBrush(wxColourToRGB(colBg.ChangeLightness(120)));
                         ::FillRect(nmtbcd->nmcd.hdc, &ddrc, bgBrush);
                     }
-                    else {
+                    else
+                    {
                         AutoHBRUSH bgBrush(wxColourToRGB(colBg));
                         ::FillRect(nmtbcd->nmcd.hdc, &ddrc, bgBrush);
                     }
 
                     int arrowCenterX = (ddrc.left + ddrc.right) / 2;
                     int arrowCenterY = (ddrc.top + ddrc.bottom) / 2;
-                    POINT ptsArrow[3] = {
+                    POINT ptsArrow[3] =
+                    {
                         { arrowCenterX - FromDIP(3), arrowCenterY - FromDIP(2)},
                         { arrowCenterX + FromDIP(3), arrowCenterY - FromDIP(2) },
                         { arrowCenterX, arrowCenterY + FromDIP(2) }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1725,7 +1725,7 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                         { arrowCenterX, arrowCenterY + FromDIP(2) }
                     };
 
-                    HBRUSH fgBrush = CreateSolidBrush(wxColourToRGB(GetForegroundColour()));
+                    AutoHBRUSH fgBrush(wxColourToRGB(GetForegroundColour()));
                     HPEN hPen = CreatePen(PS_SOLID, 1, wxColourToRGB(GetForegroundColour()));
                     SelectObject(nmtbcd->nmcd.hdc, hPen);
                     SelectObject(nmtbcd->nmcd.hdc, fgBrush);

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1699,8 +1699,7 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
 
             case CDDS_ITEMPOSTPAINT: {
                 // custom draw the drop-down arrow here, as it is always black
-                TBBUTTONINFO bi = { 0 };
-                bi.cbSize = sizeof(TBBUTTONINFO);
+                WinStruct<TBBUTTONINFO> bi;
                 bi.dwMask = TBIF_STYLE | TBIF_COMMAND;
                 int itemIndex = (int) ::SendMessage(GetHwnd(), TB_GETBUTTONINFO, (WPARAM)nmtbcd->nmcd.dwItemSpec, (LPARAM)&bi);
                 if (itemIndex >= 0 && bi.fsStyle & TBSTYLE_DROPDOWN) {


### PR DESCRIPTION
As you can see here, the dropdown arrows are barely visible and this is an MSW issue as there is no way to change that:

![image](https://github.com/user-attachments/assets/212b96a5-8213-4f18-af1b-dc97b8c4b252)

Drawing of the icon is now customized and uses the foreground color now:

![image](https://github.com/user-attachments/assets/c490f648-1e32-45c1-a0b2-6e72de3d9b83)
