### PR TITLE
don't draw mnemonics in controls in wxUniv

### DIFF
--- a/include/wx/univ/control.h
+++ b/include/wx/univ/control.h
@@ -64,8 +64,11 @@ public:
     // accelerator char (the one immediately after '&') into m_chAccel
     virtual void SetLabel(const wxString& label) override;
 
-    // return the current label
-    virtual wxString GetLabel() const override { return m_label; }
+    // return the current label with mnemonics
+    virtual wxString GetLabel() const override { return wxControlBase::GetLabel(); }
+
+    // return the current label without mnemonics
+    virtual wxString GetLabelText() const override { return m_label; }
 
     // wxUniversal-specific methods
 

--- a/include/wx/univ/control.h
+++ b/include/wx/univ/control.h
@@ -65,7 +65,7 @@ public:
     virtual void SetLabel(const wxString& label) override;
 
     // return the current label
-    virtual wxString GetLabel() const override { return wxControlBase::GetLabel(); }
+    virtual wxString GetLabel() const override { return m_label; }
 
     // wxUniversal-specific methods
 

--- a/src/univ/checkbox.cpp
+++ b/src/univ/checkbox.cpp
@@ -157,7 +157,7 @@ void wxCheckBox::DoDraw(wxControlRenderer *renderer)
 
     renderer->GetRenderer()->
         DrawCheckButton(dc,
-                        GetLabel(),
+                        GetLabelText(),
                         bitmap,
                         renderer->GetRect(),
                         flags,

--- a/src/univ/ctrlrend.cpp
+++ b/src/univ/ctrlrend.cpp
@@ -68,11 +68,10 @@ void wxControlRenderer::DrawLabel()
     m_dc.SetFont(m_window->GetFont());
     m_dc.SetTextForeground(m_window->GetForegroundColour());
 
-    wxString label = m_window->GetLabel();
+    wxControl *ctrl = wxStaticCast(m_window, wxControl);
+    wxString label = ctrl->GetLabelText();
     if ( !label.empty() )
     {
-        wxControl *ctrl = wxStaticCast(m_window, wxControl);
-
         m_renderer->DrawLabel(m_dc,
                               label,
                               m_rect,
@@ -89,7 +88,9 @@ void wxControlRenderer::DrawButtonLabel(const wxBitmap& bitmap,
     m_dc.SetFont(m_window->GetFont());
     m_dc.SetTextForeground(m_window->GetForegroundColour());
 
-    wxString label = m_window->GetLabel();
+    wxControl *ctrl = wxStaticCast(m_window, wxControl);
+    wxString label = ctrl->GetLabelText();
+
     if ( !label.empty() || bitmap.IsOk() )
     {
         wxRect rectLabel = m_rect;
@@ -97,8 +98,6 @@ void wxControlRenderer::DrawButtonLabel(const wxBitmap& bitmap,
         {
             rectLabel.Inflate(-marginX, -marginY);
         }
-
-        wxControl *ctrl = wxStaticCast(m_window, wxControl);
 
         m_renderer->DrawButtonLabel(m_dc,
                                     label,
@@ -119,7 +118,7 @@ void wxControlRenderer::DrawFrame()
     wxControl *ctrl = wxStaticCast(m_window, wxControl);
 
     m_renderer->DrawFrame(m_dc,
-                          m_window->GetLabel(),
+                          ctrl->GetLabelText(),
                           m_rect,
                           m_window->GetStateFlags(),
                           ctrl->GetAlignment(),

--- a/src/univ/stdrend.cpp
+++ b/src/univ/stdrend.cpp
@@ -253,10 +253,9 @@ void wxStdRenderer::DrawButtonLabel(wxDC& dc,
                                     wxRect *rectBounds)
 {
     wxDCTextColourChanger clrChanger(dc);
-    wxString labelWithoutMnemonics = wxControlBase::GetLabelText(label);
 
     wxRect rectLabel = rect;
-    if ( !labelWithoutMnemonics.empty() && (flags & wxCONTROL_DISABLED) )
+    if ( !label.empty() && (flags & wxCONTROL_DISABLED) )
     {
         if ( flags & wxCONTROL_PRESSED )
         {
@@ -268,7 +267,7 @@ void wxStdRenderer::DrawButtonLabel(wxDC& dc,
         clrChanger.Set(m_penHighlight.GetColour());
         wxRect rectShadow = rect;
         rectShadow.Offset(1, 1);
-        dc.DrawLabel(labelWithoutMnemonics, rectShadow, alignment, indexAccel);
+        dc.DrawLabel(label, rectShadow, alignment, indexAccel);
 
         // make the main label text grey
         clrChanger.Set(m_penDarkGrey.GetColour());
@@ -280,9 +279,9 @@ void wxStdRenderer::DrawButtonLabel(wxDC& dc,
         }
     }
 
-    dc.DrawLabel(labelWithoutMnemonics, image, rectLabel, alignment, indexAccel, rectBounds);
+    dc.DrawLabel(label, image, rectLabel, alignment, indexAccel, rectBounds);
 
-    if ( !labelWithoutMnemonics.empty() && (flags & wxCONTROL_FOCUSED) )
+    if ( !label.empty() && (flags & wxCONTROL_FOCUSED) )
     {
         rectLabel.Inflate(-1);
 

--- a/src/univ/stdrend.cpp
+++ b/src/univ/stdrend.cpp
@@ -253,9 +253,10 @@ void wxStdRenderer::DrawButtonLabel(wxDC& dc,
                                     wxRect *rectBounds)
 {
     wxDCTextColourChanger clrChanger(dc);
+    wxString labelWithoutMnemonics = wxControlBase::GetLabelText(label);
 
     wxRect rectLabel = rect;
-    if ( !label.empty() && (flags & wxCONTROL_DISABLED) )
+    if ( !labelWithoutMnemonics.empty() && (flags & wxCONTROL_DISABLED) )
     {
         if ( flags & wxCONTROL_PRESSED )
         {
@@ -267,7 +268,7 @@ void wxStdRenderer::DrawButtonLabel(wxDC& dc,
         clrChanger.Set(m_penHighlight.GetColour());
         wxRect rectShadow = rect;
         rectShadow.Offset(1, 1);
-        dc.DrawLabel(label, rectShadow, alignment, indexAccel);
+        dc.DrawLabel(labelWithoutMnemonics, rectShadow, alignment, indexAccel);
 
         // make the main label text grey
         clrChanger.Set(m_penDarkGrey.GetColour());
@@ -279,9 +280,9 @@ void wxStdRenderer::DrawButtonLabel(wxDC& dc,
         }
     }
 
-    dc.DrawLabel(label, image, rectLabel, alignment, indexAccel, rectBounds);
+    dc.DrawLabel(labelWithoutMnemonics, image, rectLabel, alignment, indexAccel, rectBounds);
 
-    if ( !label.empty() && (flags & wxCONTROL_FOCUSED) )
+    if ( !labelWithoutMnemonics.empty() && (flags & wxCONTROL_FOCUSED) )
     {
         rectLabel.Inflate(-1);
 


### PR DESCRIPTION
I don't know when and where the regression happened but in the past mnemonics weren't drawn in wxUniv builds. This patch fixes it.

Before patch it looks as follow: 
![wxUniv_broken_mnemonics](https://github.com/user-attachments/assets/f57042ec-c1fc-4aab-bc25-1ffafb473dce)

After patch if looks as follow:
![wxUniv_fixed_mnemonics](https://github.com/user-attachments/assets/8cc48e43-4bf9-485e-bcf0-8004ed30dcd2)
