### PR TITLE
Fix syntax errors in gen_iface.py

### DIFF
--- a/src/stc/gen_iface.py
+++ b/src/stc/gen_iface.py
@@ -1561,10 +1561,10 @@ def parseVal(line, values, docs, icat):
 #----------------------------------------------------------------------------
 
 funregex = re.compile(r'\s*([a-zA-Z0-9_]+)'  # <ws>return type
-                      '\s+([a-zA-Z0-9_]+)='  # <ws>name=
-                      '([0-9]+)'             # number
-                      '\(([ a-zA-Z0-9_]*),'  # (param,
-                      '([ a-zA-Z0-9_]*),*\)')  # param)
+                      r'\s+([a-zA-Z0-9_]+)='  # <ws>name=
+                      r'([0-9]+)'             # number
+                      r'\(([ a-zA-Z0-9_]*),'  # (param,
+                      r'([ a-zA-Z0-9_]*),*\)')  # param)
 
 def parseFun(line, methods, docs, values, is_const, msgcodes, icat):
     def parseParam(param):


### PR DESCRIPTION
Add `r` prefix in front of each segment of raw string; otherwise, these segments aren't seen as raw strings and causes a syntax error. Refer to https://stackoverflow.com/questions/46003452/how-to-correctly-write-a-raw-multiline-string-in-python.

Tested with Python 3.13.1 on Windows 11 (which is where I got syntax errors for each line the first time I ran this file, runs fine after change).