### PR TITLE
Mark property (in property grid) dirty when SetPropertyValue() is called

### DIFF
--- a/src/propgrid/propgridpagestate.cpp
+++ b/src/propgrid/propgridpagestate.cpp
@@ -1225,6 +1225,7 @@ bool wxPropertyGridPageState::DoSetPropertyValueString( wxPGProperty* p, const w
 #endif // WXWIN_COMPATIBILITY_3_2 | !WXWIN_COMPATIBILITY_3_2
         {
             p->SetValue(variant);
+            p->SetModifiedStatus(true);
             if ( p == m_pPropGrid->GetSelection() && IsDisplayed() )
                 m_pPropGrid->RefreshEditor();
         }
@@ -1241,6 +1242,7 @@ bool wxPropertyGridPageState::DoSetPropertyValue( wxPGProperty* p, wxVariant& va
     if ( p )
     {
         p->SetValue(value);
+        p->SetModifiedStatus(true);
         if ( p == m_pPropGrid->GetSelection() && IsDisplayed() )
             m_pPropGrid->RefreshEditor();
 
@@ -1493,6 +1495,7 @@ void wxPropertyGridPageState::DoSetPropertyValues( const wxVariantList& list, wx
                         );
 
                         p->SetValue(*current);
+                        p->SetModifiedStatus(true);
                     }
                 }
                 else


### PR DESCRIPTION
With a property grid, when I call `SetPropertyValue()` programmatically, `IsPropertyModified()` currently returns false when called on the property whose value I just changed. IMO, the modified flag should be getting set anytime the various `DoSetPropertyValue...` functions get called.