### PR TITLE
wxUniv accel support for controls

### DIFF
--- a/include/wx/univ/control.h
+++ b/include/wx/univ/control.h
@@ -31,6 +31,7 @@ typedef wxString wxControlAction;
 // in the controls headers)
 
 #define wxACTION_NONE    wxT("")           // no action to perform
+#define wxEMPTY_ACCEL_CHAR    wxT('\0')
 
 // ----------------------------------------------------------------------------
 // wxControl: the base class for all GUI controls
@@ -52,6 +53,8 @@ public:
 
         Create(parent, id, pos, size, style, validator, name);
     }
+
+    virtual ~wxControl();
 
     bool Create(wxWindow *parent,
                 wxWindowID id,
@@ -78,7 +81,7 @@ public:
     // return the accel char itself or 0 if none
     wxChar GetAccelChar() const
     {
-        return m_indexAccel == -1 ? wxT('\0') : (wxChar)m_label[m_indexAccel];
+        return m_indexAccel == -1 ? wxEMPTY_ACCEL_CHAR : (wxChar)m_label[m_indexAccel];
     }
 
     virtual wxWindow *GetInputWindow() const override

--- a/include/wx/univ/control.h
+++ b/include/wx/univ/control.h
@@ -31,7 +31,7 @@ typedef wxString wxControlAction;
 // in the controls headers)
 
 #define wxACTION_NONE    wxT("")           // no action to perform
-#define wxEMPTY_ACCEL_CHAR    wxT('\0')
+#define wxNO_ACCEL_CHAR    wxT('\0')
 
 // ----------------------------------------------------------------------------
 // wxControl: the base class for all GUI controls
@@ -81,7 +81,7 @@ public:
     // return the accel char itself or 0 if none
     wxChar GetAccelChar() const
     {
-        return m_indexAccel == -1 ? wxEMPTY_ACCEL_CHAR : (wxChar)m_label[m_indexAccel];
+        return m_indexAccel == -1 ? wxNO_ACCEL_CHAR : (wxChar)m_label[m_indexAccel];
     }
 
     virtual wxWindow *GetInputWindow() const override

--- a/src/univ/control.cpp
+++ b/src/univ/control.cpp
@@ -74,15 +74,15 @@ wxControl::~wxControl()
 #if wxUSE_ACCEL
     wxChar accelChar = GetAccelChar();
 
-    for ( wxWindow *win = this; win; win = win->GetParent() )
+    if ( accelChar != wxEMPTY_ACCEL_CHAR )
     {
-        if ( win->IsTopLevel() )
+        wxWindow *win = wxGetTopLevelParent(this);
+        if ( win )
         {
-            if ( accelChar != wxEMPTY_ACCEL_CHAR )
-            {
-                wxAcceleratorEntry accelEntry(wxACCEL_NORMAL, (int)accelChar);
-                win->GetAcceleratorTable()->Remove(accelEntry);
-            }
+            wxAcceleratorEntry accelEntry(wxACCEL_ALT, (int)accelChar);
+            wxAcceleratorTable *accelTable = win->GetAcceleratorTable();
+            if ( accelTable && accelTable->IsOk() )
+                accelTable->Remove(accelEntry);
         }
     }
 #endif // wxUSE_ACCEL
@@ -115,21 +115,19 @@ void wxControl::UnivDoSetLabel(const wxString& label)
 
     if ( accelCharOld != accelChar )
     {
-        for ( wxWindow *win = this; win; win = win->GetParent() )
+        wxWindow *win = wxGetTopLevelParent(this);
+        if ( win )
         {
-            if ( win->IsTopLevel() )
+            if ( accelCharOld != wxEMPTY_ACCEL_CHAR )
             {
-                if ( accelCharOld != wxEMPTY_ACCEL_CHAR )
-                {
-                    wxAcceleratorEntry accelEntryOld(wxACCEL_NORMAL, (int)accelCharOld);
-                    win->GetAcceleratorTable()->Remove(accelEntryOld);
-                }
+                wxAcceleratorEntry accelEntryOld(wxACCEL_ALT, (int)accelCharOld);
+                win->GetAcceleratorTable()->Remove(accelEntryOld);
+            }
 
-                if ( accelChar != wxEMPTY_ACCEL_CHAR )
-                {
-                    wxAcceleratorEntry accelEntryNew(wxACCEL_NORMAL, (int)accelChar, GetId());
-                    win->GetAcceleratorTable()->Add(accelEntryNew);
-                }
+            if ( accelChar != wxEMPTY_ACCEL_CHAR )
+            {
+                wxAcceleratorEntry accelEntryNew(wxACCEL_ALT, (int)accelChar, GetId());
+                win->GetAcceleratorTable()->Add(accelEntryNew);
             }
         }
     }

--- a/src/univ/control.cpp
+++ b/src/univ/control.cpp
@@ -74,10 +74,9 @@ wxControl::~wxControl()
 #if wxUSE_ACCEL
     wxChar accelChar = GetAccelChar();
 
-    if ( accelChar != wxEMPTY_ACCEL_CHAR )
+    if ( accelChar != wxNO_ACCEL_CHAR )
     {
-        wxWindow *win = wxGetTopLevelParent(this);
-        if ( win )
+        if ( wxWindow *win = wxGetTopLevelParent(this) )
         {
             wxAcceleratorEntry accelEntry(wxACCEL_ALT, (int)accelChar);
             wxAcceleratorTable *accelTable = win->GetAcceleratorTable();
@@ -115,19 +114,23 @@ void wxControl::UnivDoSetLabel(const wxString& label)
 
     if ( accelCharOld != accelChar )
     {
-        wxWindow *win = wxGetTopLevelParent(this);
-        if ( win )
+        if ( wxWindow *win = wxGetTopLevelParent(this) )
         {
-            if ( accelCharOld != wxEMPTY_ACCEL_CHAR )
+            if ( wxAcceleratorTable *accelTable = win->GetAcceleratorTable() )
             {
-                wxAcceleratorEntry accelEntryOld(wxACCEL_ALT, (int)accelCharOld);
-                win->GetAcceleratorTable()->Remove(accelEntryOld);
-            }
+                // remove entry only from valid accelerator table
+                if ( ( accelCharOld != wxNO_ACCEL_CHAR ) && accelTable->IsOk() )
+                {
+                    wxAcceleratorEntry accelEntryOld(wxACCEL_ALT, (int)accelCharOld);
+                    accelTable->Remove(accelEntryOld);
+                }
 
-            if ( accelChar != wxEMPTY_ACCEL_CHAR )
-            {
-                wxAcceleratorEntry accelEntryNew(wxACCEL_ALT, (int)accelChar, GetId());
-                win->GetAcceleratorTable()->Add(accelEntryNew);
+                // accelerator table doesn't have to be valid to add
+                if ( accelChar != wxNO_ACCEL_CHAR )
+                {
+                    wxAcceleratorEntry accelEntryNew(wxACCEL_ALT, (int)accelChar, GetId());
+                    accelTable->Add(accelEntryNew);
+                }
             }
         }
     }


### PR DESCRIPTION
This change adds accel support for mnemonics used in control labels. Previously accel chars were displayed but didn't work. You can see result of this PR in menu or minimal samples. Just build and run sample, press F1 to invoke menu accel (worked fine) and open about dialog, then press O to invoke control accel (implemented in this PR) and cause OK button event.