### PR TITLE
Use PCRE2 function for counting the number of captures

### DIFF
--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -1009,35 +1009,7 @@ bool wxRegExImpl::Compile(wxString expr, int flags)
         {
             // we will alloc the array later (only if really needed) but count
             // the number of sub-expressions in the regex right now
-
-            // there is always one for the whole expression
-            m_nMatches = 1;
-
-            // and some more for bracketed subexperessions
-            for ( const wxChar *cptr = expr.c_str(); *cptr; cptr++ )
-            {
-                if ( *cptr == wxT('\\') )
-                {
-                    // in basic RE syntax groups are inside \(...\)
-                    if ( *++cptr == wxT('(') && (flags & wxRE_BASIC) )
-                    {
-                        m_nMatches++;
-                    }
-                }
-                else if ( *cptr == wxT('(') && !(flags & wxRE_BASIC) )
-                {
-                    // we know that the previous character is not an unquoted
-                    // backslash because it would have been eaten above, so we
-                    // have a bare '(' and this indicates a group start for the
-                    // extended syntax. '(?' is used for extensions by perl-
-                    // like REs (e.g. advanced), and is not valid for POSIX
-                    // extended, so ignore them always.
-                    if ( cptr[1] != wxT('?')
-                        && cptr[1] != wxT('*')
-                            )
-                        m_nMatches++;
-                }
-            }
+            m_nMatches = pcre2_get_ovector_count(m_RegEx.match_data);
         }
 
         m_isCompiled = true;

--- a/tests/regex/wxregextest.cpp
+++ b/tests/regex/wxregextest.cpp
@@ -65,6 +65,9 @@ TEST_CASE("wxRegEx::Compile", "[regex][compile]")
     CHECK      ( re.Compile("foo*") );
     CHECK      ( re.Compile("foo+") );
     CHECK      ( re.Compile("foo?") );
+
+    // Valid even if unusual, used to trigger a bug in wxRegEx::Compile().
+    CHECK      ( re.Compile("\\0\\Q\\") );
 }
 
 static void


### PR DESCRIPTION
Don't try parsing the regex ourselves, which is not just slower but also more buggy: in particular, we didn't handle regexes with trailing backslash correctly and could keep reading after the end of the buffer in this case.

cc @oetr