### PR TITLE
Implement support for markup in wxMSW wxStaticText

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
               git submodule update --init --depth=1 --recursive
               git log -1 --format='%H'
 
-              # We can't easily install Go neither, so skip the tests requiring
+              # We can't easily install Go either, so skip the tests requiring
               # httpbin.
               echo WX_TEST_WEBREQUEST_URL=0 >> $GITHUB_ENV
               ;;

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -537,7 +537,7 @@ if(wxUSE_GUI)
             if(NOT (CMAKE_CXX_STANDARD GREATER_EQUAL 17 OR wxHAVE_CXX17))
                 # We shouldn't disable this option as it's disabled by default and
                 # if it is on, it means that CEF is meant to be used, but we can't
-                # continue neither as libcef_dll_wrapper will fail to build
+                # continue either as libcef_dll_wrapper will fail to build
                 # (actually it may still succeed with CEF v116 which provided
                 # its own stand-in for std::in_place used in CEF headers, but
                 # not with the later versions, so just fail instead of trying

--- a/include/wx/generic/private/markuptext.h
+++ b/include/wx/generic/private/markuptext.h
@@ -27,8 +27,16 @@ class WXDLLIMPEXP_CORE wxMarkupTextBase
 public:
     virtual ~wxMarkupTextBase() = default;
 
-    // Update the markup string.
-    void SetMarkup(const wxString& markup) { m_markup = markup; }
+    // Update the markup string, return false if it didn't change.
+    bool SetMarkup(const wxString& markup)
+    {
+        if ( markup == m_markup )
+            return false;
+
+        m_markup = markup;
+
+        return true;
+    }
 
     // Return the width and height required by the given string and optionally
     // the height of the visible part above the baseline (i.e. ascent minus

--- a/include/wx/generic/private/markuptext.h
+++ b/include/wx/generic/private/markuptext.h
@@ -81,11 +81,6 @@ public:
 
     // Default copy ctor, assignment operator and dtor are ok.
 
-    // Update the markup string.
-    //
-    // The same rules for mnemonics as in the ctor apply to this string.
-    void SetMarkup(const wxString& markup) { m_markup = markup; }
-
     // Render the markup string into the given DC in the specified rectangle.
     //
     // Notice that while the function uses the provided rectangle for alignment

--- a/include/wx/msw/stattext.h
+++ b/include/wx/msw/stattext.h
@@ -42,6 +42,10 @@ public:
 
 protected:
     // implement/override some base class virtuals
+#if wxUSE_MARKUP
+    virtual bool DoSetLabelMarkup(const wxString& markup) override;
+#endif // wxUSE_MARKUP
+
     virtual void DoSetSize(int x, int y, int w, int h,
                            int sizeFlags = wxSIZE_AUTO) override;
     virtual wxSize DoGetBestClientSize() const override;
@@ -53,6 +57,13 @@ protected:
 
     virtual wxString WXGetVisibleLabel() const override;
     virtual void WXSetVisibleLabel(const wxString& str) override;
+
+#if wxUSE_MARKUP
+    class wxMarkupText* m_markupText = nullptr;
+
+    // This is only used when m_markupText is non-null.
+    void WXOnPaint(wxPaintEvent& event);
+#endif // wxUSE_MARKUP
 
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxStaticText);
 };

--- a/interface/wx/control.h
+++ b/interface/wx/control.h
@@ -342,10 +342,9 @@ public:
             remains unchanged.
 
 
-        Currently wxButton supports markup in all major ports (wxMSW, wxGTK and
-        wxOSX/Cocoa) while wxStaticText supports it in wxGTK and wxOSX and its
-        generic version (which can be used under MSW if markup support is
-        required). Extending support to more controls is planned in the future.
+        Currently wxButton and wxStaticText support markup in all major ports
+        (wxMSW, wxGTK and wxOSX/Cocoa). Extending support to more controls is
+        planned in the future.
 
         @since 2.9.2
     */

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -563,7 +563,7 @@ WebFrame::WebFrame(const wxString& url, int flags, wxWebViewWindowFeatures* wind
 
         // Chromium backend can't be used immediately after creation, so wait
         // until the browser is created before calling GetUserAgent(), but we
-        // can't do it unconditionally neither as doing it with WebViewGTK
+        // can't do it unconditionally either as doing it with WebViewGTK
         // triggers https://gitlab.gnome.org/GNOME/gtk/-/issues/124 and just
         // kills the sample.
         const auto initShow = [this](){

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -1274,7 +1274,7 @@ wxDateTime& wxDateTime::Set(wxDateTime_t day,
     // Epoch and, for 32-bit time_t, before 2038 (for 64-bit time_t, the range
     // is unlimited and while we can't be sure that the standard library works
     // for the dates in the distant future, we are not going to do better
-    // ourselves neither, so let it handle them).
+    // ourselves either, so let it handle them).
     static const int yearMinInRange = 1970;
     static const int yearMaxInRange = 2037;
 

--- a/src/common/webview_chromium.cpp
+++ b/src/common/webview_chromium.cpp
@@ -204,7 +204,7 @@ void AppImplData::StartThreadDispatch(GMainContext* threadContext)
     m_wakeupSource = g_source_new(&wakeupSourceVtbl, sizeof(GSource));
 
     // Note that we need to attach it to the main context, not the thread one
-    // (otherwise this source itself would be never used neither).
+    // (otherwise this source itself would be never used either).
     g_source_attach(m_wakeupSource, nullptr /* main context */);
 }
 

--- a/src/generic/stattextg.cpp
+++ b/src/generic/stattextg.cpp
@@ -124,10 +124,11 @@ bool wxGenericStaticText::DoSetLabelMarkup(const wxString& markup)
     if ( !wxStaticTextBase::DoSetLabelMarkup(markup) )
         return false;
 
+    if ( m_markupText && !m_markupText->SetMarkup(markup) )
+        return true;
+
     if ( !m_markupText )
         m_markupText = new wxMarkupText(markup);
-    else
-        m_markupText->SetMarkup(markup);
 
     AutoResizeIfNecessary();
 

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -1121,7 +1121,7 @@ bool wxWebSessionWinHTTP::SetProxy(const wxWebProxy& proxy)
         }
 
         // Final step: WinHttpOpen() doesn't accept trailing slashes in the URL
-        // neither (it just fails with ERROR_INVALID_PARAMETER), so remove them.
+        // either (it just fails with ERROR_INVALID_PARAMETER), so remove them.
         while ( m_proxyURLWithoutCredentials.Last() == '/' )
             m_proxyURLWithoutCredentials.RemoveLast();
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1566,7 +1566,7 @@ wxBorder wxWindowMSW::DoTranslateBorder(wxBorder border) const
         // In dark mode the standard sunken border is too bright, so prefer
         // using a simple(r) and darker border instead.
         //
-        // And themed borders don't look good neither in dark mode, so don't
+        // And themed borders don't look good either in dark mode, so don't
         // use them in it.
         if ( wxMSWDarkMode::IsActive() )
             return wxBORDER_SIMPLE;

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -2085,7 +2085,7 @@ TEST_CASE("wxBitmap::ResourceExhaustion", "[.]")
     }
 
     // Copying bitmaps (triggered by modifying the scale factor) doesn't work
-    // neither, but still shouldn't crash.
+    // either, but still shouldn't crash.
     wxBitmap bmp1x2 = bmp1;
     bmp1x2.SetScaleFactor(2);
 


### PR DESCRIPTION
Use generic-like implementation, i.e. simply draw the label ourselves in this case.

---

Small but IMO useful change to allow using the usual `wxStaticText`, instead of having to switch to `wxGenericStaticText` (which may not be that simple, e.g. it's not supported by XRC), to show simple markup.