### PR TITLE
Fix tests compilation with Clang 19.1.6 on Fedora Rawhide

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -669,7 +669,7 @@ typedef short int WXTYPE;
 #endif
 
 /* Specific macros for -Wcast-function-type warning new in gcc 8. */
-#if wxCHECK_GCC_VERSION(8, 0)
+#if wxCHECK_GCC_VERSION(8, 0) || defined(__clang__)
     #define wxGCC_WARNING_SUPPRESS_CAST_FUNCTION_TYPE() \
         wxGCC_WARNING_SUPPRESS(cast-function-type)
     #define wxGCC_WARNING_RESTORE_CAST_FUNCTION_TYPE() \

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -669,7 +669,7 @@ typedef short int WXTYPE;
 #endif
 
 /* Specific macros for -Wcast-function-type warning new in gcc 8. */
-#if wxCHECK_GCC_VERSION(8, 0) || defined(__clang__)
+#if wxCHECK_GCC_VERSION(8, 0)
     #define wxGCC_WARNING_SUPPRESS_CAST_FUNCTION_TYPE() \
         wxGCC_WARNING_SUPPRESS(cast-function-type)
     #define wxGCC_WARNING_RESTORE_CAST_FUNCTION_TYPE() \

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -137,9 +137,11 @@ inline wxEventFunction wxEventFunctionCast(void (wxEvtHandler::*func)(T&))
     // code using event table macros.
 
     wxGCC_WARNING_SUPPRESS_CAST_FUNCTION_TYPE()
+    wxCLANG_WARNING_SUPPRESS(cast-function-type)
 
     return reinterpret_cast<wxEventFunction>(func);
 
+    wxCLANG_WARNING_RESTORE(cast-function-type)
     wxGCC_WARNING_RESTORE_CAST_FUNCTION_TYPE()
 }
 


### PR DESCRIPTION
There was an error about an incompatible cast:
```
In file included from ../../tests/allheaders.cpp:369: In file included from ../../tests/testprec.h:5:
In file included from ../../include/wx/evtloop.h:13: ../../include/wx/event.h:141:12: error: cast from 'void (wxEvtHandler::*)(wxFocusEvent &)' to 'wxEventFunction' (aka 'void (wxEvtHandler::*)(wxEvent &)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
  141 |     return reinterpret_cast<wxEventFunction>(func);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This warning/error was already suppressed on GCC; just enable the same `wxGCC_WARNING_SUPPRESS_CAST_FUNCTION_TYPE()` macro for Clang also.