### PR TITLE
Do not set `wxDC` attributes unnecessarily

### DIFF
--- a/include/wx/dcbuffer.h
+++ b/include/wx/dcbuffer.h
@@ -146,31 +146,14 @@ class WXDLLIMPEXP_CORE wxBufferedPaintDC : public wxBufferedDC
 public:
     // If no bitmap is supplied by the user, a temporary one will be created.
     wxBufferedPaintDC(wxWindow *window, wxBitmap& buffer, int style = wxBUFFER_CLIENT_AREA)
-        : m_paintdc(window)
+        : wxBufferedPaintDC(window, &buffer, style)
     {
-        SetWindow(window);
-
-        // If we're buffering the virtual window, scale the paint DC as well
-        if (style & wxBUFFER_VIRTUAL_AREA)
-            window->PrepareDC( m_paintdc );
-
-        if( buffer.IsOk() )
-            Init(&m_paintdc, buffer, style);
-        else
-            Init(&m_paintdc, GetBufferedSize(window, style), style);
     }
 
     // If no bitmap is supplied by the user, a temporary one will be created.
     explicit wxBufferedPaintDC(wxWindow *window, int style = wxBUFFER_CLIENT_AREA)
-        : m_paintdc(window)
+        : wxBufferedPaintDC(window, nullptr, style)
     {
-        SetWindow(window);
-
-        // If we're using the virtual window, scale the paint DC as well
-        if (style & wxBUFFER_VIRTUAL_AREA)
-            window->PrepareDC( m_paintdc );
-
-        Init(&m_paintdc, GetBufferedSize(window, style), style);
     }
 
     // default copy ctor ok.
@@ -192,6 +175,22 @@ protected:
     }
 
 private:
+    // If no bitmap is supplied, a temporary one will be created.
+    wxBufferedPaintDC(wxWindow *window, wxBitmap* buffer, int style)
+        : m_paintdc(window)
+    {
+        SetWindow(window);
+
+        // If we're buffering the virtual window, scale the paint DC as well
+        if (style & wxBUFFER_VIRTUAL_AREA)
+            window->PrepareDC( m_paintdc );
+
+        if ( buffer && buffer->IsOk() )
+            Init(&m_paintdc, *buffer, style);
+        else
+            Init(&m_paintdc, GetBufferedSize(window, style), style);
+    }
+
     wxPaintDC m_paintdc;
 
     wxDECLARE_ABSTRACT_CLASS(wxBufferedPaintDC);

--- a/include/wx/dcbuffer.h
+++ b/include/wx/dcbuffer.h
@@ -189,6 +189,10 @@ private:
             Init(&m_paintdc, *buffer, style);
         else
             Init(&m_paintdc, GetBufferedSize(window, style), style);
+
+        // This class should behave similarly to wxPaintDC, which inherits the
+        // font and colours of the associated window, so do it here as well.
+        GetImpl()->InheritAttributes(window);
     }
 
     wxPaintDC m_paintdc;

--- a/include/wx/dcbuffer.h
+++ b/include/wx/dcbuffer.h
@@ -161,7 +161,7 @@ public:
     }
 
     // If no bitmap is supplied by the user, a temporary one will be created.
-    wxBufferedPaintDC(wxWindow *window, int style = wxBUFFER_CLIENT_AREA)
+    explicit wxBufferedPaintDC(wxWindow *window, int style = wxBUFFER_CLIENT_AREA)
         : m_paintdc(window)
     {
         SetWindow(window);
@@ -216,7 +216,7 @@ class WXDLLIMPEXP_CORE wxAutoBufferedPaintDC : public wxAutoBufferedPaintDCBase
 {
 public:
 
-    wxAutoBufferedPaintDC(wxWindow* win)
+    explicit wxAutoBufferedPaintDC(wxWindow* win)
         : wxAutoBufferedPaintDCBase(win)
     {
         wxASSERT_MSG( win->GetBackgroundStyle() == wxBG_STYLE_PAINT,

--- a/src/generic/buttonbar.cpp
+++ b/src/generic/buttonbar.cpp
@@ -409,7 +409,6 @@ void wxButtonToolBar::DoLayout()
                     if (!tool->GetShortHelp().empty())
                     {
                         wxInfoDC dc(this);
-                        dc.SetFont(GetFont());
                         int tw, th;
                         dc.GetTextExtent(tool->GetShortHelp(), & tw, & th);
 
@@ -495,7 +494,6 @@ void wxButtonToolBar::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(this);
 
-    dc.SetFont(GetFont());
     dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
     for ( wxToolBarToolsList::compatibility_iterator node = m_tools.GetFirst();

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -745,8 +745,6 @@ void wxGenericCalendarCtrl::RecalcGeometry()
 {
     wxInfoDC dc(this);
 
-    dc.SetFont(GetFont());
-
     // determine the column width (weekday names are not necessarily wider
     // than the numbers (in some languages), so let's not assume that they are)
     m_widthCol = 0;
@@ -789,8 +787,6 @@ void wxGenericCalendarCtrl::RecalcGeometry()
 void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(this);
-
-    dc.SetFont(GetFont());
 
     RecalcGeometry();
 

--- a/src/generic/combog.cpp
+++ b/src/generic/combog.cpp
@@ -320,8 +320,6 @@ void wxGenericComboCtrl::OnPaintEvent( wxPaintEvent& WXUNUSED(event) )
         if ( m_text )
             tcRect.width = m_widthCustomPaint;
 
-        dc.SetFont( GetFont() );
-
         dc.SetClippingRegion(tcRect);
         if ( m_popupInterface )
             m_popupInterface->PaintComboControl(dc, tcRect);

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -2534,7 +2534,6 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 
     // prepare the DC
     GetOwner()->PrepareDC( dc );
-    dc.SetFont( GetFont() );
 
     wxRect update = GetUpdateRegion().GetBox();
     m_owner->CalcUnscrolledPosition( update.x, update.y, &update.x, &update.y );

--- a/src/generic/fontdlgg.cpp
+++ b/src/generic/fontdlgg.cpp
@@ -72,8 +72,6 @@ void wxFontPreviewer::OnPaint(wxPaintEvent& WXUNUSED(event))
 
     if ( font.IsOk() )
     {
-        dc.SetFont(font);
-        dc.SetTextForeground(GetForegroundColour());
         dc.SetClippingRegion(2, 2, size.x-4, size.y-4);
         dc.DrawText(_("ABCDEFGabcdefg12345"),
                      10, (size.y - dc.GetTextExtent(wxT("X")).y)/2);

--- a/src/generic/hyperlinkg.cpp
+++ b/src/generic/hyperlinkg.cpp
@@ -199,9 +199,6 @@ wxRect wxGenericHyperlinkCtrl::GetLabelRect() const
 void wxGenericHyperlinkCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(this);
-    dc.SetFont(GetFont());
-    dc.SetTextForeground(GetForegroundColour());
-    dc.SetTextBackground(GetBackgroundColour());
 
     dc.DrawText(GetLabel(), GetLabelRect().GetTopLeft());
     if (HasFocus())

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1005,15 +1005,12 @@ void wxListHeaderWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 
     AdjustDC( dc );
 
-    dc.SetFont( GetFont() );
-
     // width and height of the entire header window
     int w, h;
     GetClientSize( &w, &h );
     parent->CalcUnscrolledPosition(w, 0, &w, nullptr);
 
     dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
-    dc.SetTextForeground(GetForegroundColour());
 
     int x = HEADER_OFFSET_X;
     int numColumns = m_owner->GetColumnCount();
@@ -1680,7 +1677,6 @@ wxCoord wxListMainWindow::GetLineHeight() const
         wxListMainWindow *self = wxConstCast(this, wxListMainWindow);
 
         wxInfoDC dc( self );
-        dc.SetFont( GetFont() );
 
         wxCoord y;
         dc.GetTextExtent(wxT("H"), nullptr, &y);
@@ -2027,8 +2023,6 @@ void wxListMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 
     int dev_x, dev_y;
     GetListCtrl()->CalcScrolledPosition( 0, 0, &dev_x, &dev_y );
-
-    dc.SetFont( GetFont() );
 
     if ( InReportView() )
     {
@@ -3983,7 +3977,6 @@ void wxListMainWindow::RecalculatePositions()
     const int lineHeight = GetLineHeight();
 
     wxInfoDC dc( this );
-    dc.SetFont( GetFont() );
 
     const size_t count = GetItemCount();
 
@@ -4652,8 +4645,6 @@ int wxListMainWindow::GetItemWidthWithImage(wxListItem * item)
 {
     int width = 0;
     wxInfoDC dc(this);
-
-    dc.SetFont( GetFont() );
 
     if (item->GetImage() != -1)
     {

--- a/src/generic/statusbr.cpp
+++ b/src/generic/statusbr.cpp
@@ -442,9 +442,6 @@ void wxStatusBarGeneric::OnPaint(wxPaintEvent& WXUNUSED(event) )
     }
 #endif // __WXGTK__
 
-    if (GetFont().IsOk())
-        dc.SetFont(GetFont());
-
     // compute char height only once for all panes:
     int textHeight = dc.GetCharHeight();
 

--- a/src/generic/tipwin.cpp
+++ b/src/generic/tipwin.cpp
@@ -228,7 +228,6 @@ wxTipWindowView::wxTipWindowView(wxWindow *parent)
 void wxTipWindowView::Adjust(const wxString& text, wxCoord maxLength)
 {
     wxInfoDC dc(this);
-    dc.SetFont(GetFont());
 
     // calculate the length: we want each line be no longer than maxLength
     // pixels and we only break lines at words boundary
@@ -303,10 +302,6 @@ void wxTipWindowView::OnPaint(wxPaintEvent& WXUNUSED(event))
     dc.DrawRectangle(rect);
 
     // and then draw the text line by line
-    dc.SetTextBackground(GetBackgroundColour());
-    dc.SetTextForeground(GetForegroundColour());
-    dc.SetFont(GetFont());
-
     wxPoint pt;
     pt.x = TEXT_MARGIN_X;
     pt.y = TEXT_MARGIN_Y;

--- a/src/msw/checkbox.cpp
+++ b/src/msw/checkbox.cpp
@@ -122,7 +122,6 @@ wxSize wxCheckBox::DoGetBestClientSize() const
     if ( !str.empty() )
     {
         wxInfoDC dc(const_cast<wxCheckBox *>(this));
-        dc.SetFont(GetFont());
         dc.GetMultiLineTextExtent(GetLabelText(str), &wCheckbox, &hCheckbox);
         wCheckbox += checkSize + GetCharWidth();
 

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -494,8 +494,6 @@ void wxComboCtrl::OnPaintEvent( wxPaintEvent& WXUNUSED(event) )
         if ( m_text )
             rectTextField.width = m_widthCustomPaint;
 
-        dc.SetFont( GetFont() );
-
         dc.SetClippingRegion(rectTextField);
         if ( m_popupInterface )
             m_popupInterface->PaintComboControl(dc,rectTextField);

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -122,8 +122,6 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
 
     dc.SetTextForeground(tlw == keyWindow ? m_textActive : m_textInactive);
 
-    if ( GetFont().IsOk() )
-        dc.SetFont(GetFont());
     dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
     // compute char height only once for all panes:

--- a/src/osx/listbox_osx.cpp
+++ b/src/osx/listbox_osx.cpp
@@ -255,7 +255,6 @@ wxSize wxListBox::DoGetBestSize() const
 
     {
         wxInfoDC dc(const_cast<wxListBox*>(this));
-        dc.SetFont(GetFont());
 
         // Find the widest line
         for (unsigned int i = 0; i < GetCount(); i++)

--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -1621,8 +1621,6 @@ void wxSimpleCheckBox::OnPaint( wxPaintEvent& WXUNUSED(event) )
     dc.SetBrush( bgcol );
     dc.SetPen( bgcol );
 
-    dc.SetTextForeground(GetForegroundColour());
-
     wxSimpleCheckBoxStates state = m_state;
     if ( !(state & wxSimpleCheckBoxStates::Unspecified) &&
          GetFont().GetWeight() == wxFONTWEIGHT_BOLD )

--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -457,8 +457,6 @@ void wxRichTextCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 
         PrepareDC(dc);
 
-        dc.SetFont(GetFont());
-
         wxRect drawingArea(GetUpdateRegion().GetBox());
         drawingArea.SetPosition(GetUnscaledPoint(GetLogicalPoint(drawingArea.GetPosition())));
         drawingArea.SetSize(GetUnscaledSize(drawingArea.GetSize()));
@@ -607,7 +605,6 @@ void wxRichTextCtrl::OnLeftClick(wxMouseEvent& event)
 
     wxInfoDC dc(this);
     PrepareDC(dc);
-    dc.SetFont(GetFont());
 
     // TODO: detect change of focus object
     long position = 0;
@@ -686,7 +683,6 @@ void wxRichTextCtrl::OnLeftUp(wxMouseEvent& event)
         // See if we clicked on a URL
         wxInfoDC dc(this);
         PrepareDC(dc);
-        dc.SetFont(GetFont());
 
         long position = 0;
         wxPoint logicalPt = event.GetLogicalPosition(dc);
@@ -887,7 +883,6 @@ void wxRichTextCtrl::OnMoveMouse(wxMouseEvent& event)
 
     wxInfoDC dc(this);
     PrepareDC(dc);
-    dc.SetFont(GetFont());
 
     long position = 0;
     wxPoint logicalPt = event.GetLogicalPosition(dc);
@@ -1025,7 +1020,6 @@ void wxRichTextCtrl::OnRightClick(wxMouseEvent& event)
 
     wxInfoDC dc(this);
     PrepareDC(dc);
-    dc.SetFont(GetFont());
 
     long position = 0;
     wxPoint logicalPt = event.GetLogicalPosition(dc);
@@ -1075,7 +1069,6 @@ void wxRichTextCtrl::OnLeftDClick(wxMouseEvent& event)
         {
             wxInfoDC dc(this);
             PrepareDC(dc);
-            dc.SetFont(GetFont());
 
             long position = 0;
             wxPoint logicalPt = event.GetLogicalPosition(dc);
@@ -2115,7 +2108,6 @@ bool wxRichTextCtrl::MoveRight(int noPositions, int flags)
         long newPos = 0;
         wxInfoDC dc(this);
         PrepareDC(dc);
-        dc.SetFont(GetFont());
 
         wxRichTextObject* hitObj = nullptr;
         wxRichTextObject* contextObj = nullptr;
@@ -2312,7 +2304,6 @@ bool wxRichTextCtrl::MoveDown(int noLines, int flags)
     long newPos = 0;
     wxInfoDC dc(this);
     PrepareDC(dc);
-    dc.SetFont(GetFont());
 
     wxRichTextObject* hitObj = nullptr;
     wxRichTextObject* contextObj = nullptr;
@@ -3243,7 +3234,6 @@ wxRichTextCtrl::FindContainerAtPoint(const wxPoint& pt, long& position, int& hit
 {
     wxInfoDC dc(this);
     PrepareDC(dc);
-    dc.SetFont(GetFont());
 
     wxPoint logicalPt = GetLogicalPoint(pt);
 
@@ -3901,7 +3891,6 @@ int wxRichTextCtrl::PrepareContextMenu(wxMenu* menu, const wxPoint& pt, bool add
 {
     wxInfoDC dc(this);
     PrepareDC(dc);
-    dc.SetFont(GetFont());
 
     m_contextMenuPropertiesInfo.Clear();
 
@@ -4197,7 +4186,6 @@ bool wxRichTextCtrl::GetCaretPositionForIndex(long position, wxRect& rect, wxRic
     wxInfoDC dc(this);
     PrepareDC(dc);
     dc.SetUserScale(GetScale(), GetScale());
-    dc.SetFont(GetFont());
 
     wxPoint pt;
     int height = 0;
@@ -4286,7 +4274,6 @@ bool wxRichTextCtrl::LayoutContent(bool onlyVisibleRect)
         wxInfoDC dc(this);
 
         PrepareDC(dc);
-        dc.SetFont(GetFont());
         dc.SetUserScale(GetScale(), GetScale());
 
         wxRichTextDrawingContext context(& GetBuffer());

--- a/src/richtext/richtextformatdlg.cpp
+++ b/src/richtext/richtextformatdlg.cpp
@@ -513,7 +513,6 @@ void wxRichTextFontPreviewCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 
     if ( font.IsOk() )
     {
-        dc.SetFont(font);
         // Calculate vertical and horizontal centre
         wxCoord w = 0, h = 0;
 
@@ -530,7 +529,6 @@ void wxRichTextFontPreviewCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
         if ( GetTextEffects() & wxTEXT_ATTR_EFFECT_SUBSCRIPT )
             cy += h/2;
 
-        dc.SetTextForeground(GetForegroundColour());
         dc.SetClippingRegion(2, 2, size.x-4, size.y-4);
         dc.DrawText(text, cx, cy);
 

--- a/src/richtext/richtextsymboldlg.cpp
+++ b/src/richtext/richtextsymboldlg.cpp
@@ -937,9 +937,6 @@ void wxSymbolListCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
     dc.SetBackground(GetBackgroundColour());
     dc.Clear();
 
-    // set the font to be displayed
-    dc.SetFont(GetFont());
-
     // the bounding rectangle of the current line
     wxRect rectRow;
     rectRow.width = clientSize.x;

--- a/src/univ/checkbox.cpp
+++ b/src/univ/checkbox.cpp
@@ -180,7 +180,6 @@ wxSize wxCheckBox::GetBitmapSize() const
 wxSize wxCheckBox::DoGetBestClientSize() const
 {
     wxInfoDC dc(wxConstCast(this, wxCheckBox));
-    dc.SetFont(GetFont());
     wxCoord width, height;
     dc.GetMultiLineTextExtent(GetLabel(), &width, &height);
 

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -2870,7 +2870,6 @@ wxTextCtrlHitTestResult wxTextCtrl::HitTestLine(const wxString& line,
     int col;
     wxTextCtrl *self = wxConstCast(this, wxTextCtrl);
     wxInfoDC dc(self);
-    dc.SetFont(GetFont());
     self->DoPrepareReadOnlyDC(dc);
 
     wxCoord width;
@@ -3550,7 +3549,6 @@ wxCoord wxTextCtrl::GetMaxWidth() const
 
         wxTextCtrl *self = wxConstCast(this, wxTextCtrl);
         wxInfoDC dc(self);
-        dc.SetFont(GetFont());
 
         self->MData().m_widthMax = 0;
 


### PR DESCRIPTION
I got tired of seeing all these `dc.SetFont(GetFont())` calls and thinking whether they were really needed or not, so I've just decided to remove all of them which seem to be unnecessary because they're done on `wxDC` classes that already call `InheritAttributes()` during construction — and which now include `wxBufferedPaintDC` as well because it should behave in the same way as `wxPaintDC`.

Any comments/objections?