### PR TITLE
Make wxWARN_UNUSED work with Clang (again)

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -282,8 +282,8 @@ typedef short int WXTYPE;
 /* wxWARN_UNUSED is used as an attribute to a class, stating that unused instances
    should be warned about (in case such warnings are enabled in the first place) */
 
-#ifdef __has_cpp_attribute
-    #if __has_cpp_attribute(warn_unused)
+#ifdef __has_attribute /* __has_cpp_attribute(warn_unused) would return false with Clang, */
+    #if __has_attribute(warn_unused) /* so use __has_attribute instead */
         #define wxWARN_UNUSED __attribute__((warn_unused))
     #endif
 #endif


### PR DESCRIPTION
Checking for availability of 'warn_unused' using `__has_cpp_attribute` evaluates to false with Clang, even when the attribute is actually available. `__has_attribute` gives the correct result, so use it instead, despite the aesthetical inconsitency with other checks.

See also: PR #24833

I wish the CI could be used to ensure that something *does* fail to compile, but no idea if that is possible.