### PR TITLE
CMake: Fix using static runtime with msvc

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -140,6 +140,15 @@ function(wx_set_common_target_properties target_name)
             set(MSVC_WARNING_LEVEL "/W4")
         endif()
         target_compile_options(${target_name} PRIVATE ${MSVC_WARNING_LEVEL})
+
+        if(CMAKE_VERSION GREATER_EQUAL "3.15")
+            set(msvc_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+            if(wxBUILD_USE_STATIC_RUNTIME)
+                set(msvc_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+            endif()
+            set_target_properties(${target_name} PROPERTIES MSVC_RUNTIME_LIBRARY ${msvc_runtime})
+        endif()
+
     elseif(NOT wxCOMMON_TARGET_PROPS_DEFAULT_WARNINGS)
         set(common_gcc_clang_compile_options
             -Wall

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -83,6 +83,14 @@ if(MSVC)
     endforeach()
     endif()
 
+    if(wxBUILD_SHARED AND wxBUILD_USE_STATIC_RUNTIME AND wxUSE_STD_IOSTREAM)
+        # Objects like std::cout are defined as extern in <iostream> and implemented in libcpmt.
+        # This is statically linked into wxbase (stdstream.cpp).
+        # When building an application with both wxbase and libcpmt,
+        # the linker gives 'multiply defined symbols' error.
+        message(WARNING "wxUSE_STD_IOSTREAM combined with wxBUILD_USE_STATIC_RUNTIME will fail to link when using std::cout or similar functions")
+    endif()
+
     if(wxBUILD_OPTIMISE)
         set(MSVC_LINKER_RELEASE_FLAGS " /LTCG /OPT:REF /OPT:ICF")
         wx_string_append(CMAKE_EXE_LINKER_FLAGS_RELEASE "${MSVC_LINKER_RELEASE_FLAGS}")

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -52,6 +52,8 @@ else()
 endif()
 
 if(MSVC)
+    if(CMAKE_VERSION VERSION_LESS "3.15")
+    # CMake 3.15 and later use MSVC_RUNTIME_LIBRARY property, see functions.cmake
     # Determine MSVC runtime library flag
     set(MSVC_LIB_USE "/MD")
     set(MSVC_LIB_REPLACE "/MT")
@@ -79,6 +81,7 @@ if(MSVC)
               "Flags used by the CXX compiler during ${cfg_upper} builds." FORCE)
         endif()
     endforeach()
+    endif()
 
     if(wxBUILD_OPTIMISE)
         set(MSVC_LINKER_RELEASE_FLAGS " /LTCG /OPT:REF /OPT:ICF")

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -36,7 +36,11 @@ wx_option(wxBUILD_DEBUG_LEVEL "Debug Level" Default STRINGS Default 0 1 2)
 mark_as_advanced(wxBUILD_DEBUG_LEVEL)
 
 if(NOT APPLE)
-    wx_option(wxBUILD_USE_STATIC_RUNTIME "Link using the static runtime library" OFF)
+    set(wxBUILD_USE_STATIC_RUNTIME_DEFAULT OFF)
+    if(MSVC AND CMAKE_MSVC_RUNTIME_LIBRARY)
+        set(wxBUILD_USE_STATIC_RUNTIME_DEFAULT ON)
+    endif()
+    wx_option(wxBUILD_USE_STATIC_RUNTIME "Link using the static runtime library" ${wxBUILD_USE_STATIC_RUNTIME_DEFAULT})
     mark_as_advanced(wxBUILD_USE_STATIC_RUNTIME)
 endif()
 

--- a/build/cmake/policies.cmake
+++ b/build/cmake/policies.cmake
@@ -84,6 +84,11 @@ if(POLICY CMP0079)
     cmake_policy(SET CMP0079 NEW)
 endif()
 
+if(POLICY CMP0091)
+    # MSVC runtime library flags are selected by an abstraction.
+    cmake_policy(SET CMP0091 NEW)
+endif()
+
 if(POLICY CMP0092)
     # MSVC warning flags are not in CMAKE_<LANG>_FLAGS by default.
     cmake_policy(SET CMP0092 NEW)


### PR DESCRIPTION
This was broken with recent CMake versions, see wx-dev discussion https://groups.google.com/g/wx-dev/c/0ECwYNf8TfU