### PR TITLE
Stop changing logical page order in `wxAuiNotebook` when pages are reordered

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -117,6 +117,12 @@ Changes in behaviour not resulting in compilation errors
   under all platforms instead of behaving as SetValue() under MSW and doing
   nothing elsewhere.
 
+- The meaning of page index in wxAuiNotebook has changed if the pages have
+  been reordered (see wxAUI_NB_TAB_MOVE) and now always refers to the page
+  logical index, which is not affected by reordering. To get the position of
+  the page on screen, which doesn't make sense without reference to the tab
+  control containing it, use GetPagePosition() to retrieve both of them.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -287,6 +287,13 @@ private:
 };
 
 
+// Simple struct combining wxAuiTabCtrl with the position inside it.
+struct wxAuiNotebookPosition
+{
+    wxAuiTabCtrl* tabctrl = nullptr;
+    int page = wxNOT_FOUND;
+};
+
 
 
 class WXDLLIMPEXP_AUI wxAuiNotebook : public wxCompositeBookCtrlBase
@@ -352,6 +359,11 @@ public:
     int SetSelection(size_t newPage) override;
     int GetSelection() const override;
 
+    // Return the tab control containing the page with the given index and its
+    // visual position in it (i.e. 0 for the leading one).
+    wxAuiNotebookPosition GetPagePosition(size_t page) const;
+
+
     virtual void Split(size_t page, int direction);
 
     const wxAuiManager& GetAuiManager() const { return m_mgr; }
@@ -399,7 +411,9 @@ public:
 
     wxAuiTabCtrl* GetTabCtrlFromPoint(const wxPoint& pt);
     wxAuiTabCtrl* GetActiveTabCtrl();
-    bool FindTab(wxWindow* page, wxAuiTabCtrl** ctrl, int* idx);
+
+    // Internal, don't use: use GetPagePosition() instead.
+    bool FindTab(wxWindow* page, wxAuiTabCtrl** ctrl, int* idx) const;
 
 protected:
     // Common part of all ctors.

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -204,7 +204,10 @@ protected:
 protected:
 
     wxAuiTabArt* m_art;
+
+    // Contains pages in the display order.
     wxAuiNotebookPageArray m_pages;
+
     wxAuiTabContainerButtonArray m_buttons;
     wxAuiTabContainerButtonArray m_tabCloseButtons;
     wxRect m_rect;
@@ -462,8 +465,13 @@ protected:
 protected:
 
     wxAuiManager m_mgr;
+
+    // Contains all pages in the insertion order.
     wxAuiTabContainer m_tabs;
+
+    // Current page index in m_tabs or wxNOT_FOUND if none.
     int m_curPage;
+
     int m_tabIdCounter;
     wxWindow* m_dummyWnd;
 
@@ -482,6 +490,13 @@ private:
 
     // Create the main tab control unconditionally.
     wxAuiTabCtrl* CreateMainTabCtrl();
+
+    // Inserts the page at the given position into the given tab control.
+    void InsertPageAt(wxAuiNotebookPage& info,
+                      size_t page_idx,
+                      wxAuiTabCtrl* tabctrl,
+                      int tab_page_idx, // Can be -1 to append.
+                      bool select);
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxAuiNotebook);

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -50,6 +50,20 @@ enum wxAuiNotebookOption
     glossy look and feel.
     The theme can be changed by calling wxAuiNotebook::SetArtProvider.
 
+    @section auibook_tabs Multiple Tab Controls
+
+    By default, wxAuiNotebook uses a single tab control for all tabs, however
+    when wxAUI_NB_TAB_SPLIT style is used (which is the case by default), the
+    user will be able to drag pages out of it and create new tab controls, that
+    can then themselves be dragged to be docked in a different place inside the
+    notebook. Also, whether wxAUI_NB_TAB_SPLIT is specified or not, Split()
+    function can always be used to create new tab controls programmatically.
+
+    When using multiple tab controls, exactly one of them is active at any
+    time. This tab control can be retrieved by calling GetActiveTabCtrl() and
+    is always used for appending or inserting new pages.
+
+
     @beginStyleTable
     @style{wxAUI_NB_DEFAULT_STYLE}
            Defined as wxAUI_NB_TOP | wxAUI_NB_TAB_SPLIT | wxAUI_NB_TAB_MOVE |
@@ -279,6 +293,10 @@ public:
         should be inserted. It may be equal to the current number of pages in
         the notebook, in which case this function is equivalent to AddPage(),
         but can't be strictly greater than it.
+
+        Note that if the page with the given index is not in the currently
+        active tab control, the new page will be added at the end of the active
+        tab instead of being inserted into another tab control.
     */
     bool InsertPage(size_t page_idx, wxWindow* page,
                     const wxString& caption,

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -32,6 +32,21 @@ enum wxAuiNotebookOption
 
 
 /**
+    Simple struct combining wxAuiTabCtrl with the position inside it.
+
+    This information fully determines the position of the page in
+    wxAuiNotebook, see wxAuiNotebook::GetPagePosition().
+
+    @since 3.3.0
+*/
+struct wxAuiNotebookPosition
+{
+    wxAuiTabCtrl* tabctrl = nullptr;
+    int page = wxNOT_FOUND;
+};
+
+
+/**
     @class wxAuiNotebook
 
     wxAuiNotebook is part of the wxAUI class framework, which represents a
@@ -63,6 +78,17 @@ enum wxAuiNotebookOption
     time. This tab control can be retrieved by calling GetActiveTabCtrl() and
     is always used for appending or inserting new pages.
 
+
+    @section auibook_order Pages Order
+
+    The logical order of the pages in the notebook is determined by the order
+    in which they are added to it, i.e. the first page added has index 0, the
+    second one has index 1, and so on. Since wxWidgets 3.3.0 this order is not
+    affected any longer by reodering the visual order of the pages in the UI,
+    which can be done by dragging them around if the wxAUI_NB_TAB_MOVE style is
+    used (which is the case by default).
+
+    To get the visual position of the page, GetPagePosition() can be used.
 
     @beginStyleTable
     @style{wxAUI_NB_DEFAULT_STYLE}
@@ -260,6 +286,30 @@ public:
         recommended to use that generic method instead of this one.
     */
     int GetPageIndex(wxWindow* page_wnd) const;
+
+    /**
+        Returns the position of the page in the notebook.
+
+        For example, to determine if one page is located immediately next to
+        another one, the following code could be used:
+
+        @code
+        wxAuiNotebookPosition pos1 = notebook->GetPagePosition(page1);
+        wxAuiNotebookPosition pos2 = notebook->GetPagePosition(page2);
+        if ( pos1.tabctrl == pos2.tabctrl && pos1.page + 1 == pos2.page )
+        {
+            // page1 is immediately before page2
+        }
+        @endcode
+
+        Note that it would be wrong to just check that `page1 + 1 == page2`
+        here because the logical page index may not correspond to their visual
+        position if they have been reordered by the user in a control with
+        wxAUI_NB_TAB_MOVE style.
+
+        @since 3.3.0
+    */
+    wxAuiNotebookPosition GetPagePosition(size_t page) const;
 
     /**
         Returns the tab label for the page.

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -2128,10 +2128,10 @@ wxAuiNotebook* MyFrame::CreateNotebook()
                 wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxNO_BORDER) , "wxTextCtrl 2" );
 
    ctrl->AddPage( new wxTextCtrl( ctrl, wxID_ANY, "Some more text",
-                wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxNO_BORDER) , "wxTextCtrl 3" );
-
-   ctrl->AddPage( new wxTextCtrl( ctrl, wxID_ANY, "Some more text",
                 wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxNO_BORDER) , "wxTextCtrl 4" );
+
+   ctrl->InsertPage( 4, new wxTextCtrl( ctrl, wxID_ANY, "Page inserted before another one",
+                wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxNO_BORDER) , "wxTextCtrl 3" );
 
    ctrl->AddPage( new wxTextCtrl( ctrl, wxID_ANY, "Some more text",
                 wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxNO_BORDER) , "wxTextCtrl 5" );

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2392,7 +2392,7 @@ wxAuiTabCtrl* wxAuiNotebook::CreateMainTabCtrl()
 // FindTab() finds the tab control that currently contains the window as well
 // as the index of the window in the tab control.  It returns true if the
 // window was found, otherwise false.
-bool wxAuiNotebook::FindTab(wxWindow* page, wxAuiTabCtrl** ctrl, int* idx)
+bool wxAuiNotebook::FindTab(wxWindow* page, wxAuiTabCtrl** ctrl, int* idx) const
 {
     for ( const auto& pane : m_mgr.GetAllPanes() )
     {
@@ -2411,6 +2411,15 @@ bool wxAuiNotebook::FindTab(wxWindow* page, wxAuiTabCtrl** ctrl, int* idx)
     }
 
     return false;
+}
+
+wxAuiNotebookPosition wxAuiNotebook::GetPagePosition(size_t page) const
+{
+    wxAuiNotebookPosition pos;
+
+    FindTab(GetPage(page), &pos.tabctrl, &pos.page);
+
+    return pos;
 }
 
 void wxAuiNotebook::Split(size_t page, int direction)


### PR DESCRIPTION
This didn't make much sense with a single tab control and none at all with multiple ones, so don't do it.

See #10848.