### PR TITLE
Fix non-ASCII msgids with wxGETTEXT_IN_CONTEXT_PLURAL

### DIFF
--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -60,12 +60,14 @@ using wxTranslationsHashMap = std::unordered_map<wxString, wxString>;
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
 #define wxGETTEXT_IN_CONTEXT(c, s) \
     wxGetTranslation((s), wxString(), c)
+#define wxGETTEXT_IN_CONTEXT_PLURAL(c, sing, plur, n) \
+    wxGetTranslation((sing), (plur), n, wxString(), c)
 #else
 #define wxGETTEXT_IN_CONTEXT(c, s) \
     wxGetTranslation(wxASCII_STR(s), wxString(), wxASCII_STR(c))
-#endif
 #define wxGETTEXT_IN_CONTEXT_PLURAL(c, sing, plur, n) \
     wxGetTranslation(wxASCII_STR(sing), wxASCII_STR(plur), n, wxString(), wxASCII_STR(c))
+#endif
 
 // another one which just marks the strings for extraction, but doesn't
 // perform the translation (use -kwxTRANSLATE with xgettext!)


### PR DESCRIPTION
The compilation fix in PR #24925, a47b560 (Fix
wxGETTEXT_IN_CONTEXT* with wxNO_IMPLICIT_WXSTRING_ENCODING, 2024-10-29) aimed for the wxNO_IMPLICIT_WXSTRING_ENCODING case presumably also has the side effect of preventing non-ASCII (non-English) msgids with wxGETTEXT_IN_CONTEXT_PLURAL, also in the regular case when implicit encoding is permitted.

It is best to define wxGETTEXT_IN_CONTEXT_PLURAL separately for both wxNO_IMPLICIT_WXSTRING_ENCODING and without it, similarly to how wxGETTEXT_IN_CONTEXT is defined. For some reason it was defined only once until now.

This commit reverts the definition of
wxGETTEXT_IN_CONTEXT_PLURAL for the regular case to what it was before.