### PR TITLE
Account for axis sign when handling device origin in wxMSW wxDC

### DIFF
--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -96,10 +96,10 @@ static const int VIEWPORT_EXTENT = 134217727;
         device  = physical/scale + logicalOrigin = logical + deviceOrigin/scale
  */
 
-#define XLOG2DEV(x) ((x) + (m_deviceOriginX / m_scaleX))
-#define YLOG2DEV(y) ((y) + (m_deviceOriginY / m_scaleY))
-#define XDEV2LOG(x) ((x) - (m_deviceOriginX / m_scaleX))
-#define YDEV2LOG(y) ((y) - (m_deviceOriginY / m_scaleY))
+#define XLOG2DEV(x) ((x) + (m_deviceOriginX*m_signX / m_scaleX))
+#define YLOG2DEV(y) ((y) + (m_deviceOriginY*m_signY / m_scaleY))
+#define XDEV2LOG(x) ((x) - (m_deviceOriginX*m_signX / m_scaleX))
+#define YDEV2LOG(y) ((y) - (m_deviceOriginY*m_signY / m_scaleY))
 
 // ---------------------------------------------------------------------------
 // private functions


### PR DESCRIPTION
Changes of 4f9186f1a1 (Increase usable scrolling range in wxMSW by a factor of 10,000, 2022-04-30) broke device origin handling if axis had non-default direction because we didn't account for their signs at all.

Just do it now by interpreting the origin correctly depending on direction.

Closes #24198.