### PR TITLE
Add missing documentation for wxBoxSizer::InformFirstDirection()

### DIFF
--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -2065,5 +2065,13 @@ public:
             arguments had to be overridden in the derived classes instead.
     */
     virtual void RepositionChildren(const wxSize& minSize);
+
+    /**
+       Inform sizer about the first direction that has been decided (by
+       parent item).  Returns true if it made use of the information (and
+       recalculated min size).
+    */
+    virtual bool InformFirstDirection(int direction, int size, int availableOtherDir);
+
 };
 


### PR DESCRIPTION
Please backport to 3.2 also.