### PR TITLE
Fix wxGETTEXT_IN_CONTEXT* failing with wxNO_IMPLICIT_WXSTRING_ENCODING

### DIFF
--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -62,10 +62,10 @@ using wxTranslationsHashMap = std::unordered_map<wxString, wxString>;
     wxGetTranslation((s), wxString(), c)
 #else
 #define wxGETTEXT_IN_CONTEXT(c, s) \
-    wxGetTranslation(wxASCII_STR(s), wxString(), c)
+    wxGetTranslation(wxASCII_STR(s), wxString(), wxASCII_STR(c))
 #endif
 #define wxGETTEXT_IN_CONTEXT_PLURAL(c, sing, plur, n) \
-    wxGetTranslation((sing), (plur), n, wxString(), c)
+    wxGetTranslation(wxASCII_STR(sing), wxASCII_STR(plur), n, wxString(), wxASCII_STR(c))
 
 // another one which just marks the strings for extraction, but doesn't
 // perform the translation (use -kwxTRANSLATE with xgettext!)

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -413,4 +413,12 @@ TEST_CASE("wxNO_IMPLICIT_WXSTRING_ENCODING", "[string]")
 #endif
 
     wxLogSysError(wxASCII_STR("Bogus error for testing"));
+
+    // Check that all translation macros expand to compilable
+    // code also when wxNO_IMPLICIT_WXSTRING_ENCODING is enabled.
+
+    _("some text");
+    wxPLURAL("singular", "plural", 2);
+    wxGETTEXT_IN_CONTEXT("context", "text");
+    wxGETTEXT_IN_CONTEXT_PLURAL("context", "singular", "plural", 3);
 }


### PR DESCRIPTION
The call to `wxGetTranslation()` was ambiguous. Fix this by using `wxASCII_STR()` for all string literal arguments in
`wxGETTEXT_IN_CONTEXT`/`_PLURAL`, just as it is used for the argument of `_()`.

Also test that all translation macros expand to compilable code when `wxNO_IMPLICIT_WXSTRING_ENCODING` is enabled.

See also: PR #24916