### PR TITLE
Recognize Windows Server 2025 in wxGetOsDescription()

### DIFF
--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -952,6 +952,12 @@ wxString wxGetOsDescription();
             <th>Build number</th>
         </tr>
         <tr>
+            <td>Windows Server 2025</td>
+            <td>10</td>
+            <td>0</td>
+            <td>26100</td>
+        </tr>
+        <tr>
             <td>Windows 11</td>
             <td>10</td>
             <td>0</td>

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1099,6 +1099,7 @@ int wxIsWindowsServer()
 static const int WINDOWS_SERVER2016_BUILD = 14393;
 static const int WINDOWS_SERVER2019_BUILD = 17763;
 static const int WINDOWS_SERVER2022_BUILD = 20348;
+static const int WINDOWS_SERVER2025_BUILD = 26100;
 
 // Windows 11 uses the same version as Windows 10 but its build numbers start
 // from 22000, which provides a way to test for it.
@@ -1180,6 +1181,9 @@ wxString wxGetOsDescription()
                                 break;
                             case WINDOWS_SERVER2022_BUILD:
                                 str = "Windows Server 2022";
+                                break;
+                            case WINDOWS_SERVER2025_BUILD:
+                                str = "Windows Server 2025";
                                 break;
                         }
                     }


### PR DESCRIPTION
Recognize Windows Server 2025 in wxGetOsDescription().

This should be backported.