### PR TITLE
Fix indent of imageless `wxTreeCtrl` in high DPI under MSW

### DIFF
--- a/include/wx/msw/treectrl.h
+++ b/include/wx/msw/treectrl.h
@@ -266,6 +266,8 @@ protected:
 
     virtual void MSWUpdateFontOnDPIChange(const wxSize& newDPI) override;
 
+    void OnDPIChanged(wxDPIChangedEvent& event);
+
     // data used only while editing the item label:
     wxTextCtrl  *m_textCtrl;        // text control in which it is edited
     wxTreeItemId m_idEdited;        // the item being edited
@@ -347,6 +349,7 @@ private:
     friend class wxTreeSortHelper;
 
     wxDECLARE_DYNAMIC_CLASS(wxTreeCtrl);
+    wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxTreeCtrl);
 };
 

--- a/include/wx/msw/treectrl.h
+++ b/include/wx/msw/treectrl.h
@@ -349,7 +349,6 @@ private:
     friend class wxTreeSortHelper;
 
     wxDECLARE_DYNAMIC_CLASS(wxTreeCtrl);
-    wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxTreeCtrl);
 };
 

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -717,10 +717,6 @@ bool wxTreeTraversal::Traverse(const wxTreeItemId& root, bool recursively)
     return true;
 }
 
-wxBEGIN_EVENT_TABLE(wxTreeCtrl, wxTreeCtrlBase)
-    EVT_DPI_CHANGED(wxTreeCtrl::OnDPIChanged)
-wxEND_EVENT_TABLE()
-
 // ----------------------------------------------------------------------------
 // construction and destruction
 // ----------------------------------------------------------------------------
@@ -819,10 +815,14 @@ bool wxTreeCtrl::Create(wxWindow *parent,
         EnableSystemThemeByDefault();
     }
 
-    // Scale the default indent with the DPI scaling factor as Windows doesn't
-    // do it and the "+" buttons would be displayed too small if the tree is
-    // used without images.
-    SetIndent( FromDIP(GetIndent()) );
+    // When using non-standard DPI, we need to scale the default indent with
+    // the DPI scaling factor as Windows doesn't do it and the "+" buttons
+    // would be displayed too small if the tree is used without images.
+    if ( GetDPIScaleFactor() > 1.0 )
+        SetIndent(FromDIP(GetIndent()));
+
+    // And ensure we adjust it again if the DPI changes in the future.
+    Bind(wxEVT_DPI_CHANGED, &wxTreeCtrl::OnDPIChanged, this);
 
     return true;
 }
@@ -2312,7 +2312,7 @@ void wxTreeCtrl::MSWUpdateFontOnDPIChange(const wxSize& newDPI)
 void wxTreeCtrl::OnDPIChanged(wxDPIChangedEvent& event)
 {
     // Adjust the indent to the new DPI scaling factor as Windows doesn't do it.
-    SetIndent( event.ScaleX( GetIndent() ) );
+    SetIndent(event.ScaleX(GetIndent()));
 
     event.Skip();
 }

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -717,6 +717,10 @@ bool wxTreeTraversal::Traverse(const wxTreeItemId& root, bool recursively)
     return true;
 }
 
+wxBEGIN_EVENT_TABLE(wxTreeCtrl, wxTreeCtrlBase)
+    EVT_DPI_CHANGED(wxTreeCtrl::OnDPIChanged)
+wxEND_EVENT_TABLE()
+
 // ----------------------------------------------------------------------------
 // construction and destruction
 // ----------------------------------------------------------------------------
@@ -814,6 +818,11 @@ bool wxTreeCtrl::Create(wxWindow *parent,
         // this style to it.
         EnableSystemThemeByDefault();
     }
+
+    // Scale the default indent with the DPI scaling factor as Windows doesn't
+    // do it and the "+" buttons would be displayed too small if the tree is
+    // used without images.
+    SetIndent( FromDIP(GetIndent()) );
 
     return true;
 }
@@ -2298,6 +2307,14 @@ void wxTreeCtrl::MSWUpdateFontOnDPIChange(const wxSize& newDPI)
         if ( kv.second->HasFont() )
             SetItemFont(kv.first, kv.second->GetFont());
     }
+}
+
+void wxTreeCtrl::OnDPIChanged(wxDPIChangedEvent& event)
+{
+    // Adjust the indent to the new DPI scaling factor as Windows doesn't do it.
+    SetIndent( event.ScaleX( GetIndent() ) );
+
+    event.Skip();
 }
 
 bool wxTreeCtrl::MSWIsOnItem(unsigned flags) const


### PR DESCRIPTION
Fixes #24640 while taking into account that users can set a custom indent via `wxTreeCtrl::SetIndent()`.