### PR TITLE
Fix phantom GTK mouse release events

### DIFF
--- a/include/wx/gtk/evtloop.h
+++ b/include/wx/gtk/evtloop.h
@@ -22,6 +22,7 @@ class WXDLLIMPEXP_CORE wxGUIEventLoop : public wxEventLoopBase
 {
 public:
     wxGUIEventLoop();
+    virtual ~wxGUIEventLoop();
 
     virtual void ScheduleExit(int rc = 0) override;
     virtual bool Pending() const override;
@@ -29,8 +30,14 @@ public:
     virtual int DispatchTimeout(unsigned long timeout) override;
     virtual void WakeUp() override;
 
+    // implementation only from now on
+
     void StoreGdkEventForLaterProcessing(GdkEvent* ev)
         { m_queuedGdkEvents.push_back(ev); }
+
+    // Check if this event is the same as the last event passed to this
+    // function and store it for future checks.
+    bool GTKIsSameAsLastEvent(const GdkEvent* ev, size_t size);
 
 protected:
     virtual int DoRun() override;
@@ -42,6 +49,9 @@ private:
 
     // used to temporarily store events processed in DoYieldFor()
     std::vector<GdkEvent*> m_queuedGdkEvents;
+
+    // last event passed to GTKIsSameAsLastEvent()
+    GdkEvent* m_lastEvent;
 
     wxDECLARE_NO_COPY_CLASS(wxGUIEventLoop);
 };

--- a/src/gtk/dnd.cpp
+++ b/src/gtk/dnd.cpp
@@ -883,7 +883,7 @@ wxDragResult wxDropSource::DoDragDrop(int flags)
                 target_list,
                 (GdkDragAction)allowed_actions,
                 g_lastButtonNumber,  // number of mouse button which started drag
-                (GdkEvent*) g_lastMouseEvent );
+                g_lastMouseEvent );
 
     wxGCC_WARNING_RESTORE(deprecated-declarations)
 

--- a/src/gtk/evtloop.cpp
+++ b/src/gtk/evtloop.cpp
@@ -46,6 +46,12 @@ GdkWindow* wxGetTopLevelGDK();
 wxGUIEventLoop::wxGUIEventLoop()
 {
     m_exitcode = 0;
+    m_lastEvent = new GdkEvent;
+}
+
+wxGUIEventLoop::~wxGUIEventLoop()
+{
+    delete m_lastEvent;
 }
 
 int wxGUIEventLoop::DoRun()
@@ -103,6 +109,15 @@ void wxGUIEventLoop::WakeUp()
     //       nothing when we don't...
     if ( wxTheApp )
         wxTheApp->WakeUpIdle();
+}
+
+bool wxGUIEventLoop::GTKIsSameAsLastEvent(const GdkEvent* ev, size_t size)
+{
+    if ( memcmp(m_lastEvent, ev, size) == 0 )
+        return true;
+
+    memcpy(m_lastEvent, ev, size);
+    return false;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1718,6 +1718,11 @@ gtk_window_button_press_callback( GtkWidget* WXUNUSED_IN_GTK3(widget),
                                   GdkEventButton *gdk_event,
                                   wxWindowGTK *win )
 {
+    wxLogTrace(TRACE_MOUSE, "Press for button %d at %g,%g in %s at t=%u",
+               gdk_event->button, gdk_event->x, gdk_event->y,
+               wxDumpWindow(win),
+               gdk_event->time);
+
     /*
       GTK does not set the button1 mask when the event comes from the left
       button of a mouse. but for some reason, it sets it when the event comes
@@ -1860,6 +1865,11 @@ gtk_window_button_release_callback( GtkWidget *WXUNUSED(widget),
                                     GdkEventButton *gdk_event,
                                     wxWindowGTK *win )
 {
+    wxLogTrace(TRACE_MOUSE, "Release for button %d at %g,%g in %s at t=%u",
+               gdk_event->button, gdk_event->x, gdk_event->y,
+               wxDumpWindow(win),
+               gdk_event->time);
+
     wxPROCESS_EVENT_ONCE(GdkEventButton, gdk_event);
 
     if ( AreGTKEventsBlocked() )

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1939,11 +1939,8 @@ gtk_window_button_release_callback( GtkWidget *WXUNUSED(widget),
     event.SetEventObject( win );
     event.SetId( win->GetId() );
 
-    // We ignore the result of the event processing here as we don't really
-    // want to prevent the other handlers from running even if we did process
-    // this event ourselves, there is no real advantage in doing this and it
-    // could actually be harmful, see #16055.
-    (void)win->GTKProcessEvent(event);
+    if ( win->GTKProcessEvent(event) )
+        return TRUE;
 
     return FALSE;
 }


### PR DESCRIPTION
The only important commit here is the last one, the rest are just debugging helpers or some cleanups. But the last commit is important because it fixes a long-standing bug (I was _sure_ we had an issue for this but I couldn't find it, even after searching for it for quite some time) when the controls in the parent window were unexpectedly activated after dismissing a modal dialog. And I've finally understood what was going on here and described it in the last commit message and implemented a fix for it.

Note that I tried to make it work with `g_signal_connect_after()` for quite some time first, but couldn't do it: as also explained in that commit message, stopping `key-pressed` propagation by returning `TRUE` from its "after" handler breaks built-in keyboard handling, while doing what `wxgtk_tlw_key_press_event()` does in it results in infinite recursion. If anybody sees how to make this work, it would be IMO preferable to the current approach, which is not that obvious, unlike just stopping the signal propagation would be, but for now this is better than nothing.