### PR TITLE
Improve window sizing documentation

### DIFF
--- a/docs/doxygen/groups/class_winlayout.h
+++ b/docs/doxygen/groups/class_winlayout.h
@@ -15,7 +15,7 @@ classes known as "sizers". Sizers allow for flexible window positioning and
 sizes that can help with automatically handling localization differences, as
 well as making it easy to write user resizable windows.
 
-Related Overviews: @ref overview_sizer
+Related Overviews: @ref overview_sizer, @ref overview_windowsizing
 
 */
 

--- a/docs/doxygen/overviews/sizer.h
+++ b/docs/doxygen/overviews/sizer.h
@@ -25,7 +25,7 @@ For information about the wxWidgets resource system, which can describe
 sizer-based dialogs, see the @ref overview_xrc.
 
 @see wxSizer, wxBoxSizer, wxStaticBoxSizer, wxStdDialogButtonSizer, wxWrapSizer,
-     wxGridSizer, wxFlexGridSizer, wxGridBagSizer
+     wxGridSizer, wxFlexGridSizer, wxGridBagSizer, @ref overview_windowsizing
 
 
 

--- a/docs/doxygen/overviews/windowsizing.h
+++ b/docs/doxygen/overviews/windowsizing.h
@@ -121,4 +121,6 @@ some simple explanations of things.
     the only child of the top-level window to cover its entire client area if
     there is no sizer associated with the window. Note that this only happens
     if there is exactly one child.
+
+See also @ref overview_sizer
 */

--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -1651,7 +1651,7 @@ public:
     wxSizerFlags& Right();
 
     /**
-        Set the @c wx_SHAPED flag which indicates that the elements should
+        Sets the @c wxSHAPED flag which indicates that the elements should
         always keep the fixed width to height ratio equal to its original value.
     */
     wxSizerFlags& Shaped();


### PR DESCRIPTION
Fix the flag name in wxSizerFlags::Shaped() description.

Add a reference to Windows Sizing Overview to Window Layout page and Sizers Overview.

Add a reference to Sizers Overview to Window Sizing Overview.

---

I was itching to change verbs from imperative to third person where it is not such in interface/wx/sizer.h but I let it be.

This PR could also be backported.