### PR TITLE
[wxOSX] Fix wxEvent timestamp narrowing

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -455,7 +455,7 @@ void wxWidgetCocoaImpl::SetupKeyEvent(wxKeyEvent &wxevent , NSEvent * nsEvent, N
     wxevent.m_rawCode = [nsEvent keyCode];
     wxevent.m_rawFlags = modifiers;
 
-    wxevent.SetTimestamp( (int)([nsEvent timestamp] * 1000) ) ;
+    wxevent.SetTimestamp( static_cast<long>([nsEvent timestamp] * 1000) ) ;
     wxevent.m_isRepeat = (eventType == NSKeyDown) && [nsEvent isARepeat];
 
     wxString chars;
@@ -614,7 +614,7 @@ wxWidgetCocoaImpl::TranslateMouseEvent( NSEvent * nsEvent )
     wxevent->m_rawControlDown = modifiers & NSControlKeyMask;
     wxevent->m_altDown = modifiers & NSAlternateKeyMask;
     wxevent->m_controlDown = modifiers & NSCommandKeyMask;
-    wxevent->SetTimestamp( (int)([nsEvent timestamp] * 1000) ) ;
+    wxevent->SetTimestamp( static_cast<long>([nsEvent timestamp] * 1000) ) ;
 
     UInt32 mouseChord = 0;
 
@@ -3867,7 +3867,7 @@ bool wxWidgetCocoaImpl::DoHandleCharEvent(NSEvent *event, NSString *text)
                 wxevent.SetId(peer->GetId());
 
                 if ( event )
-                    wxevent.SetTimestamp( (int)([event timestamp] * 1000) ) ;
+                    wxevent.SetTimestamp( static_cast<long>([event timestamp] * 1000) ) ;
             }
             
             result = peer->OSXHandleKeyEvent(wxevent) || result;


### PR DESCRIPTION
`wxEvent::m_timeStamp` is of type `long`, expressed in miliseconds. On macOS this value is assigned after conversion from `[NSEvent timestamp]` which is of type `double`, expressed in seconds. In several such assigment instances the original value is narrowed to `int`, apparently to silence implicit conversion warnings, see e490b0d.

However, the narrowing limits the applicability to `MAX_INT` milliseconds. Given that `int` is 32 bit on mac and that `NSEvent`'s `timestamp` returns the time in seconds since system startup, an interval between two events can only be checked when macOS uptime is less then 24.9 days.

As macs tend to run quite stable for long periods of time without the need for a reboot, this is a real-world problem.

Fix this by casting the source milliseconds value to `long`, which is 64 bit on mac.