### PR TITLE
Add support for extended length Windows paths

### DIFF
--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -235,6 +235,10 @@ jobs:
           # to exclude the tests that are not run by default, so start with this.
           excluded_tests=('~[.]')
 
+          # Somehow, this test itself passes, but causes subsequent tests, such
+          # as FileFunctions::CopyFile, to fail. It would be nice to debug this.
+          excluded_tests+=('~wxFileName::LongPath')
+
           # There is 1 day difference in creation time under Wine somehow.
           excluded_tests+=('~wxFileName::SetTimes')
 

--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -492,6 +492,10 @@ public:
     // is the char a path separator for this format?
     static bool IsPathSeparator(wxChar ch, wxPathFormat format = wxPATH_NATIVE);
 
+    // is this is a DOS path which begins with "\\?\"?
+    static bool IsMSWExtendedLengthPath(const wxString& path,
+                                        wxPathFormat format = wxPATH_NATIVE);
+
     // is this is a DOS path which begins with a windows unique volume name
     // ('\\?\Volume{guid}\')?
     static bool IsMSWUniqueVolumeNamePath(const wxString& path,

--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -632,7 +632,8 @@ private:
         SetPath_MayHaveVolume = 1
     };
 
-    // helper of public SetPath() also used internally
+    // helpers of public functions with the corresponding names
+    wxString DoGetPath(int flags, wxPathFormat format) const;
     void DoSetPath(const wxString& path, wxPathFormat format,
                    int flags = SetPath_MayHaveVolume);
 

--- a/interface/wx/filename.h
+++ b/interface/wx/filename.h
@@ -870,8 +870,11 @@ public:
 
         - Just a single letter, for the usual drive letter volumes, e.g. @c C.
         - A share name preceded by a double backslash, e.g. `\\share`.
-        - A GUID volume preceded by a double backslash and a question mark,
-          e.g. `\\?\Volume{12345678-9abc-def0-1234-56789abcdef0}`.
+        - The first part of a so-called "Windows NT device" path, also called
+          "extended length" path, in the form of `\\.\X:` or a raw volume path,
+          e.g. `\\?\Volume{12345678-9abc-def0-1234-56789abcdef0}`. Such volumes
+          always start with a double backslash and a question mark. See also
+          IsMSWExtendedLengthPath().
     */
     wxString GetVolume() const;
 
@@ -1032,6 +1035,20 @@ public:
     */
     static bool IsPathSeparator(wxChar ch,
                                 wxPathFormat format = wxPATH_NATIVE);
+
+    /**
+        Returns @true if the path starts with a double backslash and a question
+        mark.
+
+        Such paths are known as "Windows NT device" paths or "extended length"
+        paths and are passed directly to the file system, allowing to access
+        objects not accessible using the normal paths and avoiding the 260
+        character path length restriction.
+
+        @since 3.3.0
+     */
+    static bool IsMSWExtendedLengthPath(const wxString& path,
+                                        wxPathFormat format = wxPATH_NATIVE);
 
     /**
         Returns @true if the volume part of the path is a unique volume name.

--- a/interface/wx/filename.h
+++ b/interface/wx/filename.h
@@ -869,9 +869,9 @@ public:
         one of the following forms:
 
         - Just a single letter, for the usual drive letter volumes, e.g. @c C.
-        - A share name preceded by a double backslash, e.g. @c \\\\share.
+        - A share name preceded by a double backslash, e.g. `\\share`.
         - A GUID volume preceded by a double backslash and a question mark,
-          e.g. @c \\\\?\\Volume{12345678-9abc-def0-1234-56789abcdef0}.
+          e.g. `\\?\Volume{12345678-9abc-def0-1234-56789abcdef0}`.
     */
     wxString GetVolume() const;
 

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -1153,7 +1153,9 @@ public:
             is returned by AfterFirst() but it is more efficient to use this
             output parameter if both the "before" and "after" parts are needed
             than calling both functions one after the other. This parameter is
-            available in wxWidgets version 2.9.2 and later only.
+            available in wxWidgets version 2.9.2 and later only. Since
+            wxWidgets 3.3.0, this parameter can be equal to the string on which
+            this function is called.
         @return Part of the string before the first occurrence of @a ch.
     */
     wxString BeforeFirst(wxUniChar ch, wxString *rest = nullptr) const;

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -635,7 +635,7 @@ bool wxMkdir(const wxString& dir, int perm)
   #endif
 #else  // MSW and VC++
     wxUnusedVar(perm);
-    if ( wxMkDir(dir.fn_str()) != 0 )
+    if ( wxMkDir(dir) != 0 )
 #endif // !MSW/MSW
     {
         wxLogSysError(_("Directory '%s' couldn't be created"), dir);

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -1297,16 +1297,18 @@ bool wxFileName::Mkdir( const wxString& dir, int perm, int flags )
             currPath << wxGetVolumeString(filename.GetVolume(), wxPATH_NATIVE);
         }
 
-        wxArrayString dirs = filename.GetDirs();
-        size_t count = dirs.GetCount();
-        for ( size_t i = 0; i < count; i++ )
+        bool hasPrevious = false;
+        for ( const auto& pathComponent : filename.GetDirs() )
         {
             // Do not use IsAbsolute() here because we want the path to start
             // with the separator even if it doesn't have any volume, but
             // IsAbsolute() would return false in this case.
-            if ( i > 0 || !filename.m_relative )
+            if ( hasPrevious || !filename.m_relative )
                 currPath += wxFILE_SEP_PATH;
-            currPath += dirs[i];
+
+            hasPrevious = true;
+
+            currPath += pathComponent;
 
             if (!DirExists(currPath))
             {

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -2600,9 +2600,9 @@ bool wxFileName::SetPermissions(int permissions)
     if ( m_dontFollowLinks &&
             Exists(GetFullPath(), wxFILE_EXISTS_SYMLINK|wxFILE_EXISTS_NO_FOLLOW) )
     {
-        // Looks like changing permissions for a symlinc is only supported
+        // Looks like changing permissions for a symlink is only supported
         // on BSD where lchmod is present and correctly implemented.
-        // http://lists.gnu.org/archive/html/bug-coreutils/2009-09/msg00268.html
+        // https://lists.gnu.org/archive/html/bug-coreutils/2009-09/msg00268.html
         return false;
     }
 

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -27,8 +27,8 @@
                 its current mount point, i.e. you can change a volume's mount
                 point from D: to E:, or even remove it, and still be able to
                 access it through its unique volume name. More on the subject can
-                be found in MSDN's article "Naming a Volume" that is currently at
-                http://msdn.microsoft.com/en-us/library/aa365248(VS.85).aspx.
+                be found in Microsoft's "Naming a Volume" documentation at
+                https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-volume
 
 
    wxPATH_MAC:  Mac OS 8/9 only, not used any longer, absolute file

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -2219,9 +2219,16 @@ wxString wxFileName::GetPath( int flags, wxPathFormat format ) const
         fnAbs.MakeAbsolute();
         const wxString absPath = fnAbs.DoGetPath(flags, format);
 
-        // No need to do anything if it fits. Note that the exact inequality is
-        // important here, paths of exactly MAX_PATH length don't work.
-        if ( absPath.length() < MAX_PATH )
+        // No need to do anything if it fits: note that normally paths up to
+        // MAX_PATH should work but in practice the limit is lower than that
+        // depending on whether it's a file or a directory, whether it's in the
+        // root directory or a subdirectory, Windows version and probably the
+        // phase of the moon as well, so keep things simple and use the lowest
+        // known limit which is 248 (which is MAX_PATH minus 12, where 12 is,
+        // apparently, the length of a 8.3 filename) characters for a directory:
+        // it does no real harm to use extended length limit paths for shorter
+        // paths while not using them would result in a "file not found" error.
+        if ( absPath.length() < 248 )
             return fullpath;
 
         // But if it doesn't, we have to switch to using absolute path and

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -2230,7 +2230,7 @@ wxString wxFileName::GetShortPath() const
 {
     wxString path(GetFullPath());
 
-#if defined(__WINDOWS__) && defined(__WIN32__)
+#if defined(__WINDOWS__)
     DWORD sz = ::GetShortPathName(path.t_str(), nullptr, 0);
     if ( sz != 0 )
     {

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -94,7 +94,7 @@
     #include "wx/vector.h"
 #endif
 
-#if defined(__WIN32__) && defined(__MINGW32__)
+#if defined(__WINDOWS__) && defined(__MINGW32__)
     #include "wx/msw/gccpriv.h"
 #endif
 
@@ -145,7 +145,7 @@ static constexpr size_t
 
 // small helper class which opens and closes the file - we use it just to get
 // a file handle for the given file name to pass it to some Win32 API function
-#if defined(__WIN32__)
+#if defined(__WINDOWS__)
 
 class wxFileHandle
 {
@@ -211,13 +211,13 @@ private:
     HANDLE m_hFile;
 };
 
-#endif // __WIN32__
+#endif // __WINDOWS__
 
 // ----------------------------------------------------------------------------
 // private functions
 // ----------------------------------------------------------------------------
 
-#if wxUSE_DATETIME && defined(__WIN32__)
+#if wxUSE_DATETIME && defined(__WINDOWS__)
 
 // Convert between wxDateTime and FILETIME which is a 64-bit value representing
 // the number of 100-nanosecond intervals since January 1, 1601 UTC.
@@ -245,7 +245,7 @@ static void ConvertWxToFileTime(FILETIME *ft, const wxDateTime& dt)
     ft->dwLowDateTime = t.GetLo();
 }
 
-#endif // wxUSE_DATETIME && __WIN32__
+#endif // wxUSE_DATETIME && __WINDOWS__
 
 // return a string with the volume par
 static wxString wxGetVolumeString(const wxString& volume, wxPathFormat format)
@@ -303,7 +303,7 @@ static bool IsUNCPath(const wxString& path)
 }
 
 // Under Unix-ish systems (basically everything except Windows but we can't
-// just test for non-__WIN32__ because Cygwin defines it, yet we want to use
+// just test for non-__WINDOWS__ because Cygwin defines it, yet we want to use
 // lstat() under it, so test for all the rest explicitly) we may work either
 // with the file itself or its target if it's a symbolic link and we should
 // dereference it, as determined by wxFileName::ShouldFollowLink() and the
@@ -1554,7 +1554,7 @@ bool wxFileName::Normalize(int flags,
         m_dirs.Add(dir);
     }
 
-#if defined(__WIN32__) && wxUSE_OLE
+#if defined(__WINDOWS__) && wxUSE_OLE
     if ( (flags & wxPATH_NORM_SHORTCUT) )
     {
         wxString filename;
@@ -1566,7 +1566,7 @@ bool wxFileName::Normalize(int flags,
     }
 #endif
 
-#if defined(__WIN32__)
+#if defined(__WINDOWS__)
     if ( (flags & wxPATH_NORM_LONG) && (format == wxPATH_DOS) )
     {
         Assign(GetLongPath());
@@ -1647,7 +1647,7 @@ bool wxFileName::ReplaceHomeDir(wxPathFormat format)
 // get the shortcut target
 // ----------------------------------------------------------------------------
 
-#if defined(__WIN32__) && wxUSE_OLE
+#if defined(__WINDOWS__) && wxUSE_OLE
 
 bool wxFileName::GetShortcutTarget(const wxString& shortcutPath,
                                    wxString& targetFilename,
@@ -1702,7 +1702,7 @@ bool wxFileName::GetShortcutTarget(const wxString& shortcutPath,
     return success;
 }
 
-#endif // __WIN32__
+#endif // __WINDOWS__
 
 // ----------------------------------------------------------------------------
 // Resolve links
@@ -2256,7 +2256,7 @@ wxString wxFileName::GetLongPath() const
     wxString pathOut,
              path = GetFullPath();
 
-#if defined(__WIN32__)
+#if defined(__WINDOWS__)
 
     DWORD dwSize = ::GetLongPathName(path.t_str(), nullptr, 0);
     if ( dwSize > 0 )
@@ -2761,7 +2761,7 @@ bool wxFileName::SetTimes(const wxDateTime *dtAccess,
                           const wxDateTime *dtMod,
                           const wxDateTime *dtCreate) const
 {
-#if defined(__WIN32__)
+#if defined(__WINDOWS__)
     FILETIME ftAccess, ftCreate, ftWrite;
 
     if ( dtCreate )
@@ -2848,7 +2848,7 @@ bool wxFileName::GetTimes(wxDateTime *dtAccess,
                           wxDateTime *dtMod,
                           wxDateTime *dtCreate) const
 {
-#if defined(__WIN32__)
+#if defined(__WINDOWS__)
     // we must use different methods for the files and directories under
     // Windows as CreateFile(GENERIC_READ) doesn't work for the directories and
     // CreateFile(FILE_FLAG_BACKUP_SEMANTICS) works -- but only under NT and
@@ -2934,7 +2934,7 @@ wxULongLong wxFileName::GetSize(const wxString &filename)
     if (!wxFileExists(filename))
         return wxInvalidSize;
 
-#if defined(__WIN32__)
+#if defined(__WINDOWS__)
     wxFileHandle f(filename, wxFileHandle::ReadAttr);
     if (!f.IsOk())
         return wxInvalidSize;
@@ -2945,7 +2945,7 @@ wxULongLong wxFileName::GetSize(const wxString &filename)
         return wxInvalidSize;
 
     return wxULongLong(lpFileSizeHigh, ret);
-#else // ! __WIN32__
+#else // ! __WINDOWS__
     wxStructStat st;
     if (wxStat( filename, &st) != 0)
         return wxInvalidSize;

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -1291,28 +1291,17 @@ bool wxFileName::Mkdir( const wxString& dir, int perm, int flags )
         wxFileName filename;
         filename.AssignDir(dir);
 
-        wxString currPath;
-        if ( filename.HasVolume())
-        {
-            currPath << wxGetVolumeString(filename.GetVolume(), wxPATH_NATIVE);
-        }
+        // create the directories one by one
+        wxFileName currPath(filename);
+        currPath.m_dirs.Clear();
 
-        bool hasPrevious = false;
         for ( const auto& pathComponent : filename.GetDirs() )
         {
-            // Do not use IsAbsolute() here because we want the path to start
-            // with the separator even if it doesn't have any volume, but
-            // IsAbsolute() would return false in this case.
-            if ( hasPrevious || !filename.m_relative )
-                currPath += wxFILE_SEP_PATH;
+            currPath.AppendDir(pathComponent);
 
-            hasPrevious = true;
-
-            currPath += pathComponent;
-
-            if (!DirExists(currPath))
+            if (!currPath.DirExists())
             {
-                if (!wxMkdir(currPath, perm))
+                if (!wxMkdir(currPath.GetPath(), perm))
                 {
                     // no need to try creating further directories
                     return false;

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -2210,6 +2210,26 @@ wxString wxFileName::GetPath( int flags, wxPathFormat format ) const
         fullpath += wxT(']');
     }
 
+#ifdef __WINDOWS__
+    // Paths have to use "extended length" form to be longer than MAX_PATH
+    // under Windows, check if we need to use it.
+    if ( format == wxPATH_DOS && fullpath.length() > MAX_PATH )
+    {
+        // We can switch to extended length paths for paths using normal driver
+        // letters or UNC paths.
+        if ( fullpath[1] == GetVolumeSeparator() )
+        {
+            // Turn C: into \\?\C:
+            fullpath.insert(0, wxMSW_EXTENDED_PATH_PREFIX);
+        }
+        else if ( fullpath.StartsWith(R"(\\)") && fullpath[2] != '?' )
+        {
+            // Turn \\share into \\?\UNC\share
+            fullpath.insert(1, R"(\?\UNC)");
+        }
+    }
+#endif // __WINDOWS__
+
     return fullpath;
 }
 

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1127,20 +1127,22 @@ wxString wxString::Left(size_t nCount) const
 // (returns the whole string if ch not found)
 wxString wxString::BeforeFirst(wxUniChar ch, wxString *rest) const
 {
+  wxString ret;
   int iPos = Find(ch);
   if ( iPos == wxNOT_FOUND )
   {
-    iPos = length();
+    ret = *this;
     if ( rest )
       rest->clear();
   }
   else
   {
+    ret.assign(*this, 0, iPos);
     if ( rest )
       rest->assign(*this, iPos + 1, npos);
   }
 
-  return wxString(*this, 0, iPos);
+  return ret;
 }
 
 /// get all characters before the last occurrence of ch

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -1052,3 +1052,36 @@ TEST_CASE("wxFileName::GetSizeSpecial", "[filename][linux][special-file]")
 }
 
 #endif // __LINUX__
+
+// This test is disabled by default as it requires the environment variable
+// below to be defined to point to the file to test.
+TEST_CASE("wxFileName::Test", "[.]")
+{
+    wxString file;
+    REQUIRE( wxGetEnv("WX_TEST_FILENAME", &file) );
+
+    wxFileName fn{file};
+    fn.MakeAbsolute();
+
+    WARN
+    (
+        "Absolute path:\t\"" << fn.GetFullPath() << "\"\n"
+        "Volume:\t\t\"" << fn.GetVolume() << "\"\n"
+        "Name:\t\t\t\"" << fn.GetName() << "\"\n"
+        "Extension:\t\t\"" << fn.GetExt() << "\"\n"
+        "Path:\t\t\t[" << wxJoin(fn.GetDirs(), ' ', '\\') << "]\n"
+    );
+
+    if ( fn.FileExists() )
+    {
+        WARN("File of size:\t" << fn.GetHumanReadableSize() << "\n");
+    }
+    else if ( fn.DirExists() )
+    {
+        WARN("Is a directory");
+    }
+    else
+    {
+        FAIL("Does not exist");
+    }
+}

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -82,6 +82,7 @@ static struct TestFileNameInfo
     { "c:foo.bar", "c", "", "foo", "bar", false, wxPATH_DOS },
     { "c:\\foo.bar", "c", "\\", "foo", "bar", true, wxPATH_DOS },
     { "c:\\Windows\\command.com", "c", "\\Windows", "command", "com", true, wxPATH_DOS },
+    { R"(\\?\c:\Windows\System32\cmd.exe)", R"(\\?\c:)", R"(\Windows\System32)", R"(cmd)", R"(exe)", true, wxPATH_DOS },
     { "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}\\",
       "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}", "\\", "", "", true, wxPATH_DOS },
     { "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}\\Program Files\\setup.exe",

--- a/tests/strings/strings.cpp
+++ b/tests/strings/strings.cpp
@@ -1127,12 +1127,20 @@ TEST_CASE("StringBeforeAndAfter", "[wxString]")
     CHECK( s.BeforeFirst('!', &r) == s );
     CHECK( r == "" );
 
+    const wxString phrase("Two words apart");
+    r = phrase;
+    CHECK( r.BeforeFirst(' ', &r) == "Two" );
+    CHECK( r == "words apart" );
 
     CHECK( s.BeforeLast('=', &r) == FIRST_PART wxT("=") MIDDLE_PART );
     CHECK( r == LAST_PART );
 
     CHECK( s.BeforeLast('!', &r) == "" );
     CHECK( r == s );
+
+    r = phrase;
+    CHECK( r.BeforeLast(' ', &r) == "Two words" );
+    CHECK( r == "apart" );
 
 
     CHECK( s.AfterFirst('=') == MIDDLE_PART wxT("=") LAST_PART );


### PR DESCRIPTION
Recognize such paths if we're given them and also use them if necessary to support paths longer than `MAX_PATH` characters.

See #25033.