### PR TITLE
Define wxCharNN as typedefs for charNN_t, not wxUintNN

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1013,20 +1013,23 @@ typedef double wxDouble;
 
 /* Define wxChar16 and wxChar32                                              */
 
+#ifdef __cplusplus
+
 #if SIZEOF_WCHAR_T == 2
     #define wxWCHAR_T_IS_WXCHAR16
     typedef wchar_t wxChar16;
 #else
-    typedef wxUint16 wxChar16;
+    typedef char16_t wxChar16;
 #endif
 
 #if SIZEOF_WCHAR_T == 4
     #define wxWCHAR_T_IS_WXCHAR32
     typedef wchar_t wxChar32;
 #else
-    typedef wxUint32 wxChar32;
+    typedef char32_t wxChar32;
 #endif
 
+#endif /* __cplusplus */
 
 /*
     Helper macro expanding into the given "m" macro invoked with each of the


### PR DESCRIPTION
This makes more sense, as they're supposed to be character types, not integer ones, and fixes the build with libc++ 19 which doesn't provide std::char_traits specializations for types other than char, wchar_t and charNN_t, so that std::basic_string<wxUint32> can't be compiled with it any more without specializing std::char_traits on our own which we'd rather avoid.

Closes #24958.