### PR TITLE
wxAUI notebook pages dragging-related fixes

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -334,6 +334,8 @@ public:
 
     const wxAuiManager& GetAuiManager() const { return m_mgr; }
 
+    void SetManagerFlags(unsigned int flags) { m_mgr.SetFlags(flags); }
+
     // Sets the normal font
     void SetNormalFont(const wxFont& font);
 

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -485,12 +485,12 @@ public:
     wxRect CalculateHintRect(
                  wxWindow* paneWindow,
                  const wxPoint& pt,
-                 const wxPoint& offset);
+                 const wxPoint& offset = wxPoint{});
 
     void DrawHintRect(
                  wxWindow* paneWindow,
                  const wxPoint& pt,
-                 const wxPoint& offset);
+                 const wxPoint& offset = wxPoint{});
 
     void UpdateHint(const wxRect& rect);
 

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -492,6 +492,10 @@ public:
                  const wxPoint& pt,
                  const wxPoint& offset);
 
+    void UpdateHint(const wxRect& rect);
+
+    // These functions are public for compatibility reasons, but should never
+    // be called directly, use UpdateHint() above instead.
     virtual void ShowHint(const wxRect& rect);
     virtual void HideHint();
 

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -321,6 +321,28 @@ public:
     virtual bool SetFont(const wxFont& font);
 
     /**
+        Sets the flags for the wxAuiManager used by wxAuiNotebook.
+
+        Please note that it makes sense to use only some of wxAuiManager flags,
+        documented in wxAuiManagerOption, with wxAuiNotebook, but the other
+        ones are simply ignored, so it is always possible to reuse the same
+        flags for the main wxAuiManager and the one used by the notebook.
+
+        Example of using this function to disable the fade effect for the
+        notebook:
+        @code
+            auiNotebook->SetManagerFlags(
+                wxAuiManager::GetManager()->GetFlags() & ~wxAUI_MGR_HINT_FADE
+            );
+        @endcode
+
+        @see wxAuiManager::SetFlags(), wxAuiManagerOption
+
+        @since 3.3.0
+    */
+    void SetManagerFlags(unsigned int flags);
+
+    /**
         Sets the font for measuring tab labels.
     */
     void SetMeasuringFont(const wxFont& font);

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -243,12 +243,15 @@ public:
         @param paneWindow The window pointer of the pane being dragged.
         @param pt The mouse position, in client coordinates.
         @param offset Describes the offset that the mouse is from the upper-left
-            corner of the item being dragged.
+            corner of the item being dragged, 0 by default (since wxWidgets
+            3.3.0, this parameter had to be specified in the earlier versions).
         @return The rectangle hint will be returned in screen coordinates if the pane
             would indeed become docked at the specified drop point.
             Otherwise, an empty rectangle is returned.
     */
-    wxRect CalculateHintRect(wxWindow* paneWindow, const wxPoint& pt, const wxPoint& offset);
+    wxRect CalculateHintRect(wxWindow* paneWindow,
+                             const wxPoint& pt,
+                             const wxPoint& offset = wxPoint{0, 0});
 
     /**
         Check if a key modifier is pressed (actually ::WXK_CONTROL or
@@ -284,8 +287,16 @@ public:
 
         Calling it is equivalent to calling CalculateHintRect() and
         UpdateHint() with the resulting rectangle.
+
+        @param paneWindow Window passed to CalculateHintRect().
+        @param pt Mouse position passed to CalculateHintRect().
+        @param offset Offset passed to CalculateHintRect(), 0 by default (since
+            wxWidgets 3.3.0, this parameter had to be specified in the earlier
+            versions).
     */
-    void DrawHintRect(wxWindow* paneWindow, const wxPoint& pt, const wxPoint& offset);
+    void DrawHintRect(wxWindow* paneWindow,
+                      const wxPoint& pt,
+                      const wxPoint& offset = wxPoint{0, 0});
 
     /**
         Returns an array of all panes managed by the frame manager.

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -281,6 +281,9 @@ public:
 
         It is rarely called, and is mostly used by controls implementing custom
         pane drag/drop behaviour.
+
+        Calling it is equivalent to calling CalculateHintRect() and
+        UpdateHint() with the resulting rectangle.
     */
     void DrawHintRect(wxWindow* paneWindow, const wxPoint& pt, const wxPoint& offset);
 
@@ -353,6 +356,8 @@ public:
 
     /**
         HideHint() hides any docking hint that may be visible.
+
+        @see UpdateHint()
     */
     virtual void HideHint();
 
@@ -518,10 +523,16 @@ public:
     void SetManagedWindow(wxWindow* managed_wnd);
 
     /**
-        This function is used by controls to explicitly show a hint window at the
-        specified rectangle. It is rarely called, and is mostly used by controls
-        implementing custom pane drag/drop behaviour.
-        The specified rectangle should be in screen coordinates.
+        This function is used to show a hint window at the specified rectangle.
+
+        It can be overridden to customize the hint appearance. When overriding
+        it, HideHint() should normally be also overridden as well.
+
+        Do not call this function directly to show the hint, use UpdateHint()
+        instead.
+
+        @param rect The area where the hint window should be shown, in screen
+            coordinates, or an empty rectangle to hide the window.
     */
     virtual void ShowHint(const wxRect& rect);
 
@@ -550,6 +561,18 @@ public:
         pane flicker to be avoided by updating the whole layout at one time.
     */
     void Update();
+
+    /**
+        Show or hide the hint window.
+
+        This function is mostly used internally.
+
+        @param rect The area where the hint window should be shown, in screen
+            coordinates, or an empty rectangle to hide the window.
+
+        @since 3.3.0
+     */
+    void UpdateHint(const wxRect& rect);
 
 protected:
 

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1185,6 +1185,15 @@ void MyFrame::OnManagerFlag(wxCommandEvent& event)
     if (flag)
     {
         m_mgr.SetFlags(m_mgr.GetFlags() ^ flag);
+
+        // Propagate the flags to the notebooks too.
+        for ( auto& pane : m_mgr.GetAllPanes() )
+        {
+            if (auto* nb = wxDynamicCast(pane.window, wxAuiNotebook) )
+            {
+                nb->SetManagerFlags(m_mgr.GetFlags());
+            }
+        }
     }
 
     m_mgr.Update();

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1550,6 +1550,16 @@ public:
         m_tabCtrlHeight = h;
     }
 
+    // As we don't have a valid HWND, the base class version doesn't work for
+    // this window, so override it to return the appropriate DPI.
+    wxSize GetDPI() const override
+    {
+        if (!m_tabs)
+            return wxWindow::GetDPI();
+
+        return m_tabs->GetDPI();
+    }
+
 protected:
     void DoSetSize(int x, int y,
                    int width, int height,

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2709,9 +2709,7 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
 
                 if (nb != this)
                 {
-                    wxRect hint_rect = tab_ctrl->GetClientRect();
-                    tab_ctrl->ClientToScreen(&hint_rect.x, &hint_rect.y);
-                    m_mgr.UpdateHint(hint_rect);
+                    m_mgr.UpdateHint(tab_ctrl->GetScreenRect());
                     return;
                 }
             }
@@ -2745,9 +2743,7 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
 
     if (dest_tabs)
     {
-        wxRect hint_rect = dest_tabs->GetRect();
-        ClientToScreen(&hint_rect.x, &hint_rect.y);
-        m_mgr.UpdateHint(hint_rect);
+        m_mgr.UpdateHint(dest_tabs->GetScreenRect());
     }
     else
     {

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2628,7 +2628,6 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
 {
     wxPoint screen_pt = ::wxGetMousePosition();
     wxPoint client_pt = ScreenToClient(screen_pt);
-    wxPoint zero(0,0);
 
     wxAuiTabCtrl* src_tabs = (wxAuiTabCtrl*)evt.GetEventObject();
     wxAuiTabCtrl* dest_tabs = GetTabCtrlFromPoint(client_pt);
@@ -2752,7 +2751,7 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
     }
     else
     {
-        m_mgr.DrawHintRect(m_dummyWnd, client_pt, zero);
+        m_mgr.DrawHintRect(m_dummyWnd, client_pt);
     }
 }
 
@@ -2911,10 +2910,8 @@ void wxAuiNotebook::OnTabEndDrag(wxAuiNotebookEvent& evt)
         }
         else
         {
-            wxPoint zero(0,0);
             wxRect rect = m_mgr.CalculateHintRect(m_dummyWnd,
-                                                  mouse_client_pt,
-                                                  zero);
+                                                  mouse_client_pt);
             if (rect.IsEmpty())
             {
                 // there is no suitable drop location here, exit out

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2712,7 +2712,7 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
                 {
                     wxRect hint_rect = tab_ctrl->GetClientRect();
                     tab_ctrl->ClientToScreen(&hint_rect.x, &hint_rect.y);
-                    m_mgr.ShowHint(hint_rect);
+                    m_mgr.UpdateHint(hint_rect);
                     return;
                 }
             }
@@ -2748,7 +2748,7 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
     {
         wxRect hint_rect = dest_tabs->GetRect();
         ClientToScreen(&hint_rect.x, &hint_rect.y);
-        m_mgr.ShowHint(hint_rect);
+        m_mgr.UpdateHint(hint_rect);
     }
     else
     {

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3218,10 +3218,13 @@ void wxAuiManager::OnHintFadeTimer(wxTimerEvent& WXUNUSED(event))
     ShowHint(m_lastHint);
 }
 
-void wxAuiManager::ShowHint(const wxRect& rect)
+void wxAuiManager::ShowHint(const wxRect& rectScreen)
 {
     wxOverlayDC dc(m_overlay, m_frame);
     dc.Clear();
+
+    wxRect rect = rectScreen;
+    m_frame->ScreenToClient(&rect.x, &rect.y);
 
     wxDCClipper clip(dc, rect);
 
@@ -3359,7 +3362,7 @@ void wxAuiManager::StartPaneDrag(wxWindow* pane_window,
 // first calls DoDrop() to determine the exact position the pane would
 // be at were if dropped.  If the pane would indeed become docked at the
 // specified drop point, the rectangle hint will be returned in
-// client coordinates.  Otherwise, an empty rectangle is returned.
+// screen coordinates.  Otherwise, an empty rectangle is returned.
 // |pane_window| is the window pointer of the pane being dragged, |pt| is
 // the mouse position, in client coordinates.  |offset| describes the offset
 // that the mouse is from the upper-left corner of the item being dragged
@@ -3430,15 +3433,15 @@ wxRect wxAuiManager::CalculateHintRect(wxWindow* pane_window,
 
     delete sizer;
 
-    if ( !rect.IsEmpty() )
-    {
-        rect.Offset( m_frame->GetClientAreaOrigin() );
+    if ( rect.IsEmpty() )
+        return rect;
 
-        if ( m_frame->GetLayoutDirection() == wxLayout_RightToLeft )
-        {
-            // Mirror rectangle in RTL mode
-            rect.x -= rect.GetWidth();
-        }
+    m_frame->ClientToScreen(&rect.x, &rect.y);
+
+    if ( m_frame->GetLayoutDirection() == wxLayout_RightToLeft )
+    {
+        // Mirror rectangle in RTL mode
+        rect.x -= rect.GetWidth();
     }
 
     return rect;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -4487,16 +4487,9 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
             }
             else
             {
-                wxRect rect(pos, m_actionPart->rect.GetSize());
-
-                if (!m_actionHintRect.IsEmpty())
-                {
-                    m_actionHintRect = wxRect();
-                }
-
                 // draw resize hint
-                m_actionHintRect = rect;
-                wxDrawOverlayResizeHint(m_frame, m_overlay, rect);
+                m_actionHintRect = wxRect(pos, m_actionPart->rect.GetSize());
+                wxDrawOverlayResizeHint(m_frame, m_overlay, m_actionHintRect);
             }
         }
     }

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -4496,7 +4496,6 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
 
                 // draw resize hint
                 m_actionHintRect = rect;
-                rect.SetPosition(rect.GetPosition() + m_frame->GetClientAreaOrigin());
                 wxDrawOverlayResizeHint(m_frame, m_overlay, rect);
             }
         }

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -826,8 +826,14 @@ bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
     if (pinfo.best_size == wxDefaultSize &&
         pinfo.window)
     {
-        pinfo.best_size = pinfo.window->GetBestSize();
+        // It's important to use the current window size and not the best size
+        // when adding a pane corresponding to a previously docked window: it
+        // shouldn't change its size if it's dragged and docked in a different
+        // place.
+        pinfo.best_size = pinfo.window->GetSize();
 
+        // But we still shouldn't make it too small.
+        pinfo.best_size.IncTo(pinfo.window->GetBestSize());
         pinfo.best_size.IncTo(pinfo.min_size);
     }
 

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -828,13 +828,7 @@ bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
     {
         pinfo.best_size = pinfo.window->GetBestSize();
 
-        if (pinfo.min_size != wxDefaultSize)
-        {
-            if (pinfo.best_size.x < pinfo.min_size.x)
-                pinfo.best_size.x = pinfo.min_size.x;
-            if (pinfo.best_size.y < pinfo.min_size.y)
-                pinfo.best_size.y = pinfo.min_size.y;
-        }
+        pinfo.best_size.IncTo(pinfo.min_size);
     }
 
 

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3455,13 +3455,18 @@ void wxAuiManager::DrawHintRect(wxWindow* pane_window,
                                 const wxPoint& pt,
                                 const wxPoint& offset)
 {
-    wxRect rect = CalculateHintRect(pane_window, pt, offset);
+    const wxRect rect = CalculateHintRect(pane_window, pt, offset);
+    if (rect != m_lastHint)
+        UpdateHint(rect);
+}
 
+void wxAuiManager::UpdateHint(const wxRect& rect)
+{
     if (rect.IsEmpty())
     {
         HideHint();
     }
-    else if (m_lastHint != rect) // if the hint rect is the same as last time, don't do anything
+    else
     {
         m_lastHint = rect;
 


### PR DESCRIPTION
This fixes user-visible #24890 and #24892, but, as discussed in the latter, I'm not sure if we shouldn't restore the old behaviour of `ShowHint()` and pass it the rectangle in screen coordinates.