### PR TITLE
Fully disassociate HWND in OnEndSession

### DIFF
--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -879,7 +879,7 @@ void wxApp::OnEndSession(wxCloseEvent& WXUNUSED(event))
     // destroyed: this will result in a leak of a HWND, of course, but who
     // cares when the process is being killed anyhow
     if ( !wxTopLevelWindows.empty() )
-        wxTopLevelWindows[0]->SetHWND(0);
+        wxTopLevelWindows[0]->DissociateHandle();
 
     // Destroy all the remaining TLWs before calling OnExit() to have the same
     // sequence of events in this case as in case of the normal shutdown,


### PR DESCRIPTION
It is important to also remove the `HWND` from HWND-to-wxWindow mapping, because `~wxWindow` won't do it after setting its `HWND` to null. Otherwise `wxWndProc` may crash trying to access a window that was already deleted.

I *think* this is safe to do, because the window is already FUBAR when you set its HWND to 0; also restoring its wndproc, which this change does, is not going to make a significant difference. That is, unless some late-stage win32 event still need to be delivered to wxWindow right before deletion? [^1]

Tested with `rmlogotest.exe`. Should go to 3.2 too.

[^1]: I found this while debugging Sentry reports of double-deletion crashes (where `WM_ENDSESSION` would be processed while already in a window's destructor in response to `WM_QUERYENDSESSION`; this patch does not fix that much more involved situation) — so some event processing does happen that late...
