### PR TITLE
Refresh control when only position of mnemonic in label is changed

### DIFF
--- a/src/univ/control.cpp
+++ b/src/univ/control.cpp
@@ -84,9 +84,11 @@ void wxControl::SetLabel(const wxString& label)
 void wxControl::UnivDoSetLabel(const wxString& label)
 {
     wxString labelOld = m_label;
+    int indexAccelOld = m_indexAccel;
+
     m_indexAccel = FindAccelIndex(label, &m_label);
 
-    if ( m_label != labelOld )
+    if ( ( m_label != labelOld ) || ( m_indexAccel != indexAccelOld ) )
     {
         Refresh();
     }


### PR DESCRIPTION
The problem is visible in samples/widgets sample. In this sample, in "Button" page, on the most right there is text field with "&Press me!" text and button presenting it. When you change "&Press me!" to "Press &me!" and click "Change label" button, the button with this label is not refreshed. This patch fixes it.