### PR TITLE
Remove/fix outdated information in the internat sample and its readme.txt

### DIFF
--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -531,17 +531,8 @@ void MyFrame::OnPlay(wxCommandEvent& WXUNUSED(event))
     }
     else
     {
-        // this is a more implicit way to write _() but note that if you use it
-        // you must ensure that the strings get extracted in the message
-        // catalog as by default xgettext won't do it; it only knows of _(),
-        // not of wxTRANSLATE(). As internat's readme.txt says you should thus
-        // call xgettext with -kwxTRANSLATE.
-        str = wxGetTranslation(wxTRANSLATE("Bad luck! try again..."));
-
-        // note also that if we want 'str' to contain a localized string
-        // we need to use wxGetTranslation explicitly as wxTRANSLATE just
-        // tells xgettext to extract the string but has no effect on the
-        // runtime of the program!
+        // this is a more verbose way to write _()
+        str = wxGetTranslation("Bad luck! try again...");
     }
 
     wxMessageBox(str, _("Result"), wxOK | wxICON_INFORMATION);

--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -309,8 +309,6 @@ MyFrame::MyFrame()
     test_menu->Append(INTERNAT_TEST_MSGBOX, _("&Message box test"),
                       _("Tests message box buttons labels translation"));
 
-    // Note that all these strings are currently "translated" only in French
-    // catalog, so you need to use French locale to see them in action.
     wxMenu *macro_menu = new wxMenu;
     macro_menu->Append(INTERNAT_MACRO_1, _("item"));
     macro_menu->Append(INTERNAT_MACRO_2, wxGETTEXT_IN_CONTEXT("context_1", "item"));

--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -571,8 +571,9 @@ void MyFrame::OnTestLocaleAvail(wxCommandEvent& WXUNUSED(event))
 
 void MyFrame::OnOpen(wxCommandEvent& WXUNUSED(event))
 {
-    // open a bogus file -- the error message should be also translated if
-    // you've got wxstd.mo somewhere in the search path (see MyApp::OnInit)
+    // open a bogus file -- the error message should be also either
+    // partially or fully translated if you've got wxstd.mo somewhere
+    // and/or your operating system provides localized error messages.
     wxFile file("NOTEXIST.ING");
 }
 

--- a/samples/internat/readme.txt
+++ b/samples/internat/readme.txt
@@ -24,16 +24,8 @@ Q. Why the message when I enter '17' is only partly translated?
 A. This will only work under some versions of Linux, don't worry if the second
    half of the sentence is not translated.
 
-Q. I don't speak french, what about translations to <language>?
-A. Please write them - see the next question. French is chosen by default
-   because it's the only translation which is currently available. To test
-   translations to the other languages please run the sample with 2 command line
-   arguments: the full language name and the name of the directory where the
-   message catalogs for this language are (will be taken as 2 first letters of
-   the language name if only 1 argument is given).
-
 Q. How to do translations to other language?
-A. First of all, you will need the GNU gettext tools (see the next questions).
+A. First of all, you will need the GNU gettext tools.
    After you've probably installed them, type the following (example is for Unix
    and you should do exactly the same under Windows).
 
@@ -61,7 +53,7 @@ A. First of all, you will need the GNU gettext tools (see the next questions).
    ./internat <language>
 
 Q. How to do update the translation of 'internat' sample for a language?
-A. First of all, you will need the GNU gettext tools (see the next question).
+A. First of all, you will need the GNU gettext tools.
    After you've probably installed them, type the following (example is for Unix
    and you should do exactly the same under Windows).
 
@@ -81,15 +73,5 @@ A. First of all, you will need the GNU gettext tools (see the next question).
    # update the message catalog:
    msgfmt -vco internat.mo internat.po
 
-Q. How to get the gettext tools?
-A. For Unix, you should be able to get the source distribution of any GNU mirror
-   (see www.gnu.org for a start). gettext() version 0.10 is buggy, try to get at
-   least version strictly greater than 0.10. gettext RPMs can be downloaded from
-   the standard locations for Linux. For Windows, you can get the precompiled
-   binaries from wxWidgets web page.
-
 Q. What's i18n?
 A. Count the number of letters in the word "internationalization".
-
-Q. Where to send comments, or additional translations?
-A. wxWidgets mailing list <wx-dev@googlegroups.com>.

--- a/samples/internat/readme.txt
+++ b/samples/internat/readme.txt
@@ -25,7 +25,7 @@ A. This will only work under some versions of Linux, don't worry if the second
    half of the sentence is not translated.
 
 Q. How to do translations to other language?
-A. First of all, you will need the GNU gettext tools.
+A. First of all, you will need the GNU gettext tools or, if you prefer GUI applications, a program such as poedit.
    After you've probably installed them, type the following (example is for Unix
    and you should do exactly the same under Windows).
 

--- a/samples/internat/readme.txt
+++ b/samples/internat/readme.txt
@@ -37,30 +37,24 @@ A. First of all, you will need the GNU gettext tools (see the next questions).
    After you've probably installed them, type the following (example is for Unix
    and you should do exactly the same under Windows).
 
-   # all translations forgiven language should be in a separate directory.
+   # all translations for a given language should be in a separate directory.
    # Please use the standard abbreviation for the language names!
    mkdir <language>
    cd <language>
 
-   # generate the .po file for the program itself
-   # see `xgettext --help' for options, "-C" is important!
-   xgettext -C -k_ -kwxPLURAL:1,2 -kwxGETTEXT_IN_CONTEXT:1c,2 -kwxGETTEXT_IN_CONTEXT_PLURAL:1c,2,3 -kwxTRANSLATE -kwxTRANSLATE_IN_CONTEXT:1c,2 -kwxGetTranslation -o internat.po ../internat.cpp
+   # generate the .pot (template) file for the program itself
+   # see `xgettext --help' for options
+   xgettext -k_ -kwxPLURAL:1,2 -kwxGETTEXT_IN_CONTEXT:1c,2 -kwxGETTEXT_IN_CONTEXT_PLURAL:1c,2,3 -kwxTRANSLATE -kwxTRANSLATE_IN_CONTEXT:1c,2 -kwxGetTranslation -o internat.pot ../internat.cpp
 
-   # .po file for wxWidgets might be generated in the same way. An already
-   # generated wxstd.pot as well as translations for some languages can be
-   # found in the locale directory.
-   cp ../../locale/<language>.po ./wxstd.pot
-   - or -
-   cp ../../locale/wxstd.pot .
+   # initialize the translation for your language
+   msginit -l <language> -o internat.po
 
-   # now edit the files and do translate strings (this isn't done by gettext)
-   # you can use another editor if you wish :-) No need to edit wxstd.pot if you
-   # already got a translated one.
-   vi internat.po wxstd.pot
+   # now edit the file and do translate strings (this isn't done by gettext)
+   # you can use another editor if you wish :-)
+   vi internat.po
 
-   # create the message catalog files
-   msgfmt -o internat.mo internat.po
-   msgfmt -o wxstd.mo wxstd.pot
+   # create the message catalog file
+   msgfmt -vco internat.mo internat.po
 
    # run the sample to test it
    cd ..
@@ -74,14 +68,18 @@ A. First of all, you will need the GNU gettext tools (see the next question).
    # enter the directory of an already-existing translations which needs to be updated
    cd <language>
 
-   # the -j flag tells xgettext to merge and not simply overwrite the output file
-   xgettext -j -C -k_ -kwxPLURAL:1,2 -kwxGETTEXT_IN_CONTEXT:1c,2 -kwxGETTEXT_IN_CONTEXT_PLURAL:1c,2,3 -kwxTRANSLATE -kwxTRANSLATE_IN_CONTEXT:1c,2 -kwxGetTranslation -o internat.po ../internat.cpp
+   # generate the .pot (template) file for the program itself
+   # see `xgettext --help' for options
+   xgettext -k_ -kwxPLURAL:1,2 -kwxGETTEXT_IN_CONTEXT:1c,2 -kwxGETTEXT_IN_CONTEXT_PLURAL:1c,2,3 -kwxTRANSLATE -kwxTRANSLATE_IN_CONTEXT:1c,2 -kwxGetTranslation -o internat.pot ../internat.cpp
 
-   # now edit the files and do translate the new strings (this isn't done by gettext)
+   # merge updated strings from the .pot (template) into your translation
+   msgmerge -U internat.po internat.pot
+
+   # now edit the file and do translate the new strings (this isn't done by gettext)
    vi internat.po
 
    # update the message catalog:
-   msgfmt -o internat.mo internat.po
+   msgfmt -vco internat.mo internat.po
 
 Q. How to get the gettext tools?
 A. For Unix, you should be able to get the source distribution of any GNU mirror


### PR DESCRIPTION
Internat sample's readme.txt is severely outdated, and gives unusual instructions for using `xgettext`. Fixing those instructions, and simply removing some outdated paragraphs. Also fixing/removing comments within `internat.cpp`.