### PR TITLE
Make wxMSW date/time picker controls locale aware

### DIFF
--- a/include/wx/msw/datetimectrl.h
+++ b/include/wx/msw/datetimectrl.h
@@ -51,6 +51,9 @@ protected:
 #if wxUSE_INTL
     // Override to return the date/time format used by this control.
     virtual wxLocaleInfo MSWGetFormat() const = 0;
+
+    // Set the format used by the native control.
+    void MSWSetTimeFormat(wxLocaleInfo index);
 #endif // wxUSE_INTL
 
     // Override to indicate whether we can have no date at all.

--- a/include/wx/msw/private/uilocale.h
+++ b/include/wx/msw/private/uilocale.h
@@ -21,4 +21,6 @@
 
 WXDLLIMPEXP_BASE wxString wxTranslateFromUnicodeFormat(const wxString& fmt);
 
+WXDLLIMPEXP_BASE wxString wxGetMSWDateTimeFormat(wxLocaleInfo index);
+
 #endif // _WX_MSW_PRIVATE_UILOCALE_H_

--- a/include/wx/msw/timectrl.h
+++ b/include/wx/msw/timectrl.h
@@ -10,6 +10,8 @@
 #ifndef _WX_MSW_TIMECTRL_H_
 #define _WX_MSW_TIMECTRL_H_
 
+#include "wx/uilocale.h"
+
 // ----------------------------------------------------------------------------
 // wxTimePickerCtrl
 // ----------------------------------------------------------------------------
@@ -39,12 +41,7 @@ public:
                 const wxSize& size = wxDefaultSize,
                 long style = wxTP_DEFAULT,
                 const wxValidator& validator = wxDefaultValidator,
-                const wxString& name = wxTimePickerCtrlNameStr)
-    {
-        return MSWCreateDateTimePicker(parent, id, dt,
-                                       pos, size, style,
-                                       validator, name);
-    }
+                const wxString& name = wxTimePickerCtrlNameStr);
 
     // Override MSW-specific functions used during control creation.
     virtual WXDWORD MSWGetStyle(long style, WXDWORD *exstyle) const override;

--- a/src/msw/datectrl.cpp
+++ b/src/msw/datectrl.cpp
@@ -32,6 +32,8 @@
 
 #include "wx/datectrl.h"
 #include "wx/dateevt.h"
+#include "wx/uilocale.h"
+#include "wx/msw/private/uilocale.h"
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxDatePickerCtrl, wxControl);
 
@@ -57,9 +59,16 @@ wxDatePickerCtrl::Create(wxWindow *parent,
     if ( !(style & wxDP_DROPDOWN) )
         style |= wxDP_SPIN;
 
-    return MSWCreateDateTimePicker(parent, id, dt,
-                                   pos, size, style,
-                                   validator, name);
+    bool ok = MSWCreateDateTimePicker(parent, id, dt,
+                                      pos, size, style,
+                                      validator, name);
+#if wxUSE_INTL
+    if (ok)
+    {
+        MSWSetTimeFormat(wxLOCALE_SHORT_DATE_FMT);
+    }
+#endif
+    return ok;
 }
 
 WXDWORD wxDatePickerCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const

--- a/src/msw/datetimectrl.cpp
+++ b/src/msw/datetimectrl.cpp
@@ -32,6 +32,7 @@
 #endif // WX_PRECOMP
 
 #include "wx/msw/private/datecontrols.h"
+#include "wx/msw/private/uilocale.h"
 
 // apparently some versions of mingw define these macros erroneously
 #ifndef DateTime_GetSystemtime
@@ -120,6 +121,16 @@ wxDateTimePickerCtrl::MSWCreateDateTimePicker(wxWindow *parent,
     }
 
     return true;
+}
+
+void wxDateTimePickerCtrl::MSWSetTimeFormat(wxLocaleInfo index)
+{
+    const wxString format = wxGetMSWDateTimeFormat(index);
+    if ( !format.empty() )
+    {
+        DateTime_SetFormat(GetHwnd(),
+                           static_cast<const wchar_t*>(format.t_str()));
+    }
 }
 
 void wxDateTimePickerCtrl::SetValue(const wxDateTime& dt)

--- a/src/msw/timectrl.cpp
+++ b/src/msw/timectrl.cpp
@@ -27,11 +27,35 @@
 #include "wx/timectrl.h"
 #include "wx/dateevt.h"
 
+#include "wx/msw/private/uilocale.h"
+
 wxIMPLEMENT_DYNAMIC_CLASS(wxTimePickerCtrl, wxControl);
 
 // ============================================================================
 // wxTimePickerCtrl implementation
 // ============================================================================
+
+bool
+wxTimePickerCtrl::Create(wxWindow *parent,
+                         wxWindowID id,
+                         const wxDateTime& dt,
+                         const wxPoint& pos,
+                         const wxSize& size,
+                         long style,
+                         const wxValidator& validator,
+                         const wxString& name)
+{
+    if ( !MSWCreateDateTimePicker(parent, id, dt,
+                                  pos, size, style,
+                                  validator, name) )
+        return false;
+
+#if wxUSE_INTL
+    MSWSetTimeFormat(wxLOCALE_TIME_FMT);
+#endif
+
+    return true;
+}
 
 WXDWORD wxTimePickerCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
 {

--- a/src/msw/uilocale.cpp
+++ b/src/msw/uilocale.cpp
@@ -109,6 +109,32 @@ LCTYPE wxGetLCTYPEFormatFromLocalInfo(wxLocaleInfo index)
     return 0;
 }
 
+WXDLLIMPEXP_BASE wxString wxGetMSWDateTimeFormat(wxLocaleInfo index)
+{
+    wxString format;
+    wxString localeName = wxUILocale::GetCurrent().GetName();
+    if (localeName.IsSameAs("C"))
+    {
+        localeName = "en-US";
+    }
+
+    const wchar_t* name = localeName.wc_str();
+    LCTYPE lctype = wxGetLCTYPEFormatFromLocalInfo(index);
+    if (lctype != 0)
+    {
+        wchar_t buf[256];
+        if (::GetLocaleInfoEx(name, lctype, buf, WXSIZEOF(buf)))
+        {
+            format = buf;
+        }
+        else
+        {
+            wxLogLastError(wxT("GetLocaleInfoEx"));
+        }
+    }
+    return format;
+}
+
 // ----------------------------------------------------------------------------
 // wxLocaleIdent::GetName() implementation for MSW
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Set the date/time format corresponding to the current locale after creating the control.

Closes #23965.