### PR TITLE
Add support for HTML ID attribute

### DIFF
--- a/build/cmake/samples/html.cmake
+++ b/build/cmake/samples/html.cmake
@@ -30,7 +30,7 @@ wx_add_sample(printing DATA logo6.gif test.htm LIBRARIES wxhtml NAME htmlprintin
 wx_add_sample(test
     DATA
         imagemap.png pic.png pic2.bmp i18n.gif
-        imagemap.htm tables.htm test.htm listtest.htm 8859_2.htm cp1250.htm
+        imagemap.htm tables.htm test.htm id.html listtest.htm 8859_2.htm cp1250.htm
         regres.htm foo.png subsup.html
     LIBRARIES wxnet wxhtml NAME htmltest)
 wx_add_sample(virtual DATA start.htm LIBRARIES wxhtml)

--- a/docs/doxygen/overviews/string.h
+++ b/docs/doxygen/overviews/string.h
@@ -40,7 +40,7 @@ them.
 @section overview_string_iterating Iterating over wxString
 
 It is possible to iterate over strings using indices, but the recommended way
-to do it is to use use b iterators, either explicitly:
+to do it is to use iterators, either explicitly:
 
 @code
 wxString s = "hello";

--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -202,7 +202,7 @@ enum wxHtmlScriptMode
 class WXDLLIMPEXP_HTML wxHtmlCell : public wxObject
 {
 public:
-    wxHtmlCell();
+    wxHtmlCell() = default;
     virtual ~wxHtmlCell();
 
     void SetParent(wxHtmlContainerCell *p) {m_Parent = p;}
@@ -396,23 +396,25 @@ protected:
 
 
     // pointer to the next cell
-    wxHtmlCell *m_Next;
+    wxHtmlCell *m_Next = nullptr;
     // pointer to parent cell
-    wxHtmlContainerCell *m_Parent;
+    wxHtmlContainerCell *m_Parent = nullptr;
 
     // dimensions of fragment (m_Descent is used to position text & images)
-    int m_Width, m_Height, m_Descent;
+    int m_Width = 0,
+        m_Height = 0,
+        m_Descent = 0;
     // position where the fragment is drawn:
     int m_PosX, m_PosY;
 
     // superscript/subscript/normal:
-    wxHtmlScriptMode m_ScriptMode;
-    long m_ScriptBaseline;
+    wxHtmlScriptMode m_ScriptMode = wxHTML_SCRIPT_NORMAL;
+    long m_ScriptBaseline = 0;
 
     // destination address if this fragment is hypertext link, nullptr otherwise
-    wxHtmlLinkInfo *m_Link;
+    wxHtmlLinkInfo *m_Link = nullptr;
     // true if this cell can be placed on pagebreak, false otherwise
-    bool m_CanLiveOnPagebreak;
+    bool m_CanLiveOnPagebreak = true;
     // unique identifier of the cell, generated from "id" property of tags
     wxString m_id;
 

--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -585,29 +585,36 @@ protected:
                                   wxHtmlCell *cell) const;
 
 protected:
-    int m_IndentLeft, m_IndentRight, m_IndentTop, m_IndentBottom;
+    int m_IndentLeft = 0,
+        m_IndentRight = 0,
+        m_IndentTop = 0,
+        m_IndentBottom = 0;
             // indentation of subcells. There is always m_Indent pixels
             // big space between given border of the container and the subcells
             // it m_Indent < 0 it is in PERCENTS, otherwise it is in pixels
-    int m_MinHeight, m_MinHeightAlign;
+    int m_MinHeight = 0,
+        m_MinHeightAlign = wxHTML_ALIGN_TOP;
         // minimal height.
-    wxHtmlCell *m_Cells, *m_LastCell;
+    wxHtmlCell *m_Cells = nullptr,
+               *m_LastCell = nullptr;
             // internal cells, m_Cells points to the first of them, m_LastCell to the last one.
             // (LastCell is needed only to speed-up InsertCell)
-    int m_AlignHor, m_AlignVer;
+    int m_AlignHor = wxHTML_ALIGN_LEFT,
+        m_AlignVer = wxHTML_ALIGN_BOTTOM;
             // alignment horizontal and vertical (left, center, right)
-    int m_WidthFloat, m_WidthFloatUnits;
+    int m_WidthFloat = 100,
+        m_WidthFloatUnits = wxHTML_UNITS_PERCENT;
             // width float is used in adjustWidth
     wxColour m_BkColour;
             // background color of this container
-    int m_Border;
+    int m_Border = 0;
             // border size. Draw only if m_Border > 0
     wxColour m_BorderColour1, m_BorderColour2;
             // borders color of this container
-    int m_LastLayout;
+    int m_LastLayout = -1;
             // if != -1 then call to Layout may be no-op
             // if previous call to Layout has same argument
-    int m_MaxTotalWidth;
+    int m_MaxTotalWidth = 0;
             // Maximum possible length if ignoring line wrap
 
 

--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -228,6 +228,7 @@ public:
     bool IsFormattingCell() const { return m_Width == 0 && m_Height == 0; }
 
     const wxString& GetId() const { return m_id; }
+    bool HasId() const { return !m_id.empty(); }
     void SetId(const wxString& id) { m_id = id; }
 
     // returns the link associated with this cell. The position is position

--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -285,8 +285,8 @@ public:
     // Condition is unique condition identifier (see htmldefs.h)
     // (user-defined condition IDs should start from 10000)
     // and param is optional parameter
-    // Example : m_Cell->Find(wxHTML_COND_ISANCHOR, "news");
-    //   returns pointer to anchor news
+    // Example : m_Cell->Find(wxHTML_COND_ISANCHOR, &string);
+    //   returns pointer to anchor with the name specified by the string
     virtual const wxHtmlCell* Find(int condition, const void* param) const;
 
 

--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -203,6 +203,10 @@ class WXDLLIMPEXP_HTML wxHtmlCell : public wxObject
 {
 public:
     wxHtmlCell() = default;
+    explicit wxHtmlCell(const wxHtmlTag& tag)
+        : m_id(tag.GetParam(wxASCII_STR("id")))
+    {
+    }
     virtual ~wxHtmlCell();
 
     void SetParent(wxHtmlContainerCell *p) {m_Parent = p;}
@@ -230,6 +234,7 @@ public:
     const wxString& GetId() const { return m_id; }
     bool HasId() const { return !m_id.empty(); }
     void SetId(const wxString& id) { m_id = id; }
+    void CopyId(const wxHtmlTag& tag) { m_id = tag.GetParam(wxASCII_STR("id")); }
 
     // returns the link associated with this cell. The position is position
     // within the cell so it varies from 0 to m_Width, from 0 to m_Height
@@ -383,7 +388,8 @@ protected:
     virtual wxString GetDescription() const;
 
     // Can be used in Find() to check if the condition is wxHTML_COND_ISANCHOR
-    // and the parameter matches the given string.
+    // and the parameter matches the given string or, in the overload not
+    // taking anchor, the ID of this cell.
     //
     // This is supposed to only be used as a helper from Find().
     bool CheckIsAnchor(int cond, const void* p, const wxString& anchor) const
@@ -392,6 +398,11 @@ protected:
         // wxString for this condition.
         return cond == wxHTML_COND_ISANCHOR &&
                     *static_cast<const wxString*>(p) == anchor;
+    }
+
+    bool CheckIsAnchor(int cond, const void* p) const
+    {
+        return CheckIsAnchor(cond, p, GetId());
     }
 
 
@@ -499,6 +510,7 @@ class WXDLLIMPEXP_HTML wxHtmlContainerCell : public wxHtmlCell
 {
 public:
     explicit wxHtmlContainerCell(wxHtmlContainerCell *parent);
+    wxHtmlContainerCell(const wxHtmlTag& tag, wxHtmlContainerCell *parent);
     virtual ~wxHtmlContainerCell();
 
     virtual void Layout(int w) override;
@@ -618,6 +630,9 @@ protected:
             // Maximum possible length if ignoring line wrap
 
 
+private:
+    void InitParent(wxHtmlContainerCell *parent);
+
     wxDECLARE_ABSTRACT_CLASS(wxHtmlContainerCell);
     wxDECLARE_NO_COPY_CLASS(wxHtmlContainerCell);
 };
@@ -660,6 +675,7 @@ class WXDLLIMPEXP_HTML wxHtmlFontCell : public wxHtmlCell
 {
 public:
     wxHtmlFontCell(wxFont *font) : wxHtmlCell(), m_Font(*font) { }
+    wxHtmlFontCell(const wxHtmlTag& tag, wxFont *font) : wxHtmlCell(tag), m_Font(*font) { }
     virtual void Draw(wxDC& dc, int x, int y, int view_y1, int view_y2,
                       wxHtmlRenderingInfo& info) override;
     virtual void DrawInvisible(wxDC& dc, int x, int y,

--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -287,6 +287,7 @@ public:
     // and param is optional parameter
     // Example : m_Cell->Find(wxHTML_COND_ISANCHOR, &string);
     //   returns pointer to anchor with the name specified by the string
+    // (see protected CheckIsAnchor() helper)
     virtual const wxHtmlCell* Find(int condition, const void* param) const;
 
 
@@ -380,6 +381,18 @@ public:
 protected:
     // Return the description used by Dump().
     virtual wxString GetDescription() const;
+
+    // Can be used in Find() to check if the condition is wxHTML_COND_ISANCHOR
+    // and the parameter matches the given string.
+    //
+    // This is supposed to only be used as a helper from Find().
+    bool CheckIsAnchor(int cond, const void* p, const wxString& anchor) const
+    {
+        // Note that we know that the parameter is always a valid pointer to
+        // wxString for this condition.
+        return cond == wxHTML_COND_ISANCHOR &&
+                    *static_cast<const wxString*>(p) == anchor;
+    }
 
 
     // pointer to the next cell

--- a/interface/wx/html/htmlcell.h
+++ b/interface/wx/html/htmlcell.h
@@ -379,6 +379,13 @@ public:
     int GetWidth() const;
 
     /**
+        Returns true if this cell has a non-empty ID.
+
+        @since 3.3.0
+     */
+    bool HasId() const;
+
+    /**
         Layouts the cell.
 
         This method performs two actions:

--- a/samples/html/test/Makefile.in
+++ b/samples/html/test/Makefile.in
@@ -194,7 +194,7 @@ test$(EXEEXT): $(TEST_OBJECTS) $(__test___win32rc)
 
 data: 
 	@mkdir -p .
-	@for f in imagemap.png pic.png pic2.bmp i18n.gif imagemap.htm tables.htm test.htm listtest.htm 8859_2.htm cp1250.htm regres.htm foo.png subsup.html; do \
+	@for f in imagemap.png pic.png pic2.bmp i18n.gif imagemap.htm tables.htm test.htm id.html listtest.htm 8859_2.htm cp1250.htm regres.htm foo.png subsup.html; do \
 	if test ! -f ./$$f -a ! -d ./$$f ; \
 	then x=yep ; \
 	else x=`find $(srcdir)/$$f -newer ./$$f -print` ; \

--- a/samples/html/test/id.html
+++ b/samples/html/test/id.html
@@ -1,0 +1,339 @@
+<html>
+
+<head>
+    <title>id test</title>
+</head>
+
+<body>
+    <ul>
+        <li><a href="#h1">h1</a></li>
+        <li><a href="#h2">h2</a></li>
+        <li><a href="#h3">h3</a></li>
+        <li><a href="#h4">h4</a></li>
+        <li><a href="#h5">h5</a></li>
+        <li><a href="#h6">h6</a></li>
+        <li><a href="#p1">p1</a></li>
+        <li><a href="#div1">div1</a></li>
+        <li><a href="#span1">span1</a></li>
+        <li><a href="#br1">br1</a></li>
+        <li><a href="#a1">a1</a></li>
+        <li><a href="#dl1">dl1</a></li>
+        <li><a href="#dt1">dt1</a></li>
+        <li><a href="#dd1">dd1</a></li>
+        <li><a href="#ol1">ol1</a></li>
+        <li><a href="#ul1">ul1</a></li>
+        <li><a href="#li4">li4</a></li>
+        <li><a href="#hr1">hr1</a></li>
+        <li><a href="#pre1">pre1</a></li>
+        <li><a href="#table1">table1</a></li>
+        <li><a href="#blockquote1">blockquote1</a></li>
+    </ul>
+
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h1 id="h1">Header 1</h1>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h2 id="h2">Header 2</h2>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h3 id="h3">Header 3</h3>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h4 id="h4">Header 4</h4>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h5 id="h5">Header 5</h5>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <h6 id="h6">Header 6</h6>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>p1</h6>
+    <p id="p1">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
+        et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea
+        takimata sanctus
+        </span> est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>span1</h6>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
+        et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea <span id="span1"> takimata sanctus</span> est Lorem ipsum dolor sit amet. Lorem
+        ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
+        magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+        gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>div1</h6>
+    <div id="div1">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut
+        labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea
+        rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+        amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+        erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no
+        sea takimata sanctus est Lorem ipsum dolor sit amet.</div>
+    <h6>a1</h6>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. <a id="a1">At</a> vero eos et accusam et justo duo dolores et ea
+        rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>br1</h6>
+    <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr,<br id="br1"> sed diam nonumy eirmod tempor invidunt ut
+        labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.</p>
+    <h6>dl1</h6>
+    <dl id="dl1">
+        <dt id="dt1">Beast of Bodmin</dt>
+        <dd id="dd1">A large feline inhabiting Bodmin Moor.</dd>
+
+        <dt id="dt2">Morgawr</dt>
+        <dd id="dd2">A sea serpent.</dd>
+
+        <dt id="dt3">Owlman</dt>
+        <dd id="dd3">A giant owl-like creature.</dd>
+    </dl>
+    <h6>ol1</h6>
+    <ol id="ol1">
+        <li id="li1">Mix flour, baking powder, sugar, and salt.</li>
+        <li id="li2">In another bowl, mix eggs, milk, and oil.</li>
+        <li id="li3">Stir both mixtures together.</li>
+        <li id="li4">Fill muffin tray 3/4 full.</li>
+        <li id="li5">Bake for 20 minutes.</li>
+    </ol>
+    <h6>ul1</h6>
+    <ul id="ul1">
+        <li id="li6">Milk</li>
+        <li id="li7">
+            Cheese
+            <ul id="ul2">
+                <li id="li8">Blue cheese</li>
+                <li id="li9">Feta</li>
+            </ul>
+        </li>
+    </ul>
+    <h6>hr1</h6>
+    <hr id="hr1">
+    <h6>pre1</h6>
+    <pre id="pre1">
+        L          TE
+          A       A
+            C    V
+             R A
+             DOU
+             LOU
+            REUSE
+            QUE TU
+            PORTES
+          ET QUI T'
+          ORNE O CI
+           VILISÉ
+          OTE-  TU VEUX
+           LA    BIEN
+          SI      RESPI
+                  RER       - Apollinaire
+      </pre>
+    <h6>table1</h6>
+    <table id="table1">
+        <caption>
+            Front-end web developer course 2021
+        </caption>
+        <thead>
+            <tr>
+                <th scope="col">Person</th>
+                <th scope="col">Most interest in</th>
+                <th scope="col">Age</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th scope="row">Chris</th>
+                <td>HTML tables</td>
+                <td>22</td>
+            </tr>
+            <tr>
+                <th scope="row">Dennis</th>
+                <td>Web accessibility</td>
+                <td>45</td>
+            </tr>
+            <tr>
+                <th scope="row">Sarah</th>
+                <td>JavaScript frameworks</td>
+                <td>29</td>
+            </tr>
+            <tr>
+                <th scope="row">Karen</th>
+                <td>Web performance</td>
+                <td>36</td>
+            </tr>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th scope="row" colspan="2">Average age</th>
+                <td>33</td>
+            </tr>
+        </tfoot>
+    </table>
+    <h6>blockquote1</h6>
+    <blockquote id="blockquote1">
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </blockquote>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+    <p>
+        Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+        dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet
+        clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+        consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+        diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+        takimata sanctus est Lorem ipsum dolor sit amet.
+    </p>
+
+</body>
+
+</html>

--- a/samples/html/test/makefile.gcc
+++ b/samples/html/test/makefile.gcc
@@ -220,7 +220,7 @@ $(OBJS)\test.exe: $(TEST_OBJECTS) $(OBJS)\test_sample_rc.o
 
 data: 
 	if not exist $(OBJS) mkdir $(OBJS)
-	for %%f in (imagemap.png pic.png pic2.bmp i18n.gif imagemap.htm tables.htm test.htm listtest.htm 8859_2.htm cp1250.htm regres.htm foo.png subsup.html) do if not exist $(OBJS)\%%f copy .\%%f $(OBJS)
+	for %%f in (imagemap.png pic.png pic2.bmp i18n.gif imagemap.htm tables.htm test.htm id.html listtest.htm 8859_2.htm cp1250.htm regres.htm foo.png subsup.html) do if not exist $(OBJS)\%%f copy .\%%f $(OBJS)
 
 $(OBJS)\test_sample_rc.o: ./../../../samples/sample.rc
 	$(WINDRES) -i$< -o$@    --define __WXMSW__ $(__WXUNIV_DEFINE_p_1) $(__DEBUG_DEFINE_p_1) $(__NDEBUG_DEFINE_p_1) $(__EXCEPTIONS_DEFINE_p_1) $(__RTTI_DEFINE_p_1) $(__THREAD_DEFINE_p_1) --include-dir $(SETUPHDIR) --include-dir ./../../../include $(__CAIRO_INCLUDEDIR_p) --include-dir . $(__DLLFLAG_p_1) --define wxUSE_DPI_AWARE_MANIFEST=$(USE_DPI_AWARE_MANIFEST) --include-dir ./../../../samples --define NOPCH

--- a/samples/html/test/makefile.vc
+++ b/samples/html/test/makefile.vc
@@ -440,7 +440,7 @@ $(OBJS)\test.exe: $(TEST_OBJECTS) $(OBJS)\test_sample.res
 
 data: 
 	if not exist $(OBJS) mkdir $(OBJS)
-	for %f in (imagemap.png pic.png pic2.bmp i18n.gif imagemap.htm tables.htm test.htm listtest.htm 8859_2.htm cp1250.htm regres.htm foo.png subsup.html) do if not exist $(OBJS)\%f copy .\%f $(OBJS)
+	for %f in (imagemap.png pic.png pic2.bmp i18n.gif imagemap.htm tables.htm test.htm id.html listtest.htm 8859_2.htm cp1250.htm regres.htm foo.png subsup.html) do if not exist $(OBJS)\%f copy .\%f $(OBJS)
 
 $(OBJS)\test_sample.res: .\..\..\..\samples\sample.rc
 	rc /fo$@  /d WIN32 $(____DEBUGRUNTIME_3_p_1) /d _CRT_SECURE_NO_DEPRECATE=1 /d _CRT_NON_CONFORMING_SWPRINTFS=1 /d _SCL_SECURE_NO_WARNINGS=1 $(__NO_VC_CRTDBG_p_1)  $(__TARGET_CPU_COMPFLAG_p_1) /d __WXMSW__ $(__WXUNIV_DEFINE_p_1) $(__DEBUG_DEFINE_p_1) $(__NDEBUG_DEFINE_p_1) $(__EXCEPTIONS_DEFINE_p_1) $(__RTTI_DEFINE_p_1) $(__THREAD_DEFINE_p_1) /i $(SETUPHDIR) /i .\..\..\..\include $(____CAIRO_INCLUDEDIR_FILENAMES_1_p) /i . $(__DLLFLAG_p_1)  /d _WINDOWS /i .\..\..\..\samples /d NOPCH .\..\..\..\samples\sample.rc

--- a/samples/html/test/test.bkl
+++ b/samples/html/test/test.bkl
@@ -15,7 +15,7 @@
     <wx-data id="data">
         <files>
             imagemap.png pic.png pic2.bmp i18n.gif
-            imagemap.htm tables.htm test.htm listtest.htm 8859_2.htm cp1250.htm
+            imagemap.htm tables.htm test.htm id.html listtest.htm 8859_2.htm cp1250.htm
             regres.htm foo.png subsup.html
         </files>
     </wx-data>

--- a/samples/html/test/test.htm
+++ b/samples/html/test/test.htm
@@ -33,6 +33,8 @@
 <b><a href="cp1250.htm">i18n demo 2 (cp1250)</a></b>
 <p>
 <b><a href="regres.htm">some wxHTML regression tests</a></b>
+<p>
+<b><a href="id.html">id test</a></b>
 </font>
 
 <p>

--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -180,8 +180,11 @@ void wxHtmlCell::Layout(int WXUNUSED(w))
 
 
 
-const wxHtmlCell* wxHtmlCell::Find(int WXUNUSED(condition), const void* WXUNUSED(param)) const
+const wxHtmlCell* wxHtmlCell::Find(int condition, const void* param) const
 {
+    if ( CheckIsAnchor(condition, param) )
+        return this;
+
     return nullptr;
 }
 
@@ -655,10 +658,22 @@ wxString wxHtmlWordCell::GetDescription() const
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxHtmlContainerCell, wxHtmlCell);
 
-wxHtmlContainerCell::wxHtmlContainerCell(wxHtmlContainerCell *parent) : wxHtmlCell()
+void wxHtmlContainerCell::InitParent(wxHtmlContainerCell *parent)
 {
     m_Parent = parent;
     if (m_Parent) m_Parent->InsertCell(this);
+}
+
+wxHtmlContainerCell::wxHtmlContainerCell(wxHtmlContainerCell *parent) : wxHtmlCell()
+{
+    InitParent(parent);
+}
+
+wxHtmlContainerCell::wxHtmlContainerCell(const wxHtmlTag& tag,
+                                         wxHtmlContainerCell *parent)
+    : wxHtmlCell(tag)
+{
+    InitParent(parent);
 }
 
 wxHtmlContainerCell::~wxHtmlContainerCell()
@@ -1258,6 +1273,9 @@ void wxHtmlContainerCell::SetWidthFloat(const wxHtmlTag& tag, double pixel_scale
 
 const wxHtmlCell* wxHtmlContainerCell::Find(int condition, const void* param) const
 {
+    if ( CheckIsAnchor(condition, param) )
+        return this;
+
     if (m_Cells)
     {
         for (wxHtmlCell *cell = m_Cells; cell; cell = cell->GetNext())

--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -77,17 +77,6 @@ GetSelectedTextBgColour(const wxColour& WXUNUSED(clr))
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxHtmlCell, wxObject);
 
-wxHtmlCell::wxHtmlCell() : wxObject()
-{
-    m_Next = nullptr;
-    m_Parent = nullptr;
-    m_Width = m_Height = m_Descent = 0;
-    m_ScriptMode = wxHTML_SCRIPT_NORMAL;        // <sub> or <sup> mode
-    m_ScriptBaseline = 0;                       // <sub> or <sup> baseline
-    m_CanLiveOnPagebreak = true;
-    m_Link = nullptr;
-}
-
 wxHtmlCell::~wxHtmlCell()
 {
     delete m_Link;

--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -657,18 +657,8 @@ wxIMPLEMENT_ABSTRACT_CLASS(wxHtmlContainerCell, wxHtmlCell);
 
 wxHtmlContainerCell::wxHtmlContainerCell(wxHtmlContainerCell *parent) : wxHtmlCell()
 {
-    m_Cells = m_LastCell = nullptr;
     m_Parent = parent;
-    m_MaxTotalWidth = 0;
     if (m_Parent) m_Parent->InsertCell(this);
-    m_AlignHor = wxHTML_ALIGN_LEFT;
-    m_AlignVer = wxHTML_ALIGN_BOTTOM;
-    m_IndentLeft = m_IndentRight = m_IndentTop = m_IndentBottom = 0;
-    m_WidthFloat = 100; m_WidthFloatUnits = wxHTML_UNITS_PERCENT;
-    m_Border = 0;
-    m_MinHeight = 0;
-    m_MinHeightAlign = wxHTML_ALIGN_TOP;
-    m_LastLayout = -1;
 }
 
 wxHtmlContainerCell::~wxHtmlContainerCell()

--- a/src/html/m_dflist.cpp
+++ b/src/html/m_dflist.cpp
@@ -35,16 +35,19 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
 
         if (tag.GetName() == wxT("DL"))
         {
-            if (m_WParser->GetContainer()->GetFirstChild() != nullptr)
+            if (m_WParser->GetContainer()->GetFirstChild() != nullptr ||
+                    m_WParser->GetContainer()->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
             }
+            m_WParser->GetContainer()->CopyId(tag);
             m_WParser->GetContainer()->SetIndent(m_WParser->GetCharHeight(), wxHTML_INDENT_TOP);
 
             ParseInner(tag);
 
-            if (m_WParser->GetContainer()->GetFirstChild() != nullptr)
+            if (m_WParser->GetContainer()->GetFirstChild() != nullptr ||
+                    m_WParser->GetContainer()->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -57,6 +60,7 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
         {
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();
+            c->CopyId(tag);
             c->SetAlignHor(wxHTML_ALIGN_LEFT);
             c->SetMinHeight(m_WParser->GetCharHeight());
             return false;
@@ -65,6 +69,7 @@ TAG_HANDLER_BEGIN(DEFLIST, "DL,DT,DD" )
         {
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();
+            c->CopyId(tag);
             c->SetIndent(5 * m_WParser->GetCharWidth(), wxHTML_INDENT_LEFT);
             return false;
         }

--- a/src/html/m_fonts.cpp
+++ b/src/html/m_fonts.cpp
@@ -287,12 +287,13 @@ TAG_HANDLER_BEGIN(Hx, "H1,H2,H3,H4,H5,H6")
         }
 
         c = m_WParser->GetContainer();
-        if (c->GetFirstChild())
+        if (c->GetFirstChild() || c->HasId())
         {
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();
         }
 
+        c->CopyId(tag);
         c->SetAlign(tag);
         c->InsertCell(new wxHtmlFontCell(m_WParser->CreateCurrentFont()));
         c->SetIndent(m_WParser->GetCharHeight(), wxHTML_INDENT_TOP);

--- a/src/html/m_fonts.cpp
+++ b/src/html/m_fonts.cpp
@@ -290,10 +290,8 @@ TAG_HANDLER_BEGIN(Hx, "H1,H2,H3,H4,H5,H6")
         if (c->GetFirstChild())
         {
             m_WParser->CloseContainer();
-            m_WParser->OpenContainer();
-            c = m_WParser->GetContainer();
+            c = m_WParser->OpenContainer();
         }
-        c = m_WParser->GetContainer();
 
         c->SetAlign(tag);
         c->InsertCell(new wxHtmlFontCell(m_WParser->CreateCurrentFont()));

--- a/src/html/m_hline.cpp
+++ b/src/html/m_hline.cpp
@@ -32,7 +32,8 @@ FORCE_LINK_ME(m_hline)
 class wxHtmlLineCell : public wxHtmlCell
 {
     public:
-        wxHtmlLineCell(int size, bool shading) : wxHtmlCell() {m_Height = size; m_HasShading = shading;}
+        wxHtmlLineCell(const wxHtmlTag& tag, int size, bool shading)
+            : wxHtmlCell(tag) {m_Height = size; m_HasShading = shading;}
         void Draw(wxDC& dc, int x, int y, int view_y1, int view_y2,
                   wxHtmlRenderingInfo& info) override;
         void Layout(int w) override
@@ -84,7 +85,7 @@ TAG_HANDLER_BEGIN(HR, "HR")
         sz = 1;
         tag.GetParamAsInt(wxT("SIZE"), &sz);
         HasShading = !(tag.HasParam(wxT("NOSHADE")));
-        c->InsertCell(new wxHtmlLineCell((int)((double)sz * m_WParser->GetPixelScale()), HasShading));
+        c->InsertCell(new wxHtmlLineCell(tag, (int)((double)sz * m_WParser->GetPixelScale()), HasShading));
 
         m_WParser->CloseContainer();
         m_WParser->OpenContainer();

--- a/src/html/m_image.cpp
+++ b/src/html/m_image.cpp
@@ -54,7 +54,8 @@ class wxHtmlImageMapAreaCell : public wxHtmlCell
         celltype type;
         int radius;
     public:
-        wxHtmlImageMapAreaCell(celltype t,
+        wxHtmlImageMapAreaCell(const wxHtmlTag& tag,
+                               celltype t,
                                wxString coords,
                                double pixel_scale = 1.0);
         virtual wxHtmlLinkInfo *GetLink( int x = 0, int y = 0 ) const override;
@@ -71,10 +72,11 @@ class wxHtmlImageMapAreaCell : public wxHtmlCell
 
 
 
-wxHtmlImageMapAreaCell::wxHtmlImageMapAreaCell(celltype t,
+wxHtmlImageMapAreaCell::wxHtmlImageMapAreaCell(const wxHtmlTag& tag,
+                                               celltype t,
                                                wxString x,
                                                double pixel_scale)
-    : wxHtmlCell(), type(t)
+    : wxHtmlCell(tag), type(t)
 {
     int i;
 
@@ -232,7 +234,7 @@ wxHtmlLinkInfo *wxHtmlImageMapAreaCell::GetLink( int x, int y ) const
 class wxHtmlImageMapCell : public wxHtmlCell
 {
     public:
-        wxHtmlImageMapCell( wxString &name );
+        wxHtmlImageMapCell( const wxHtmlTag& tag, wxString &name );
     protected:
         wxString m_Name;
     public:
@@ -247,8 +249,9 @@ class wxHtmlImageMapCell : public wxHtmlCell
 };
 
 
-wxHtmlImageMapCell::wxHtmlImageMapCell( wxString &name )
-    : m_Name(name)
+wxHtmlImageMapCell::wxHtmlImageMapCell( const wxHtmlTag& tag, wxString &name )
+    : wxHtmlCell(tag),
+      m_Name(name)
 {
 }
 
@@ -282,7 +285,8 @@ const wxHtmlCell *wxHtmlImageMapCell::Find( int cond, const void *param ) const
 class wxHtmlImageCell : public wxHtmlCell
 {
 public:
-    wxHtmlImageCell(wxHtmlWindowInterface *windowIface,
+    wxHtmlImageCell(const wxHtmlTag& tag,
+                    wxHtmlWindowInterface *windowIface,
                     wxFSFile *input, double scaleHDPI = 1.0,
                     int w = wxDefaultCoord, bool wpercent = false,
                     int h = wxDefaultCoord, bool hpresent = false,
@@ -356,10 +360,11 @@ class wxGIFTimer : public wxTimer
 //----------------------------------------------------------------------------
 
 
-wxHtmlImageCell::wxHtmlImageCell(wxHtmlWindowInterface *windowIface,
+wxHtmlImageCell::wxHtmlImageCell(const wxHtmlTag& tag,
+                                 wxHtmlWindowInterface *windowIface,
                                  wxFSFile *input, double scaleHDPI,
                                  int w, bool wpercent, int h, bool hpresent, double scale, int align,
-                                 const wxString& mapname) : wxHtmlCell()
+                                 const wxString& mapname) : wxHtmlCell(tag)
     , m_mapName(mapname)
 {
     m_windowIface = windowIface;
@@ -744,13 +749,13 @@ TAG_HANDLER_BEGIN(IMG, "IMG,MAP,AREA")
                     }
                 }
                 wxHtmlImageCell *cel = new wxHtmlImageCell(
+                                          tag,
                                           m_WParser->GetWindowInterface(),
                                           str, scaleHDPI, w, wpercent, h, hpresent,
                                           m_WParser->GetPixelScale(),
                                           al, mn);
                 m_WParser->ApplyStateToCell(cel);
                 m_WParser->StopCollapsingSpaces();
-                cel->SetId(tag.GetParam(wxT("id"))); // may be empty
                 cel->SetAlt(tag.GetParam(wxT("alt")));
                 m_WParser->GetContainer()->InsertCell(cel);
                 delete str;
@@ -761,9 +766,10 @@ TAG_HANDLER_BEGIN(IMG, "IMG,MAP,AREA")
             m_WParser->CloseContainer();
             m_WParser->OpenContainer();
             wxString tmp;
-            if (tag.GetParamAsString(wxT("NAME"), &tmp))
+            if (tag.GetParamAsString(wxT("NAME"), &tmp) ||
+                    tag.HasParam(wxT("ID")))
             {
-                wxHtmlImageMapCell *cel = new wxHtmlImageMapCell( tmp );
+                wxHtmlImageMapCell *cel = new wxHtmlImageMapCell( tag, tmp );
                 m_WParser->GetContainer()->InsertCell( cel );
             }
             ParseInner( tag );
@@ -787,7 +793,7 @@ TAG_HANDLER_BEGIN(IMG, "IMG,MAP,AREA")
                 else
                     return false;
 
-                auto* const cel = new wxHtmlImageMapAreaCell( t, tag.GetParam(wxT("COORDS")), m_WParser->GetPixelScale() );
+                auto* const cel = new wxHtmlImageMapAreaCell( tag, t, tag.GetParam(wxT("COORDS")), m_WParser->GetPixelScale() );
                 wxString href;
                 if (tag.GetParamAsString(wxT("HREF"), &href))
                     cel->SetLink(wxHtmlLinkInfo(href, tag.GetParam(wxT("TARGET"))));

--- a/src/html/m_image.cpp
+++ b/src/html/m_image.cpp
@@ -54,7 +54,9 @@ class wxHtmlImageMapAreaCell : public wxHtmlCell
         celltype type;
         int radius;
     public:
-        wxHtmlImageMapAreaCell( celltype t, wxString &coords, double pixel_scale = 1.0);
+        wxHtmlImageMapAreaCell(celltype t,
+                               wxString coords,
+                               double pixel_scale = 1.0);
         virtual wxHtmlLinkInfo *GetLink( int x = 0, int y = 0 ) const override;
         void Draw(wxDC& WXUNUSED(dc),
                   int WXUNUSED(x), int WXUNUSED(y),
@@ -69,12 +71,13 @@ class wxHtmlImageMapAreaCell : public wxHtmlCell
 
 
 
-wxHtmlImageMapAreaCell::wxHtmlImageMapAreaCell( wxHtmlImageMapAreaCell::celltype t, wxString &incoords, double pixel_scale )
+wxHtmlImageMapAreaCell::wxHtmlImageMapAreaCell(celltype t,
+                                               wxString x,
+                                               double pixel_scale)
+    : wxHtmlCell(), type(t)
 {
     int i;
-    wxString x = incoords;
 
-    type = t;
     while ((i = x.Find( ',' )) != wxNOT_FOUND)
     {
         coords.push_back( (int)(pixel_scale * (double)wxAtoi( x.Left( i ).c_str())) );
@@ -772,26 +775,23 @@ TAG_HANDLER_BEGIN(IMG, "IMG,MAP,AREA")
             wxString tmp;
             if (tag.GetParamAsString(wxT("SHAPE"), &tmp))
             {
-                wxString coords = tag.GetParam(wxT("COORDS"));
                 tmp.MakeUpper();
-                wxHtmlImageMapAreaCell *cel = nullptr;
+
+                wxHtmlImageMapAreaCell::celltype t;
                 if (tmp == wxT("POLY"))
-                {
-                    cel = new wxHtmlImageMapAreaCell( wxHtmlImageMapAreaCell::POLY, coords, m_WParser->GetPixelScale() );
-                }
+                    t = wxHtmlImageMapAreaCell::POLY;
                 else if (tmp == wxT("CIRCLE"))
-                {
-                    cel = new wxHtmlImageMapAreaCell( wxHtmlImageMapAreaCell::CIRCLE, coords, m_WParser->GetPixelScale() );
-                }
+                    t = wxHtmlImageMapAreaCell::CIRCLE;
                 else if (tmp == wxT("RECT"))
-                {
-                    cel = new wxHtmlImageMapAreaCell( wxHtmlImageMapAreaCell::RECT, coords, m_WParser->GetPixelScale() );
-                }
+                    t = wxHtmlImageMapAreaCell::RECT;
+                else
+                    return false;
+
+                auto* const cel = new wxHtmlImageMapAreaCell( t, tag.GetParam(wxT("COORDS")), m_WParser->GetPixelScale() );
                 wxString href;
-                if (cel != nullptr && tag.GetParamAsString(wxT("HREF"), &href))
+                if (tag.GetParamAsString(wxT("HREF"), &href))
                     cel->SetLink(wxHtmlLinkInfo(href, tag.GetParam(wxT("TARGET"))));
-                if (cel != nullptr)
-                    m_WParser->GetContainer()->InsertCell( cel );
+                m_WParser->GetContainer()->InsertCell( cel );
             }
         }
 

--- a/src/html/m_layout.cpp
+++ b/src/html/m_layout.cpp
@@ -60,7 +60,7 @@ FORCE_LINK_ME(m_layout)
 class wxHtmlPageBreakCell : public wxHtmlCell
 {
 public:
-    wxHtmlPageBreakCell() {}
+    explicit wxHtmlPageBreakCell(const wxHtmlTag& tag) : wxHtmlCell(tag) {}
 
     bool AdjustPagebreak(int* pagebreak, int pageHeight) const override;
 
@@ -95,11 +95,13 @@ TAG_HANDLER_BEGIN(P, "P")
 
     TAG_HANDLER_PROC(tag)
     {
-        if (m_WParser->GetContainer()->GetFirstChild() != nullptr)
+        if (m_WParser->GetContainer()->GetFirstChild() != nullptr ||
+                m_WParser->GetContainer()->HasId())
         {
             m_WParser->CloseContainer();
             m_WParser->OpenContainer();
         }
+        m_WParser->GetContainer()->CopyId(tag);
         m_WParser->GetContainer()->SetIndent(m_WParser->GetCharHeight(), wxHTML_INDENT_TOP);
         m_WParser->GetContainer()->SetAlign(tag);
         return false;
@@ -119,6 +121,7 @@ TAG_HANDLER_BEGIN(BR, "BR")
 
         m_WParser->CloseContainer();
         c = m_WParser->OpenContainer();
+        c->CopyId(tag);
         c->SetAlignHor(al);
         c->SetAlign(tag);
         c->SetMinHeight(m_WParser->GetCharHeight());
@@ -138,7 +141,7 @@ TAG_HANDLER_BEGIN(CENTER, "CENTER")
         wxHtmlContainerCell *c = m_WParser->GetContainer();
 
         m_WParser->SetAlign(wxHTML_ALIGN_CENTER);
-        if (c->GetFirstChild() != nullptr)
+        if (c->GetFirstChild() != nullptr || c->HasId())
         {
             m_WParser->CloseContainer();
             m_WParser->OpenContainer();
@@ -151,7 +154,7 @@ TAG_HANDLER_BEGIN(CENTER, "CENTER")
             ParseInner(tag);
 
             m_WParser->SetAlign(old);
-            if (c->GetFirstChild() != nullptr)
+            if (c->GetFirstChild() != nullptr || c->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -179,7 +182,7 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
             if(style.IsSameAs(wxT("PAGE-BREAK-BEFORE:ALWAYS"), false))
             {
                 m_WParser->CloseContainer();
-                m_WParser->OpenContainer()->InsertCell(new wxHtmlPageBreakCell);
+                m_WParser->OpenContainer()->InsertCell(new wxHtmlPageBreakCell(tag));
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
                 return false;
@@ -188,13 +191,14 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
             {
                 // As usual, reuse the current container if it's empty.
                 wxHtmlContainerCell *c = m_WParser->GetContainer();
-                if (c->GetFirstChild() != nullptr)
+                if (c->GetFirstChild() != nullptr || c->HasId())
                 {
                     // If not, open a new one.
                     m_WParser->CloseContainer();
                     c = m_WParser->OpenContainer();
                 }
 
+                c->CopyId(tag);
                 // Force this container to live entirely on the same page.
                 c->SetCanLiveOnPagebreak(false);
 
@@ -223,7 +227,7 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
         {
             int old = m_WParser->GetAlign();
             wxHtmlContainerCell *c = m_WParser->GetContainer();
-            if (c->GetFirstChild() != nullptr)
+            if (c->GetFirstChild() != nullptr || c->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -236,11 +240,12 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
                 c->SetAlign(tag);
                 m_WParser->SetAlign(c->GetAlignHor());
             }
+            c->CopyId(tag);
 
             ParseInner(tag);
 
             m_WParser->SetAlign(old);
-            if (c->GetFirstChild() != nullptr)
+            if (c->GetFirstChild() != nullptr || c->HasId())
             {
                 m_WParser->CloseContainer();
                 m_WParser->OpenContainer();
@@ -258,6 +263,7 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
 
             m_WParser->CloseContainer();
             c = m_WParser->OpenContainer();
+            c->CopyId(tag);
             c->SetAlignHor(al);
             c->SetAlign(tag);
             c->SetMinHeight(m_WParser->GetCharHeight());
@@ -354,6 +360,7 @@ TAG_HANDLER_BEGIN(BLOCKQUOTE, "BLOCKQUOTE")
         m_WParser->CloseContainer();
         c = m_WParser->OpenContainer();
 
+        c->CopyId(tag);
         if (c->GetAlignHor() == wxHTML_ALIGN_RIGHT)
             c->SetIndent(5 * m_WParser->GetCharWidth(), wxHTML_INDENT_RIGHT);
         else

--- a/src/html/m_links.cpp
+++ b/src/html/m_links.cpp
@@ -37,8 +37,7 @@ public:
 
     virtual const wxHtmlCell* Find(int condition, const void* param) const override
     {
-        if ((condition == wxHTML_COND_ISANCHOR) &&
-            (m_AnchorName == (*((const wxString*)param))))
+        if (CheckIsAnchor(condition, param, m_AnchorName))
         {
             return this;
         }

--- a/src/html/m_links.cpp
+++ b/src/html/m_links.cpp
@@ -28,7 +28,7 @@ private:
     wxString m_AnchorName;
 
 public:
-    wxHtmlAnchorCell(const wxString& name) : wxHtmlCell()
+    wxHtmlAnchorCell(const wxHtmlTag& tag, const wxString& name) : wxHtmlCell(tag)
         , m_AnchorName(name) { }
     void Draw(wxDC& WXUNUSED(dc),
               int WXUNUSED(x), int WXUNUSED(y),
@@ -37,7 +37,8 @@ public:
 
     virtual const wxHtmlCell* Find(int condition, const void* param) const override
     {
-        if (CheckIsAnchor(condition, param, m_AnchorName))
+        if (CheckIsAnchor(condition, param, m_AnchorName) ||
+            CheckIsAnchor(condition, param))
         {
             return this;
         }
@@ -58,9 +59,9 @@ TAG_HANDLER_BEGIN(A, "A")
     TAG_HANDLER_PROC(tag)
     {
         wxString name;
-        if (tag.GetParamAsString(wxT("NAME"), &name))
+        if (tag.GetParamAsString(wxT("NAME"), &name) || tag.HasParam(wxT("ID")))
         {
-            m_WParser->GetContainer()->InsertCell(new wxHtmlAnchorCell(name));
+            m_WParser->GetContainer()->InsertCell(new wxHtmlAnchorCell(tag, name));
         }
 
         wxString href;

--- a/src/html/m_list.cpp
+++ b/src/html/m_list.cpp
@@ -84,7 +84,7 @@ class wxHtmlListCell : public wxHtmlContainerCell
         int m_ListmarkWidth;
 
     public:
-        wxHtmlListCell(wxHtmlContainerCell *parent);
+        wxHtmlListCell(const wxHtmlTag& tag, wxHtmlContainerCell *parent);
         virtual ~wxHtmlListCell();
         void AddRow(wxHtmlContainerCell *mark, wxHtmlContainerCell *cont);
         virtual void Layout(int w) override;
@@ -92,7 +92,8 @@ class wxHtmlListCell : public wxHtmlContainerCell
     wxDECLARE_NO_COPY_CLASS(wxHtmlListCell);
 };
 
-wxHtmlListCell::wxHtmlListCell(wxHtmlContainerCell *parent) : wxHtmlContainerCell(parent)
+wxHtmlListCell::wxHtmlListCell(const wxHtmlTag& tag, wxHtmlContainerCell *parent)
+    : wxHtmlContainerCell(tag, parent)
 {
     m_NumRows = 0;
     m_RowInfo = nullptr;
@@ -201,7 +202,9 @@ void wxHtmlListCell::ComputeMinMaxWidths()
 class wxHtmlListcontentCell : public wxHtmlContainerCell
 {
 public:
-    wxHtmlListcontentCell(wxHtmlContainerCell *p) : wxHtmlContainerCell(p) {}
+    wxHtmlListcontentCell(const wxHtmlTag& tag, wxHtmlContainerCell *p)
+        : wxHtmlContainerCell(tag, p) {}
+
     virtual void Layout(int w) override {
         // Reset top indentation, fixes <li><p>
         SetIndent(0, wxHTML_INDENT_TOP);
@@ -258,7 +261,7 @@ TAG_HANDLER_BEGIN(OLULLI, "OL,UL,LI")
 
             m_List->AddRow(mark, c);
             c = m_WParser->OpenContainer();
-            m_WParser->SetContainer(new wxHtmlListcontentCell(c));
+            m_WParser->SetContainer(new wxHtmlListcontentCell(tag, c));
 
             if (m_Numbering != 0) m_Numbering++;
         }
@@ -275,7 +278,7 @@ TAG_HANDLER_BEGIN(OLULLI, "OL,UL,LI")
             oldcont = c = m_WParser->OpenContainer();
 
             wxHtmlListCell *oldList = m_List;
-            m_List = new wxHtmlListCell(c);
+            m_List = new wxHtmlListCell(tag, c);
             m_List->SetIndent(2 * m_WParser->GetCharWidth(), wxHTML_INDENT_LEFT);
 
             ParseInner(tag);

--- a/src/html/m_pre.cpp
+++ b/src/html/m_pre.cpp
@@ -100,6 +100,7 @@ TAG_HANDLER_BEGIN(PRE, "PRE")
 
         m_WParser->CloseContainer();
         c = m_WParser->OpenContainer();
+        c->CopyId(tag);
         c->SetWidthFloat(tag);
         c = m_WParser->OpenContainer();
         c->SetAlignHor(wxHTML_ALIGN_LEFT);

--- a/src/html/m_span.cpp
+++ b/src/html/m_span.cpp
@@ -51,7 +51,7 @@ TAG_HANDLER_BEGIN(SPAN, "SPAN" )
         m_WParser->SetFontFace(oldfontface);
         m_WParser->SetFontItalic(olditalic);
         m_WParser->GetContainer()->InsertCell(
-                new wxHtmlFontCell(m_WParser->CreateCurrentFont()));
+                new wxHtmlFontCell(tag, m_WParser->CreateCurrentFont()));
 
         if (oldclr != m_WParser->GetActualColor())
         {

--- a/src/html/m_tables.cpp
+++ b/src/html/m_tables.cpp
@@ -122,7 +122,7 @@ private:
 
 
 wxHtmlTableCell::wxHtmlTableCell(wxHtmlContainerCell *parent, const wxHtmlTag& tag, double pixel_scale)
- : wxHtmlContainerCell(parent)
+ : wxHtmlContainerCell(tag, parent)
 {
     m_PixelScale = pixel_scale;
     m_ColsInfo = nullptr;


### PR DESCRIPTION
This is a slightly simplified (IMO) version of #24915.

It contains other cleanups, but the one I originally mentioned in the other PR discussion is in the last commit: instead of setting the ID manually, it just passes the tag to the ctors. I think this is preferable because there is no risk to forget to set the ID like this, and if there are no objections I'm going to squash this commit with the main 24267dad122e774f661231a5ac6a422c5af96674 one and merge this.