### PR TITLE
Log traits fixes

### DIFF
--- a/include/wx/private/log.h
+++ b/include/wx/private/log.h
@@ -20,7 +20,7 @@
 class wxLogOutputBest : public wxLog
 {
 public:
-    wxLogOutputBest() { }
+    wxLogOutputBest() = default;
 
 protected:
     virtual void DoLogText(const wxString& msg) override

--- a/include/wx/private/log.h
+++ b/include/wx/private/log.h
@@ -1,0 +1,35 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/log.h
+// Purpose:     Private wxLog-related declarations.
+// Author:      Vadim Zeitlin
+// Created:     2025-01-19 (extracted from log.cpp)
+// Copyright:   (c) 2025 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_LOG_H_
+#define _WX_PRIVATE_LOG_H_
+
+#include "wx/log.h"
+#include "wx/msgout.h"
+
+// ----------------------------------------------------------------------------
+// wxLogOutputBest: wxLog wrapper around wxMessageOutputBest
+// ----------------------------------------------------------------------------
+
+class wxLogOutputBest : public wxLog
+{
+public:
+    wxLogOutputBest() { }
+
+protected:
+    virtual void DoLogText(const wxString& msg) override
+    {
+        wxMessageOutputBest().Output(msg);
+    }
+
+private:
+    wxDECLARE_NO_COPY_CLASS(wxLogOutputBest);
+};
+
+#endif // _WX_PRIVATE_LOG_H_

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -60,6 +60,10 @@
     #include "wx/fontmap.h"
 #endif // wxUSE_FONTMAP
 
+#if wxUSE_LOG
+    #include "wx/private/log.h"
+#endif // wxUSE_LOG
+
 #if wxDEBUG_LEVEL
     #if wxUSE_STACKWALKER
         #include "wx/stackwalk.h"
@@ -886,14 +890,14 @@ void wxAppConsoleBase::SetCLocale()
 
 wxLog *wxConsoleAppTraitsBase::CreateLogTarget()
 {
-    return new wxLogStderr;
+    return new wxLogOutputBest;
 }
 
 #endif // wxUSE_LOG
 
 wxMessageOutput *wxConsoleAppTraitsBase::CreateMessageOutput()
 {
-    return new wxMessageOutputStderr;
+    return new wxMessageOutputBest;
 }
 
 #if wxUSE_FONTMAP

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -40,6 +40,8 @@
 #include "wx/crt.h"
 #include "wx/vector.h"
 
+#include "wx/private/log.h"
+
 // other standard headers
 #include <errno.h>
 
@@ -159,25 +161,6 @@ inline ComponentLevelsMap& GetComponentLevels()
     static ComponentLevelsMap s_componentLevels;
     return s_componentLevels;
 }
-
-// ----------------------------------------------------------------------------
-// wxLogOutputBest: wxLog wrapper around wxMessageOutputBest
-// ----------------------------------------------------------------------------
-
-class wxLogOutputBest : public wxLog
-{
-public:
-    wxLogOutputBest() { }
-
-protected:
-    virtual void DoLogText(const wxString& msg) override
-    {
-        wxMessageOutputBest().Output(msg);
-    }
-
-private:
-    wxDECLARE_NO_COPY_CLASS(wxLogOutputBest);
-};
 
 } // anonymous namespace
 

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -509,10 +509,7 @@ wxLog *wxLog::GetMainThreadActiveTarget()
             s_bInGetActiveTarget = true;
 
             // ask the application to create a log target for us
-            if ( wxTheApp != nullptr )
-                ms_pLogger = wxTheApp->GetTraits()->CreateLogTarget();
-            else
-                ms_pLogger = new wxLogOutputBest;
+            ms_pLogger = wxApp::GetValidTraits().CreateLogTarget();
 
             s_bInGetActiveTarget = false;
 

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -152,9 +152,6 @@ PreviousLogInfo gs_prevLog;
 // map containing all components for which log level was explicitly set
 //
 // NB: all accesses to it must be protected by GetLevelsCS() critical section
-namespace
-{
-
 using ComponentLevelsMap = std::unordered_map<wxString, wxLogLevel>;
 
 inline ComponentLevelsMap& GetComponentLevels()
@@ -162,8 +159,6 @@ inline ComponentLevelsMap& GetComponentLevels()
     static ComponentLevelsMap s_componentLevels;
     return s_componentLevels;
 }
-
-} // anonymous namespace
 
 // ----------------------------------------------------------------------------
 // wxLogOutputBest: wxLog wrapper around wxMessageOutputBest

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -512,9 +512,17 @@ wxLog *wxLog::GetMainThreadActiveTarget()
             ms_pLogger = wxApp::GetValidTraits().CreateLogTarget();
 
             s_bInGetActiveTarget = false;
-
-            // do nothing if it fails - what can we do?
         }
+    }
+
+    if ( !ms_pLogger )
+    {
+        // if we still don't have any logger, provide the default fallback, but
+        // don't remember it -- we don't want to use it if a real logger if we
+        // can call CreateLogTarget() successfully later
+        static wxLogOutputBest s_defaultLogger;
+
+        return &s_defaultLogger;
     }
 
     return ms_pLogger;


### PR DESCRIPTION
This is mostly about fixing #25096, but also contains a couple of minor improvements to `wxLog`, notably don't just throw away any log messages if `CreateLogTarget()` fails (even if it's still not supposed to).