### PR TITLE
samples/widgets sample build fix for lack of native windows in wxUniv

### DIFF
--- a/include/wx/nativewin.h
+++ b/include/wx/nativewin.h
@@ -31,7 +31,7 @@
 //    all platforms except GTK where we also can work with Window/XID)
 //
 //  - wxNativeWindowHandle for child windows, i.e. HWND/GtkWidget*/NSControl
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     #include "wx/msw/wrapwin.h"
 
     typedef HWND wxNativeContainerWindowId;

--- a/samples/widgets/native.cpp
+++ b/samples/widgets/native.cpp
@@ -35,9 +35,9 @@
     #include "wx/sizer.h"
 #endif // !WX_PRECOMP
 
-#ifdef wxHAS_NATIVE_WINDOW
-
 #include "wx/nativewin.h"
+
+#ifdef wxHAS_NATIVE_WINDOW
 
 #include "widgets.h"
 

--- a/samples/widgets/native.cpp
+++ b/samples/widgets/native.cpp
@@ -35,9 +35,9 @@
     #include "wx/sizer.h"
 #endif // !WX_PRECOMP
 
-#include "wx/nativewin.h"
-
 #ifdef wxHAS_NATIVE_WINDOW
+
+#include "wx/nativewin.h"
 
 #include "widgets.h"
 


### PR DESCRIPTION
I suppose wxHAS_NATIVE_WINDOW should be guarded inside of wx/nativewin.h however this file is shared by the ports I'm unable to test so I prefer to stay on safe side and only move check inside of sample. Without this change widgets sample fail to build under wxUniv