### PR TITLE
Fix compilation of <wx/archive.h> on Clang 19 on Fedora

### DIFF
--- a/include/wx/archive.h
+++ b/include/wx/archive.h
@@ -217,9 +217,9 @@ public:
 
     wxArchiveIterator& operator =(const wxArchiveIterator& it) {
         if (it.m_rep)
-            it.m_rep.AddRef();
+            it.m_rep->AddRef();
         if (m_rep)
-            this->m_rep.UnRef();
+            m_rep->UnRef();
         m_rep = it.m_rep;
         return *this;
     }

--- a/tests/archive/archivetest.cpp
+++ b/tests/archive/archivetest.cpp
@@ -1028,6 +1028,11 @@ void ArchiveTestCase<ClassFactoryT>::TestSmartIterator(wxInputStream& in)
 
     for (CatalogIter it = cat.begin(); it != cat.end(); ++it)
         CPPUNIT_ASSERT(m_testEntries.count((*it)->GetName(wxPATH_UNIX)));
+
+    Iter a, b;
+    // test assignment
+    a = b;
+    CPPUNIT_ASSERT(a == b);
 }
 
 // pair iterator using smart pointers


### PR DESCRIPTION
Clang 19.1.0 on Fedora Rawhide fails to compile `<wx/archive.h>` because m_rep's members are accessed as if m_rep was not a pointer, but it is.

This is obviously wrong with any compiler, but apparently because `wxArchiveIterator` is a template class, and its `operator=()` is never called in tests, its brokenness went unnoticed.

It has been broken ever since the commit where the code was added, 00375592f92f68c4ca3f44d8e839bcfd47adc4e1, 20 years ago.