### PR TITLE
Add missing wxTextCtrl styles to its XRC handler

### DIFF
--- a/src/xrc/xh_text.cpp
+++ b/src/xrc/xh_text.cpp
@@ -35,11 +35,14 @@ wxTextCtrlXmlHandler::wxTextCtrlXmlHandler() : wxXmlResourceHandler()
     XRC_ADD_STYLE(wxTE_AUTO_URL);
     XRC_ADD_STYLE(wxTE_NOHIDESEL);
     XRC_ADD_STYLE(wxTE_LEFT);
+    XRC_ADD_STYLE(wxTE_CENTER);
     XRC_ADD_STYLE(wxTE_CENTRE);
     XRC_ADD_STYLE(wxTE_RIGHT);
     XRC_ADD_STYLE(wxTE_DONTWRAP);
     XRC_ADD_STYLE(wxTE_CHARWRAP);
     XRC_ADD_STYLE(wxTE_WORDWRAP);
+    XRC_ADD_STYLE(wxTE_BESTWRAP);
+    XRC_ADD_STYLE(wxTE_CAPITALIZE);
 
     // this style doesn't exist since wx 2.9.0 but we still support it (by
     // ignoring it silently) in XRC files to avoid unimportant warnings when


### PR DESCRIPTION
A wxFormBuilder user discovered that the wxTextCtrl XRC handler does not support the style `wxTE_CENTER` (it only supports the `wxTE_CENTRE` variant). Although the documentation does not mention the `wxTE_CENTER` variant it does in fact exist in the code, so i added this style to the XRC handler. I found two additional missing styles and added these as well. I did not update the documentation because i have no idea how to do this.