### PR TITLE
Fix double negatives used with 'neither'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
               git submodule update --init --depth=1 --recursive
               git log -1 --format='%H'
 
-              # We can't easily install Go neither, so skip the tests requiring
+              # We can't easily install Go either, so skip the tests requiring
               # httpbin.
               echo WX_TEST_WEBREQUEST_URL=0 >> $GITHUB_ENV
               ;;

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -537,7 +537,7 @@ if(wxUSE_GUI)
             if(NOT (CMAKE_CXX_STANDARD GREATER_EQUAL 17 OR wxHAVE_CXX17))
                 # We shouldn't disable this option as it's disabled by default and
                 # if it is on, it means that CEF is meant to be used, but we can't
-                # continue neither as libcef_dll_wrapper will fail to build
+                # continue either as libcef_dll_wrapper will fail to build
                 # (actually it may still succeed with CEF v116 which provided
                 # its own stand-in for std::in_place used in CEF headers, but
                 # not with the later versions, so just fail instead of trying

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -563,7 +563,7 @@ WebFrame::WebFrame(const wxString& url, int flags, wxWebViewWindowFeatures* wind
 
         // Chromium backend can't be used immediately after creation, so wait
         // until the browser is created before calling GetUserAgent(), but we
-        // can't do it unconditionally neither as doing it with WebViewGTK
+        // can't do it unconditionally either as doing it with WebViewGTK
         // triggers https://gitlab.gnome.org/GNOME/gtk/-/issues/124 and just
         // kills the sample.
         const auto initShow = [this](){

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -1274,7 +1274,7 @@ wxDateTime& wxDateTime::Set(wxDateTime_t day,
     // Epoch and, for 32-bit time_t, before 2038 (for 64-bit time_t, the range
     // is unlimited and while we can't be sure that the standard library works
     // for the dates in the distant future, we are not going to do better
-    // ourselves neither, so let it handle them).
+    // ourselves either, so let it handle them).
     static const int yearMinInRange = 1970;
     static const int yearMaxInRange = 2037;
 

--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -204,7 +204,7 @@ void AppImplData::StartThreadDispatch(GMainContext* threadContext)
     m_wakeupSource = g_source_new(&wakeupSourceVtbl, sizeof(GSource));
 
     // Note that we need to attach it to the main context, not the thread one
-    // (otherwise this source itself would be never used neither).
+    // (otherwise this source itself would be never used either).
     g_source_attach(m_wakeupSource, nullptr /* main context */);
 }
 

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -1121,7 +1121,7 @@ bool wxWebSessionWinHTTP::SetProxy(const wxWebProxy& proxy)
         }
 
         // Final step: WinHttpOpen() doesn't accept trailing slashes in the URL
-        // neither (it just fails with ERROR_INVALID_PARAMETER), so remove them.
+        // either (it just fails with ERROR_INVALID_PARAMETER), so remove them.
         while ( m_proxyURLWithoutCredentials.Last() == '/' )
             m_proxyURLWithoutCredentials.RemoveLast();
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1566,7 +1566,7 @@ wxBorder wxWindowMSW::DoTranslateBorder(wxBorder border) const
         // In dark mode the standard sunken border is too bright, so prefer
         // using a simple(r) and darker border instead.
         //
-        // And themed borders don't look good neither in dark mode, so don't
+        // And themed borders don't look good either in dark mode, so don't
         // use them in it.
         if ( wxMSWDarkMode::IsActive() )
             return wxBORDER_SIMPLE;

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -2085,7 +2085,7 @@ TEST_CASE("wxBitmap::ResourceExhaustion", "[.]")
     }
 
     // Copying bitmaps (triggered by modifying the scale factor) doesn't work
-    // neither, but still shouldn't crash.
+    // either, but still shouldn't crash.
     wxBitmap bmp1x2 = bmp1;
     bmp1x2.SetScaleFactor(2);
 


### PR DESCRIPTION
Replace most 'neither' words introduced after 2b0ee48ef77 (Fix double negatives used with 'neither', 2023-11-25) with 'either'.

All changes are to comments only.