### PR TITLE
Revert changes allowing adding multiple headers with the same name to `wxWebSession`

### DIFF
--- a/include/wx/private/webrequest.h
+++ b/include/wx/private/webrequest.h
@@ -16,11 +16,10 @@
 
 #include <memory>
 #include <unordered_map>
-#include <vector>
 
 class WXDLLIMPEXP_FWD_BASE wxURI;
 
-using wxWebRequestHeaderMap = std::unordered_map<wxString, std::vector<wxString>>;
+using wxWebRequestHeaderMap = std::unordered_map<wxString, wxString>;
 
 // Trace mask used for the messages in wxWebRequest code.
 #define wxTRACE_WEBREQUEST "webrequest"
@@ -63,15 +62,7 @@ public:
     virtual ~wxWebRequestImpl() = default;
 
     void SetHeader(const wxString& name, const wxString& value)
-    {
-        if (value.empty())
-            m_headers.erase(name);
-        else
-            m_headers[name] = { value };
-    }
-
-    void AddHeader(const wxString& name, const wxString& value)
-        { m_headers[name].push_back(value); }
+    { m_headers[name] = value; }
 
     void SetMethod(const wxString& method) { m_method = method; }
 
@@ -334,16 +325,8 @@ public:
     bool SetBaseURL(const wxString& url);
     const wxURI* GetBaseURL() const;
 
-    void SetCommonHeader(const wxString& name, const wxString& value)
-    {
-        if (value.empty())
-            m_headers.erase(name);
-        else
-            m_headers[name] = { value };
-    }
-
     void AddCommonHeader(const wxString& name, const wxString& value)
-        { m_headers[name].push_back(value); }
+        { m_headers[name] = value; }
 
     void SetTempDir(const wxString& dir) { m_tempDir = dir; }
 

--- a/include/wx/private/webrequest_curl.h
+++ b/include/wx/private/webrequest_curl.h
@@ -21,6 +21,7 @@
 #include "curl/curl.h"
 
 #include <unordered_map>
+#include <vector>
 
 class wxWebRequestCURL;
 class wxWebResponseCURL;
@@ -144,7 +145,12 @@ public:
     int CURLOnProgress(curl_off_t);
 
 private:
-    wxWebRequestHeaderMap m_headers;
+    // We can receive multiple headers with the same name (classic example is
+    // "Set-Cookie:"), so we can't use wxWebRequestHeaderMap here and need to
+    // define our own "multi-map" for headers: it maps the header name to a
+    // collection of all its values, possibly from multiple header lines.
+    using AllHeadersMap = std::unordered_map<wxString, std::vector<wxString>>;
+    AllHeadersMap m_headers;
     wxString m_statusText;
     wxFileOffset m_knownDownloadSize;
 

--- a/include/wx/webrequest.h
+++ b/include/wx/webrequest.h
@@ -198,8 +198,6 @@ public:
 
     void SetHeader(const wxString& name, const wxString& value);
 
-    void AddHeader(const wxString& name, const wxString& value);
-
     void SetMethod(const wxString& method);
 
     void SetData(const wxString& text, const wxString& contentType, const wxMBConv& conv = wxConvUTF8);

--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -320,34 +320,9 @@ public:
         @param name
             Name of the header
         @param value
-            String value of the header. An empty string will remove all headers
-            with the same name.
-
-        @see AddHeader()
+            String value of the header. An empty string will remove the header.
     */
     void SetHeader(const wxString& name, const wxString& value);
-
-    /**
-        Adds a request header which will be sent to the server by this request.
-
-        The header will be added even if a header with the same name has been
-        set before.
-
-        @param name
-            Name of the header
-        @param value
-            String value of the header.
-
-        @note
-            The URLSession backend does not support multiple headers with the
-            same name. The last added header with a given name is used as a
-            fallback.
-
-        @since 3.3.0
-
-        @see SetHeader()
-    */
-    void AddHeader(const wxString& name, const wxString& value);
 
     /**
         Set <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html">common</a>
@@ -762,34 +737,9 @@ public:
         @param name
             Name of the header
         @param value
-            String value of the header. An empty string will remove all headers
-            with the same name.
-
-        @see AddHeader()
+            String value of the header. An empty string will remove the header.
     */
     void SetHeader(const wxString& name, const wxString& value);
-
-    /**
-        Adds a request header which will be sent to the server by this request.
-
-        The header will be added even if a header with the same name has been
-        set before.
-
-        @param name
-            Name of the header
-        @param value
-            String value of the header.
-
-        @note
-            The URLSession backend does not support multiple headers with the
-            same name. The last added header with a given name is used as a
-            fallback.
-
-        @since 3.3.0
-
-        @see SetHeader()
-    */
-    void AddHeader(const wxString& name, const wxString& value);
 
     /**
         Set <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html">common</a>
@@ -1072,8 +1022,6 @@ public:
         could not be found.
 
         @param name Name of the header field
-
-        @see GetAllHeaderValues()
     */
     wxString GetHeader(const wxString& name) const;
 
@@ -1082,11 +1030,6 @@ public:
         vector if the header could not be found at all.
 
         @param name Name of the header fields
-
-        @note
-            The URLSession backend does not support multiple headers with the
-            same name. The last added header with a given name is used as a
-            fallback.
 
         @since 3.3.0
 
@@ -1285,40 +1228,16 @@ public:
 
     /**
         Sets a request header in every wxWebRequest created from this session
-        after it has been set.
+        after is has been set.
 
         A good example for a session-wide request header is the @c User-Agent
         header.
 
-        Calling this function with the same header name again replaces all
-        previously added headers with that name.
-
-        @param name Name of the header
-        @param value String value of the header. An empty string will remove
-            all headers with the same name.
-
-        @see AddCommonHeader()
-
-        @since 3.3.0
-    */
-    void SetCommonHeader(const wxString& name, const wxString& value);
-
-    /**
-        Adds a request header to every wxWebRequest created from this session
-        after it has been added.
-
-        Calling this function with the same header name again adds another
-        header with the same name.
+        Calling this function with the same header name again replaces the
+        previously used value.
 
         @param name Name of the header
         @param value String value of the header
-
-        @note
-            The URLSession backend does not support multiple headers with the
-            same name. The last added header with a given name is used as a
-            fallback.
-
-        @see SetCommonHeader()
     */
     void AddCommonHeader(const wxString& name, const wxString& value);
 

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -337,7 +337,7 @@ SplitParameters(const wxString& s, wxWebRequestHeaderMap& parameters)
         }
         pvalue.Trim();
         if ( !pname.empty() )
-            parameters[pname] = { pvalue };
+            parameters[pname] = pvalue;
         if ( it != end )
             ++it;
     }
@@ -434,13 +434,6 @@ void wxWebRequestBase::SetHeader(const wxString& name, const wxString& value)
     wxCHECK_IMPL_VOID();
 
     m_impl->SetHeader(name, value);
-}
-
-void wxWebRequestBase::AddHeader(const wxString& name, const wxString& value)
-{
-    wxCHECK_IMPL_VOID();
-
-    m_impl->AddHeader(name, value);
 }
 
 void wxWebRequestBase::SetMethod(const wxString& method)
@@ -725,10 +718,10 @@ wxString wxWebResponseImpl::GetSuggestedFileName() const
     wxString contentDisp = GetHeader("Content-Disposition");
     wxWebRequestHeaderMap params;
     const wxString disp = wxPrivate::SplitParameters(contentDisp, params);
-    if ( disp == "attachment" && !params["filename"].empty() )
+    if ( disp == "attachment" )
     {
         // Parse as filename to filter potential path names
-        wxFileName fn(params["filename"].back());
+        wxFileName fn(params["filename"]);
         suggestedFilename = fn.GetFullName();
     }
 

--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -269,8 +269,8 @@ wxString wxWebResponseCURL::GetURL() const
 
 wxString wxWebResponseCURL::GetHeader(const wxString& name) const
 {
-    wxWebRequestHeaderMap::const_iterator it = m_headers.find(name.Upper());
-    if ( it != m_headers.end() && !it->second.empty() )
+    const auto it = m_headers.find(name.Upper());
+    if ( it != m_headers.end() )
         return it->second.back();
 
     return wxString();
@@ -278,13 +278,11 @@ wxString wxWebResponseCURL::GetHeader(const wxString& name) const
 
 std::vector<wxString> wxWebResponseCURL::GetAllHeaderValues(const wxString& name) const
 {
-    std::vector<wxString> result;
-
-    wxWebRequestHeaderMap::const_iterator it = m_headers.find(name.Upper());
+    const auto it = m_headers.find(name.Upper());
     if ( it != m_headers.end() )
-        result = it->second;
+        return it->second;
 
-    return result;
+    return {};
 }
 
 int wxWebResponseCURL::GetStatus() const
@@ -456,13 +454,10 @@ wxWebRequest::Result wxWebRequestCURL::DoFinishPrepare()
     for ( wxWebRequestHeaderMap::const_iterator it = m_headers.begin();
         it != m_headers.end(); ++it )
     {
-        for ( const wxString& value : it->second )
-        {
-            // TODO: We need to implement RFC 2047 encoding here instead of blindly
-            //       sending UTF-8 which is against the standard.
-            wxString hdrStr = wxString::Format("%s: %s", it->first, value);
-            m_headerList = curl_slist_append(m_headerList, hdrStr.utf8_str());
-        }
+        // TODO: We need to implement RFC 2047 encoding here instead of blindly
+        //       sending UTF-8 which is against the standard.
+        wxString hdrStr = wxString::Format("%s: %s", it->first, it->second);
+        m_headerList = curl_slist_append(m_headerList, hdrStr.utf8_str());
     }
     wxCURLSetOpt(m_handle, CURLOPT_HTTPHEADER, m_headerList);
 

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -753,8 +753,7 @@ wxWebRequest::Result wxWebRequestWinHTTP::SendRequest()
           header != m_headers.end();
           ++header )
     {
-        for ( const wxString& value : header->second )
-            allHeaders.append(wxString::Format("%s: %s\n", header->first, value));
+        allHeaders.append(wxString::Format("%s: %s\n", header->first, header->second));
     }
 
     if ( m_dataSize )
@@ -996,7 +995,7 @@ bool wxWebSessionWinHTTP::Open()
 
     m_handle = wxWinHTTP::WinHttpOpen
                  (
-                    GetHeaders().find("User-Agent")->second.back().wc_str(),
+                    GetHeaders().find("User-Agent")->second.wc_str(),
                     accessType,
                     proxyName,
                     WINHTTP_NO_PROXY_BYPASS,

--- a/src/osx/webrequest_urlsession.mm
+++ b/src/osx/webrequest_urlsession.mm
@@ -190,10 +190,8 @@ wxWebRequestURLSession::DoPrepare(void (^completionHandler)(NSData*, NSURLRespon
     // Set request headers
     for (wxWebRequestHeaderMap::const_iterator it = m_headers.begin(); it != m_headers.end(); ++it)
     {
-        // TODO: URLSession does not support multiple headers with the same name.
-        //       Fall back to last header with given name.
-        [req setValue:wxCFStringRef(it->second.back()).AsNSString() forHTTPHeaderField:
-        wxCFStringRef(it->first).AsNSString()];
+        [req setValue:wxCFStringRef(it->second).AsNSString() forHTTPHeaderField:
+         wxCFStringRef(it->first).AsNSString()];
     }
 
     if (m_dataSize)

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -458,21 +458,6 @@ TEST_CASE_METHOD(RequestFixture,
 }
 
 TEST_CASE_METHOD(RequestFixture,
-    "WebRequest::Headers", "[net][webrequest][headers]")
-{
-    if ( !InitBaseURL() )
-        return;
-
-    Create("headers");
-    request.SetHeader("One", "1");
-    request.AddHeader("Two", "2");
-    Run();
-
-    CheckExpectedJSON( request.GetResponse().AsString(), "One", "1" );
-    CheckExpectedJSON( request.GetResponse().AsString(), "Two", "2" );
-}
-
-TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Get::Param", "[net][webrequest][get]")
 {
     if ( !InitBaseURL() )

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -1207,7 +1207,7 @@ TEST_CASE_METHOD(SyncRequestFixture,
     DumpResponse(request.GetResponse());
 }
 
-using wxWebRequestHeaderMap = std::unordered_map<wxString, std::vector<wxString>>;
+using wxWebRequestHeaderMap = std::unordered_map<wxString, wxString>;
 
 namespace wxPrivate
 {
@@ -1225,8 +1225,7 @@ TEST_CASE("WebRequestUtils", "[net][webrequest]")
     value = wxPrivate::SplitParameters(header, params);
     CHECK( value == "multipart/mixed" );
     CHECK( params.size() == 1 );
-    REQUIRE( !params["boundary"].empty() );
-    CHECK( params["boundary"].back() == "MIME_boundary_01234567" );
+    CHECK( params["boundary"] == "MIME_boundary_01234567" );
 }
 
 // This is not a real test, run it to see the version of the library used.


### PR DESCRIPTION
See [this comment](https://github.com/wxWidgets/wxWidgets/pull/24881#issuecomment-2555917885)