### PR TITLE
Stop serializing docks separately in wxAUI

### DIFF
--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -161,6 +161,7 @@ public:
         dock_layer = 0;
         dock_row = 0;
         dock_pos = 0;
+        dock_size = 0;
         dock_proportion = 0;
 
         DefaultPane();
@@ -383,6 +384,7 @@ public:
     int dock_layer;       // layer number (0 = innermost layer)
     int dock_row;         // row number on the docking bar (0 = first row)
     int dock_pos;         // position inside the row (0 = first position)
+    int dock_size;        // size of the containing dock (0 if not set)
 
     wxSize best_size;     // size that the layout engine will prefer
     wxSize min_size;      // minimum size the pane window can tolerate

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -131,6 +131,8 @@ class wxAuiManagerEvent;
 class wxAuiSerializer;
 class wxAuiDeserializer;
 
+struct wxAuiPaneLayoutInfo;
+
 using wxAuiDockUIPartArray = wxBaseArray<wxAuiDockUIPart>;
 using wxAuiDockInfoArray = wxBaseArray<wxAuiDockInfo>;
 using wxAuiDockInfoPtrArray = wxBaseArray<wxAuiDockInfo*>;
@@ -499,6 +501,12 @@ public:
     // be called directly, use UpdateHint() above instead.
     virtual void ShowHint(const wxRect& rect);
     virtual void HideHint();
+
+    // Internal functions, don't use them outside of wxWidgets itself.
+    void CopyLayoutFrom(wxAuiPaneLayoutInfo& layoutInfo,
+                        const wxAuiPaneInfo& pane) const;
+    void CopyLayoutTo(const wxAuiPaneLayoutInfo& layoutInfo,
+                      wxAuiPaneInfo& pane) const;
 
 public:
 

--- a/include/wx/aui/serializer.h
+++ b/include/wx/aui/serializer.h
@@ -89,7 +89,11 @@ public:
     // layout and allows to create windows on the fly.
     //
     // If this function returns nullptr, the pane is not added to the manager.
-    virtual wxWindow* CreatePaneWindow(const wxAuiPaneInfo& WXUNUSED(pane))
+    //
+    // Note that the pane may (and usually will, if a window is created) be
+    // modified, to set fields such as caption or icon that wouldn't normally
+    // be serialized.
+    virtual wxWindow* CreatePaneWindow(wxAuiPaneInfo& WXUNUSED(pane))
     {
         return nullptr;
     }

--- a/include/wx/aui/serializer.h
+++ b/include/wx/aui/serializer.h
@@ -34,6 +34,13 @@ struct wxAuiPaneLayoutInfo
     int dock_pos         = 0;
     int dock_proportion  = 0;
 
+    // Size of the containing dock.
+    //
+    // Note that storing the dock size is redundant as it can be calculated
+    // from pane sizes, but storing all pane sizes would be redundant too, so
+    // we prefer to keep things simple and store just this size.
+    int dock_size        = 0;
+
 
     // Floating pane geometry, may be invalid.
     wxPoint floating_pos = wxDefaultPosition;
@@ -78,16 +85,6 @@ public:
     // Called after the last call to SavePane(), does nothing by default.
     virtual void AfterSavePanes() { }
 
-    // Called before starting to save information about the docks, does nothing
-    // by default.
-    virtual void BeforeSaveDocks() { }
-
-    // Save information about the given dock.
-    virtual void SaveDock(const wxAuiDockInfo& dock) = 0;
-
-    // Called after the last call to SaveDock(), does nothing by default.
-    virtual void AfterSaveDocks() { }
-
     // Called after saving everything, does nothing by default.
     virtual void AfterSave() { }
 };
@@ -130,9 +127,6 @@ public:
     {
         return nullptr;
     }
-
-    // Load information about all the docks previously saved with SaveDock().
-    virtual std::vector<wxAuiDockInfo> LoadDocks() = 0;
 
     // Called after restoring everything, calls Update() on the manager by
     // default.

--- a/include/wx/aui/serializer.h
+++ b/include/wx/aui/serializer.h
@@ -10,9 +10,42 @@
 #ifndef _WX_AUI_SERIALIZER_H_
 #define _WX_AUI_SERIALIZER_H_
 
+#include <utility>
+
 // ----------------------------------------------------------------------------
 // Classes used to save/load wxAuiManager layout.
 // ----------------------------------------------------------------------------
+
+// This struct contains the pane name and information about its layout that can
+// be manipulated by the user interactively.
+struct wxAuiPaneLayoutInfo
+{
+    // Ctor sets the name, which is always required.
+    explicit wxAuiPaneLayoutInfo(wxString name_) : name{std::move(name_)} { }
+
+    // Unique name of the pane.
+    wxString name;
+
+
+    // Identifies the dock containing the pane.
+    int dock_direction   = wxAUI_DOCK_LEFT;
+    int dock_layer       = 0;
+    int dock_row         = 0;
+    int dock_pos         = 0;
+    int dock_proportion  = 0;
+
+
+    // Floating pane geometry, may be invalid.
+    wxPoint floating_pos = wxDefaultPosition;
+    wxSize floating_size = wxDefaultSize;
+
+
+    // True if the pane is currently maximized.
+    //
+    // Note that it's the only field of this struct which doesn't directly
+    // correspond to a field of wxAuiPaneInfo.
+    bool is_maximized   = false;
+};
 
 // wxAuiSerializer is used with wxAuiManager::SaveLayout().
 //
@@ -40,7 +73,7 @@ public:
     virtual void BeforeSavePanes() { }
 
     // Save information about the given pane.
-    virtual void SavePane(const wxAuiPaneInfo& pane) = 0;
+    virtual void SavePane(const wxAuiPaneLayoutInfo& pane) = 0;
 
     // Called after the last call to SavePane(), does nothing by default.
     virtual void AfterSavePanes() { }
@@ -82,7 +115,7 @@ public:
     virtual void BeforeLoad() { }
 
     // Load information about all the panes previously saved with SavePane().
-    virtual std::vector<wxAuiPaneInfo> LoadPanes() = 0;
+    virtual std::vector<wxAuiPaneLayoutInfo> LoadPanes() = 0;
 
     // Create the window to be managed by the given pane: this is called if any
     // of the panes returned by LoadPanes() doesn't exist in the existing
@@ -90,9 +123,9 @@ public:
     //
     // If this function returns nullptr, the pane is not added to the manager.
     //
-    // Note that the pane may (and usually will, if a window is created) be
-    // modified, to set fields such as caption or icon that wouldn't normally
-    // be serialized.
+    // Note that the pane info may (and usually will, if a window is created)
+    // be modified, to set fields such as caption or icon and any flags other
+    // "maximized".
     virtual wxWindow* CreatePaneWindow(wxAuiPaneInfo& WXUNUSED(pane))
     {
         return nullptr;

--- a/interface/wx/aui/serializer.h
+++ b/interface/wx/aui/serializer.h
@@ -175,8 +175,13 @@ public:
 
         If this function returns @NULL, as it does by default, the pane is not
         added to the manager.
+
+        If the function does create a new window, it should typically modify @a
+        pane parameter to fill in the fields such as `caption` or `icon` that
+        wouldn't normally be serialized and so wouldn't be restored by
+        LoadPanes().
      */
-    virtual wxWindow* CreatePaneWindow(const wxAuiPaneInfo& pane);
+    virtual wxWindow* CreatePaneWindow(wxAuiPaneInfo& pane);
 
     /**
         Load information about all the docks previously saved with SaveDock().

--- a/interface/wx/aui/serializer.h
+++ b/interface/wx/aui/serializer.h
@@ -42,6 +42,9 @@ struct wxAuiPaneLayoutInfo
     /// Relative proportion of the dock allocated to this pane.
     int dock_proportion  = 0;
 
+    /// Size of the containing dock.
+    int dock_size        = 0;
+
 
     /// Position of the pane when floating, may be invalid.
     wxPoint floating_pos = wxDefaultPosition;
@@ -124,32 +127,6 @@ public:
     virtual void AfterSavePanes();
 
     /**
-        Called before starting to save information about the docks.
-
-        Does nothing by default.
-     */
-    virtual void BeforeSaveDocks();
-
-    /**
-        Save information about the given dock.
-
-        This function will be called for all docks and must be implemented to
-        save their data in a format from which it can be restored later using a
-        matching wxAuiDeserializer implementation.
-
-        As with SavePane(), the coordinates in @a dock are always in DIPs and
-        this function does _not_ need to perform any scaling itself.
-     */
-    virtual void SaveDock(const wxAuiDockInfo& dock) = 0;
-
-    /**
-        Called after the last call to SaveDock().
-
-        Does nothing by default.
-     */
-    virtual void AfterSaveDocks();
-
-    /**
         Called after saving everything.
 
         Does nothing by default.
@@ -229,14 +206,6 @@ public:
         LoadPanes().
      */
     virtual wxWindow* CreatePaneWindow(wxAuiPaneInfo& pane);
-
-    /**
-        Load information about all the docks previously saved with SaveDock().
-
-        As with LoadPanes(), this function doesn't need to perform any scaling
-        itself.
-     */
-    virtual std::vector<wxAuiDockInfo> LoadDocks() = 0;
 
     /**
         Called after restoring everything.

--- a/interface/wx/aui/serializer.h
+++ b/interface/wx/aui/serializer.h
@@ -8,6 +8,53 @@
 /////////////////////////////////////////////////////////////////////////////
 
 /**
+    Description of user-modifiable pane layout information.
+
+    This struct is used with wxAuiSerializer and wxAuiDeserializer to store the
+    pane layout. Its fields have the same meaning as the corresponding fields
+    in wxAuiPaneInfo (with the exception of `is_maximized`), but it doesn't
+    contain the fields that it wouldn't make sense to serialize.
+
+    @since 3.3.0
+ */
+struct wxAuiPaneLayoutInfo
+{
+    /**
+        Ctor sets the name, which is always required.
+     */
+    explicit wxAuiPaneLayoutInfo(wxString name);
+
+    /// Unique name of the pane.
+    wxString name;
+
+    /// Direction of the dock containing the pane.
+    int dock_direction   = wxAUI_DOCK_LEFT;
+
+    /// Layer of the dock containing the pane.
+    int dock_layer       = 0;
+
+    /// Row of the dock containing the pane.
+    int dock_row         = 0;
+
+    /// Position of the pane in the dock containing it.
+    int dock_pos         = 0;
+
+    /// Relative proportion of the dock allocated to this pane.
+    int dock_proportion  = 0;
+
+
+    /// Position of the pane when floating, may be invalid.
+    wxPoint floating_pos = wxDefaultPosition;
+
+    /// Size of the pane when floating, may be invalid.
+    wxSize floating_size = wxDefaultSize;
+
+
+    /// True if the pane is currently maximized.
+    bool is_maximized   = false;
+};
+
+/**
     @class wxAuiSerializer
 
     wxAuiSerializer is used by wxAuiManager::SaveLayout() to store layout
@@ -67,7 +114,7 @@ public:
         it does _not_ need to perform any scaling itself to ensure that the
         stored values are restored correctly if the resolution changes.
      */
-    virtual void SavePane(const wxAuiPaneInfo& pane) = 0;
+    virtual void SavePane(const wxAuiPaneLayoutInfo& pane) = 0;
 
     /**
         Called after the last call to SavePane().

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1724,7 +1724,7 @@ public:
         return panes;
     }
 
-    virtual wxWindow* CreatePaneWindow(const wxAuiPaneInfo& pane) override
+    virtual wxWindow* CreatePaneWindow(wxAuiPaneInfo& pane) override
     {
         wxLogWarning("Unknown pane \"%s\"", pane.name);
         return nullptr;

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1810,8 +1810,8 @@ private:
         wxString strY;
         const wxString strX = strXY.BeforeFirst(',', &strY);
 
-        unsigned int x, y;
-        if ( !strX.ToUInt(&x) || !strY.ToUInt(&y) )
+        int x, y;
+        if ( !strX.ToInt(&x) || !strY.ToInt(&y) )
             throw std::runtime_error("Failed to parse position");
 
         return wxRect(wxPoint(x, y), GetSize(strWH));


### PR DESCRIPTION
This simplifies writing AUI layout [de]serializers and will also make serializing `wxAuiNotebook` layout simpler.

As mentioned in #24235, this is an incompatible change, but the old code has been there for very short time and it seems unlikely that anybody has started using it already. If anybody did — sorry, you will have to change it. However the changes should be pretty simple:

1. Rip out the dock-related functions.
2. Change `wxAuiPaneInfo` to `wxAuiPaneLayoutInfo` in a couple of places.
3. Serialize `dock_size` in addition to the other fields too.