### PR TITLE
Add darkmode support to MSW ribbon, fixes to AUI dark mode ribbon

### DIFF
--- a/include/wx/ribbon/art_internal.h
+++ b/include/wx/ribbon/art_internal.h
@@ -11,7 +11,7 @@
 #define _WX_RIBBON_ART_INTERNAL_H_
 
 #include "wx/defs.h"
-#include <wx/settings.h>
+#include "wx/settings.h"
 
 #if wxUSE_RIBBON
 

--- a/include/wx/ribbon/art_internal.h
+++ b/include/wx/ribbon/art_internal.h
@@ -11,6 +11,7 @@
 #define _WX_RIBBON_ART_INTERNAL_H_
 
 #include "wx/defs.h"
+#include <wx/settings.h>
 
 #if wxUSE_RIBBON
 

--- a/samples/ribbon/ribbondemo.cpp
+++ b/samples/ribbon/ribbondemo.cpp
@@ -195,10 +195,6 @@ bool MyApp::OnInit()
     if(!wxApp::OnInit())
         return false;
 
-#ifdef __WXMSW__
-    MSWEnableDarkMode();
-#endif
-
     wxFrame* frame = new MyFrame;
     frame->Show();
 

--- a/samples/ribbon/ribbondemo.cpp
+++ b/samples/ribbon/ribbondemo.cpp
@@ -195,6 +195,10 @@ bool MyApp::OnInit()
     if(!wxApp::OnInit())
         return false;
 
+#ifdef __WXMSW__
+    MSWEnableDarkMode();
+#endif
+
     wxFrame* frame = new MyFrame;
     frame->Show();
 

--- a/src/ribbon/art_aui.cpp
+++ b/src/ribbon/art_aui.cpp
@@ -252,11 +252,18 @@ void wxRibbonAUIArtProvider::SetColourScheme(
 #ifdef __WXOSX__
     m_tab_label_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
 #else
-    m_tab_label_colour = LikePrimary(0.1);
+    if (wxSystemSettings::GetAppearance().IsDark())
+    {
+        m_tab_label_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
+    }
+    else
+    {
+        m_tab_label_colour = LikePrimary(0.1);
+    }
 #endif
     m_tab_active_label_colour = m_tab_label_colour;
     m_tab_hover_label_colour = m_tab_label_colour;
-    m_tab_hover_background_top_colour =  primary_hsl.ToRGB();
+    m_tab_hover_background_top_colour = primary_hsl.ToRGB();
 #ifdef __WXOSX__
     m_tab_hover_background_top_gradient_colour = m_tab_hover_background_top_colour;
 #else
@@ -281,7 +288,8 @@ void wxRibbonAUIArtProvider::SetColourScheme(
     m_panel_label_background_colour = LikePrimary(0.85);
     m_panel_label_background_gradient_colour = LikePrimary(0.97);
     m_panel_hover_label_background_gradient_colour = secondary_hsl.ToRGB();
-    m_panel_hover_label_background_colour = secondary_hsl.Lighter(0.2f).ToRGB();
+    m_panel_hover_label_background_colour = wxSystemSettings::GetAppearance().IsDark() ?
+        secondary_hsl.Darker(0.2f).ToRGB() : secondary_hsl.Lighter(0.2f).ToRGB();
     m_button_bar_hover_border_pen = secondary_hsl.ToRGB();
     m_button_bar_hover_background_brush = LikeSecondary(1.7);
     m_button_bar_active_background_brush = LikeSecondary(1.4);

--- a/src/ribbon/art_aui.cpp
+++ b/src/ribbon/art_aui.cpp
@@ -252,9 +252,9 @@ void wxRibbonAUIArtProvider::SetColourScheme(
 #ifdef __WXOSX__
     m_tab_label_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
 #else
-    m_tab_label_colour = wxSystemSettings::SelectLightDark()
-        ? LikePrimary(0.1)
-        : wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
+    m_tab_label_colour = wxSystemSettings::SelectLightDark(
+                            LikePrimary(0.1),
+                            wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT));
 #endif
     m_tab_active_label_colour = m_tab_label_colour;
     m_tab_hover_label_colour = m_tab_label_colour;
@@ -283,8 +283,9 @@ void wxRibbonAUIArtProvider::SetColourScheme(
     m_panel_label_background_colour = LikePrimary(0.85);
     m_panel_label_background_gradient_colour = LikePrimary(0.97);
     m_panel_hover_label_background_gradient_colour = secondary_hsl.ToRGB();
-    m_panel_hover_label_background_colour = wxSystemSettings::GetAppearance().IsDark() ?
-        secondary_hsl.Darker(0.2f).ToRGB() : secondary_hsl.Lighter(0.2f).ToRGB();
+    m_panel_hover_label_background_colour = wxSystemSettings::SelectLightDark(
+        secondary_hsl.Lighter(0.2f).ToRGB(),
+        secondary_hsl.Darker(0.2f).ToRGB());
     m_button_bar_hover_border_pen = secondary_hsl.ToRGB();
     m_button_bar_hover_background_brush = LikeSecondary(1.7);
     m_button_bar_active_background_brush = LikeSecondary(1.4);

--- a/src/ribbon/art_aui.cpp
+++ b/src/ribbon/art_aui.cpp
@@ -252,14 +252,9 @@ void wxRibbonAUIArtProvider::SetColourScheme(
 #ifdef __WXOSX__
     m_tab_label_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
 #else
-    if (wxSystemSettings::GetAppearance().IsDark())
-    {
-        m_tab_label_colour = wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
-    }
-    else
-    {
-        m_tab_label_colour = LikePrimary(0.1);
-    }
+    m_tab_label_colour = wxSystemSettings::SelectLightDark()
+        ? LikePrimary(0.1)
+        : wxSystemSettings::GetColour(wxSYS_COLOUR_CAPTIONTEXT);
 #endif
     m_tab_active_label_colour = m_tab_label_colour;
     m_tab_hover_label_colour = m_tab_label_colour;

--- a/src/ribbon/art_internal.cpp
+++ b/src/ribbon/art_internal.cpp
@@ -100,10 +100,12 @@ void wxRibbonDrawParallelGradientLines(wxDC& dc,
 }
 
 wxRibbonHSLColour wxRibbonShiftLuminance(wxRibbonHSLColour colour,
-                                                float amount)
+                                         float amount)
 {
-    if(amount <= 1.0f)
+    if (amount <= 1.0f)
         return colour.Darker(colour.luminance * (1.0f - amount));
+    else if (wxSystemSettings::GetAppearance().IsDark())
+        return colour.Darker(colour.luminance * (amount - 1.0f));
     else
         return colour.Lighter((1.0f - colour.luminance) * (amount - 1.0f));
 }

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -272,12 +272,22 @@ wxRibbonMSWArtProvider::wxRibbonMSWArtProvider(bool set_colour_scheme)
     m_button_bar_label_font = m_tab_label_font;
     m_panel_label_font = m_tab_label_font;
 
-    if(set_colour_scheme)
+    if (set_colour_scheme)
     {
-        SetColourScheme(
-            wxColour(194, 216, 241),
-            wxColour(255, 223, 114),
-            wxColour(  0,   0,   0));
+        if (wxSystemSettings::GetAppearance().IsDark())
+        {
+            SetColourScheme(
+                wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE),
+                wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT),
+                wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
+        }
+        else
+        {
+            SetColourScheme(
+                wxColour(194, 216, 241),
+                wxColour(255, 223, 114),
+                wxColour(0, 0, 0));
+        }
     }
 
     m_cached_tab_separator_visibility = -10.0; // valid visibilities are in range [0, 1]
@@ -357,14 +367,30 @@ void wxRibbonMSWArtProvider::SetColourScheme(
     const auto LikePrimary = [primary_hsl, primary_is_gray]
         (double h, double s, double l)
         {
-            return primary_hsl.ShiftHue(h).Saturated(primary_is_gray ? 0.0 : s)
-                .Lighter(l).ToRGB();
+            if (wxSystemSettings::GetAppearance().IsDark())
+            {
+                return primary_hsl.ShiftHue(h).Saturated(primary_is_gray ? 0.0 : s)
+                    .Darker(l).ToRGB();
+            }
+            else
+            {
+                return primary_hsl.ShiftHue(h).Saturated(primary_is_gray ? 0.0 : s)
+                    .Lighter(l).ToRGB();
+            }
         };
     const auto LikeSecondary = [secondary_hsl, secondary_is_gray]
         (double h, double s, double l)
         {
-            return secondary_hsl.ShiftHue(h).Saturated(secondary_is_gray ? 0.0 : s)
-                .Lighter(l).ToRGB();
+            if (wxSystemSettings::GetAppearance().IsDark())
+            {
+                return secondary_hsl.ShiftHue(h).Saturated(secondary_is_gray ? 0.0 : s)
+                    .Darker(l).ToRGB();
+            }
+            else
+            {
+                return secondary_hsl.ShiftHue(h).Saturated(secondary_is_gray ? 0.0 : s)
+                    .Lighter(l).ToRGB();
+            }
         };
 
     m_page_border_pen = LikePrimary(1.4, 0.00, -0.08);


### PR DESCRIPTION
# MSW Ribbon

MSW ribbon before would use the blue theme under dark mode. Now it will appear as this:

![New MSW ribbon dark](https://github.com/user-attachments/assets/7a2962d3-1c64-4a5a-b43a-56e1885c3b9d)

# AUI Ribbon

## Before

AUI ribbon under dark mode looked like this:

![Old AUI under dark](https://github.com/user-attachments/assets/9cd7e7a5-80d0-41fe-a7d0-a2379a7fde20)

The tabs and hovered items would be a light gradient (and the text was black), making it difficult to see things.

## After

Now it will appear as such:

![New AUI under dark](https://github.com/user-attachments/assets/2b6a2e11-5e05-4444-a245-6ae40336aaaa)

The ribbon demo has been updated to apply dark mode under MSW.
