### PR TITLE
TextCtrlTestCase::Url fix

### DIFF
--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -489,6 +489,7 @@ void TextCtrlTestCase::Url()
 
     wxUIActionSimulator sim;
     sim.MouseMove(m_text->ClientToScreen(wxPoint(5, 5)));
+    url.Clear();
     sim.MouseClick();
     wxYield();
 


### PR DESCRIPTION
On my system (`mingw32-make -f makefile.gcc BUILD=debug SHARED=0 MONOLITHIC=0 USE_GUI=1`) this test fails under Windows 10. Somehow it asserts with
```
controls/textctrltest.cpp:495: FAILED:
  REQUIRE( 1 == url.GetCount() )
with expansion:
  1 == 2
```
clearing `EventCounter` between mouse move and mouse click solves problem but I'm not sure if it is the best solution or if it is not symptom of some deeper problem.