### PR TITLE
wxHtmlPrintout i18n and DPI fixes

### DIFF
--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -118,7 +118,7 @@ enum {
 class WXDLLIMPEXP_HTML wxHtmlPrintout : public wxPrintout
 {
 public:
-    wxHtmlPrintout(const wxString& title = _("Printout"));
+    wxHtmlPrintout(const wxString& title = /* TRANSLATORS: HTML printout default title. */_("Printout"));
 
     void SetHtmlText(const wxString& html, const wxString &basepath = wxEmptyString, bool isdir = true);
             // prepares the class for printing this html document.
@@ -231,7 +231,7 @@ private:
 class WXDLLIMPEXP_HTML wxHtmlEasyPrinting : public wxObject
 {
 public:
-    wxHtmlEasyPrinting(const wxString& name = _("Printing"),
+    wxHtmlEasyPrinting(const wxString& name = /* TRANSLATORS: HTML easy print default title. */_("Printing"),
                        wxWindow *parentWindow = nullptr);
     virtual ~wxHtmlEasyPrinting();
 

--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -118,7 +118,7 @@ enum {
 class WXDLLIMPEXP_HTML wxHtmlPrintout : public wxPrintout
 {
 public:
-    wxHtmlPrintout(const wxString& title = wxGETTEXT_IN_CONTEXT(L"HTML printout default title", L"Printout"));
+    wxHtmlPrintout(const wxString& title = _("Printout"));
 
     void SetHtmlText(const wxString& html, const wxString &basepath = wxEmptyString, bool isdir = true);
             // prepares the class for printing this html document.
@@ -231,7 +231,7 @@ private:
 class WXDLLIMPEXP_HTML wxHtmlEasyPrinting : public wxObject
 {
 public:
-    wxHtmlEasyPrinting(const wxString& name = wxGETTEXT_IN_CONTEXT(L"HTML easy printer default title", L"Printing"),
+    wxHtmlEasyPrinting(const wxString& name = _("Printing"),
                        wxWindow *parentWindow = nullptr);
     virtual ~wxHtmlEasyPrinting();
 

--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -118,7 +118,7 @@ enum {
 class WXDLLIMPEXP_HTML wxHtmlPrintout : public wxPrintout
 {
 public:
-    wxHtmlPrintout(const wxString& title = wxT("Printout"));
+    wxHtmlPrintout(const wxString& title = _("Printout"));
 
     void SetHtmlText(const wxString& html, const wxString &basepath = wxEmptyString, bool isdir = true);
             // prepares the class for printing this html document.
@@ -231,7 +231,7 @@ private:
 class WXDLLIMPEXP_HTML wxHtmlEasyPrinting : public wxObject
 {
 public:
-    wxHtmlEasyPrinting(const wxString& name = wxT("Printing"), wxWindow *parentWindow = nullptr);
+    wxHtmlEasyPrinting(const wxString& name = _("Printing"), wxWindow *parentWindow = nullptr);
     virtual ~wxHtmlEasyPrinting();
 
     bool PreviewFile(const wxString &htmlfile);

--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -118,7 +118,7 @@ enum {
 class WXDLLIMPEXP_HTML wxHtmlPrintout : public wxPrintout
 {
 public:
-    wxHtmlPrintout(const wxString& title = _("Printout"));
+    wxHtmlPrintout(const wxString& title = wxGETTEXT_IN_CONTEXT("HTML printout default title", "Printout"));
 
     void SetHtmlText(const wxString& html, const wxString &basepath = wxEmptyString, bool isdir = true);
             // prepares the class for printing this html document.
@@ -231,7 +231,8 @@ private:
 class WXDLLIMPEXP_HTML wxHtmlEasyPrinting : public wxObject
 {
 public:
-    wxHtmlEasyPrinting(const wxString& name = _("Printing"), wxWindow *parentWindow = nullptr);
+    wxHtmlEasyPrinting(const wxString& name = wxGETTEXT_IN_CONTEXT("HTML easy printer default title", "Printing"),
+                       wxWindow *parentWindow = nullptr);
     virtual ~wxHtmlEasyPrinting();
 
     bool PreviewFile(const wxString &htmlfile);

--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -118,7 +118,7 @@ enum {
 class WXDLLIMPEXP_HTML wxHtmlPrintout : public wxPrintout
 {
 public:
-    wxHtmlPrintout(const wxString& title = wxGetTranslation("Printout", wxString(), "HTML printout default title"));
+    wxHtmlPrintout(const wxString& title = wxGetTranslation(wxString("Printout"), wxString(), wxString("HTML printout default title")));
 
     void SetHtmlText(const wxString& html, const wxString &basepath = wxEmptyString, bool isdir = true);
             // prepares the class for printing this html document.
@@ -231,7 +231,7 @@ private:
 class WXDLLIMPEXP_HTML wxHtmlEasyPrinting : public wxObject
 {
 public:
-    wxHtmlEasyPrinting(const wxString& name = wxGetTranslation("Printing", wxString(), "HTML easy printer default title"),
+    wxHtmlEasyPrinting(const wxString& name = wxGetTranslation(wxString("Printing"), wxString(), wxString("HTML easy printer default title")),
                        wxWindow *parentWindow = nullptr);
     virtual ~wxHtmlEasyPrinting();
 

--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -118,7 +118,7 @@ enum {
 class WXDLLIMPEXP_HTML wxHtmlPrintout : public wxPrintout
 {
 public:
-    wxHtmlPrintout(const wxString& title = wxGETTEXT_IN_CONTEXT("HTML printout default title", "Printout"));
+    wxHtmlPrintout(const wxString& title = wxGetTranslation("Printout", wxString(), "HTML printout default title"));
 
     void SetHtmlText(const wxString& html, const wxString &basepath = wxEmptyString, bool isdir = true);
             // prepares the class for printing this html document.
@@ -231,7 +231,7 @@ private:
 class WXDLLIMPEXP_HTML wxHtmlEasyPrinting : public wxObject
 {
 public:
-    wxHtmlEasyPrinting(const wxString& name = wxGETTEXT_IN_CONTEXT("HTML easy printer default title", "Printing"),
+    wxHtmlEasyPrinting(const wxString& name = wxGetTranslation("Printing", wxString(), "HTML easy printer default title"),
                        wxWindow *parentWindow = nullptr);
     virtual ~wxHtmlEasyPrinting();
 

--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -118,7 +118,7 @@ enum {
 class WXDLLIMPEXP_HTML wxHtmlPrintout : public wxPrintout
 {
 public:
-    wxHtmlPrintout(const wxString& title = wxGetTranslation(wxString("Printout"), wxString(), wxString("HTML printout default title")));
+    wxHtmlPrintout(const wxString& title = wxGETTEXT_IN_CONTEXT(wxString("HTML printout default title"), wxString("Printout")));
 
     void SetHtmlText(const wxString& html, const wxString &basepath = wxEmptyString, bool isdir = true);
             // prepares the class for printing this html document.
@@ -231,7 +231,7 @@ private:
 class WXDLLIMPEXP_HTML wxHtmlEasyPrinting : public wxObject
 {
 public:
-    wxHtmlEasyPrinting(const wxString& name = wxGetTranslation(wxString("Printing"), wxString(), wxString("HTML easy printer default title")),
+    wxHtmlEasyPrinting(const wxString& name = wxGETTEXT_IN_CONTEXT(wxString("HTML easy printer default title"), wxString("Printing")),
                        wxWindow *parentWindow = nullptr);
     virtual ~wxHtmlEasyPrinting();
 

--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -118,7 +118,7 @@ enum {
 class WXDLLIMPEXP_HTML wxHtmlPrintout : public wxPrintout
 {
 public:
-    wxHtmlPrintout(const wxString& title = wxGETTEXT_IN_CONTEXT(wxString("HTML printout default title"), wxString("Printout")));
+    wxHtmlPrintout(const wxString& title = wxGETTEXT_IN_CONTEXT(L"HTML printout default title", L"Printout"));
 
     void SetHtmlText(const wxString& html, const wxString &basepath = wxEmptyString, bool isdir = true);
             // prepares the class for printing this html document.
@@ -231,7 +231,7 @@ private:
 class WXDLLIMPEXP_HTML wxHtmlEasyPrinting : public wxObject
 {
 public:
-    wxHtmlEasyPrinting(const wxString& name = wxGETTEXT_IN_CONTEXT(wxString("HTML easy printer default title"), wxString("Printing")),
+    wxHtmlEasyPrinting(const wxString& name = wxGETTEXT_IN_CONTEXT(L"HTML easy printer default title", L"Printing"),
                        wxWindow *parentWindow = nullptr);
     virtual ~wxHtmlEasyPrinting();
 

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -709,7 +709,7 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
     }
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
-                                wxString::Format(_("%s Preview"), m_Name),
+                                wxString::Format(/* TRANSLATORS: %s may be a document title. */_("%s Preview"), m_Name),
                                 wxDefaultPosition,
                                 wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
     frame->Centre(wxBOTH);

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -710,9 +710,9 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
         wxGetTranslation(wxString::Format(_("%s Preview"), m_Name), wxString(),
-            "HTML easy printer preview title (%s may be the name of the document)"),
-                                               wxDefaultPosition,
-                                               wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
+            wxString("HTML easy printer preview title (%s may be the name of the document)")),
+        wxDefaultPosition,
+        wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
     frame->Centre(wxBOTH);
     frame->Initialize();
     frame->Show(true);

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -709,10 +709,9 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
     }
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
-            wxGETTEXT_IN_CONTEXT(L"HTML easy printer preview title (%s may be the name of the document)",
-                                 wxString::Format(_("%s Preview"), m_Name)),
-        wxDefaultPosition,
-        wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
+                                wxString::Format(_("%s Preview"), m_Name),
+                                wxDefaultPosition,
+                                wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
     frame->Centre(wxBOTH);
     frame->Initialize();
     frame->Show(true);

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -710,7 +710,7 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
                                                wxString::Format(_("%s Preview"), m_Name),
-                                               wxPoint(100, 100),
+                                               wxDefaultPosition,
                                                wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
     frame->Centre(wxBOTH);
     frame->Initialize();

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -709,8 +709,8 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
     }
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
-                                               wxGETTEXT_IN_CONTEXT("HTML easy printer preview title (%s may be the name of the document)",
-                                                                    wxString::Format(_("%s Preview"), m_Name)),
+        wxGetTranslation(wxString::Format(_("%s Preview"), m_Name), wxString(),
+            "HTML easy printer preview title (%s may be the name of the document)"),
                                                wxDefaultPosition,
                                                wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
     frame->Centre(wxBOTH);

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -709,7 +709,7 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
     }
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
-            wxGETTEXT_IN_CONTEXT(wxString("HTML easy printer preview title (%s may be the name of the document)"),
+            wxGETTEXT_IN_CONTEXT(L"HTML easy printer preview title (%s may be the name of the document)",
                                  wxString::Format(_("%s Preview"), m_Name)),
         wxDefaultPosition,
         wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -711,9 +711,7 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
                                                wxString::Format(_("%s Preview"), m_Name),
                                                wxPoint(100, 100),
-                                               m_ParentWindow ?
-                                                   m_ParentWindow->FromDIP(wxSize(650, 500)) :
-                                                   wxSize(650, 500));
+                                               wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
     frame->Centre(wxBOTH);
     frame->Initialize();
     frame->Show(true);

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -562,7 +562,7 @@ wxString wxHtmlPrintout::TranslateHeader(const wxString& instr, int page)
     num.Printf("%i", page);
     r.Replace("@PAGENUM@", num);
 
-    num.Printf("%lu", (unsigned long)(m_PageBreaks.size() - 1));
+    num.Printf("%zu", m_PageBreaks.size() - 1);
     r.Replace("@PAGESCNT@", num);
 
 #if wxUSE_DATETIME

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -709,7 +709,8 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
     }
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
-                                               wxString::Format(_("%s Preview"), m_Name),
+                                               wxGETTEXT_IN_CONTEXT("HTML easy printer preview title (%s may be the name of the document)",
+                                                                    wxString::Format(_("%s Preview"), m_Name)),
                                                wxDefaultPosition,
                                                wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
     frame->Centre(wxBOTH);

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -559,22 +559,22 @@ wxString wxHtmlPrintout::TranslateHeader(const wxString& instr, int page)
     wxString r = instr;
     wxString num;
 
-    num.Printf(wxT("%i"), page);
-    r.Replace(wxT("@PAGENUM@"), num);
+    num.Printf("%i", page);
+    r.Replace("@PAGENUM@", num);
 
-    num.Printf(wxT("%lu"), (unsigned long)(m_PageBreaks.size() - 1));
-    r.Replace(wxT("@PAGESCNT@"), num);
+    num.Printf("%lu", (unsigned long)(m_PageBreaks.size() - 1));
+    r.Replace("@PAGESCNT@", num);
 
 #if wxUSE_DATETIME
     const wxDateTime now = wxDateTime::Now();
-    r.Replace(wxT("@DATE@"), now.FormatDate());
-    r.Replace(wxT("@TIME@"), now.FormatTime());
+    r.Replace("@DATE@", now.FormatDate());
+    r.Replace("@TIME@", now.FormatTime());
 #else
-    r.Replace(wxT("@DATE@"), wxEmptyString);
-    r.Replace(wxT("@TIME@"), wxEmptyString);
+    r.Replace("@DATE@", wxEmptyString);
+    r.Replace("@TIME@", wxEmptyString);
 #endif
 
-    r.Replace(wxT("@TITLE@"), GetTitle());
+    r.Replace("@TITLE@", GetTitle());
 
     return r;
 }
@@ -709,8 +709,11 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
     }
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
-                                               m_Name + _(" Preview"),
-                                               wxPoint(100, 100), wxSize(650, 500));
+                                               wxString::Format(_("%s Preview"), m_Name),
+                                               wxPoint(100, 100),
+                                               m_ParentWindow ?
+                                                   m_ParentWindow->FromDIP(wxSize(650, 500)) :
+                                                   wxSize(650, 500));
     frame->Centre(wxBOTH);
     frame->Initialize();
     frame->Show(true);

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -709,8 +709,8 @@ bool wxHtmlEasyPrinting::DoPreview(wxHtmlPrintout *printout1, wxHtmlPrintout *pr
     }
 
     wxPreviewFrame *frame = new wxPreviewFrame(preview, m_ParentWindow,
-        wxGetTranslation(wxString::Format(_("%s Preview"), m_Name), wxString(),
-            wxString("HTML easy printer preview title (%s may be the name of the document)")),
+            wxGETTEXT_IN_CONTEXT(wxString("HTML easy printer preview title (%s may be the name of the document)"),
+                                 wxString::Format(_("%s Preview"), m_Name)),
         wxDefaultPosition,
         wxWindow::FromDIP(wxSize(650, 500), m_ParentWindow));
     frame->Centre(wxBOTH);


### PR DESCRIPTION
Make default titles translatable, don't piece strings together for title
Also, make initial frame size DPI aware
Remove `wxT()` macros