### PR TITLE
Don't use _() with variable, use wxGetTranslation

### DIFF
--- a/src/propgrid/props.cpp
+++ b/src/propgrid/props.cpp
@@ -2055,7 +2055,7 @@ bool wxFileProperty::DisplayEditorDialog(wxPropertyGrid* pg, wxVariant& value)
         m_dlgTitle.empty() ? _("Choose a file") : m_dlgTitle,
         m_initialPath.empty() ? path : m_initialPath,
         file,
-        m_wildcard.empty() ? _(wxALL_FILES) : m_wildcard,
+        m_wildcard.empty() ? wxGetTranslation(wxALL_FILES) : m_wildcard,
         m_dlgStyle,
         wxDefaultPosition);
 


### PR DESCRIPTION
If I understand correctly, only string literals should go into `_()`; anything else should go into `wxGetTranslation()`.