### PR TITLE
Add support for serializing wxAuiNotebook layout

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -178,6 +178,9 @@ public:
     // Make the tab visible if it wasn't already
     void MakeTabVisible(int tabPage, wxWindow* win);
 
+    // Internal, don't use.
+    void RemoveAll();
+
     // Backwards compatible variants of internal functions, which shouldn't be
     // used anyhow.
     bool AddPage(wxWindow* page, wxAuiNotebookPage info)

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -521,6 +521,9 @@ private:
     // Create the main tab control unconditionally.
     wxAuiTabCtrl* CreateMainTabCtrl();
 
+    // Get main tab control, creating it on demand if necessary.
+    wxAuiTabCtrl* GetMainTabCtrl();
+
     // Inserts the page at the given position into the given tab control.
     void InsertPageAt(wxAuiNotebookPage& info,
                       size_t page_idx,

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -26,6 +26,9 @@
 #include "wx/compositebookctrl.h"
 
 
+class wxAuiSerializer;
+class wxAuiDeserializer;
+
 class wxAuiNotebook;
 class wxAuiTabFrame;
 
@@ -431,6 +434,11 @@ public:
 
     // Internal, don't use: use GetPagePosition() instead.
     bool FindTab(wxWindow* page, wxAuiTabCtrl** ctrl, int* idx) const;
+
+    // Serialization support: this is only used by wxAuiManager, don't use
+    // directly.
+    void SaveLayout(const wxString& name, wxAuiSerializer& serializer) const;
+    void LoadLayout(const wxString& name, wxAuiDeserializer& deserializer);
 
 protected:
     // Common part of all ctors.

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -138,8 +138,8 @@ public:
     void SetFlags(unsigned int flags);
     unsigned int GetFlags() const;
 
-    bool AddPage(wxWindow* page, const wxAuiNotebookPage& info);
-    bool InsertPage(wxWindow* page, const wxAuiNotebookPage& info, size_t idx);
+    bool AddPage(const wxAuiNotebookPage& info);
+    bool InsertPage(const wxAuiNotebookPage& info, size_t idx);
     bool MovePage(wxWindow* page, size_t newIdx);
     bool RemovePage(wxWindow* page);
     void RemovePageAt(size_t idx);
@@ -178,7 +178,20 @@ public:
     // Make the tab visible if it wasn't already
     void MakeTabVisible(int tabPage, wxWindow* win);
 
-    // Compatibility only, don't use.
+    // Backwards compatible variants of internal functions, which shouldn't be
+    // used anyhow.
+    bool AddPage(wxWindow* page, wxAuiNotebookPage info)
+    {
+        info.window = page;
+        return AddPage(info);
+    }
+
+    bool InsertPage(wxWindow* page, wxAuiNotebookPage info, size_t idx)
+    {
+        info.window = page;
+        return InsertPage(info, idx);
+    }
+
     bool ButtonHitTest(int x, int y, wxAuiTabContainerButton** hit) const
     {
         auto* const button = ButtonHitTest(x, y);

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -381,6 +381,7 @@ public:
 
 
     void Split(size_t page, int direction);
+    void UnsplitAll();
 
     const wxAuiManager& GetAuiManager() const { return m_mgr; }
 

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -131,6 +131,7 @@ class wxAuiManagerEvent;
 class wxAuiSerializer;
 class wxAuiDeserializer;
 
+struct wxAuiDockLayoutInfo;
 struct wxAuiPaneLayoutInfo;
 
 using wxAuiDockUIPartArray = wxBaseArray<wxAuiDockUIPart>;
@@ -505,6 +506,11 @@ public:
     virtual void HideHint();
 
     // Internal functions, don't use them outside of wxWidgets itself.
+    void CopyDockLayoutFrom(wxAuiDockLayoutInfo& layoutInfo,
+                            const wxAuiPaneInfo& pane) const;
+    void CopyDockLayoutTo(const wxAuiDockLayoutInfo& layoutInfo,
+                          wxAuiPaneInfo& pane) const;
+
     void CopyLayoutFrom(wxAuiPaneLayoutInfo& layoutInfo,
                         const wxAuiPaneInfo& pane) const;
     void CopyLayoutTo(const wxAuiPaneLayoutInfo& layoutInfo,

--- a/include/wx/aui/serializer.h
+++ b/include/wx/aui/serializer.h
@@ -16,17 +16,8 @@
 // Classes used to save/load wxAuiManager layout.
 // ----------------------------------------------------------------------------
 
-// This struct contains the pane name and information about its layout that can
-// be manipulated by the user interactively.
-struct wxAuiPaneLayoutInfo
+struct wxAuiDockLayoutInfo
 {
-    // Ctor sets the name, which is always required.
-    explicit wxAuiPaneLayoutInfo(wxString name_) : name{std::move(name_)} { }
-
-    // Unique name of the pane.
-    wxString name;
-
-
     // Identifies the dock containing the pane.
     int dock_direction   = wxAUI_DOCK_LEFT;
     int dock_layer       = 0;
@@ -40,6 +31,17 @@ struct wxAuiPaneLayoutInfo
     // from pane sizes, but storing all pane sizes would be redundant too, so
     // we prefer to keep things simple and store just this size.
     int dock_size        = 0;
+};
+
+// This struct contains the pane name and information about its layout that can
+// be manipulated by the user interactively.
+struct wxAuiPaneLayoutInfo : wxAuiDockLayoutInfo
+{
+    // Ctor sets the name, which is always required.
+    explicit wxAuiPaneLayoutInfo(wxString name_) : name{std::move(name_)} { }
+
+    // Unique name of the pane.
+    wxString name;
 
 
     // Floating pane geometry, may be invalid.

--- a/include/wx/aui/serializer.h
+++ b/include/wx/aui/serializer.h
@@ -16,6 +16,8 @@
 // Classes used to save/load wxAuiManager layout.
 // ----------------------------------------------------------------------------
 
+// Fields common to wxAuiPaneLayoutInfo and wxAuiTabLayoutInfo containing
+// information about a docked pane or tab layout.
 struct wxAuiDockLayoutInfo
 {
     // Identifies the dock containing the pane.
@@ -31,6 +33,15 @@ struct wxAuiDockLayoutInfo
     // from pane sizes, but storing all pane sizes would be redundant too, so
     // we prefer to keep things simple and store just this size.
     int dock_size        = 0;
+};
+
+// This struct contains information about the layout of a tab control in a
+// wxAuiNotebook, including where it is docked and the order of pages in it.
+struct wxAuiTabLayoutInfo : wxAuiDockLayoutInfo
+{
+    // If this vector is empty, it means that the tab control contains all
+    // notebook pages in natural order.
+    std::vector<int> pages;
 };
 
 // This struct contains the pane name and information about its layout that can
@@ -87,6 +98,25 @@ public:
     // Called after the last call to SavePane(), does nothing by default.
     virtual void AfterSavePanes() { }
 
+    // Called before starting to save information about the notebooks, does
+    // nothing by default.
+    virtual void BeforeSaveNotebooks() { }
+
+    // Called before starting to save information about the tabs in the
+    // notebook in the AUI pane with the given name.
+    virtual void BeforeSaveNotebook(const wxString& name) = 0;
+
+    // Called to save information about a single tab control in the given
+    // notebook.
+    virtual void SaveNotebookTabControl(const wxAuiTabLayoutInfo& tab) = 0;
+
+    // Called after saving information about all the pages of the notebook in
+    // the AUI pane with the given name, does nothing by default.
+    virtual void AfterSaveNotebook() { }
+
+    // Called after the last call to SaveNotebook(), does nothing by default.
+    virtual void AfterSaveNotebooks() { }
+
     // Called after saving everything, does nothing by default.
     virtual void AfterSave() { }
 };
@@ -115,6 +145,11 @@ public:
 
     // Load information about all the panes previously saved with SavePane().
     virtual std::vector<wxAuiPaneLayoutInfo> LoadPanes() = 0;
+
+    // For a pane containing wxAuiNotebook, load information about all the tab
+    // controls inside it.
+    virtual std::vector<wxAuiTabLayoutInfo>
+    LoadNotebookTabs(const wxString& name) = 0;
 
     // Create the window to be managed by the given pane: this is called if any
     // of the panes returned by LoadPanes() doesn't exist in the existing

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -636,8 +636,8 @@ public:
     void SetFlags(unsigned int flags);
     unsigned int GetFlags() const;
 
-    bool AddPage(wxWindow* page, const wxAuiNotebookPage& info);
-    bool InsertPage(wxWindow* page, const wxAuiNotebookPage& info, size_t idx);
+    bool AddPage(const wxAuiNotebookPage& info);
+    bool InsertPage(const wxAuiNotebookPage& info, size_t idx);
     bool MovePage(wxWindow* page, size_t newIdx);
     bool RemovePage(wxWindow* page);
     void RemovePageAt(size_t idx);

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -492,6 +492,8 @@ public:
 
         The @a direction argument specifies where the pane should go, it should be one
         of the following: wxTOP, wxBOTTOM, wxLEFT, or wxRIGHT.
+
+        @see UnsplitAll()
     */
     void Split(size_t page, int direction);
 
@@ -501,6 +503,22 @@ public:
     */
     bool ShowWindowMenu();
 
+    /**
+        Remove all split tab controls, leaving only the single one.
+
+        This is the opposite of Split() function and collects all the pages
+        from all tab controls in the central tab control and removes the other
+        ones.
+
+        If there are no other tab controls, this function doesn't do anything.
+
+        Note that calling Split() followed by UnsplitAll() does _not_ preserve
+        the page order, as all previously split pages are added at the end of
+        the main tab control and not at their previous positions.
+
+        @since 3.3.0
+    */
+    void UnsplitAll();
 
     /**
         Returns the image index for the given page.

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -111,6 +111,7 @@ class MyFrame : public wxFrame
         ID_NotebookAlignTop,
         ID_NotebookAlignBottom,
         ID_NotebookSplit,
+        ID_NotebookUnsplit,
         ID_NotebookNewTab,
         ID_NotebookDeleteTab,
         ID_3CHECK,
@@ -180,6 +181,7 @@ private:
     void OnUpdateUI(wxUpdateUIEvent& evt);
 
     void OnNotebookSplit(wxCommandEvent& evt);
+    void OnNotebookUnsplit(wxCommandEvent& evt);
     void OnNotebookNewTab(wxCommandEvent& evt);
     void OnNotebookDeleteTab(wxCommandEvent& evt);
 
@@ -642,6 +644,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(ID_NotebookAlignTop,     MyFrame::OnTabAlignment)
     EVT_MENU(ID_NotebookAlignBottom,  MyFrame::OnTabAlignment)
     EVT_MENU(ID_NotebookSplit, MyFrame::OnNotebookSplit)
+    EVT_MENU(ID_NotebookUnsplit, MyFrame::OnNotebookUnsplit)
     EVT_MENU(ID_NotebookNewTab, MyFrame::OnNotebookNewTab)
     EVT_MENU(ID_NotebookDeleteTab, MyFrame::OnNotebookDeleteTab)
     EVT_MENU(ID_NoGradient, MyFrame::OnGradient)
@@ -777,6 +780,7 @@ MyFrame::MyFrame(wxWindow* parent,
     notebook_menu->AppendCheckItem(ID_NotebookTabFixedWidth, _("Fixed-width Tabs"));
     notebook_menu->AppendSeparator();
     notebook_menu->Append(ID_NotebookSplit, _("&Split Notebook"));
+    notebook_menu->Append(ID_NotebookUnsplit, _("&Unsplit Notebook"));
     notebook_menu->Append(ID_NotebookNewTab, _("Add a &New Tab"));
     notebook_menu->Append(ID_NotebookDeleteTab, _("&Delete Last Tab"));
 
@@ -1407,6 +1411,14 @@ void MyFrame::OnNotebookSplit(wxCommandEvent& WXUNUSED(evt))
     book->Split(0, wxRIGHT);
     book->Split(1, wxRIGHT);
     book->Split(2, wxBOTTOM);
+}
+
+void MyFrame::OnNotebookUnsplit(wxCommandEvent& WXUNUSED(evt))
+{
+    auto* const book =
+        wxCheckCast<wxAuiNotebook>(m_mgr.GetPane("notebook_content").window);
+
+    book->UnsplitAll();
 }
 
 void MyFrame::OnNotebookNewTab(wxCommandEvent& WXUNUSED(evt))

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2388,6 +2388,28 @@ wxAuiTabCtrl* wxAuiNotebook::CreateMainTabCtrl()
     return tabframe->m_tabs;
 }
 
+wxAuiTabCtrl* wxAuiNotebook::GetMainTabCtrl()
+{
+    wxAuiTabCtrl* tabMain = nullptr;
+    for ( const auto& pane : m_mgr.GetAllPanes() )
+    {
+        if ( IsDummyPane(pane) )
+            continue;
+
+        if ( pane.dock_direction == wxAUI_DOCK_CENTER )
+        {
+            wxASSERT_MSG( !tabMain, "Multiple main tab controls?" );
+
+            tabMain = static_cast<wxAuiTabFrame*>(pane.window)->m_tabs;
+        }
+    }
+
+    if ( !tabMain )
+        tabMain = CreateMainTabCtrl();
+
+    return tabMain;
+}
+
 // FindTab() finds the tab control that currently contains the window as well
 // as the index of the window in the tab control.  It returns true if the
 // window was found, otherwise false.

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -177,26 +177,20 @@ void wxAuiTabContainer::SetRect(const wxRect& rect, wxWindow* wnd)
     }
 }
 
-bool wxAuiTabContainer::AddPage(wxWindow* page,
-                                const wxAuiNotebookPage& info)
+bool wxAuiTabContainer::AddPage(const wxAuiNotebookPage& info)
 {
-    return InsertPage(page, info, m_pages.GetCount());
+    return InsertPage(info, m_pages.GetCount());
 }
 
-bool wxAuiTabContainer::InsertPage(wxWindow* page,
-                                   const wxAuiNotebookPage& info,
+bool wxAuiTabContainer::InsertPage(const wxAuiNotebookPage& info,
                                    size_t idx)
 {
-    wxAuiNotebookPage page_info = info;
-    page_info.window = page;
-    page_info.hover = false;
-
-    m_pages.insert(m_pages.begin() + idx, page_info);
+    m_pages.insert(m_pages.begin() + idx, info);
 
     // let the art provider know how many pages we have
     if (m_art)
     {
-        m_art->SetSizingInfo(m_rect.GetSize(), m_pages.GetCount(), page);
+        m_art->SetSizingInfo(m_rect.GetSize(), m_pages.GetCount(), info.window);
     }
 
     return true;
@@ -2051,11 +2045,11 @@ void wxAuiNotebook::InsertPageAt(wxAuiNotebookPage& info,
         select = true;
     }
 
-    m_tabs.InsertPage(page, info, page_idx);
+    m_tabs.InsertPage(info, page_idx);
 
     if ( tab_page_idx == -1 )
         tab_page_idx = tabctrl->GetPageCount();
-    tabctrl->InsertPage(page, info, tab_page_idx);
+    tabctrl->InsertPage(info, tab_page_idx);
 
     // Note that we don't need to call DoSizing() if the height has changed, as
     // it's already called from UpdateTabCtrlHeight() itself in this case.
@@ -2489,7 +2483,7 @@ void wxAuiNotebook::Split(size_t page, int direction)
 
 
     // add the page to the destination tabs
-    dest_tabs->InsertPage(page_info.window, page_info, 0);
+    dest_tabs->InsertPage(page_info, 0);
 
     if (src_tabs->GetPageCount() == 0)
     {
@@ -2751,6 +2745,7 @@ void wxAuiNotebook::OnTabEndDrag(wxAuiNotebookEvent& evt)
 
                 // make a copy of the page info
                 wxAuiNotebookPage page_info = m_tabs.GetPage(main_idx);
+                page_info.hover = false;
 
                 // remove the page from the source notebook
                 RemovePage(main_idx);
@@ -2854,7 +2849,7 @@ void wxAuiNotebook::OnTabEndDrag(wxAuiNotebookEvent& evt)
         // add the page to the destination tabs
         if (insert_idx == -1)
             insert_idx = dest_tabs->GetPageCount();
-        dest_tabs->InsertPage(page_info.window, page_info, insert_idx);
+        dest_tabs->InsertPage(page_info, insert_idx);
 
         if (src_tabs->GetPageCount() == 0)
         {

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2529,6 +2529,42 @@ void wxAuiNotebook::Split(size_t page, int direction)
     UpdateHintWindowSize();
 }
 
+void wxAuiNotebook::UnsplitAll()
+{
+    auto* const tabMain = GetMainTabCtrl();
+
+    bool changed = false;
+    for ( const auto& pane : m_mgr.GetAllPanes() )
+    {
+        if ( IsDummyPane(pane) )
+            continue;
+
+        auto* const tab = static_cast<wxAuiTabFrame*>(pane.window)->m_tabs;
+
+        // Don't move tabs from the main tab control to itself.
+        if ( tab == tabMain )
+            continue;
+
+        while ( tab->GetPageCount() )
+        {
+            wxAuiNotebookPage info = tab->GetPage(0);
+            info.active = false;
+
+            tab->RemovePageAt(0);
+
+            tabMain->AddPage(info);
+
+            changed = true;
+        }
+    }
+
+    if ( changed )
+    {
+        RemoveEmptyTabFrames();
+
+        DoSizing();
+    }
+}
 
 void wxAuiNotebook::OnSize(wxSizeEvent& evt)
 {

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -239,6 +239,11 @@ void wxAuiTabContainer::RemovePageAt(size_t idx)
     }
 }
 
+void wxAuiTabContainer::RemoveAll()
+{
+    m_pages.Clear();
+}
+
 bool wxAuiTabContainer::SetActivePage(wxWindow* wnd)
 {
     bool found = false;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -1380,30 +1380,50 @@ void MakeLogical(wxWindow* w, wxSize& size)
 
 } // anonymous namespace
 
-// Copy pane layout information between wxAuiPaneLayoutInfo and wxAuiPaneInfo,
-// used when (de)serializing the layout.
+// Copy pane layout information between structs used when (de)serializing the
+// layout and wxAuiPaneInfo itself.
+
 void
-wxAuiManager::CopyLayoutFrom(wxAuiPaneLayoutInfo& layoutInfo,
-                             const wxAuiPaneInfo& pane) const
+wxAuiManager::CopyDockLayoutFrom(wxAuiDockLayoutInfo& dockInfo,
+                                 const wxAuiPaneInfo& paneInfo) const
 {
-    layoutInfo.dock_direction = pane.dock_direction;
-    layoutInfo.dock_layer = pane.dock_layer;
-    layoutInfo.dock_row = pane.dock_row;
-    layoutInfo.dock_pos = pane.dock_pos;
-    layoutInfo.dock_proportion = pane.dock_proportion;
+    dockInfo.dock_direction = paneInfo.dock_direction;
+    dockInfo.dock_layer = paneInfo.dock_layer;
+    dockInfo.dock_row = paneInfo.dock_row;
+    dockInfo.dock_pos = paneInfo.dock_pos;
+    dockInfo.dock_proportion = paneInfo.dock_proportion;
 
     // The dock size is typically not set in the pane itself, but set in its
     // containing dock, so find it and copy it from there, as we do need to
     // save it when serializing.
-    layoutInfo.dock_size = 0;
+    dockInfo.dock_size = 0;
     for ( const auto& d : m_docks )
     {
-        if ( FindPaneInDock(d, pane.window) )
+        if ( FindPaneInDock(d, paneInfo.window) )
         {
-            layoutInfo.dock_size = d.size;
+            dockInfo.dock_size = d.size;
             break;
         }
     }
+}
+
+void
+wxAuiManager::CopyDockLayoutTo(const wxAuiDockLayoutInfo& dockInfo,
+                               wxAuiPaneInfo& paneInfo) const
+{
+    paneInfo.dock_direction = dockInfo.dock_direction;
+    paneInfo.dock_layer = dockInfo.dock_layer;
+    paneInfo.dock_row = dockInfo.dock_row;
+    paneInfo.dock_pos = dockInfo.dock_pos;
+    paneInfo.dock_proportion = dockInfo.dock_proportion;
+    paneInfo.dock_size = dockInfo.dock_size;
+}
+
+void
+wxAuiManager::CopyLayoutFrom(wxAuiPaneLayoutInfo& layoutInfo,
+                             const wxAuiPaneInfo& pane) const
+{
+    CopyDockLayoutFrom(layoutInfo, pane);
 
     layoutInfo.floating_pos = pane.floating_pos;
     layoutInfo.floating_size = pane.floating_size;
@@ -1415,12 +1435,8 @@ void
 wxAuiManager::CopyLayoutTo(const wxAuiPaneLayoutInfo& layoutInfo,
                            wxAuiPaneInfo& pane) const
 {
-    pane.dock_direction = layoutInfo.dock_direction;
-    pane.dock_layer = layoutInfo.dock_layer;
-    pane.dock_row = layoutInfo.dock_row;
-    pane.dock_pos = layoutInfo.dock_pos;
-    pane.dock_proportion = layoutInfo.dock_proportion;
-    pane.dock_size = layoutInfo.dock_size;
+    CopyDockLayoutTo(layoutInfo, pane);
+
     pane.floating_pos = layoutInfo.floating_pos;
     pane.floating_size = layoutInfo.floating_size;
 


### PR DESCRIPTION
This addresses #24950 and allows to restore exactly the same notebook layout, including splits and pages order (but not active pages — I wonder if should save those too?), as was used the last time.

This code is not that simple and the API might be not ideal neither, so any comments on the changes here before I merge them would be really welcome!