### PR TITLE
Set info bar colors in create only if not set

### DIFF
--- a/src/generic/infobar.cpp
+++ b/src/generic/infobar.cpp
@@ -66,7 +66,8 @@ bool wxInfoBarGeneric::Create(wxWindow *parent, wxWindowID winid)
         return false;
 
     // use special, easy to notice, colours
-    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOBK));
+    if( !m_hasBgCol )
+        SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOBK));
 
     // create the controls: icon, text and the button to dismiss the
     // message.
@@ -77,7 +78,8 @@ bool wxInfoBarGeneric::Create(wxWindow *parent, wxWindowID winid)
     m_text = new wxStaticText(this, wxID_ANY, wxString(),
                               wxDefaultPosition, wxDefaultSize,
                               wxST_ELLIPSIZE_MIDDLE);
-    m_text->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOTEXT));
+    if(!m_hasFgCol)
+      m_text->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOTEXT));
 
     m_button = wxBitmapButton::NewCloseButton(this, wxID_ANY);
     m_button->SetToolTip(_("Hide this notification message."));

--- a/src/generic/infobar.cpp
+++ b/src/generic/infobar.cpp
@@ -78,8 +78,9 @@ bool wxInfoBarGeneric::Create(wxWindow *parent, wxWindowID winid)
     m_text = new wxStaticText(this, wxID_ANY, wxString(),
                               wxDefaultPosition, wxDefaultSize,
                               wxST_ELLIPSIZE_MIDDLE);
+
     if(!m_hasFgCol)
-      m_text->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOTEXT));
+        m_text->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_INFOTEXT));
 
     m_button = wxBitmapButton::NewCloseButton(this, wxID_ANY);
     m_button->SetToolTip(_("Hide this notification message."));


### PR DESCRIPTION
We cannot set the background and foreground colors of the infobar before we create the infobar because these colors are set in the method for creating the infobar. If we change them later, then the close button will not fit well because it uses the background color of the infobar we want to change, so we would also need to change the background color of the close button, but there is no function to get the button. Simple solution is to just set FG and BG color if this hasn't happened yet.

Before:
![image](https://github.com/user-attachments/assets/99d32fdc-0b12-42be-8b27-f2d16982524e)

After:
![image](https://github.com/user-attachments/assets/25da719a-e173-4dad-beee-a655d6762b1d)


