### PR TITLE
Make wxTextCtrl::SetLabel() consistently do nothing everywhere

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -113,6 +113,10 @@ Changes in behaviour not resulting in compilation errors
   but may require removing any compensation for not doing this before that may
   be present in the application code.
 
+- Calling wxTextCtrl::SetLabel() now consistently does nothing and asserts
+  under all platforms instead of behaving as SetValue() under MSW and doing
+  nothing elsewhere.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -913,6 +913,10 @@ public:
         return GetCompositeControlsDefaultAttributes(variant);
     }
 
+    // Setting label for text control doesn't work portably, use SetValue() or
+    // ChangeValue() instead.
+    virtual void SetLabel(const wxString& label) override;
+
     virtual const wxTextEntry* WXGetTextEntry() const override { return this; }
 
 #if wxUSE_SPELLCHECK

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -3399,6 +3399,13 @@ public:
     /**
         Sets the window's label.
 
+        Please note that not all windows have labels and this function may do
+        nothing in this case. And some other derived windows use different
+        functions for changing the text shown in them, e.g. wxTextCtrl uses
+        wxTextCtrl::SetValue() or wxTextCtrl::ChangeValue() and trying to use
+        SetLabel() on it will assert to help to detect possibly erroneous calls
+        to SetLabel().
+
         @param label
             The window label.
 

--- a/src/common/textcmn.cpp
+++ b/src/common/textcmn.cpp
@@ -931,6 +931,11 @@ bool wxTextCtrlBase::SetDefaultStyle(const wxTextAttr& style)
     return true;
 }
 
+void wxTextCtrlBase::SetLabel(const wxString& WXUNUSED(label))
+{
+    wxFAIL_MSG("Use SetValue() or ChangeValue() instead.");
+}
+
 wxString wxTextAreaBase::GetRTFValue() const
 {
     wxFAIL_MSG("Not implemented for the current platform.");

--- a/tests/controls/label.cpp
+++ b/tests/controls/label.cpp
@@ -20,6 +20,7 @@
 #include "wx/checkbox.h"
 #include "wx/control.h"
 #include "wx/stattext.h"
+#include "wx/textctrl.h"
 
 #include "wx/generic/stattextg.h"
 
@@ -117,6 +118,17 @@ TEST_CASE("wxControl::Label", "[wxControl][label]")
         const std::unique_ptr<wxCheckBox>
             cb(new wxCheckBox(wxTheApp->GetTopWindow(), wxID_ANY, ORIGINAL_LABEL));
         DoTestLabel(cb.get());
+    }
+
+    SECTION("wxTextCtrl")
+    {
+        const std::unique_ptr<wxTextCtrl>
+            tc(new wxTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY, ORIGINAL_LABEL));
+
+        // Setting the label of a wxTextCtrl should _not_ work, it has value
+        // and not a label.
+        WX_ASSERT_FAILS_WITH_ASSERT( tc->SetLabel("something else") );
+        CHECK( tc->GetValue() == ORIGINAL_LABEL );
     }
 }
 


### PR DESCRIPTION
Previously it did the same thing as SetValue() in wxMSW but didn't do anything in wxGTK (and probably other ports), which made it easy to write code that only worked under Windows but mysteriously didn't show any text under Linux.

Change it to not do anything anywhere and add an assert to help detecting wrong uses of this function.

Also add a unit test checking this behaviour.

----

This is an incompatible change and it would, in principle, avoid it by making `wxTextCtrl::SetLabel()` call `ChangeValue()` instead, but it seems to be cleaner to not allow it unless this is done more commonly than I think — please let me know if you think we should avoid breaking Windows-only programs using `SetLabel()` to change the control's value.