### PR TITLE
Use UTF-8 for environment variables

### DIFF
--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -256,15 +256,19 @@ wxVersionInfo wxGetLibraryVersionInfo();
 using wxEnvVariableHashMap = std::unordered_map<wxString, wxString>;
 
 /**
-    This is a macro defined as @c getenv() or its wide char version in Unicode
-    mode.
+    Wrapper of the standard @c getenv() or its wide char version.
 
-    Note that under Win32 it may not return correct value for the variables set
-    with wxSetEnv(), use wxGetEnv() function instead.
+    Note that under Win32 the overload using `char*` doesn't not work for the
+    variables using non-ASCII characters, use either the overload taking
+    `wchar_t*` or, preferably, wxGetEnv() instead.
+
+    Under other platforms, `char*` overload always uses UTF-8 encoding.
 
     @header{wx/utils.h}
 */
-wxChar* wxGetenv(const wxString& var);
+char* wxGetenv(const char* s);
+wchar_t* wxGetenv(const wchar_t* ws);
+char* wxGetenv(const wxString& s);
 
 /**
     Returns the current value of the environment variable @a var in @a value.

--- a/src/common/wxcrt.cpp
+++ b/src/common/wxcrt.cpp
@@ -779,7 +779,7 @@ WXDLLIMPEXP_BASE wchar_t* wxCRT_GetenvW(const wchar_t *name)
     //     time getenv() is called, so it is OK to use static string
     //     buffer to hold the data.
     static wxWCharBuffer value;
-    value = wxConvLibc.cMB2WC(getenv(wxConvLibc.cWC2MB(name)));
+    value = wxConvWhateverWorks.cMB2WC(getenv(wxConvWhateverWorks.cWC2MB(name)));
     return value.data();
 }
 #endif // !wxCRT_GetenvW

--- a/tests/strings/crt.cpp
+++ b/tests/strings/crt.cpp
@@ -34,7 +34,7 @@ static const wxString strWX("hello, world");
 
 TEST_CASE("CRT::SetGetEnv", "[crt][getenv][setenv]")
 {
-#define TESTVAR_NAME wxT("WXTESTVAR")
+#define TESTVAR_NAME "WXTESTVAR"
 
     wxString val;
     wxSetEnv(TESTVAR_NAME, wxT("value"));
@@ -42,10 +42,11 @@ TEST_CASE("CRT::SetGetEnv", "[crt][getenv][setenv]")
     CHECK( val == "value" );
     CHECK( wxString(wxGetenv(TESTVAR_NAME)) == "value" );
 
-    wxSetEnv(TESTVAR_NAME, wxT("something else"));
+    const wxString nonASCII = wxString::FromUTF8("\xe2\x98\xba");
+    wxSetEnv(TESTVAR_NAME, nonASCII);
     CHECK( wxGetEnv(TESTVAR_NAME, &val) );
-    CHECK( val == "something else" );
-    CHECK( wxString(wxGetenv(TESTVAR_NAME)) == "something else" );
+    CHECK( val == nonASCII );
+    CHECK( wxString::FromUTF8(wxGetenv(TESTVAR_NAME)) == nonASCII );
 
     CHECK( wxUnsetEnv(TESTVAR_NAME) );
     CHECK( !wxGetEnv(TESTVAR_NAME, nullptr) );

--- a/tests/strings/crt.cpp
+++ b/tests/strings/crt.cpp
@@ -46,7 +46,15 @@ TEST_CASE("CRT::SetGetEnv", "[crt][getenv][setenv]")
     wxSetEnv(TESTVAR_NAME, nonASCII);
     CHECK( wxGetEnv(TESTVAR_NAME, &val) );
     CHECK( val == nonASCII );
+
+    // Under MSW the current locale encoding is used for storing the value in
+    // the ASCII environment block, so we can't expect to get it back unless
+    // this encoding is UTF-8, which is not the case by default.
+#ifndef __WINDOWS__
     CHECK( wxString::FromUTF8(wxGetenv(TESTVAR_NAME)) == nonASCII );
+#endif
+
+    // Wide char wxGetenv() overload does work, under both MSW and Unix.
     CHECK( wxGetenv(L"WXTESTVAR") == nonASCII );
 
     CHECK( wxUnsetEnv(TESTVAR_NAME) );

--- a/tests/strings/crt.cpp
+++ b/tests/strings/crt.cpp
@@ -47,6 +47,7 @@ TEST_CASE("CRT::SetGetEnv", "[crt][getenv][setenv]")
     CHECK( wxGetEnv(TESTVAR_NAME, &val) );
     CHECK( val == nonASCII );
     CHECK( wxString::FromUTF8(wxGetenv(TESTVAR_NAME)) == nonASCII );
+    CHECK( wxGetenv(L"WXTESTVAR") == nonASCII );
 
     CHECK( wxUnsetEnv(TESTVAR_NAME) );
     CHECK( !wxGetEnv(TESTVAR_NAME, nullptr) );


### PR DESCRIPTION
We used current locale encoding before, but this really doesn't make much sense for the env vars which are system-global and always use UTF-8 under Linux in practice.