### PR TITLE
Fix malformed accelerator keys in translations

### DIFF
--- a/locale/eu.po
+++ b/locale/eu.po
@@ -121,7 +121,7 @@ msgstr "&Irudia"
 
 #: ../include/wx/richtext/richtextbuffer.h:5959
 msgid "&Cell"
-msgstr "%Gelaxka"
+msgstr "&Gelaxka"
 
 #: ../include/wx/richtext/richtextbuffer.h:6068
 msgid "&Table"

--- a/locale/id.po
+++ b/locale/id.po
@@ -8911,7 +8911,7 @@ msgstr "&Ukuran"
 
 #: ../src/univ/themes/win32.cpp:3749
 msgid "Mi&nimize"
-msgstr "Mi%nimalkan"
+msgstr "Mi&nimalkan"
 
 #: ../src/univ/themes/win32.cpp:3751
 msgid "Ma&ximize"

--- a/locale/nb.po
+++ b/locale/nb.po
@@ -3318,7 +3318,7 @@ msgstr "&Hjelp"
 
 #: ../src/common/stockitem.cpp:145
 msgid "&About"
-msgstr "%Om"
+msgstr "&Om"
 
 #: ../src/common/stockitem.cpp:145
 #, fuzzy


### PR DESCRIPTION
Had `%` instead of `&` in translations.