### PR TITLE
Add wxTextCtrl::GTKSetPangoMarkup

### DIFF
--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -117,6 +117,9 @@ public:
     // Get the underlying text control.
     GtkEditable *GTKGetEditable() const { return GetEditable(); }
 
+#ifdef __WXGTK3__
+    void GTKSetPangoMarkup(const wxString& str);
+#endif // __WXGTK3__
 
     // Implementation from now on
     void OnDropFiles( wxDropFilesEvent &event );

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -2179,6 +2179,20 @@ public:
     */
     GtkEditable *GTKGetEditable();
 
+    /**
+        Sets the content of a multiline text control from a Pango markup buffer.
+
+        This offers more granular control of content formatting, as well as a
+        significant performance benefit with larger content.
+
+        This is the GTK analogy to SetRTFValue().
+
+        @onlyfor{wxgtk}
+
+        @since 3.3
+    */
+    void GTKSetPangoMarkup(const wxString& str);
+
     ///@}
 
     ///@{

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -2117,7 +2117,27 @@ bool wxTextCtrl::GetStyle(long position, wxTextAttr& style)
 }
 
 #ifdef __WXGTK3__
+void wxTextCtrl::GTKSetPangoMarkup(const wxString& str)
+{
+    if (!IsMultiLine())
+    {
+        wxASSERT_MSG(IsMultiLine(),
+            wxT("shouldn't be called for single line controls"));
+        return;
+    }
 
+    // multiple events may get fired while editing text, so block those
+    {
+    EventsSuppressor noevents(this);
+    // clear current content
+    GtkTextIter start, end;
+    gtk_text_buffer_get_bounds(GTKGetTextBuffer(), &start, &end);
+    gtk_text_buffer_delete(GTKGetTextBuffer(), &start, &end);
+
+    gtk_text_buffer_insert_markup(GTKGetTextBuffer(), &start, str.utf8_str(), -1);
+    }
+    SendTextUpdatedEvent(GetEditableWindow());
+}
 wxTextSearchResult wxTextCtrl::SearchText(const wxTextSearch& search) const
 {
     if ( !IsMultiLine() )

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -2119,12 +2119,7 @@ bool wxTextCtrl::GetStyle(long position, wxTextAttr& style)
 #ifdef __WXGTK3__
 void wxTextCtrl::GTKSetPangoMarkup(const wxString& str)
 {
-    if (!IsMultiLine())
-    {
-        wxASSERT_MSG(IsMultiLine(),
-            wxT("shouldn't be called for single line controls"));
-        return;
-    }
+    wxCHECK_RET(IsMultiLine(), "pango markup requires multiline control");
 
     // multiple events may get fired while editing text, so block those
     {

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -2128,7 +2128,7 @@ void wxTextCtrl::GTKSetPangoMarkup(const wxString& str)
         GtkTextIter start, end;
         gtk_text_buffer_get_bounds(m_buffer, &start, &end);
         gtk_text_buffer_delete(m_buffer, &start, &end);
-    
+
         gtk_text_buffer_insert_markup(m_buffer, &start, str.utf8_str(), -1);
     }
     SendTextUpdatedEvent(GetEditableWindow());

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -2123,13 +2123,13 @@ void wxTextCtrl::GTKSetPangoMarkup(const wxString& str)
 
     // multiple events may get fired while editing text, so block those
     {
-    EventsSuppressor noevents(this);
-    // clear current content
-    GtkTextIter start, end;
-    gtk_text_buffer_get_bounds(GTKGetTextBuffer(), &start, &end);
-    gtk_text_buffer_delete(GTKGetTextBuffer(), &start, &end);
-
-    gtk_text_buffer_insert_markup(GTKGetTextBuffer(), &start, str.utf8_str(), -1);
+        EventsSuppressor noevents(this);
+        // clear current content
+        GtkTextIter start, end;
+        gtk_text_buffer_get_bounds(m_buffer, &start, &end);
+        gtk_text_buffer_delete(m_buffer, &start, &end);
+    
+        gtk_text_buffer_insert_markup(m_buffer, &start, str.utf8_str(), -1);
     }
     SendTextUpdatedEvent(GetEditableWindow());
 }

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1464,6 +1464,19 @@ TEST_CASE("wxTextCtrl::EventsOnCreate", "[wxTextCtrl][event]")
     CHECK( updated.GetCount() == 1 );
 }
 
+#ifdef __WXGTK3__
+TEST_CASE("wxTextCtrl::GTKSetPangoMarkup", "[wxTextCtrl][pango]")
+{
+    wxWindow* const parent = wxTheApp->GetTopWindow();
+
+    std::unique_ptr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE));
+    text->SetValue("Bogus content to be replaced");
+    text->GTKSetPangoMarkup(R"(Welcome to <span background="#D3D3D3" strikethrough="true">wxWidgets</span> 3.3!)");
+
+    CHECK(text->GetValue() == wxString("Welcome to wxWidgets 3.3!"));
+}
+#endif
+
 #ifdef __WXOSX__
 TEST_CASE("wxTextCtrl::Get/SetRTFValue", "[wxTextCtrl][rtf]")
 {


### PR DESCRIPTION
New function to fill a `wxTextCtrl` with pre-formatted Pango content (GTK3 only)
Closes #24912