### PR TITLE
Fixes for owner drawn `wxListBox` items background

### DIFF
--- a/include/wx/msw/private/listboxitem.h
+++ b/include/wx/msw/private/listboxitem.h
@@ -1,0 +1,56 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/msw/private/listboxitem.h
+// Purpose:     Declaration of the wxListBoxItem class.
+// Author:      Vadim Zeitlin
+// Created:     2024-10-27 (extracted from src/msw/listbox.cpp)
+// Copyright:   (c) 2024 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_MSW_PRIVATE_LISTBOXITEM_H_
+#define _WX_MSW_PRIVATE_LISTBOXITEM_H_
+
+#include "wx/ownerdrw.h"
+
+// ----------------------------------------------------------------------------
+// wxListBoxItemBase: base class for wxListBoxItem and wxCheckListBoxItem
+// ----------------------------------------------------------------------------
+
+// The template parameter is the control containing these items.
+template <typename T>
+class wxListBoxItemBase : public wxOwnerDrawn
+{
+public:
+    using Control = T;
+
+    explicit wxListBoxItemBase(Control *parent)
+        { m_parent = parent; }
+
+    Control *GetParent() const
+        { return m_parent; }
+
+    int GetIndex() const
+        { return m_parent->GetItemIndex(const_cast<wxListBoxItemBase*>(this)); }
+
+    wxString GetName() const override
+        { return m_parent->GetString(GetIndex()); }
+
+protected:
+    void
+    GetColourToUse(wxODStatus stat,
+                   wxColour& colText,
+                   wxColour& colBack) const override
+    {
+        wxOwnerDrawn::GetColourToUse(stat, colText, colBack);
+
+        // Default background colour for the owner drawn items is the menu one,
+        // but it's not appropriate for the listboxes, so override it here.
+        if ( !(stat & wxODSelected) && !GetBackgroundColour().IsOk() )
+            colBack = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
+    }
+
+private:
+    Control *m_parent;
+};
+
+#endif // _WX_MSW_PRIVATE_LISTBOXITEM_H_

--- a/samples/ownerdrw/ownerdrw.cpp
+++ b/samples/ownerdrw/ownerdrw.cpp
@@ -283,13 +283,15 @@ OwnerDrawnFrame::OwnerDrawnFrame()
             aszChoices          // array of strings
         );
 
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     unsigned int ui;
     for ( ui = 0; ui < WXSIZEOF(aszChoices); ui += 2 )
     {
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         m_pListBox->GetItem(ui)->SetBackgroundColour(*wxBLUE);
-#endif
     }
+
+    m_pListBox->GetItem(3)->SetTextColour(*wxRED);
+#endif
 
     m_pListBox->Check(2);
 

--- a/samples/ownerdrw/ownerdrw.cpp
+++ b/samples/ownerdrw/ownerdrw.cpp
@@ -276,11 +276,6 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
                                           "goodbye", "cruel", "world",
                                           "-------", "owner-drawn", "listbox" };
 
-    wxString *astrChoices = new wxString[WXSIZEOF(aszChoices)];
-    unsigned int ui;
-    for ( ui = 0; ui < WXSIZEOF(aszChoices); ui++ )
-        astrChoices[ui] = aszChoices[ui];
-
     m_pListBox = new wxCheckListBox
         (
             pPanel,             // parent
@@ -288,11 +283,10 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
             wxPoint(10, 10),    // listbox position
             wxSize(200, 200),   // listbox size
             WXSIZEOF(aszChoices), // number of strings
-            astrChoices         // array of strings
+            aszChoices          // array of strings
         );
 
-    delete [] astrChoices;
-
+    unsigned int ui;
     for ( ui = 0; ui < WXSIZEOF(aszChoices); ui += 2 )
     {
 #if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
@@ -307,13 +301,6 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
                                          "Green", "Yellow",
                                          "Black", "Violet"  };
 
-    astrChoices = new wxString[WXSIZEOF(aszColors)];
-
-    for ( ui = 0; ui < WXSIZEOF(aszColors); ui++ )
-    {
-        astrChoices[ui] = aszColors[ui];
-    }
-
     wxListBox *pListBox = new wxListBox
         (
             pPanel,              // parent
@@ -321,7 +308,7 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
             wxPoint(220, 10),    // listbox position
             wxSize(200, 200),    // listbox size
             WXSIZEOF(aszColors), // number of strings
-            astrChoices,         // array of strings
+            aszColors,           // array of strings
             wxLB_OWNERDRAW       // owner-drawn
         );
 
@@ -353,8 +340,6 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
 #else
     wxUnusedVar( pListBox );
 #endif
-
-    delete[] astrChoices;
 
     Show(true);
 }

--- a/samples/ownerdrw/ownerdrw.cpp
+++ b/samples/ownerdrw/ownerdrw.cpp
@@ -34,9 +34,7 @@ public:
 class OwnerDrawnFrame : public wxFrame
 {
 public:
-    // ctor & dtor
-    OwnerDrawnFrame(wxFrame *frame, const wxString& title, int x, int y, int w, int h);
-    ~OwnerDrawnFrame(){}
+    OwnerDrawnFrame();
 
     // notifications
     void OnQuit             (wxCommandEvent& event);
@@ -88,7 +86,7 @@ bool OwnerDrawnApp::OnInit(void)
     if ( !wxApp::OnInit() )
         return false;
 
-    new OwnerDrawnFrame(nullptr, "wxWidgets Ownerdraw Sample", 50, 50, 450, 340);
+    new OwnerDrawnFrame();
 
     return true;
 }
@@ -250,9 +248,8 @@ void OwnerDrawnFrame::InitMenu()
 }
 
 // main frame constructor
-OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
-                                 int x, int y, int w, int h)
-         : wxFrame(frame, wxID_ANY, title, wxPoint(x, y), wxSize(w, h))
+OwnerDrawnFrame::OwnerDrawnFrame()
+         : wxFrame(nullptr, wxID_ANY, "wxWidgets Ownerdraw Sample")
 {
     // set the icon
     SetIcon(wxICON(sample));
@@ -262,7 +259,7 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
 
 #if wxUSE_STATUSBAR
     // create the status line
-    const int widths[] = { -1, 60 };
+    const int widths[] = { -1, FromDIP(60) };
     CreateStatusBar(2);
     SetStatusWidths(2, widths);
     SetStatusText("no selection", 0);
@@ -280,8 +277,8 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
         (
             pPanel,             // parent
             Control_Listbox,    // control id
-            wxPoint(10, 10),    // listbox position
-            wxSize(200, 200),   // listbox size
+            FromDIP(wxPoint(10, 10)),    // listbox position
+            FromDIP(wxSize(200, 200)),   // listbox size
             WXSIZEOF(aszChoices), // number of strings
             aszChoices          // array of strings
         );
@@ -305,8 +302,8 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
         (
             pPanel,              // parent
             Control_Listbox2,    // control id
-            wxPoint(220, 10),    // listbox position
-            wxSize(200, 200),    // listbox size
+            FromDIP(wxPoint(220, 10)),    // listbox position
+            FromDIP(wxSize(200, 200)),    // listbox size
             WXSIZEOF(aszColors), // number of strings
             aszColors,           // array of strings
             wxLB_OWNERDRAW       // owner-drawn
@@ -340,6 +337,8 @@ OwnerDrawnFrame::OwnerDrawnFrame(wxFrame *frame, const wxString& title,
 #else
     wxUnusedVar( pListBox );
 #endif
+
+    SetSize(FromDIP(wxSize(450, 340)));
 
     Show(true);
 }

--- a/src/msw/checklst.cpp
+++ b/src/msw/checklst.cpp
@@ -36,7 +36,7 @@
     #include "wx/log.h"
 #endif
 
-#include "wx/ownerdrw.h"
+#include "wx/msw/private/listboxitem.h"
 
 #include <windowsx.h>
 
@@ -69,25 +69,13 @@ namespace
 // declaration and implementation of wxCheckListBoxItem class
 // ----------------------------------------------------------------------------
 
-class wxCheckListBoxItem : public wxOwnerDrawn
+class wxCheckListBoxItem : public wxListBoxItemBase<wxCheckListBox>
 {
 public:
-    // ctor
     wxCheckListBoxItem(wxCheckListBox *parent);
 
     // drawing functions
     virtual bool OnDrawItem(wxDC& dc, const wxRect& rc, wxODAction act, wxODStatus stat) override;
-
-    // simple accessors and operations
-    wxCheckListBox *GetParent() const
-        { return m_parent; }
-
-    int GetIndex() const
-        { return m_parent->GetItemIndex(const_cast<wxCheckListBoxItem*>(this)); }
-
-    wxString GetName() const override
-        { return m_parent->GetString(GetIndex()); }
-
 
     bool IsChecked() const
         { return m_checked; }
@@ -108,22 +96,20 @@ protected:
     }
 
 private:
-    wxCheckListBox *m_parent;
     bool m_checked;
 
     wxDECLARE_NO_COPY_CLASS(wxCheckListBoxItem);
 };
 
 wxCheckListBoxItem::wxCheckListBoxItem(wxCheckListBox *parent)
+    : wxListBoxItemBase<wxCheckListBox>(parent)
 {
-    m_parent = parent;
     m_checked = false;
 
     wxSize size = wxRendererNative::Get().GetCheckBoxSize(parent);
     size.x += 2 * CHECKMARK_EXTRA_SPACE + CHECKMARK_LABEL_SPACE;
 
     SetMarginWidth(size.GetWidth());
-    SetBackgroundColour(parent->GetBackgroundColour());
 }
 
 bool wxCheckListBoxItem::OnDrawItem(wxDC& dc, const wxRect& rc,

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -64,6 +64,20 @@ public:
     wxString GetName() const override
         { return m_parent->GetString(GetIndex()); }
 
+protected:
+    void
+    GetColourToUse(wxODStatus stat,
+                   wxColour& colText,
+                   wxColour& colBack) const override
+    {
+        wxOwnerDrawn::GetColourToUse(stat, colText, colBack);
+
+        // Default background colour for the owner drawn items is the menu one,
+        // but it's not appropriate for the listboxes, so override it here.
+        if ( !(stat & wxODSelected) && !GetBackgroundColour().IsOk() )
+            colBack = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
+    }
+
 private:
     wxListBox *m_parent;
 };

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -34,7 +34,7 @@
 #include <windowsx.h>
 
 #if wxUSE_OWNER_DRAWN
-    #include  "wx/ownerdrw.h"
+    #include "wx/msw/private/listboxitem.h"
 
     namespace
     {
@@ -49,38 +49,7 @@
 
 #if wxUSE_OWNER_DRAWN
 
-class wxListBoxItem : public wxOwnerDrawn
-{
-public:
-    wxListBoxItem(wxListBox *parent)
-        { m_parent = parent; }
-
-    wxListBox *GetParent() const
-        { return m_parent; }
-
-    int GetIndex() const
-        { return m_parent->GetItemIndex(const_cast<wxListBoxItem*>(this)); }
-
-    wxString GetName() const override
-        { return m_parent->GetString(GetIndex()); }
-
-protected:
-    void
-    GetColourToUse(wxODStatus stat,
-                   wxColour& colText,
-                   wxColour& colBack) const override
-    {
-        wxOwnerDrawn::GetColourToUse(stat, colText, colBack);
-
-        // Default background colour for the owner drawn items is the menu one,
-        // but it's not appropriate for the listboxes, so override it here.
-        if ( !(stat & wxODSelected) && !GetBackgroundColour().IsOk() )
-            colBack = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
-    }
-
-private:
-    wxListBox *m_parent;
-};
+using wxListBoxItem = wxListBoxItemBase<wxListBox>;
 
 wxOwnerDrawn *wxListBox::CreateLboxItem(size_t WXUNUSED(n))
 {


### PR DESCRIPTION
This mostly addresses #24917 but also contains some related cleanup.