### PR TITLE
wxQt: translate QPainter of wxClientDC into window client area.

### DIFF
--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -115,6 +115,8 @@ wxClientDCImpl::wxClientDCImpl( wxDC *owner, wxWindow *win )
 {
      if ( m_ok )
      {
+        m_qtPainter->translate( wxQtConvertPoint(win->GetClientAreaOrigin()) );
+
         m_qtPainter->setClipRect( wxQtConvertRect(win->GetClientRect()),
                                   m_clipping ? Qt::IntersectClip : Qt::ReplaceClip );
     }


### PR DESCRIPTION
Because Qt considers the menubar and toolbar parts of the client area and we need to apply the same fix done for `wxPaintDC` in this commit 9652958 (translate `QPainter` into window client area.) to `wxClientDC` too.

Without this fix the overlay hint of a `wxAUI` window would be drawn at incorrect offset when this #24911 get merged:

![Screenshot from 2024-10-27 19-54-01](https://github.com/user-attachments/assets/274f3348-cc2d-432d-9cc4-f9ef78592d82)
