### PR TITLE
Fix wxWindowDisabler does not start a modal session on macOs

### DIFF
--- a/src/osx/cocoa/evtloop.mm
+++ b/src/osx/cocoa/evtloop.mm
@@ -513,7 +513,9 @@ void wxGUIEventLoop::EndModalSession()
     wxASSERT_MSG(m_modalSession != nullptr, "no modal session active");
     
     wxASSERT_MSG(m_modalNestedLevel > 0, "incorrect modal nesting level");
-    
+
+    m_modalWindow = nullptr;
+
     --m_modalNestedLevel;
     if ( m_modalNestedLevel == 0 )
     {


### PR DESCRIPTION
If BeginModalSession is called twice on a new window object located at the same address (i.e., allocated on the stack), the second call takes a shortcut and does not start a modal session. 

Reset m_modalWindow once the session is ended.

<details>
<summary>Minimal example of the issue:</summary>

```cpp
#include <wx/wx.h>
#include <wx/dialog.h>

class MyApp : public wxApp
{
public:
    virtual bool OnInit();
};

class MyFrame : public wxFrame
{
public:
    MyFrame(const wxString& title);

    void OnShowFirstDialog(wxCommandEvent& event);
};

class FirstDialog : public wxDialog
{
public:
    FirstDialog(wxWindow* parent);

    void OnShowSecondDialog(wxCommandEvent& event);
};

class SecondDialog : public wxDialog
{
public:
    SecondDialog(wxWindow* parent);
};

wxIMPLEMENT_APP(MyApp);

bool MyApp::OnInit()
{
    MyFrame* frame = new MyFrame("Nested modal macOs bug example");
    frame->Show(true);
    return true;
}

MyFrame::MyFrame(const wxString& title)
    : wxFrame(NULL, wxID_ANY, title, wxDefaultPosition, wxSize(400, 300))
{
    wxButton* button = new wxButton(this, wxID_ANY, "Show First Dialog", wxPoint(150, 100));
    button->Bind(wxEVT_BUTTON, &MyFrame::OnShowFirstDialog, this);
}

void MyFrame::OnShowFirstDialog(wxCommandEvent& WXUNUSED(event))
{
    FirstDialog firstDialog(this);
    firstDialog.ShowModal();
}

FirstDialog::FirstDialog(wxWindow* parent)
    : wxDialog(parent, wxID_ANY, "First Dialog", wxDefaultPosition, wxSize(300, 200))
{
    wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
    sizer->Add(new wxStaticText(this, wxID_ANY, "This is the first dialog."), 0, wxALL | wxCENTER, 10);
    wxButton* button = new wxButton(this, wxID_ANY, "Show Second Dialog");
    button->Bind(wxEVT_BUTTON, &FirstDialog::OnShowSecondDialog, this);
    sizer->Add(button, 0, wxALL | wxCENTER, 10);
    SetSizer(sizer);
    Centre();
}

void FirstDialog::OnShowSecondDialog(wxCommandEvent& WXUNUSED(event))
{
    {
        SecondDialog secondDialog(this);
        secondDialog.Show();
        {
            wxWindowDisabler disabler(&secondDialog);
            while (secondDialog.IsShown())
            {
                wxYield();
            }
        }
    }
}

SecondDialog::SecondDialog(wxWindow* parent)
    : wxDialog(parent, wxID_ANY, "Second Dialog", wxDefaultPosition, wxSize(250, 150))
{
    wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
    sizer->Add(new wxStaticText(this, wxID_ANY, "This is the second dialog."), 0, wxALL | wxCENTER, 10);
    sizer->Add(new wxButton(this, wxID_OK, "OK"), 0, wxALL | wxCENTER, 10);
    SetSizer(sizer);
    Centre();
}
```
</details>