### PR TITLE
Only accept string literals as translation macro arguments

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -407,6 +407,15 @@ more details.
         the applications using the library to disable implicit
         conversions from and to <tt>const char*</tt> in wxString class.
         Support for this option appeared in wxWidgets 3.1.4.}
+@itemdef{wxNO_REQUIRE_LITERAL_MSGIDS,
+        this symbol is not defined by wxWidgets itself, but can be defined by
+        the applications using the library to allow variables as string arguments to
+        translation macros such as _() and wxPLURAL. The default since wxWidgets
+        3.3.0 is to allow only string literals.
+        Note that passing string variables as arguments to translation macros is
+        likely to be a bug, and does not produce the expected results. If you
+        feel you need to define this macro, you should first consider whether
+        your code is doing the right thing.}
 @itemdef{WXMAKINGDLL_XXX,
         used internally and defined when building the
         library @c XXX as a DLL; when a monolithic wxWidgets build is used only a

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -335,6 +335,9 @@ inline const wxString& wxGetTranslation(const char *str1,
 
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
 
+namespace wxTransImplStrict
+{
+
 // Wrapper functions that only accept string literals as arguments,
 // not variables, not char* pointers.
 template<size_t N>
@@ -383,6 +386,61 @@ const wxString &wxGettextInContextPluralWrapper(const char (&ctx)[L],
                             wxString(), wxASCII_STR(ctx));
 #endif
 }
+
+} // namespace wxTransImplStrict
+
+namespace wxTransImplTraditional
+{
+
+// Wrapper functions that accept both string literals and variables
+// as arguments.
+inline const wxString &wxUnderscoreWrapper(const wxString& msg)
+{
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    return wxGetTranslation(msg);
+#else
+    return wxGetTranslation(wxASCII_STR(msg));
+#endif
+}
+
+inline const wxString &wxPluralWrapper(const wxString& msg, const wxString& plural, int count)
+{
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    return wxGetTranslation(msg, plural, count);
+#else
+    return wxGetTranslation(wxASCII_STR(msg), wxASCII_STR(plural), count);
+#endif
+}
+
+inline const wxString &wxGettextInContextWrapper(const wxString& ctx, const wxString& msg)
+{
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    return wxGetTranslation(msg, wxString(), ctx);
+#else
+    return wxGetTranslation(wxASCII_STR(msg), wxString(), wxASCII_STR(ctx));
+#endif
+}
+
+inline const wxString &wxGettextInContextPluralWrapper(const wxString& ctx,
+                                                       const wxString&msg,
+                                                       const wxString&plural,
+                                                       int count)
+{
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    return wxGetTranslation(msg, plural, count, wxString(), ctx);
+#else
+    return wxGetTranslation(wxASCII_STR(msg), wxASCII_STR(plural), count,
+                            wxString(), wxASCII_STR(ctx));
+#endif
+}
+
+} // namespace wxTransImplTraditional
+
+#ifdef wxNO_REQUIRE_LITERAL_MSGIDS
+using namespace wxTransImplTraditional;
+#else
+using namespace wxTransImplStrict;
+#endif
 
 #else // !wxUSE_INTL
 

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -375,9 +375,9 @@ const wxString &wxGettextInContextWrapper(const char (&ctx)[M],
 
 template<size_t L, size_t M, size_t N>
 const wxString &wxGettextInContextPluralWrapper(const char (&ctx)[L],
-                                                  const char (&msg)[M],
-                                                  const char (&plural)[N],
-                                                  int count)
+                                                const char (&msg)[M],
+                                                const char (&plural)[N],
+                                                int count)
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
     return wxGetTranslation(msg, plural, count, wxString(), ctx);

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -394,7 +394,7 @@ namespace wxTransImplTraditional
 
 // Wrapper functions that accept both string literals and variables
 // as arguments.
-inline const wxString &wxUnderscoreWrapper(const wxString& msg)
+inline const wxString &wxUnderscoreWrapper(const char *msg)
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
     return wxGetTranslation(msg);
@@ -403,7 +403,9 @@ inline const wxString &wxUnderscoreWrapper(const wxString& msg)
 #endif
 }
 
-inline const wxString &wxPluralWrapper(const wxString& msg, const wxString& plural, int count)
+inline const wxString &wxPluralWrapper(const char *msg,
+                                       const char *plural,
+                                       int count)
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
     return wxGetTranslation(msg, plural, count);
@@ -412,7 +414,8 @@ inline const wxString &wxPluralWrapper(const wxString& msg, const wxString& plur
 #endif
 }
 
-inline const wxString &wxGettextInContextWrapper(const wxString& ctx, const wxString& msg)
+inline const wxString &wxGettextInContextWrapper(const char *ctx,
+                                                 const char *msg)
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
     return wxGetTranslation(msg, wxString(), ctx);
@@ -421,9 +424,9 @@ inline const wxString &wxGettextInContextWrapper(const wxString& ctx, const wxSt
 #endif
 }
 
-inline const wxString &wxGettextInContextPluralWrapper(const wxString& ctx,
-                                                       const wxString&msg,
-                                                       const wxString&plural,
+inline const wxString &wxGettextInContextPluralWrapper(const char *ctx,
+                                                       const char *msg,
+                                                       const char *plural,
                                                        int count)
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -389,7 +389,7 @@ const wxString& wxGettextInContextPluralWrapper(const char (&ctx)[L],
 
 } // namespace wxTransImplStrict
 
-namespace wxTransImplTraditional
+namespace wxTransImplCompatible
 {
 
 // Wrapper functions that accept both string literals and variables
@@ -437,10 +437,10 @@ inline const wxString& wxGettextInContextPluralWrapper(const char *ctx,
 #endif
 }
 
-} // namespace wxTransImplTraditional
+} // namespace wxTransImplCompatible
 
 #ifdef wxNO_REQUIRE_LITERAL_MSGIDS
-using namespace wxTransImplTraditional;
+using namespace wxTransImplCompatible;
 #else
 using namespace wxTransImplStrict;
 #endif

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -45,30 +45,19 @@ using wxTranslationsHashMap = std::unordered_map<wxString, wxString>;
 // --keyword="_" --keyword="wxPLURAL:1,2" options
 // to extract the strings from the sources)
 #ifndef WXINTL_NO_GETTEXT_MACRO
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    #define _(s)                               wxGetTranslation((s))
-#else
-    #define _(s)                               wxGetTranslation(wxASCII_STR(s))
-#endif
+    #define _(s)                               wxUnderscoreWrapper((s))
 #endif
 
-#define wxPLURAL(sing, plur, n)                wxGetTranslation((sing), (plur), n)
+#define wxPLURAL(sing, plur, n)                wxPluralWrapper((sing), (plur), n)
 
 // wx-specific macro for translating strings in the given context: if you use
 // them, you need to also add
 // --keyword="wxGETTEXT_IN_CONTEXT:1c,2" --keyword="wxGETTEXT_IN_CONTEXT_PLURAL:1c,2,3"
 // options to xgettext invocation.
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
 #define wxGETTEXT_IN_CONTEXT(c, s) \
-    wxGetTranslation((s), wxString(), c)
+    wxGettextInContextWrapper((c), (s))
 #define wxGETTEXT_IN_CONTEXT_PLURAL(c, sing, plur, n) \
-    wxGetTranslation((sing), (plur), n, wxString(), c)
-#else
-#define wxGETTEXT_IN_CONTEXT(c, s) \
-    wxGetTranslation(wxASCII_STR(s), wxString(), wxASCII_STR(c))
-#define wxGETTEXT_IN_CONTEXT_PLURAL(c, sing, plur, n) \
-    wxGetTranslation(wxASCII_STR(sing), wxASCII_STR(plur), n, wxString(), wxASCII_STR(c))
-#endif
+    wxGettextInContextPluralWrapper((c), (sing), (plur), (n))
 
 // another one which just marks the strings for extraction, but doesn't
 // perform the translation (use -kwxTRANSLATE with xgettext!)
@@ -345,6 +334,55 @@ inline const wxString& wxGetTranslation(const char *str1,
 }
 
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
+
+// Wrapper functions that only accept string literals as arguments,
+// not variables, not char* pointers.
+template<size_t N>
+const wxString &wxUnderscoreWrapper(const char (&msg)[N])
+{
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    return wxGetTranslation(msg);
+#else
+    return wxGetTranslation(wxASCII_STR(msg));
+#endif
+}
+
+template<size_t M, size_t N>
+const wxString &wxPluralWrapper(const char (&msg)[M],
+                                const char (&plural)[N],
+                                int count)
+{
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    return wxGetTranslation(msg, plural, count);
+#else
+    return wxGetTranslation(wxASCII_STR(msg), wxASCII_STR(plural), count);
+#endif
+}
+
+template<size_t M, size_t N>
+const wxString &wxGettextInContextWrapper(const char (&ctx)[M],
+                                          const char (&msg)[N])
+{
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    return wxGetTranslation(msg, wxString(), ctx);
+#else
+    return wxGetTranslation(wxASCII_STR(msg), wxString(), wxASCII_STR(ctx));
+#endif
+}
+
+template<size_t L, size_t M, size_t N>
+const wxString &wxGettextInContextPluralWrapper(const char (&ctx)[L],
+                                                  const char (&msg)[M],
+                                                  const char (&plural)[N],
+                                                  int count)
+{
+#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+    return wxGetTranslation(msg, plural, count, wxString(), ctx);
+#else
+    return wxGetTranslation(wxASCII_STR(msg), wxASCII_STR(plural), count,
+                            wxString(), wxASCII_STR(ctx));
+#endif
+}
 
 #else // !wxUSE_INTL
 

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -333,6 +333,9 @@ inline const wxString& wxGetTranslation(const char *str1,
                             wxString(context, conv));
 }
 
+    #define wxTRANS_INPUT_STR(s) wxASCII_STR(s)
+#else
+    #define wxTRANS_INPUT_STR(s) s
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
 
 namespace wxTransImplStrict
@@ -343,11 +346,7 @@ namespace wxTransImplStrict
 template<size_t N>
 const wxString& wxUnderscoreWrapper(const char (&msg)[N])
 {
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    return wxGetTranslation(msg);
-#else
-    return wxGetTranslation(wxASCII_STR(msg));
-#endif
+    return wxGetTranslation(wxTRANS_INPUT_STR(msg));
 }
 
 template<size_t M, size_t N>
@@ -355,22 +354,16 @@ const wxString& wxPluralWrapper(const char (&msg)[M],
                                 const char (&plural)[N],
                                 int count)
 {
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    return wxGetTranslation(msg, plural, count);
-#else
-    return wxGetTranslation(wxASCII_STR(msg), wxASCII_STR(plural), count);
-#endif
+    return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
+                            count);
 }
 
 template<size_t M, size_t N>
 const wxString& wxGettextInContextWrapper(const char (&ctx)[M],
                                           const char (&msg)[N])
 {
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    return wxGetTranslation(msg, wxString(), ctx);
-#else
-    return wxGetTranslation(wxASCII_STR(msg), wxString(), wxASCII_STR(ctx));
-#endif
+    return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxString(),
+                            wxTRANS_INPUT_STR(ctx));
 }
 
 template<size_t L, size_t M, size_t N>
@@ -379,12 +372,8 @@ const wxString& wxGettextInContextPluralWrapper(const char (&ctx)[L],
                                                 const char (&plural)[N],
                                                 int count)
 {
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    return wxGetTranslation(msg, plural, count, wxString(), ctx);
-#else
-    return wxGetTranslation(wxASCII_STR(msg), wxASCII_STR(plural), count,
-                            wxString(), wxASCII_STR(ctx));
-#endif
+    return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
+                            count, wxString(), wxTRANS_INPUT_STR(ctx));
 }
 
 } // namespace wxTransImplStrict
@@ -396,32 +385,22 @@ namespace wxTransImplCompatible
 // as arguments.
 inline const wxString& wxUnderscoreWrapper(const char *msg)
 {
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    return wxGetTranslation(msg);
-#else
-    return wxGetTranslation(wxASCII_STR(msg));
-#endif
+    return wxGetTranslation(wxTRANS_INPUT_STR(msg));
 }
 
 inline const wxString& wxPluralWrapper(const char *msg,
                                        const char *plural,
                                        int count)
 {
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    return wxGetTranslation(msg, plural, count);
-#else
-    return wxGetTranslation(wxASCII_STR(msg), wxASCII_STR(plural), count);
-#endif
+    return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
+                            count);
 }
 
 inline const wxString& wxGettextInContextWrapper(const char *ctx,
                                                  const char *msg)
 {
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    return wxGetTranslation(msg, wxString(), ctx);
-#else
-    return wxGetTranslation(wxASCII_STR(msg), wxString(), wxASCII_STR(ctx));
-#endif
+    return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxString(),
+                            wxTRANS_INPUT_STR(ctx));
 }
 
 inline const wxString& wxGettextInContextPluralWrapper(const char *ctx,
@@ -429,12 +408,8 @@ inline const wxString& wxGettextInContextPluralWrapper(const char *ctx,
                                                        const char *plural,
                                                        int count)
 {
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-    return wxGetTranslation(msg, plural, count, wxString(), ctx);
-#else
-    return wxGetTranslation(wxASCII_STR(msg), wxASCII_STR(plural), count,
-                            wxString(), wxASCII_STR(ctx));
-#endif
+    return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
+                            count, wxString(), wxTRANS_INPUT_STR(ctx));
 }
 
 } // namespace wxTransImplCompatible

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -341,7 +341,7 @@ namespace wxTransImplStrict
 // Wrapper functions that only accept string literals as arguments,
 // not variables, not char* pointers.
 template<size_t N>
-const wxString &wxUnderscoreWrapper(const char (&msg)[N])
+const wxString& wxUnderscoreWrapper(const char (&msg)[N])
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
     return wxGetTranslation(msg);
@@ -351,7 +351,7 @@ const wxString &wxUnderscoreWrapper(const char (&msg)[N])
 }
 
 template<size_t M, size_t N>
-const wxString &wxPluralWrapper(const char (&msg)[M],
+const wxString& wxPluralWrapper(const char (&msg)[M],
                                 const char (&plural)[N],
                                 int count)
 {
@@ -363,7 +363,7 @@ const wxString &wxPluralWrapper(const char (&msg)[M],
 }
 
 template<size_t M, size_t N>
-const wxString &wxGettextInContextWrapper(const char (&ctx)[M],
+const wxString& wxGettextInContextWrapper(const char (&ctx)[M],
                                           const char (&msg)[N])
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
@@ -374,7 +374,7 @@ const wxString &wxGettextInContextWrapper(const char (&ctx)[M],
 }
 
 template<size_t L, size_t M, size_t N>
-const wxString &wxGettextInContextPluralWrapper(const char (&ctx)[L],
+const wxString& wxGettextInContextPluralWrapper(const char (&ctx)[L],
                                                 const char (&msg)[M],
                                                 const char (&plural)[N],
                                                 int count)

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -394,7 +394,7 @@ namespace wxTransImplTraditional
 
 // Wrapper functions that accept both string literals and variables
 // as arguments.
-inline const wxString &wxUnderscoreWrapper(const char *msg)
+inline const wxString& wxUnderscoreWrapper(const char *msg)
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
     return wxGetTranslation(msg);
@@ -403,7 +403,7 @@ inline const wxString &wxUnderscoreWrapper(const char *msg)
 #endif
 }
 
-inline const wxString &wxPluralWrapper(const char *msg,
+inline const wxString& wxPluralWrapper(const char *msg,
                                        const char *plural,
                                        int count)
 {
@@ -414,7 +414,7 @@ inline const wxString &wxPluralWrapper(const char *msg,
 #endif
 }
 
-inline const wxString &wxGettextInContextWrapper(const char *ctx,
+inline const wxString& wxGettextInContextWrapper(const char *ctx,
                                                  const char *msg)
 {
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
@@ -424,7 +424,7 @@ inline const wxString &wxGettextInContextWrapper(const char *ctx,
 #endif
 }
 
-inline const wxString &wxGettextInContextPluralWrapper(const char *ctx,
+inline const wxString& wxGettextInContextPluralWrapper(const char *ctx,
                                                        const char *msg,
                                                        const char *plural,
                                                        int count)

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -574,7 +574,7 @@ public:
     matching string.  As this function is used very often, an alternative (and
     also common in Unix world) syntax is provided: the _() macro is defined to
     do nearly the same thing as wxGetTranslation(), with the exception that
-    arguments to _() must be string literals.
+    the argument to _() must be a string literal.
 
     If @a context is not empty (notice that this argument is only available
     starting from wxWidgets 3.1.1), item translation is looked up in the

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -468,7 +468,7 @@ public:
     This macro is similar to _() but for the plural variant of
     wxGetTranslation().
 
-    The string arguments must be @a string @a literals.
+    The string arguments must be @em string @em literals.
 
     @return A const wxString.
 
@@ -481,7 +481,7 @@ public:
 
     See the description of @c context argument of wxGetTranslation().
 
-    The arguments must be @a string @a literals.
+    The arguments must be @em string @em literals.
 
     @see wxGETTEXT_IN_CONTEXT_PLURAL()
 
@@ -492,7 +492,7 @@ public:
 /**
     Similar to wxPLURAL() but translates the string in the given context.
 
-    The string arguments must be @a string @a literals.
+    The string arguments must be @em string @em literals.
 
     See the description of @c context argument of wxGetTranslation().
 

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -465,8 +465,10 @@ public:
 ///@{
 
 /**
-    This macro is identical to _() but for the plural variant of
+    This macro is similar to _() but for the plural variant of
     wxGetTranslation().
+
+    The string arguments must be @a string @a literals.
 
     @return A const wxString.
 
@@ -479,6 +481,8 @@ public:
 
     See the description of @c context argument of wxGetTranslation().
 
+    The arguments must be @a string @a literals.
+
     @see wxGETTEXT_IN_CONTEXT_PLURAL()
 
     @since 3.1.1
@@ -487,6 +491,8 @@ public:
 
 /**
     Similar to wxPLURAL() but translates the string in the given context.
+
+    The string arguments must be @a string @a literals.
 
     See the description of @c context argument of wxGetTranslation().
 
@@ -567,7 +573,8 @@ public:
     If @a domain is specified then only that domain/catalog is searched for a
     matching string.  As this function is used very often, an alternative (and
     also common in Unix world) syntax is provided: the _() macro is defined to
-    do the same thing as wxGetTranslation().
+    do nearly the same thing as wxGetTranslation(), with the exception that
+    arguments to _() must be string literals.
 
     If @a context is not empty (notice that this argument is only available
     starting from wxWidgets 3.1.1), item translation is looked up in the
@@ -633,7 +640,7 @@ const wxString& wxGetTranslation(const wxString& string,
 
     @header{wx/intl.h}
 */
-const wxString& _(const wxString& string);
+#define _(string)
 
 ///@}
 


### PR DESCRIPTION
Point translation macros to wrapper functions that only accept string literals. This is a backward-incompatible change, though most incompatibilities found are likely to be bugs.

While at present the arguments do not technically need to be string literals, variables can easily introduce subtle bugs that are not obvious to spot. The fact that xgettext only picks string literals is easy to forget.

Consider  the following code:
```c++
wxString itm("item");
_(itm);
wxGETTEXT_IN_CONTEXT("context_1", itm);
wxGETTEXT_IN_CONTEXT(itm, "item");
wxPLURAL(wxString::Format("%s", "singX"), "plurX", 1);
wxPLURAL("singY", wxString::Format("%s", "plurY"), 2);
wxGETTEXT_IN_CONTEXT_PLURAL("context_1", _("singZ"), "plurZ", 1);
```

All of these lines compile without warnings. However, only one string, `"singZ"`, is picked by `xgettext`, all others are silently ignored. Some lines would work if accompanied by a proper `wxTRANSLATE*` call, but nested calls (see the last line) to translation macros do not make sense in the first place.