### PR TITLE
Define wxPLURAL regardless of WXINTL_NO_GETTEXT_MACRO

### DIFF
--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -50,8 +50,9 @@ using wxTranslationsHashMap = std::unordered_map<wxString, wxString>;
 #else
     #define _(s)                               wxGetTranslation(wxASCII_STR(s))
 #endif
-    #define wxPLURAL(sing, plur, n)            wxGetTranslation((sing), (plur), n)
 #endif
+
+#define wxPLURAL(sing, plur, n)                wxGetTranslation((sing), (plur), n)
 
 // wx-specific macro for translating strings in the given context: if you use
 // them, you need to also add


### PR DESCRIPTION
The purpose of WXINTL_NO_GETTEXT_MACRO is, as I understand it, to avoid name clashes between _() and symbols with the same name introduced by other libraries or compilers.

Although wxPLURAL has forever (15d0695 (added wxPLURAL() macro, 2005-06-01)) been conditionally defined, there is no similar need with it. wxPLURAL has a longer name, and is wx-prefixed. The other, more recently introduced translation macros are not conditionally defined, which makes wxPLURAL inconsistent in this regard.