### PR TITLE
Improve padding of `wxMenu` and `wxMenuItem` in high DPI under MSW

### DIFF
--- a/include/wx/msw/private/menu.h
+++ b/include/wx/msw/private/menu.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Name:        wx/msw/private/menu.h
-// Purpose:     Structs used to custom draw menu bar in wxMSW
+// Purpose:     Structs used to custom draw and measure menu bar in wxMSW
 // Author:      Vadim Zeitlin
 // Created:     2025-01-24
 // Copyright:   (c) 2025 wxWidgets development team
@@ -16,6 +16,7 @@ namespace wxMSWMenuImpl
 // Definitions for undocumented messages and structs used in this code.
 constexpr int WM_MENUBAR_DRAWMENU = 0x91;
 constexpr int WM_MENUBAR_DRAWMENUITEM = 0x92;
+constexpr int WM_MENUBAR_MEASUREMENUITEM = 0x94;
 
 // This is passed via LPARAM of WM_MENUBAR_DRAWMENU.
 struct MenuBarDrawMenu
@@ -36,6 +37,13 @@ struct MenuBarMenuItem
 struct MenuBarDrawMenuItem
 {
     DRAWITEMSTRUCT dis;
+    MenuBarDrawMenu mbdm;
+    MenuBarMenuItem mbmi;
+};
+
+struct MenuBarMeasureMenuItem
+{
+    MEASUREITEMSTRUCT mis;
     MenuBarDrawMenu mbdm;
     MenuBarMenuItem mbmi;
 };

--- a/include/wx/msw/private/menu.h
+++ b/include/wx/msw/private/menu.h
@@ -1,0 +1,45 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/msw/private/menu.h
+// Purpose:     Structs used to custom draw menu bar in wxMSW
+// Author:      Vadim Zeitlin
+// Created:     2025-01-24
+// Copyright:   (c) 2025 wxWidgets development team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_MSW_PRIVATE_MENU_H_
+#define _WX_MSW_PRIVATE_MENU_H_
+
+namespace wxMSWMenuImpl
+{
+
+// Definitions for undocumented messages and structs used in this code.
+constexpr int WM_MENUBAR_DRAWMENU = 0x91;
+constexpr int WM_MENUBAR_DRAWMENUITEM = 0x92;
+
+// This is passed via LPARAM of WM_MENUBAR_DRAWMENU.
+struct MenuBarDrawMenu
+{
+    HMENU hmenu;
+    HDC hdc;
+    DWORD dwReserved;
+};
+
+struct MenuBarMenuItem
+{
+    int iPosition;
+
+    // There are more fields in this (undocumented) struct but we don't
+    // currently need them, so don't bother with declaring them.
+};
+
+struct MenuBarDrawMenuItem
+{
+    DRAWITEMSTRUCT dis;
+    MenuBarDrawMenu mbdm;
+    MenuBarMenuItem mbmi;
+};
+
+} // namespace wxMSWMenuImpl
+
+#endif // _WX_MSW_PRIVATE_MENU_H_

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -50,6 +50,7 @@
 
 #include "wx/msw/private/custompaint.h"
 #include "wx/msw/private/darkmode.h"
+#include "wx/msw/private/menu.h"
 
 #include <memory>
 
@@ -531,32 +532,7 @@ bool PaintIfNecessary(HWND hwnd, WXWNDPROC defWndProc)
 namespace wxMSWMenuImpl
 {
 
-// Definitions for undocumented messages and structs used in this code.
-constexpr int WM_MENUBAR_DRAWMENU = 0x91;
-constexpr int WM_MENUBAR_DRAWMENUITEM = 0x92;
-
-// This is passed via LPARAM of WM_MENUBAR_DRAWMENU.
-struct MenuBarDrawMenu
-{
-    HMENU hmenu;
-    HDC hdc;
-    DWORD dwReserved;
-};
-
-struct MenuBarMenuItem
-{
-    int iPosition;
-
-    // There are more fields in this (undocumented) struct but we don't
-    // currently need them, so don't bother with declaring them.
-};
-
-struct MenuBarDrawMenuItem
-{
-    DRAWITEMSTRUCT dis;
-    MenuBarDrawMenu mbdm;
-    MenuBarMenuItem mbmi;
-};
+using namespace ::wxMSWMenuImpl;
 
 wxColour GetMenuColour(wxMenuColour which)
 {


### PR DESCRIPTION
Fixes #24821.

At 300% DPI scaling under Windows 10

* before these changes:
  ![wxMenu-dpi-300-light-before](https://github.com/user-attachments/assets/60e54864-f365-4225-aeb0-fe8293abeacb)

* with this PR:
  ![wxMenu-dpi-300-light-PR](https://github.com/user-attachments/assets/26939584-f666-468c-9238-86d0d6fcc8d0)

* before these changes:
  ![wxMenu-dpi-300-dark-before](https://github.com/user-attachments/assets/da4cfa18-448d-4010-9975-3d545428c801)

* with this PR:
  ![wxMenu-dpi-300-dark-PR](https://github.com/user-attachments/assets/531a5b64-9915-44a4-bc88-b1daf97ea757)
