### PR TITLE
wxOSX: fix cursor getting reset to default on next mouse event

### DIFF
--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -1798,11 +1798,11 @@ bool wxWindowMac::MacSetupCursor( const wxPoint& pt )
             // if the user code caught EVT_SET_CURSOR() and returned nothing from
             // it - this is a way to say that our cursor shouldn't be used for this
             // point
-            if ( !processedEvtSetCursor && m_cursor.IsOk() )
+            if ( !processedEvtSetCursor && m_cursor.IsOk() ) {
                 cursor = m_cursor ;
-
-            if ( !wxIsBusy() && !GetParent() )
+            } else if ( !wxIsBusy() && !GetParent() ) {
                 cursor = *wxSTANDARD_CURSOR ;
+            }
         }
 
         if ( cursor.IsOk() )


### PR DESCRIPTION
Fix for issue #25131 where custom cursors get reset to default on the next mouse event.

The first line of wxWidgetCocoaImpl::DoHandleMouseEvent is to always call wxWidgetCocoaImpl::SetupCursor. Ultimately this goes to wxWindow::MacSetupCursor. It looks like the final `if` was always overwriting the choice of m_cursor with wxSTANDARD_CURSOR. Changing to `else if` fixes the issue for me. Can't say this is the perfect fix because there is a lot of logic happening before this point that isn't totally clear to me.

This also shows that the cursor set logic happens on every mouse event and thus also posts a wxSetCursor event to the app on every mouse event. This seems suboptimal to me but is way beyond my ability to try and change.