### PR TITLE
Fix deleting wxAuiMDIChildFrame in its Destroy()

### DIFF
--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -558,14 +558,13 @@ bool wxAuiMDIChildFrame::Destroy()
         pParentFrame->SetChildMenuBar(nullptr);
     }
 
-    size_t page_count = pClientWindow->GetPageCount();
-    for (size_t pos = 0; pos < page_count; pos++)
-    {
-        if (pClientWindow->GetPage(pos) == this)
-            return pClientWindow->DeletePage(pos);
-    }
+    pClientWindow->RemovePage(pClientWindow->FindPage(this));
 
-    return false;
+    // This is a child window, so we need to delete it immediately instead of
+    // postponing it until idle time as we do with real TLWs.
+    delete this;
+
+    return true;
 }
 
 #if wxUSE_MENUS


### PR DESCRIPTION
Don't rely on wxBookCtrl::DeletePage() doing it, as it calls Destroy() on the window since 68df81350f (Destroy, not delete, pages in wxBookCtrlBase::DoRemovePage(), 2024-12-07), which resulted in reentrancy and bad destruction order.

Instead, just remove the page from the book control and delete ourselves, to ensure that we do it.

Also use FindPage() instead of iterating over the pages manually to simplify the code.

Closes #25061.