### PR TITLE
Use the standard naming convention for WX_GL_COMPAT_PROFILE

### DIFF
--- a/include/wx/glcanvas.h
+++ b/include/wx/glcanvas.h
@@ -53,7 +53,7 @@ enum
     WX_GL_CORE_PROFILE,    // use an OpenGL core profile
     WX_GL_MAJOR_VERSION,   // major OpenGL version of the core profile
     WX_GL_MINOR_VERSION,   // minor OpenGL version of the core profile
-    wx_GL_COMPAT_PROFILE,  // use compatible profile (use all versions features)
+    WX_GL_COMPAT_PROFILE,  // use compatible profile (use all versions features)
     WX_GL_FORWARD_COMPAT,  // forward compatible context. OpenGL >= 3.0
     WX_GL_ES2,             // ES or ES2 context.
     WX_GL_DEBUG,           // create a debug context
@@ -62,7 +62,10 @@ enum
     WX_GL_LOSE_ON_RESET,   // if graphics reset, all context state is lost
     WX_GL_RESET_ISOLATION, // protect other apps or share contexts from reset side-effects
     WX_GL_RELEASE_FLUSH,   // on context release, flush pending commands
-    WX_GL_RELEASE_NONE     // on context release, pending commands are not flushed
+    WX_GL_RELEASE_NONE,    // on context release, pending commands are not flushed
+
+    // Old name defined (ironically) for compatibility.
+    wx_GL_COMPAT_PROFILE = WX_GL_COMPAT_PROFILE
 };
 
 #define wxGLCanvasName wxT("GLCanvas")

--- a/interface/wx/glcanvas.h
+++ b/interface/wx/glcanvas.h
@@ -656,7 +656,7 @@ enum
 
         @since 3.1.0
     */
-    wx_GL_COMPAT_PROFILE,
+    WX_GL_COMPAT_PROFILE,
 
     /**
         Request a forward-compatible context.

--- a/src/common/glcmn.cpp
+++ b/src/common/glcmn.cpp
@@ -276,7 +276,7 @@ bool wxGLCanvasBase::ParseAttribList(const int *attribList,
                 src++;
                 break;
 
-            case wx_GL_COMPAT_PROFILE:
+            case WX_GL_COMPAT_PROFILE:
                 if ( ctxAttrs )
                     ctxAttrs->CompatibilityProfile();
                 break;

--- a/src/qt/glcanvas.cpp
+++ b/src/qt/glcanvas.cpp
@@ -68,7 +68,7 @@ wxGLContextAttrs& wxGLContextAttrs::CoreProfile()
 {
 //    AddAttribBits(GLX_CONTEXT_PROFILE_MASK_ARB,
 //                  GLX_CONTEXT_CORE_PROFILE_BIT_ARB);
-    AddAttribute(wx_GL_COMPAT_PROFILE);
+    AddAttribute(WX_GL_COMPAT_PROFILE);
     SetNeedsARB();
     return *this;
 }
@@ -98,7 +98,7 @@ wxGLContextAttrs& wxGLContextAttrs::MinorVersion(int val)
 
 wxGLContextAttrs& wxGLContextAttrs::CompatibilityProfile()
 {
-    AddAttribute(wx_GL_COMPAT_PROFILE);
+    AddAttribute(WX_GL_COMPAT_PROFILE);
     SetNeedsARB();
     return *this;
 }
@@ -623,7 +623,7 @@ bool wxGLCanvas::ConvertWXAttrsToQtGL(const wxGLAttributes &wxGLAttrs, const wxG
                 format.setProfile(QSurfaceFormat::CoreProfile);
                 break;
 
-            case wx_GL_COMPAT_PROFILE:
+            case WX_GL_COMPAT_PROFILE:
                 format.setProfile(QSurfaceFormat::CompatibilityProfile);
                 break;
 


### PR DESCRIPTION
Use "WX" prefix for it, just as for all the other constants in the same enum instead of the lower-case "wx" (which is still preserved for compatibility).

Closes #24964.