### PR TITLE
make wxIMPLEMENT_WX_THEME_SUPPORT empty for wxUniv console apps

### DIFF
--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -901,7 +901,7 @@ public:
     #define wxIMPLEMENT_WXWIN_MAIN          wxIMPLEMENT_WXWIN_MAIN_CONSOLE
 #endif // defined(wxIMPLEMENT_WXWIN_MAIN)
 
-#ifdef __WXUNIVERSAL__
+#if defined(__WXUNIVERSAL__) && wxUSE_GUI
     #include "wx/univ/theme.h"
 
     #ifdef wxUNIV_DEFAULT_THEME


### PR DESCRIPTION
samples/archive is a console app but it links to themes for wxUniv build and therefore the build fails. This change fixes it.