### PR TITLE
for dialog editors, provide concrete derivation of wxVListBox

### DIFF
--- a/include/wx/vlbox.h
+++ b/include/wx/vlbox.h
@@ -313,5 +313,66 @@ private:
     wxDECLARE_ABSTRACT_CLASS(wxVListBox);
 };
 
+extern WXDLLIMPEXP_DATA_CORE(const char) wxXRCPreviewVListBoxNameStr[];
+
+// ----------------------------------------------------------------------------
+// wxXRCPreviewVListBox
+// ----------------------------------------------------------------------------
+
+/*
+    GUI editors, e.g., wxFormBuilder, typically allow users to lay out
+    instances of controls.  However, wxVListBox is an abstract class, so a GUI
+    editor can only create instances of a subclass of wxVListBox.  Rather than
+    require every GUI editor to repeat the work of subclassing wxVListBox for
+    GUI editing, and because the user's intended subclass will not exist in GUI
+    editors, provide a class that GUI editors can use.  Also, the
+    wxVListBoxXmlHandler can create instances of this class when in
+    wxXRC_NO_SUBCLASSING mode;
+ */
+class WXDLLIMPEXP_CORE wxXRCPreviewVListBox : public wxVListBox
+{
+public:
+    // default constructor, you must call Create() later
+    wxXRCPreviewVListBox() = default;
+
+    // normal constructor which calls Create() internally
+    wxXRCPreviewVListBox(wxWindow *parent,
+                            wxWindowID id = wxID_ANY,
+                            const wxPoint& pos = wxDefaultPosition,
+                            const wxSize& size = wxDefaultSize,
+                            long style = 0,
+                            const wxString& name = wxASCII_STR(wxXRCPreviewVListBoxNameStr))
+    {
+        (void)Create(parent, id, pos, size, style, name);
+    }
+
+    // really creates the control and sets the initial number of items in it
+    // (which may be changed later with SetItemCount())
+    //
+    // the only special style which may be specified here is wxLB_MULTIPLE
+    //
+    // returns true on success or false if the control couldn't be created
+    bool Create(wxWindow *parent,
+                wxWindowID id = wxID_ANY,
+                const wxPoint& pos = wxDefaultPosition,
+                const wxSize& size = wxDefaultSize,
+                long style = 0,
+                const wxString& name = wxASCII_STR(wxXRCPreviewVListBoxNameStr));
+
+protected:
+    // the derived class must implement this function to actually draw the item
+    // with the given index on the provided DC
+    void OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const override;
+
+    // the derived class must implement this method to return the height of the
+    // specified item
+    wxCoord OnMeasureItem(size_t n) const override;
+
+private:
+    wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxXRCPreviewVListBox);
+
+    wxString GetItem(size_t n) const;
+};
+
 #endif // _WX_VLBOX_H_
 

--- a/interface/wx/vlbox.h
+++ b/interface/wx/vlbox.h
@@ -351,3 +351,54 @@ protected:
     virtual wxCoord OnMeasureItem(size_t n) const = 0;
 };
 
+/**
+    @class wxXRCPreviewVListBox
+
+    GUI editors, e.g., wxFormBuilder, typically allow users to lay out
+    instances of controls.  However, wxVListBox is an abstract class, so a GUI
+    editor can only create instances of a subclass of wxVListBox.  Rather than
+    require every GUI editor to repeat the work of subclassing wxVListBox for
+    GUI editing, and because the user's intended subclass will not exist in GUI
+    editors, provide a class that GUI editors can use.  Also, the
+    wxVListBoxXmlHandler can create instances of this class when in
+    wxXRC_NO_SUBCLASSING mode;
+
+    @library{wxcore}
+    @category{ctrl}
+
+    @since 3.3.0
+*/
+class wxXRCPreviewVListBox : public wxVListBox
+{
+public:
+    /**
+        Default constructor, you must call Create() later.
+    */
+    wxXRCPreviewVListBox();
+    /**
+        Normal constructor which calls Create() internally.
+    */
+    wxXRCPreviewVListBox(wxWindow *parent,
+                            wxWindowID id = wxID_ANY,
+                            const wxPoint& pos = wxDefaultPosition,
+                            const wxSize& size = wxDefaultSize,
+                            long style = 0,
+                            const wxString& name = wxXRCPreviewVListBoxNameStr);
+
+    /**
+        Creates the control. To finish creating it you also should call
+        SetItemCount() to let it know about the number of items it contains.
+
+        The only special style which may be used with wxXRCPreviewVListBox is
+        @c wxLB_MULTIPLE which indicates that the listbox should support
+        multiple selection.
+
+        @return @true on success or @false if the control couldn't be created.
+    */
+    bool Create(wxWindow *parent,
+                wxWindowID id = wxID_ANY,
+                const wxPoint& pos = wxDefaultPosition,
+                const wxSize& size = wxDefaultSize,
+                long style = 0,
+                const wxString& name = wxXRCPreviewVListBoxNameStr);
+};

--- a/src/generic/vlbox.cpp
+++ b/src/generic/vlbox.cpp
@@ -744,4 +744,43 @@ wxVListBox::GetClassDefaultAttributes(wxWindowVariant variant)
     return wxListBox::GetClassDefaultAttributes(variant);
 }
 
+// ============================================================================
+// implementation
+// ============================================================================
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxXRCPreviewVListBox, wxVListBox);
+const char wxXRCPreviewVListBoxNameStr[] = "wxXRCPreviewVListBox";
+
+bool wxXRCPreviewVListBox::Create(wxWindow *parent,
+            wxWindowID id /*= wxID_ANY*/,
+            const wxPoint& pos /*= wxDefaultPosition*/,
+            const wxSize& size /*= wxDefaultSize*/,
+            long style /*= 0*/,
+            const wxString& name /*= wxASCII_STR(wxVListBoxNameStr)*/)
+{
+    bool retval = wxVListBox::Create(parent, id, pos, size, style, name);
+    if (retval)
+    {
+        SetItemCount(std::numeric_limits<int>::max());
+    }
+    return retval;
+}
+
+void wxXRCPreviewVListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const
+{
+    dc.DrawText(GetItem(n), rect.GetLeftTop());
+}
+
+wxCoord wxXRCPreviewVListBox::OnMeasureItem(size_t n) const
+{
+    // safe to const_cast since we're just using GetTextExtent()
+    wxInfoDC dc(const_cast<wxXRCPreviewVListBox*>(this));
+    return dc.GetTextExtent(GetItem(n)).y;
+}
+
+wxString wxXRCPreviewVListBox::GetItem(size_t n) const
+{
+    return wxString::Format("Item %zu", n);
+}
+
 #endif

--- a/src/xrc/xh_vlistbox.cpp
+++ b/src/xrc/xh_vlistbox.cpp
@@ -32,6 +32,19 @@ wxVListBoxXmlHandler::wxVListBoxXmlHandler() : wxXmlResourceHandler()
 
 wxObject * wxVListBoxXmlHandler::DoCreateResource()
 {
+    // see comment for wxXRCPreviewVListBox
+
+    /* Create() isn't virtual, but the preview class has its
+        own implementation, so we need to use the static type
+        of the pointer to get the correct version */
+    wxXRCPreviewVListBox* preview = nullptr;
+    if (!m_instance &&
+        m_resource->GetFlags() & wxXRC_NO_SUBCLASSING)
+    {
+        preview = new wxXRCPreviewVListBox;
+        m_instance = preview;
+    }
+
     /* non-standard because wxVListBox is an abstract
         class, so "subclass" must be used */
     wxCHECK_MSG(m_instance,
@@ -41,11 +54,22 @@ wxObject * wxVListBoxXmlHandler::DoCreateResource()
     if (GetBool(wxT("hidden"), 0) == 1)
         vlistbox->Hide();
 
-    vlistbox->Create(m_parentAsWindow,
-                  GetID(),
-                  GetPosition(), GetSize(),
-                  GetStyle(wxT("style"), wxTAB_TRAVERSAL),
-                  GetName());
+    if (!preview)
+    {
+        vlistbox->Create(m_parentAsWindow,
+                      GetID(),
+                      GetPosition(), GetSize(),
+                      GetStyle(wxT("style"), wxTAB_TRAVERSAL),
+                      GetName());
+    }
+    else
+    {
+        preview->Create(m_parentAsWindow,
+                      GetID(),
+                      GetPosition(), GetSize(),
+                      GetStyle(wxT("style"), wxTAB_TRAVERSAL),
+                      GetName());
+    }
 
     SetupWindow(vlistbox);
     CreateChildren(vlistbox);


### PR DESCRIPTION
Dialog editors need to create instances of controls for users to manipulate, but wxVListBox is an abstract class.  So provide wxXRCPreviewVListBox to support Dialog editors, and modify wxVListBoxXmlHandler to return wxXRCPreviewVListBox when in wxXRC_NO_SUBCLASSING mode.