### PR TITLE
Fix coordinates in click events sent to window with capture

### DIFF
--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1613,6 +1613,15 @@ static void AdjustEventButtonState(wxMouseEvent& event)
 static
 wxWindowGTK *FindWindowForMouseEvent(wxWindowGTK *win, wxCoord& x, wxCoord& y)
 {
+    // When a window has mouse capture, it should get all the events.
+    if ( g_captureWindow )
+    {
+        win->ClientToScreen(&x, &y);
+        g_captureWindow->ScreenToClient(&x, &y);
+
+        return g_captureWindow;
+    }
+
     wxCoord xx = x;
     wxCoord yy = y;
 
@@ -1817,8 +1826,7 @@ gtk_window_button_press_callback( GtkWidget* WXUNUSED_IN_GTK3(widget),
     // find the correct window to send the event to: it may be a different one
     // from the one which got it at GTK+ level because some controls don't have
     // their own X window and thus cannot get any events.
-    if ( !g_captureWindow )
-        win = FindWindowForMouseEvent(win, event.m_x, event.m_y);
+    win = FindWindowForMouseEvent(win, event.m_x, event.m_y);
 
     // reset the event object and id in case win changed.
     event.SetEventObject( win );
@@ -1903,8 +1911,7 @@ gtk_window_button_release_callback( GtkWidget *WXUNUSED(widget),
 
     AdjustEventButtonState(event);
 
-    if ( !g_captureWindow )
-        win = FindWindowForMouseEvent(win, event.m_x, event.m_y);
+    win = FindWindowForMouseEvent(win, event.m_x, event.m_y);
 
     // reset the event object and id in case win changed.
     event.SetEventObject( win );


### PR DESCRIPTION
First of all, ensure that the press and release events do go to the window with the capture, which may not have been the case at all when the capturing window didn't have a corresponding GDK window, e.g. when capturing mouse in wxStaticText-derived class.

And also adjust the coordinates to be correct for the captured window to ensure that the window receives the expected events.

----

This hopefully completes my triptych of mouse-related wxGTK PRs — at least my code works the same with wxGTK and wxMSW now. Maybe capturing the mouse in `wxStaticText` is not such a common thing to do, but if we can make it work, I prefer to do it rather than documenting that it doesn't work (which would be the other reasonable alternative).