### PR TITLE
Better errors for non literal msgid

### DIFF
--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -348,8 +348,7 @@ inline wxString wxTRANS_INPUT_STR(const wchar_t* s)
     #define wxTRANS_INPUT_STR(s) s
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
 
-namespace wxTransImplStrict
-{
+#ifndef wxNO_REQUIRE_LITERAL_MSGIDS
 
 // Wrapper functions that only accept string literals as arguments,
 // not variables, not char* pointers, and define the fall backs only in
@@ -445,10 +444,7 @@ wxString wxGettextInContextPluralWrapper(T, U, V, int)
     return {};
 }
 
-} // namespace wxTransImplStrict
-
-namespace wxTransImplCompatible
-{
+#else // wxNO_REQUIRE_LITERAL_MSGIDS
 
 // Wrapper functions that accept both string literals and variables
 // as arguments.
@@ -481,13 +477,7 @@ inline const wxString& wxGettextInContextPluralWrapper(const char *ctx,
                             count, wxString(), wxTRANS_INPUT_STR(ctx));
 }
 
-} // namespace wxTransImplCompatible
-
-#ifdef wxNO_REQUIRE_LITERAL_MSGIDS
-using namespace wxTransImplCompatible;
-#else
-using namespace wxTransImplStrict;
-#endif
+#endif // wxNO_REQUIRE_LITERAL_MSGIDS
 
 #else // !wxUSE_INTL
 

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -351,12 +351,50 @@ inline wxString wxTRANS_INPUT_STR(const wchar_t* s)
 namespace wxTransImplStrict
 {
 
-// Wrapper functions that only accept string literals (regular or wide) as
-// arguments, not variables, not char* pointers, not wchar_t* pointers.
+// Wrapper functions that only accept string literals as arguments,
+// not variables, not char* pointers, and define the fall backs only in
+// order to point out to the comment below:
+
+/*
+    LITERALS-MSGID-COMMENT:
+
+    See https://wxwidgets.org/h/msgid-literals for a more detailed and possibly
+    more up-to-date version of this comment.
+
+    If you get a compile error when using any of the translation macros, i.e.
+    _(), wxPLURAL() etc, it means that you're passing something other than
+    literal strings, i.e. just simple "whatever", to wx translation functions.
+    This most likely indicates a bug in your program which is now detected when
+    it was silently ignored before and should be fixed by changing the code to
+    use string literals. For example, existing code doing
+
+        _(wxString::Format("Hello %s", who))
+
+    wouldn't work properly even if it were allowed to compile and should be
+    changed to
+
+        wxString::Format(_("Hello %s"), who))
+
+    However if you can't do this, for some reason, you may choose to predefine
+    wxNO_REQUIRE_LITERAL_MSGIDS which disables these checks. Please note that
+    this is *NOT* recommended, as the problematic strings still won't be
+    translated, because they won't have been extracted by xgettext in the first
+    place and the right thing to do remains to fix the code instead.
+
+    End of LITERALS-MSGID-COMMENT
+*/
+
 template<size_t N, typename T>
 const wxString& wxUnderscoreWrapper(const T (&msg)[N])
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg));
+}
+
+template <typename T>
+wxString wxUnderscoreWrapper(T)
+{
+    static_assert(!sizeof(T), "Please read LITERALS-MSGID-COMMENT above.");
+    return {};
 }
 
 template<size_t M, size_t N, typename T>
@@ -368,12 +406,26 @@ const wxString& wxPluralWrapper(const T (&msg)[M],
                             count);
 }
 
+template <typename T, typename U>
+wxString wxPluralWrapper(T, U, int)
+{
+    static_assert(!sizeof(T), "Please read LITERALS-MSGID-COMMENT above.");
+    return {};
+}
+
 template<size_t M, size_t N, typename T>
 const wxString& wxGettextInContextWrapper(const T (&ctx)[M],
                                           const T (&msg)[N])
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxString(),
                             wxTRANS_INPUT_STR(ctx));
+}
+
+template <typename T, typename U>
+wxString wxGettextInContextWrapper(T, U)
+{
+    static_assert(!sizeof(T), "Please read LITERALS-MSGID-COMMENT above.");
+    return {};
 }
 
 template<size_t L, size_t M, size_t N, typename T>
@@ -384,6 +436,13 @@ const wxString& wxGettextInContextPluralWrapper(const T (&ctx)[L],
 {
     return wxGetTranslation(wxTRANS_INPUT_STR(msg), wxTRANS_INPUT_STR(plural),
                             count, wxString(), wxTRANS_INPUT_STR(ctx));
+}
+
+template <typename T, typename U, typename V>
+wxString wxGettextInContextPluralWrapper(T, U, V, int)
+{
+    static_assert(!sizeof(T), "Please read LITERALS-MSGID-COMMENT above.");
+    return {};
 }
 
 } // namespace wxTransImplStrict

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -1279,7 +1279,7 @@ test_allheaders_testableframe.o: $(srcdir)/testableframe.cpp $(TEST_ALLHEADERS_O
 	$(CXXC) -c -o $@ $(TEST_ALLHEADERS_CXXFLAGS) $(srcdir)/testableframe.cpp
 
 
-failtest: failtest_combobox failtest_evthandler failtest_weakref failtest_allheaders
+failtest: failtest_combobox failtest_evthandler failtest_msgid failtest_weakref failtest_allheaders
 
 failtest_combobox:
 	@$(RM) test_gui_comboboxtest.o
@@ -1299,6 +1299,13 @@ failtest_evthandler:
 	done; \
 	exit 0
 
+failtest_msgid:
+	@$(RM) test_intltest.o
+	if $(MAKE) CPPFLAGS=-DTEST_INVALID_MSGID test_intltest.o 2>/dev/null; then \
+	    echo "*** Compilation with TEST_INVALID_MSGID unexpectedly succeeded.">&2; \
+	    exit 1; \
+	fi;
+
 failtest_weakref:
 	@$(RM) test_weakref.o
 	if $(MAKE) CPPFLAGS=-DTEST_INVALID_INCOMPLETE_WEAKREF test_weakref.o 2>/dev/null; then \
@@ -1315,7 +1322,7 @@ failtest_allheaders:
 	fi; \
 	exit 0
 
-.PHONY: failtest failtest_combobox failtest_evthandler failtest_weakref failtest_allheaders
+.PHONY: failtest failtest_combobox failtest_evthandler failtest_msgid failtest_weakref failtest_allheaders
 
 allheaders_selfcontained:
 	@if [ -z "$$check_headers" ]; then \

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -723,6 +723,17 @@ TEST_CASE("wxUILocale::FromTag", "[.]")
          "supported:\t" << (loc.IsSupported() ? "yes" : "no"));
 }
 
+#ifdef TEST_INVALID_MSGID
+
+// This is not a real test, its compilation should fail.
+TEST_CASE("wxTranslations/msgid", "[.]")
+{
+    wxString s = _(wxString::Format("Hello %s", "world"));
+    CHECK( s == "Hello world" );
+}
+
+#endif // TEST_INVALID_MSGID
+
 namespace
 {
 

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -454,7 +454,7 @@
 
 
     <fragment format="autoconf">
-failtest: failtest_combobox failtest_evthandler failtest_weakref failtest_allheaders
+failtest: failtest_combobox failtest_evthandler failtest_msgid failtest_weakref failtest_allheaders
 
 failtest_combobox:
 	@$(RM) test_gui_comboboxtest.o
@@ -474,6 +474,13 @@ failtest_evthandler:
 	done; \
 	exit 0
 
+failtest_msgid:
+	@$(RM) test_intltest.o
+	if $(MAKE) CPPFLAGS=-DTEST_INVALID_MSGID test_intltest.o 2>/dev/null; then \
+	    echo "*** Compilation with TEST_INVALID_MSGID unexpectedly succeeded.">&amp;2; \
+	    exit 1; \
+	fi;
+
 failtest_weakref:
 	@$(RM) test_weakref.o
 	if $(MAKE) CPPFLAGS=-DTEST_INVALID_INCOMPLETE_WEAKREF test_weakref.o 2>/dev/null; then \
@@ -490,7 +497,7 @@ failtest_allheaders:
 	fi; \
 	exit 0
 
-.PHONY: failtest failtest_combobox failtest_evthandler failtest_weakref failtest_allheaders
+.PHONY: failtest failtest_combobox failtest_evthandler failtest_msgid failtest_weakref failtest_allheaders
     </fragment>
 
     <!-- Test that each header can be included independently, i.e. is self-contained. -->


### PR DESCRIPTION
@lanurmi What do you think of the first commit here?

The second one seems like a minor simplification to me, but we can omit it if you prefer to keep the namespaces, I mostly want to improve the story with the error messages here.