### PR TITLE
Fix: Prevent SDL from capturing SIGINT

### DIFF
--- a/src/unix/sound_sdl.cpp
+++ b/src/unix/sound_sdl.cpp
@@ -130,6 +130,7 @@ bool wxSoundBackendSDL::IsAvailable() const
         return true;
     if (SDL_WasInit(SDL_INIT_AUDIO) != SDL_INIT_AUDIO)
     {
+        SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
         if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_NOPARACHUTE) == -1)
             return false;
     }


### PR DESCRIPTION
This commit prevents SDL from capturing SIGINT (Ctrl+C) after wxSound is played.

### Steps to reproduce:

1. Run *sound* sample from wxWidgets with SDL backend on Linux.
2. Play some sound (SDL will be initialized)
3. Send SIGINT to the app

### Expected behavior:
* Program should be terminated

### Actual behavior:
* Nothing happens. SDL captures SIGINT and sends some SDL-ish internal event that is never received by wxWidgets.

This commit disables SDL handlers of all signals. wxWidgets already use `SDL_INIT_NOPARACHUTE` but according to the documentation:

> SDL_INIT_NOPARACHUTE Prevents SDL from catching fatal signals.

We should prevent SDL from catching *any* signals.

**I can confirm that this commit fixes the issue**.