### PR TITLE
make samples/ownerdrw sample buildable for wxUniv

### DIFF
--- a/samples/ownerdrw/ownerdrw.cpp
+++ b/samples/ownerdrw/ownerdrw.cpp
@@ -211,7 +211,9 @@ void OwnerDrawnFrame::InitMenu()
     drawn_menu->Append(pItem);
 
     pItem = new wxMenuItem(drawn_menu, Menu_Drawn5, "&Other\tCtrl+O", "other item");
+#ifndef __WXUNIVERSAL__
     pItem->SetTextColour(*wxRED);
+#endif
     drawn_menu->Append(pItem);
 
     wxMenu* native_menu = new wxMenu;


### PR DESCRIPTION
ownerdrw is wxMSW specific but wxMSW has makefiles which allow wxUniv variant. This little change allows building it for wxUniv so the global makefile for samples does not stop on this sample