### PR TITLE
Add international currency symbol support to locale classes

### DIFF
--- a/include/wx/localedefs.h
+++ b/include/wx/localedefs.h
@@ -87,6 +87,12 @@ enum wxLocaleInfo
     // the character used as decimal point (for wxLOCALE_CAT_NUMBER or MONEY)
     wxLOCALE_DECIMAL_POINT,
 
+    // the character used for currency
+    wxLOCALE_CURRENCY_SYMBOL,
+
+    // the string used for international currency symbol (e.g, USD) 
+    wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL,
+
     // the stftime()-formats used for short/long date and time representations
     // (under some platforms short and long date formats are the same)
     //

--- a/include/wx/localedefs.h
+++ b/include/wx/localedefs.h
@@ -87,9 +87,6 @@ enum wxLocaleInfo
     // the character used as decimal point (for wxLOCALE_CAT_NUMBER or MONEY)
     wxLOCALE_DECIMAL_POINT,
 
-    // the character used for currency
-    wxLOCALE_CURRENCY_SYMBOL,
-
     // the string used for international currency symbol (e.g, USD)
     wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL,
 

--- a/include/wx/localedefs.h
+++ b/include/wx/localedefs.h
@@ -90,7 +90,7 @@ enum wxLocaleInfo
     // the character used for currency
     wxLOCALE_CURRENCY_SYMBOL,
 
-    // the string used for international currency symbol (e.g, USD) 
+    // the string used for international currency symbol (e.g, USD)
     wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL,
 
     // the stftime()-formats used for short/long date and time representations

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -198,20 +198,6 @@ enum wxLocaleInfo
     wxLOCALE_DECIMAL_POINT,
 
     /**
-       Currency symbol (e.g., '$' or '€').
-
-       @note Under Unix, using this with `wxUILocale` may return additional data.
-             The returned string will include the currency symbol in the first position,
-             but may also include a `-` or `+` symbol after that. This indicates
-             whether the currency symbol should appear before or after the monetary
-             value, respectively. Refer to documentation for the function `nl_langinfo`
-             for further details.
-
-       @since 3.3.0
-    */
-    wxLOCALE_CURRENCY_SYMBOL,
-
-    /**
        International currency symbol (e.g., "USD" or "EUR").
 
        @since 3.3.0

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -198,6 +198,27 @@ enum wxLocaleInfo
     wxLOCALE_DECIMAL_POINT,
 
     /**
+       Currency symbol (e.g., '$' or '€').
+
+       @note Under Unix, using this with `wxUILocale` may return additional data.
+             The returned string will include the currency symbol in the first position,
+             but may also include a `-` or `+` symbol after that. This indicates
+             whether the currency symbol should appear before or after the monetary
+             value, respectively. Refer to documentation for the function `nl_langinfo`
+             for further details.
+
+       @since 3.3.0
+    */
+    wxLOCALE_CURRENCY_SYMBOL,
+
+    /**
+       International currency symbol (e.g., "USD" or "EUR").
+
+       @since 3.3.0
+    */
+    wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL,
+
+    /**
         Short date format.
 
         Notice that short and long date formats may be the same under POSIX

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -1209,6 +1209,12 @@ wxString wxGetStdCLocaleInfo(wxLocaleInfo index, wxLocaleCategory WXUNUSED(cat))
         case wxLOCALE_DECIMAL_POINT:
             return ".";
 
+        case wxLOCALE_CURRENCY_SYMBOL:
+            return "$";
+
+        case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
+            return "USD";
+
         case wxLOCALE_SHORT_DATE_FMT:
             return "%m/%d/%y";
 
@@ -1257,6 +1263,14 @@ wxGetInfoFromCFLocale(CFLocaleRef cfloc, wxLocaleInfo index, wxLocaleCategory WX
 
         case wxLOCALE_DECIMAL_POINT:
             cfstr = (CFStringRef) CFLocaleGetValue(cfloc, kCFLocaleDecimalSeparator);
+            break;
+
+        case wxLOCALE_CURRENCY_SYMBOL:
+            cfstr = (CFStringRef) CFLocaleGetValue(cfloc, kCFLocaleCurrencySymbol);
+            break;
+
+        case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
+            cfstr = (CFStringRef) CFLocaleGetValue(cfloc, kCFLocaleCurrencyCode);
             break;
 
         case wxLOCALE_SHORT_DATE_FMT:
@@ -1400,6 +1414,11 @@ wxString wxLocale::GetInfo(wxLocaleInfo index, wxLocaleCategory cat)
             }
             break;
 
+        case wxLOCALE_CURRENCY_SYMBOL:
+            return lc->currency_symbol;
+
+        case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
+            return lc->int_curr_symbol;
 
         case wxLOCALE_DECIMAL_POINT:
             switch ( cat )

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -1209,9 +1209,6 @@ wxString wxGetStdCLocaleInfo(wxLocaleInfo index, wxLocaleCategory WXUNUSED(cat))
         case wxLOCALE_DECIMAL_POINT:
             return ".";
 
-        case wxLOCALE_CURRENCY_SYMBOL:
-            return "$";
-
         case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
             return "USD";
 
@@ -1263,10 +1260,6 @@ wxGetInfoFromCFLocale(CFLocaleRef cfloc, wxLocaleInfo index, wxLocaleCategory WX
 
         case wxLOCALE_DECIMAL_POINT:
             cfstr = (CFStringRef) CFLocaleGetValue(cfloc, kCFLocaleDecimalSeparator);
-            break;
-
-        case wxLOCALE_CURRENCY_SYMBOL:
-            cfstr = (CFStringRef) CFLocaleGetValue(cfloc, kCFLocaleCurrencySymbol);
             break;
 
         case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
@@ -1413,9 +1406,6 @@ wxString wxLocale::GetInfo(wxLocaleInfo index, wxLocaleCategory cat)
                     wxFAIL_MSG( "invalid wxLocaleCategory" );
             }
             break;
-
-        case wxLOCALE_CURRENCY_SYMBOL:
-            return lc->currency_symbol;
 
         case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
             return lc->int_curr_symbol;

--- a/src/msw/uilocale.cpp
+++ b/src/msw/uilocale.cpp
@@ -459,6 +459,14 @@ public:
                                     : LOCALE_SDECIMAL);
                 break;
 
+            case wxLOCALE_CURRENCY_SYMBOL:
+                str = DoGetInfo(LOCALE_SCURRENCY);
+                break;
+
+            case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
+                str = DoGetInfo(LOCALE_SINTLSYMBOL);
+                break;
+
             case wxLOCALE_SHORT_DATE_FMT:
             case wxLOCALE_LONG_DATE_FMT:
             case wxLOCALE_TIME_FMT:

--- a/src/msw/uilocale.cpp
+++ b/src/msw/uilocale.cpp
@@ -459,10 +459,6 @@ public:
                                     : LOCALE_SDECIMAL);
                 break;
 
-            case wxLOCALE_CURRENCY_SYMBOL:
-                str = DoGetInfo(LOCALE_SCURRENCY);
-                break;
-
             case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
                 str = DoGetInfo(LOCALE_SINTLSYMBOL);
                 break;

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -589,6 +589,12 @@ wxUILocaleImplUnix::GetInfo(wxLocaleInfo index, wxLocaleCategory cat) const
 
             return GetLangInfo(RADIXCHAR);
 
+        case wxLOCALE_CURRENCY_SYMBOL:
+            return GetLangInfo(CURRENCY_SYMBOL);
+
+        case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
+            return GetLangInfo(INT_CURR_SYMBOL);
+
         case wxLOCALE_SHORT_DATE_FMT:
             return GetLangInfo(D_FMT);
 

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -589,9 +589,6 @@ wxUILocaleImplUnix::GetInfo(wxLocaleInfo index, wxLocaleCategory cat) const
 
             return GetLangInfo(RADIXCHAR);
 
-        case wxLOCALE_CURRENCY_SYMBOL:
-            return GetLangInfo(CURRENCY_SYMBOL);
-
         case wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL:
             return GetLangInfo(INT_CURR_SYMBOL);
 

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -423,7 +423,7 @@ TEST_CASE("wxUILocale::GetInfo", "[uilocale]")
     if (CheckSupported(locDE, "German"))
     {
         CHECK(locDE.GetInfo(wxLOCALE_DECIMAL_POINT) == ",");
-        CHECK(locDE.GetInfo(wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL) == "EUR");
+        CHECK(locDE.GetInfo(wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL).Trim() == "EUR");
     }
 
     // This one shows that "Swiss High German" locale (de_CH) correctly uses

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -420,8 +420,15 @@ TEST_CASE("wxUILocale::GetInfo", "[uilocale]")
     CHECK( wxUILocale::FromTag("en").GetInfo(wxLOCALE_DECIMAL_POINT) == "." );
 
     const wxUILocale locDE(wxUILocale::FromTag("de"));
-    if ( CheckSupported(locDE, "German") )
-        CHECK( locDE.GetInfo(wxLOCALE_DECIMAL_POINT) == "," );
+    if (CheckSupported(locDE, "German"))
+    {
+        CHECK(locDE.GetInfo(wxLOCALE_DECIMAL_POINT) == ",");
+        REQUIRE_FALSE(locDE.GetInfo(wxLOCALE_CURRENCY_SYMBOL).empty());
+        // only look at first character, Unix may include additional
+        // info after this character that we aren't interested in here
+        CHECK(locDE.GetInfo(wxLOCALE_CURRENCY_SYMBOL)[0] == "€");
+        CHECK(locDE.GetInfo(wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL) == "EUR");
+    }
 
     // This one shows that "Swiss High German" locale (de_CH) correctly uses
     // dot, and not comma, as decimal separator, even under macOS, where POSIX

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -423,10 +423,6 @@ TEST_CASE("wxUILocale::GetInfo", "[uilocale]")
     if (CheckSupported(locDE, "German"))
     {
         CHECK(locDE.GetInfo(wxLOCALE_DECIMAL_POINT) == ",");
-        REQUIRE_FALSE(locDE.GetInfo(wxLOCALE_CURRENCY_SYMBOL).empty());
-        // only look at first character, Unix may include additional
-        // info after this character that we aren't interested in here
-        CHECK(locDE.GetInfo(wxLOCALE_CURRENCY_SYMBOL).substr(0, 1) == wxString(L"\U000020AC")); // Euro symbol
         CHECK(locDE.GetInfo(wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL) == "EUR");
     }
 

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -426,7 +426,7 @@ TEST_CASE("wxUILocale::GetInfo", "[uilocale]")
         REQUIRE_FALSE(locDE.GetInfo(wxLOCALE_CURRENCY_SYMBOL).empty());
         // only look at first character, Unix may include additional
         // info after this character that we aren't interested in here
-        CHECK(locDE.GetInfo(wxLOCALE_CURRENCY_SYMBOL)[0] == "€");
+        CHECK(locDE.GetInfo(wxLOCALE_CURRENCY_SYMBOL).substr(0, 1) == wxString(L"\U000020AC")); // Euro symbol
         CHECK(locDE.GetInfo(wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL) == "EUR");
     }
 


### PR DESCRIPTION
Adds `wxLOCALE_INTERNATIONAL_CURRENCY_SYMBOL` constant to `wxLocaleInfo`.
Adds support to `wxUILocale` and `wxLocale::GetInfo` for this constant.