### PR TITLE
[macOS] Supporting PNG data on clipboard for macOS

### DIFF
--- a/src/common/dobjcmn.cpp
+++ b/src/common/dobjcmn.cpp
@@ -702,9 +702,9 @@ bool wxCustomDataObject::SetData(size_t size, const void *buf)
 #define wxIMAGE_FORMAT_BITMAP_TYPE wxBITMAP_TYPE_PNG
 #define wxIMAGE_FORMAT_NAME "PNG"
 #elif defined(__WXOSX__)
-#define wxIMAGE_FORMAT_DATA wxDF_BITMAP
-#define wxIMAGE_FORMAT_BITMAP_TYPE wxBITMAP_TYPE_TIFF
-#define wxIMAGE_FORMAT_NAME "TIFF"
+#define wxIMAGE_FORMAT_DATA wxDF_PNG
+#define wxIMAGE_FORMAT_BITMAP_TYPE wxBITMAP_TYPE_PNG
+#define wxIMAGE_FORMAT_NAME "PNG"
 #else
 #define wxIMAGE_FORMAT_DATA wxDF_BITMAP
 #define wxIMAGE_FORMAT_BITMAP_TYPE wxBITMAP_TYPE_PNG

--- a/src/osx/carbon/dataobj.cpp
+++ b/src/osx/carbon/dataobj.cpp
@@ -123,6 +123,10 @@ wxDataFormat::NativeFormat wxDataFormat::GetFormatForType(wxDataFormatId type)
             f = kUTTypeFileURL;
             break;
             
+        case wxDF_PNG:
+            f = kUTTypePNG;
+            break;
+
         default:
             wxFAIL_MSG( wxS("unsupported data format") );
             break;
@@ -206,6 +210,10 @@ void wxDataFormat::SetId( NativeFormat format )
     else if ( UTTypeConformsTo( (CFStringRef)format, kUTTypePlainText ) )
     {
         m_type = wxDF_TEXT;
+    }
+    else if (  UTTypeConformsTo( (CFStringRef)format, kUTTypePNG ) )
+    {
+        m_type = wxDF_PNG;
     }
     else if (  UTTypeConformsTo( (CFStringRef)format, kUTTypeImage ) )
     {


### PR DESCRIPTION
PNG data on clipboards is currently not supported by wxWidgets when using macOS. Though, it seems to be that it can be supported basically out of the box.
Patches are included.
