### PR TITLE
swap parent menu with sub menu when setting zorder

### DIFF
--- a/src/univ/menu.cpp
+++ b/src/univ/menu.cpp
@@ -450,7 +450,7 @@ void wxPopupMenuWindow::Popup(wxWindow *focus)
         // if we're shown, the parent menu must be also shown
         wxCHECK_RET( win, wxT("parent menu is not shown?") );
 
-        if ( !::SetWindowPos(GetHwndOf(win), GetHwnd(),
+        if ( !::SetWindowPos(GetHwnd(), GetHwndOf(win),
                              0, 0, 0, 0,
                              SWP_NOMOVE | SWP_NOSIZE | SWP_NOREDRAW) )
         {


### PR DESCRIPTION
It probably never worked as expected and described in comment in the code.

Before this change submenu is shown under parent menu and in menu sample looks like:
![wxUniv_submenu_under(broken)](https://github.com/user-attachments/assets/b9641c53-bf98-4774-852c-9fdc4af7749c)

After this change submenu is shown over parent menu and in menu sample looks like:
![wxUniv_submenu_ontop(fixed)](https://github.com/user-attachments/assets/97399dea-a32a-461a-aa4c-619f31ccee9e)
