### PR TITLE
placement of check mark repaired in wxUnivGTK theme

### DIFF
--- a/src/univ/themes/gtk.cpp
+++ b/src/univ/themes/gtk.cpp
@@ -1671,6 +1671,7 @@ void wxGTKRenderer::DoDrawMenuItem(wxDC& dc,
 
         if ( bmp.IsOk() )
         {
+            rect.x = MENU_BMP_MARGIN;
             rect.SetRight(geometryInfo->GetLabelOffset());
             wxControlRenderer::DrawBitmap(dc, bmp, rect);
         }
@@ -1780,6 +1781,16 @@ wxMenuGeometryInfo *wxGTKRenderer::GetMenuGeometry(wxWindow *win,
             if ( widthAccel > widthAccelMax )
             {
                 widthAccelMax = widthAccel;
+            }
+
+            if ( item->IsCheckable() )
+            {
+                wxCoord width = GetCheckBitmapSize().x;
+                if ( width > widthBmpMax )
+                    widthBmpMax = width;
+                width = GetRadioBitmapSize().x;
+                if ( width > widthBmpMax )
+                    widthBmpMax = width;
             }
 
             const wxBitmap& bmp = item->GetBitmap();


### PR DESCRIPTION
I noticed placement of check marks was broken with wxUnivGTK theme. Before this fix it looked like: 
![wxUniv_broken_check_menu_icon](https://github.com/user-attachments/assets/ee71a888-45cc-4ad0-af4a-c03093b135f7)
and afer this change it looks like: 
![wxUniv_fixed_check_menu_icon](https://github.com/user-attachments/assets/e48bdb7f-7044-4518-8da4-a2269bbed835)
