### PR TITLE
wxRibbonToolBar does not remove tool highlight after moving mouse cursor to a disabled tool

### DIFF
--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -1092,12 +1092,7 @@ void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
     }
 #endif
 
-    if(new_hover && new_hover->state & wxRIBBON_TOOLBAR_TOOL_DISABLED)
-    {
-        m_hover_tool = new_hover;
-        new_hover = nullptr; // A disabled tool can not be hilighted
-    }
-    else if(new_hover != m_hover_tool)
+    if(new_hover != m_hover_tool)
     {
         if(m_hover_tool)
         {
@@ -1105,6 +1100,10 @@ void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
                 | wxRIBBON_TOOLBAR_TOOL_ACTIVE_MASK);
         }
         m_hover_tool = new_hover;
+
+        if(new_hover && new_hover->state & wxRIBBON_TOOLBAR_TOOL_DISABLED)
+            new_hover = nullptr; // A disabled tool can not be highlighted
+
         if(new_hover)
         {
             long what = wxRIBBON_TOOLBAR_TOOL_NORMAL_HOVERED;


### PR DESCRIPTION
Steps to reproduce:
1) Compile and run ribbon sample
2) In the toolbar group, hover the mouse cursor over the 'new' button
3) The 'new' button now turns yellow as all enabled buttons do when the mouse hovers it
4) Move the mouse cursor directly to the disabled 'open' button, without leaving the toolbar first
5) The 'new' button remains yellow. 
Expected behavior is that the 'new' button goes back to its normal state.