### PR TITLE
Save from STC using wxConvAuto, not current code page

### DIFF
--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -5203,7 +5203,7 @@ wxStyledTextCtrl::DoSaveFile(const wxString& filename, int WXUNUSED(fileType))
     wxFile file(filename, wxFile::write);
 #endif
 
-    if ( file.IsOpened() && file.Write(GetValue(), wxConvUTF8) )
+    if ( file.IsOpened() && file.Write(GetValue()) )
     {
         SetSavePoint();
 
@@ -5232,7 +5232,7 @@ wxStyledTextCtrl::DoLoadFile(const wxString& filename, int WXUNUSED(fileType))
     if ( file.IsOpened() )
     {
         wxString text;
-        if ( file.ReadAll(&text, wxConvAuto()) )
+        if ( file.ReadAll(&text) )
         {
             // Detect the EOL: we use just the first line because there is not
             // much we can do if the file uses inconsistent EOLs anyhow, we'd

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -5203,7 +5203,7 @@ wxStyledTextCtrl::DoSaveFile(const wxString& filename, int WXUNUSED(fileType))
     wxFile file(filename, wxFile::write);
 #endif
 
-    if ( file.IsOpened() && file.Write(GetValue(), *wxConvCurrent) )
+    if ( file.IsOpened() && file.Write(GetValue(), wxConvUTF8) )
     {
         SetSavePoint();
 

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -452,7 +452,7 @@ wxStyledTextCtrl::DoSaveFile(const wxString& filename, int WXUNUSED(fileType))
     wxFile file(filename, wxFile::write);
 #endif
 
-    if ( file.IsOpened() && file.Write(GetValue(), *wxConvCurrent) )
+    if ( file.IsOpened() && file.Write(GetValue()) )
     {
         SetSavePoint();
 
@@ -481,7 +481,7 @@ wxStyledTextCtrl::DoLoadFile(const wxString& filename, int WXUNUSED(fileType))
     if ( file.IsOpened() )
     {
         wxString text;
-        if ( file.ReadAll(&text, wxConvAuto()) )
+        if ( file.ReadAll(&text) )
         {
             // Detect the EOL: we use just the first line because there is not
             // much we can do if the file uses inconsistent EOLs anyhow, we'd


### PR DESCRIPTION
I think STC should be saving as UTF-8, not the current character set. That seems to be the safest option, and UTF-8 tends to be the default elsewhere.

To demonstrate the issue:

Windows 11, latest wx 3.3

1. Open the STC sample
2. Open "de.po" from the locale folder
3. Type a letter to make the document dirty
4. Select Save As and save it
5. Note that the file that was saved to is totally empty