### PR TITLE
Set HTML ids and search for them.

### DIFF
--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -229,6 +229,7 @@ public:
 
     const wxString& GetId() const { return m_id; }
     void SetId(const wxString& id) { m_id = id; }
+    bool HasId() const { return !m_id.IsEmpty(); }
 
     // returns the link associated with this cell. The position is position
     // within the cell so it varies from 0 to m_Width, from 0 to m_Height

--- a/samples/html/test/id.html
+++ b/samples/html/test/id.html
@@ -1,0 +1,339 @@
+<html>
+
+<head>
+    <title>id test</title>
+</head>
+
+<body>
+    <ul>
+        <li><a href="#h1">h1</a></li>
+        <li><a href="#h2">h2</a></li>
+        <li><a href="#h3">h3</a></li>
+        <li><a href="#h4">h4</a></li>
+        <li><a href="#h5">h5</a></li>
+        <li><a href="#h6">h6</a></li>
+        <li><a href="#p1">p1</a></li>
+        <li><a href="#div1">div1</a></li>
+        <li><a href="#span1">span1</a></li>
+        <li><a href="#br1">br1</a></li>
+        <li><a href="#a1">a1</a></li>
+        <li><a href="#dl1">dl1</a></li>
+        <li><a href="#dt1">dt1</a></li>
+        <li><a href="#dd1">dd1</a></li>
+        <li><a href="#ol1">ol1</a></li>
+        <li><a href="#ul1">ul1</a></li>
+        <li><a href="#li4">li4</a></li>
+        <li><a href="#hr1">hr1</a></li>
+        <li><a href="#pre1">pre1</a></li>
+        <li><a href="#table1">table1</a></li>
+        <li><a href="#blockquote1">blockquote1</a></li>
+    </ul>
+
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h1 id="h1">Header 1</h1>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h2 id="h2">Header 2</h2>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h3 id="h3">Header 3</h3>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h4 id="h4">Header 4</h4>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h5 id="h5">Header 5</h5>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h6 id="h6">Header 6</h6>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>p1</h6>
+    <p id="p1">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
+        et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea
+        takimata sanctus
+        </span> est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>span1</h6>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
+        et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea <span id="span1"> takimata sanctus</span> est Lorem ipsum dolor sit amet. Lorem
+        ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
+        magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+        gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>div1</h6>
+    <div id="div1">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+        labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea
+        rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+        amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+        erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no
+        sea takimata sanctus est Lorem ipsum dolor sit amet.</div>
+    <h6>a1</h6>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. <a id="a1">At</a> vero eos et accusam et justo duo dolores et ea
+        rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>br1</h6>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr,<br id="br1"> sed diam nonumy eirmod tempor invidunt ut
+        labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>dl1</h6>
+    <dl id="dl1">
+        <dt id="dt1">Beast of Bodmin</dt>
+        <dd id="dd1">A large feline inhabiting Bodmin Moor.</dd>
+
+        <dt id="dt2">Morgawr</dt>
+        <dd id="dd2">A sea serpent.</dd>
+
+        <dt id="dt3">Owlman</dt>
+        <dd id="dd3">A giant owl-like creature.</dd>
+    </dl>
+    <h6>ol1</h6>
+    <ol id="ol1">
+        <li id="li1">Mix flour, baking powder, sugar, and salt.</li>
+        <li id="li2">In another bowl, mix eggs, milk, and oil.</li>
+        <li id="li3">Stir both mixtures together.</li>
+        <li id="li4">Fill muffin tray 3/4 full.</li>
+        <li id="li5">Bake for 20 minutes.</li>
+    </ol>
+    <h6>ul1</h6>
+    <ul id="ul1">
+        <li id="li6">Milk</li>
+        <li id="li7">
+            Cheese
+            <ul id="ul2">
+                <li id="li8">Blue cheese</li>
+                <li id="li9">Feta</li>
+            </ul>
+        </li>
+    </ul>
+    <h6>hr1</h6>
+    <hr id="hr1">
+    <h6>pre1</h6>
+    <pre id="pre1">
+        L          TE
+          A       A
+            C    V
+             R A
+             DOU
+             LOU
+            REUSE
+            QUE TU
+            PORTES
+          ET QUI T'
+          ORNE O CI
+           VILISÉ
+          OTE-  TU VEUX
+           LA    BIEN
+          SI      RESPI
+                  RER       - Apollinaire
+      </pre>
+    <h6>table1</h6>
+    <table id="table1">
+        <caption>
+            Front-end web developer course 2021
+        </caption>
+        <thead>
+            <tr>
+                <th scope="col">Person</th>
+                <th scope="col">Most interest in</th>
+                <th scope="col">Age</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th scope="row">Chris</th>
+                <td>HTML tables</td>
+                <td>22</td>
+            </tr>
+            <tr>
+                <th scope="row">Dennis</th>
+                <td>Web accessibility</td>
+                <td>45</td>
+            </tr>
+            <tr>
+                <th scope="row">Sarah</th>
+                <td>JavaScript frameworks</td>
+                <td>29</td>
+            </tr>
+            <tr>
+                <th scope="row">Karen</th>
+                <td>Web performance</td>
+                <td>36</td>
+            </tr>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th scope="row" colspan="2">Average age</th>
+                <td>33</td>
+            </tr>
+        </tfoot>
+    </table>
+    <h6>blockquote1</h6>
+    <blockquote id="blockquote1">
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </blockquote>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+
+</body>
+
+</html>

--- a/samples/html/test/test.htm
+++ b/samples/html/test/test.htm
@@ -33,6 +33,8 @@
 <b><a href="cp1250.htm">i18n demo 2 (cp1250)</a></b>
 <p>
 <b><a href="regres.htm">some wxHTML regression tests</a></b>
+<p>
+<b><a href="id.html">id test</a></b>
 </font>
 
 <p>

--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -193,7 +193,7 @@ void wxHtmlCell::Layout(int WXUNUSED(w))
 
 const wxHtmlCell* wxHtmlCell::Find(int condition, const void* param) const
 {
-    return condition == wxHTML_COND_ISANCHOR && !GetId().IsEmpty() && GetId() == (*((const wxString*)param)) ? this : nullptr;
+    return condition == wxHTML_COND_ISANCHOR && HasId() && GetId() == *static_cast<const wxString*>(param) ? this : nullptr;
 }
 
 
@@ -1287,7 +1287,7 @@ const wxHtmlCell* wxHtmlContainerCell::Find(int condition, const void* param) co
             if (r) return r;
         }
     }
-    return condition == wxHTML_COND_ISANCHOR && !GetId().IsEmpty() && GetId() == (*((const wxString*)param)) ? this : nullptr;
+    return condition == wxHTML_COND_ISANCHOR && HasId() && GetId() == *static_cast<const wxString*>(param) ? this : nullptr;
 }
 
 

--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -191,9 +191,9 @@ void wxHtmlCell::Layout(int WXUNUSED(w))
 
 
 
-const wxHtmlCell* wxHtmlCell::Find(int WXUNUSED(condition), const void* WXUNUSED(param)) const
+const wxHtmlCell* wxHtmlCell::Find(int condition, const void* param) const
 {
-    return nullptr;
+    return condition == wxHTML_COND_ISANCHOR && !GetId().IsEmpty() && GetId() == (*((const wxString*)param)) ? this : nullptr;
 }
 
 
@@ -1287,7 +1287,7 @@ const wxHtmlCell* wxHtmlContainerCell::Find(int condition, const void* param) co
             if (r) return r;
         }
     }
-    return nullptr;
+    return condition == wxHTML_COND_ISANCHOR && !GetId().IsEmpty() && GetId() == (*((const wxString*)param)) ? this : nullptr;
 }
 
 

--- a/src/html/m_dflist.cpp
+++ b/src/html/m_dflist.cpp
@@ -35,16 +35,17 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
 
         if (tag.GetName() == wxT("DL"))
         {
-            if (m_WParser->GetContainer()->GetFirstChild() != nullptr)
+            if (m_WParser->GetContainer()->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
             }
+            m_WParser->GetContainer()->SetId(tag.GetParam(wxT("id")));
             m_WParser->GetContainer()->SetIndent(m_WParser->GetCharHeight(), wxHTML_INDENT_TOP);
 
             ParseInner(tag);
 
-            if (m_WParser->GetContainer()->GetFirstChild() != nullptr)
+            if (m_WParser->GetContainer()->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -57,6 +58,7 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
         {
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();
+            c->SetId(tag.GetParam(wxT("id")));
             c->SetAlignHor(wxHTML_ALIGN_LEFT);
             c->SetMinHeight(m_WParser->GetCharHeight());
             return false;
@@ -65,6 +67,7 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
         {
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();
+            c->SetId(tag.GetParam(wxT("id")));
             c->SetIndent(5 * m_WParser->GetCharWidth(), wxHTML_INDENT_LEFT);
             return false;
         }

--- a/src/html/m_dflist.cpp
+++ b/src/html/m_dflist.cpp
@@ -35,7 +35,7 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
 
         if (tag.GetName() == wxT("DL"))
         {
-            if (m_WParser->GetContainer()->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
+            if (m_WParser->GetContainer()->GetFirstChild() != nullptr || m_WParser->GetContainer()->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -45,7 +45,7 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
 
             ParseInner(tag);
 
-            if (m_WParser->GetContainer()->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
+            if (m_WParser->GetContainer()->GetFirstChild() != nullptr || m_WParser->GetContainer()->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();

--- a/src/html/m_fonts.cpp
+++ b/src/html/m_fonts.cpp
@@ -287,14 +287,13 @@ TAG_HANDLER_BEGIN(Hx, "H1,H2,H3,H4,H5,H6")
         }
 
         c = m_WParser->GetContainer();
-        if (c->GetFirstChild())
+        if (c->GetFirstChild() || !m_WParser->GetContainer()->GetId().IsEmpty())
         {
             m_WParser->CloseContainer();
-            m_WParser->OpenContainer();
-            c = m_WParser->GetContainer();
+            c = m_WParser->OpenContainer();
         }
-        c = m_WParser->GetContainer();
 
+        c->SetId(tag.GetParam(wxT("id")));
         c->SetAlign(tag);
         c->InsertCell(new wxHtmlFontCell(m_WParser->CreateCurrentFont()));
         c->SetIndent(m_WParser->GetCharHeight(), wxHTML_INDENT_TOP);

--- a/src/html/m_fonts.cpp
+++ b/src/html/m_fonts.cpp
@@ -287,7 +287,7 @@ TAG_HANDLER_BEGIN(Hx, "H1,H2,H3,H4,H5,H6")
         }
 
         c = m_WParser->GetContainer();
-        if (c->GetFirstChild() || !m_WParser->GetContainer()->GetId().IsEmpty())
+        if (c->GetFirstChild() || c->HasId())
         {
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();

--- a/src/html/m_hline.cpp
+++ b/src/html/m_hline.cpp
@@ -84,7 +84,9 @@ TAG_HANDLER_BEGIN(HR, "HR")
         sz = 1;
         tag.GetParamAsInt(wxT("SIZE"), &sz);
         HasShading = !(tag.HasParam(wxT("NOSHADE")));
-        c->InsertCell(new wxHtmlLineCell((int)((double)sz * m_WParser->GetPixelScale()), HasShading));
+        auto cell = new wxHtmlLineCell((int)((double)sz * m_WParser->GetPixelScale()), HasShading);
+        cell->SetId(tag.GetParam(wxT("id")));
+        c->InsertCell(cell);
 
         m_WParser->CloseContainer();
         m_WParser->OpenContainer();

--- a/src/html/m_image.cpp
+++ b/src/html/m_image.cpp
@@ -757,10 +757,11 @@ TAG_HANDLER_BEGIN(IMG, "IMG,MAP,AREA")
         {
             m_WParser->CloseContainer();
             m_WParser->OpenContainer();
-            wxString tmp;
-            if (tag.GetParamAsString(wxT("NAME"), &tmp))
+            wxString name, id;
+            if (tag.GetParamAsString(wxT("NAME"), &name) || tag.GetParamAsString(wxT("ID"), &id))
             {
-                wxHtmlImageMapCell *cel = new wxHtmlImageMapCell( tmp );
+                wxHtmlImageMapCell *cel = new wxHtmlImageMapCell( name );
+                cel->SetId(tag.GetParam(wxT("id")));
                 m_WParser->GetContainer()->InsertCell( cel );
             }
             ParseInner( tag );
@@ -787,6 +788,8 @@ TAG_HANDLER_BEGIN(IMG, "IMG,MAP,AREA")
                 {
                     cel = new wxHtmlImageMapAreaCell( wxHtmlImageMapAreaCell::RECT, coords, m_WParser->GetPixelScale() );
                 }
+                if (cel != nullptr)
+                    cel->SetId(tag.GetParam(wxT("id")));
                 wxString href;
                 if (cel != nullptr && tag.GetParamAsString(wxT("HREF"), &href))
                     cel->SetLink(wxHtmlLinkInfo(href, tag.GetParam(wxT("TARGET"))));

--- a/src/html/m_image.cpp
+++ b/src/html/m_image.cpp
@@ -761,6 +761,7 @@ TAG_HANDLER_BEGIN(IMG, "IMG,MAP,AREA")
             if (tag.GetParamAsString(wxT("NAME"), &name) || tag.GetParamAsString(wxT("ID"), &id))
             {
                 wxHtmlImageMapCell *cel = new wxHtmlImageMapCell( name );
+                // since the || operator is short-circuiting, we do not know if we got the id
                 cel->SetId(tag.GetParam(wxT("id")));
                 m_WParser->GetContainer()->InsertCell( cel );
             }

--- a/src/html/m_layout.cpp
+++ b/src/html/m_layout.cpp
@@ -95,7 +95,7 @@ TAG_HANDLER_BEGIN(P, "P")
 
     TAG_HANDLER_PROC(tag)
     {
-        if (m_WParser->GetContainer()->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
+        if (m_WParser->GetContainer()->GetFirstChild() != nullptr || m_WParser->GetContainer()->HasId())
         {
             m_WParser->CloseContainer();
             m_WParser->OpenContainer();
@@ -140,7 +140,7 @@ TAG_HANDLER_BEGIN(CENTER, "CENTER")
         wxHtmlContainerCell *c = m_WParser->GetContainer();
 
         m_WParser->SetAlign(wxHTML_ALIGN_CENTER);
-        if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
+        if (c->GetFirstChild() != nullptr || c->HasId())
         {
             m_WParser->CloseContainer();
             m_WParser->OpenContainer();
@@ -153,7 +153,7 @@ TAG_HANDLER_BEGIN(CENTER, "CENTER")
             ParseInner(tag);
 
             m_WParser->SetAlign(old);
-            if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
+            if (c->GetFirstChild() != nullptr || c->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -192,7 +192,7 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
             {
                 // As usual, reuse the current container if it's empty.
                 wxHtmlContainerCell *c = m_WParser->GetContainer();
-                if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
+                if (c->GetFirstChild() != nullptr || c->HasId())
                 {
                     // If not, open a new one.
                     m_WParser->CloseContainer();
@@ -228,7 +228,7 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
         {
             int old = m_WParser->GetAlign();
             wxHtmlContainerCell *c = m_WParser->GetContainer();
-            if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
+            if (c->GetFirstChild() != nullptr || c->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -246,7 +246,7 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
             ParseInner(tag);
 
             m_WParser->SetAlign(old);
-            if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
+            if (c->GetFirstChild() != nullptr || c->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();

--- a/src/html/m_layout.cpp
+++ b/src/html/m_layout.cpp
@@ -95,11 +95,12 @@ TAG_HANDLER_BEGIN(P, "P")
 
     TAG_HANDLER_PROC(tag)
     {
-        if (m_WParser->GetContainer()->GetFirstChild() != nullptr)
+        if (m_WParser->GetContainer()->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
         {
             m_WParser->CloseContainer();
             m_WParser->OpenContainer();
         }
+        m_WParser->GetContainer()->SetId(tag.GetParam(wxT("id")));
         m_WParser->GetContainer()->SetIndent(m_WParser->GetCharHeight(), wxHTML_INDENT_TOP);
         m_WParser->GetContainer()->SetAlign(tag);
         return false;
@@ -119,6 +120,7 @@ TAG_HANDLER_BEGIN(BR, "BR")
 
         m_WParser->CloseContainer();
         c = m_WParser->OpenContainer();
+        c->SetId(tag.GetParam(wxT("id")));
         c->SetAlignHor(al);
         c->SetAlign(tag);
         c->SetMinHeight(m_WParser->GetCharHeight());
@@ -138,7 +140,7 @@ TAG_HANDLER_BEGIN(CENTER, "CENTER")
         wxHtmlContainerCell *c = m_WParser->GetContainer();
 
         m_WParser->SetAlign(wxHTML_ALIGN_CENTER);
-        if (c->GetFirstChild() != nullptr)
+        if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
         {
             m_WParser->CloseContainer();
             m_WParser->OpenContainer();
@@ -151,7 +153,7 @@ TAG_HANDLER_BEGIN(CENTER, "CENTER")
             ParseInner(tag);
 
             m_WParser->SetAlign(old);
-            if (c->GetFirstChild() != nullptr)
+            if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -179,7 +181,9 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
             if(style.IsSameAs(wxT("PAGE-BREAK-BEFORE:ALWAYS"), false))
             {
                 m_WParser->CloseContainer();
-                m_WParser->OpenContainer()->InsertCell(new wxHtmlPageBreakCell);
+                auto cell = new wxHtmlPageBreakCell;
+                cell->SetId(tag.GetParam(wxT("id")));
+                m_WParser->OpenContainer()->InsertCell(cell);
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
                 return false;
@@ -188,13 +192,14 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
             {
                 // As usual, reuse the current container if it's empty.
                 wxHtmlContainerCell *c = m_WParser->GetContainer();
-                if (c->GetFirstChild() != nullptr)
+                if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
                 {
                     // If not, open a new one.
                     m_WParser->CloseContainer();
                     c = m_WParser->OpenContainer();
                 }
 
+                c->SetId(tag.GetParam(wxT("id")));
                 // Force this container to live entirely on the same page.
                 c->SetCanLiveOnPagebreak(false);
 
@@ -223,7 +228,7 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
         {
             int old = m_WParser->GetAlign();
             wxHtmlContainerCell *c = m_WParser->GetContainer();
-            if (c->GetFirstChild() != nullptr)
+            if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -236,11 +241,12 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
                 c->SetAlign(tag);
                 m_WParser->SetAlign(c->GetAlignHor());
             }
+            c->SetId(tag.GetParam(wxT("id")));
 
             ParseInner(tag);
 
             m_WParser->SetAlign(old);
-            if (c->GetFirstChild() != nullptr)
+            if (c->GetFirstChild() != nullptr || !m_WParser->GetContainer()->GetId().IsEmpty())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -258,6 +264,7 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
 
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();
+            c->SetId(tag.GetParam(wxT("id")));
             c->SetAlignHor(al);
             c->SetAlign(tag);
             c->SetMinHeight(m_WParser->GetCharHeight());
@@ -354,6 +361,7 @@ TAG_HANDLER_BEGIN(BLOCKQUOTE, "BLOCKQUOTE")
         m_WParser->CloseContainer();
         c = m_WParser->OpenContainer();
 
+        c->SetId(tag.GetParam(wxT("id")));
         if (c->GetAlignHor() == wxHTML_ALIGN_RIGHT)
             c->SetIndent(5 * m_WParser->GetCharWidth(), wxHTML_INDENT_RIGHT);
         else

--- a/src/html/m_links.cpp
+++ b/src/html/m_links.cpp
@@ -38,7 +38,7 @@ public:
     virtual const wxHtmlCell* Find(int condition, const void* param) const override
     {
         if ((condition == wxHTML_COND_ISANCHOR) &&
-            (m_AnchorName == (*((const wxString*)param)) || (!GetId().IsEmpty() && GetId() == (*((const wxString*)param)))))
+            (m_AnchorName == *static_cast<const wxString*>(param) || (HasId() && GetId() == *static_cast<const wxString*>(param))))
         {
             return this;
         }
@@ -62,6 +62,7 @@ TAG_HANDLER_BEGIN(A, "A")
         if (tag.GetParamAsString(wxT("NAME"), &name) || tag.GetParamAsString(wxT("ID"), &id))
         {
             auto cell = new wxHtmlAnchorCell(name);
+            // since the || operator is short-circuiting, we do not know if we got the id
             cell->SetId(tag.GetParam(wxT("id")));
             m_WParser->GetContainer()->InsertCell(cell);
         }

--- a/src/html/m_links.cpp
+++ b/src/html/m_links.cpp
@@ -38,7 +38,7 @@ public:
     virtual const wxHtmlCell* Find(int condition, const void* param) const override
     {
         if ((condition == wxHTML_COND_ISANCHOR) &&
-            (m_AnchorName == (*((const wxString*)param))))
+            (m_AnchorName == (*((const wxString*)param)) || (!GetId().IsEmpty() && GetId() == (*((const wxString*)param)))))
         {
             return this;
         }
@@ -58,10 +58,12 @@ TAG_HANDLER_BEGIN(A, "A")
 
     TAG_HANDLER_PROC(tag)
     {
-        wxString name;
-        if (tag.GetParamAsString(wxT("NAME"), &name))
+        wxString name, id;
+        if (tag.GetParamAsString(wxT("NAME"), &name) || tag.GetParamAsString(wxT("ID"), &id))
         {
-            m_WParser->GetContainer()->InsertCell(new wxHtmlAnchorCell(name));
+            auto cell = new wxHtmlAnchorCell(name);
+            cell->SetId(tag.GetParam(wxT("id")));
+            m_WParser->GetContainer()->InsertCell(cell);
         }
 
         wxString href;

--- a/src/html/m_list.cpp
+++ b/src/html/m_list.cpp
@@ -258,7 +258,9 @@ TAG_HANDLER_BEGIN(OLULLI, "OL,UL,LI")
 
             m_List->AddRow(mark, c);
             c = m_WParser->OpenContainer();
-            m_WParser->SetContainer(new wxHtmlListcontentCell(c));
+            auto cell = new wxHtmlListcontentCell(c);
+            cell->SetId(tag.GetParam(wxT("id")));
+            m_WParser->SetContainer(cell);
 
             if (m_Numbering != 0) m_Numbering++;
         }
@@ -276,6 +278,7 @@ TAG_HANDLER_BEGIN(OLULLI, "OL,UL,LI")
 
             wxHtmlListCell *oldList = m_List;
             m_List = new wxHtmlListCell(c);
+            m_List->SetId(tag.GetParam(wxT("id")));
             m_List->SetIndent(2 * m_WParser->GetCharWidth(), wxHTML_INDENT_LEFT);
 
             ParseInner(tag);

--- a/src/html/m_pre.cpp
+++ b/src/html/m_pre.cpp
@@ -100,6 +100,7 @@ TAG_HANDLER_BEGIN(PRE, "PRE")
 
         m_WParser->CloseContainer();
         c = m_WParser->OpenContainer();
+        c->SetId(tag.GetParam(wxT("id")));
         c->SetWidthFloat(tag);
         c = m_WParser->OpenContainer();
         c->SetAlignHor(wxHTML_ALIGN_LEFT);

--- a/src/html/m_span.cpp
+++ b/src/html/m_span.cpp
@@ -38,6 +38,10 @@ TAG_HANDLER_BEGIN(SPAN, "SPAN" )
         int oldunderlined = m_WParser->GetFontUnderlined();
         wxString oldfontface = m_WParser->GetFontFace();
 
+        auto cell = new wxHtmlFontCell(m_WParser->CreateCurrentFont());
+        cell->SetId(tag.GetParam(wxT("id")));
+        m_WParser->GetContainer()->InsertCell(cell);
+
         // Load any style parameters
         wxHtmlStyleParams styleParams(tag);
 

--- a/src/html/m_tables.cpp
+++ b/src/html/m_tables.cpp
@@ -730,6 +730,7 @@ TAG_HANDLER_BEGIN(TABLE, "TABLE,TR,TD,TH")
             m_enclosingContainer = c = m_WParser->OpenContainer();
 
             m_Table = new wxHtmlTableCell(c, tag, m_WParser->GetPixelScale());
+            m_Table->SetId(tag.GetParam(wxT("id")));
 
             // width:
             {


### PR DESCRIPTION
Fixes #17728.

I noticed the problem when trying to use [xCHM](https://github.com/rzvncj/xCHM) - a CHM reader. It is almost unusable because it does not jump to a fragment like `#tab-completion-and-history-editing` in the URL `file:E:\\python.chm#xchm://tutorial/interactive.html#tab-completion-and-history-editing`. `#tab-completion-and-history-editing` is the ID of an HTML element and the browser can jump to such a fragment ID.