### PR TITLE
wxDataObject::IsSupportedFormat optimization

### DIFF
--- a/src/osx/carbon/dataobj.cpp
+++ b/src/osx/carbon/dataobj.cpp
@@ -270,29 +270,7 @@ wxDataObject::wxDataObject()
 
 bool wxDataObject::IsSupportedFormat( const wxDataFormat& rFormat, Direction vDir ) const
 {
-    size_t nFormatCount = GetFormatCount( vDir );
-    bool found = false;
-
-    if (nFormatCount == 1)
-    {
-        found = (rFormat == GetPreferredFormat());
-    }
-    else
-    {
-        wxScopedArray<wxDataFormat> array(nFormatCount);
-        GetAllFormats( array.get(), vDir );
-
-        for (size_t n = 0; n < nFormatCount; n++)
-        {
-            if (array[n] == rFormat)
-            {
-                found = true;
-                break;
-            }
-        }
-    }
-
-    return found;
+    return wxDataObjectBase::IsSupported(rFormat,vDir);
 }
 
 void wxDataObject::WriteToSink(wxOSXDataSink * datatransfer) const

--- a/src/qt/dataobj.cpp
+++ b/src/qt/dataobj.cpp
@@ -135,22 +135,7 @@ wxDataObject::~wxDataObject()
 bool wxDataObject::IsSupportedFormat(const wxDataFormat& format,
                                      Direction dir) const
 {
-    const size_t formatCount = GetFormatCount(dir);
-    if ( formatCount == 1 )
-    {
-        return format == GetPreferredFormat();
-    }
-
-    wxScopedArray<wxDataFormat> formats(formatCount);
-    GetAllFormats(formats.get(), dir);
-
-    for ( size_t n = 0; n < formatCount; ++n )
-    {
-        if ( formats[n] == format )
-            return true;
-    }
-
-    return false;
+    return wxDataObjectBase::IsSupported(format,dir);
 }
 
 void wxDataObject::QtAddDataTo(QMimeData &mimeData) const

--- a/src/x11/dataobj.cpp
+++ b/src/x11/dataobj.cpp
@@ -153,28 +153,7 @@ wxDataObject::wxDataObject()
 
 bool wxDataObject::IsSupportedFormat(const wxDataFormat& format, Direction dir) const
 {
-    size_t nFormatCount = GetFormatCount(dir);
-    if ( nFormatCount == 1 )
-    {
-        return format == GetPreferredFormat();
-    }
-    else
-    {
-        wxDataFormat *formats = new wxDataFormat[nFormatCount];
-        GetAllFormats(formats,dir);
-
-        size_t n;
-        for ( n = 0; n < nFormatCount; n++ )
-        {
-            if ( formats[n] == format )
-                break;
-        }
-
-        delete [] formats;
-
-        // found?
-        return n < nFormatCount;
-    }
+    return wxDataObjectBase::IsSupported(format,dir);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
In general, wxDataObject::IsSupportedFormat is not documented, though wxDataObjectBase::IsSupported is.

On macOS, qt and X11 wxDataObject::IsSupportedFormat's implementation is identical to wxDataObjectBase::IsSupported. Therefore, on these platforms wxDataObject::IsSupportedFormat is now calling wxDataObjectBase::IsSupported.
On MSW wxDataObject::IsSupportedFormat is not defined as on all the other platforms (missing direction parameter). But the current implementation already calls wxDataObjectBase::IsSupported.
On GTK wxDataObject::IsSupportedFormat is slightly differently implemented and its implementation is therefore kept.