### PR TITLE
MSW console output fixes

### DIFF
--- a/src/common/msgout.cpp
+++ b/src/common/msgout.cpp
@@ -167,6 +167,10 @@ void wxMessageOutputDebug::Output(const wxString& str)
     out.Replace(wxT("\t"), wxT("        "));
     out.Replace(wxT("\n"), wxT("\r\n"));
     ::OutputDebugString(out.t_str());
+
+    // If we have a console under Windows, send this there too (if not, this
+    // won't do anything, so it's safe to call it unconditionally).
+    wxMessageOutputStderr::Output(str);
 #elif defined(__ANDROID__)
     const wxCharBuffer& buf = PrepareForOutput(str);
 

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -419,20 +419,20 @@ private:
 
 bool wxConsoleStderr::DoInit()
 {
+    if ( !::AttachConsole(ATTACH_PARENT_PROCESS) )
+        return false;
+
     HANDLE hStderr = ::GetStdHandle(STD_ERROR_HANDLE);
 
     if ( hStderr == INVALID_HANDLE_VALUE || !hStderr )
         return false;
 
+    // console attached, set m_hStderr now to ensure that we free it in the dtor
+    m_hStderr = hStderr;
+
+    // dynamically load the undocumented GetConsoleCommandHistory{,Length}()
     if ( !m_dllKernel32.Load(wxT("kernel32.dll")) )
         return false;
-
-    if ( !::AttachConsole(ATTACH_PARENT_PROCESS) )
-        return false;
-
-    // console attached, set m_hStderr now to ensure that we free it in the
-    // dtor
-    m_hStderr = hStderr;
 
     wxDL_INIT_FUNC_AW(m_pfn, GetConsoleCommandHistory, m_dllKernel32);
     if ( !m_pfnGetConsoleCommandHistory )


### PR DESCRIPTION
I've decided to drastically simplify/remove most of the code dealing with console output, as I don't think it's justified to have it for something that can be done much simpler. It also seems like this code has never been actually used for anything as there was a bug which prevented it from working in non-console applications, so we're not losing much.

On the bright side, using `stderr` works now if we have an associated console.