### PR TITLE
Use GtkFileChooserNative for wxFileDialog/wxDirDialog when possible

### DIFF
--- a/include/wx/gtk/dirdlg.h
+++ b/include/wx/gtk/dirdlg.h
@@ -6,8 +6,10 @@
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
-#ifndef __GTKDIRDLGH__
-#define __GTKDIRDLGH__
+#ifndef _WX_GTKDIRDLG_H_
+#define _WX_GTKDIRDLG_H_
+
+typedef struct _GtkFileChooser GtkFileChooser;
 
 //-------------------------------------------------------------------------
 // wxDirDialog
@@ -15,6 +17,7 @@
 
 class WXDLLIMPEXP_CORE wxDirDialog : public wxDirDialogBase
 {
+    typedef wxDirDialogBase BaseType;
 public:
     wxDirDialog() = default;
 
@@ -32,13 +35,11 @@ public:
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
                 const wxString& name = wxASCII_STR(wxDirDialogNameStr));
-    virtual ~wxDirDialog() = default;
+    ~wxDirDialog();
 
-
-public:     // overrides from wxGenericDirDialog
-
+    virtual int ShowModal() override;
+    virtual bool Show(bool show = true) override;
     void SetPath(const wxString& path) override;
-
 
     // Implementation only.
 
@@ -54,7 +55,10 @@ protected:
 
 
 private:
+    void GTKAccept();
+    GtkFileChooser* m_fileChooserNative = nullptr;
+
     wxDECLARE_DYNAMIC_CLASS(wxDirDialog);
 };
 
-#endif // __GTKDIRDLGH__
+#endif // _WX_GTKDIRDLG_H_

--- a/include/wx/gtk/dirdlg.h
+++ b/include/wx/gtk/dirdlg.h
@@ -38,7 +38,6 @@ public:
     ~wxDirDialog();
 
     virtual int ShowModal() override;
-    virtual bool Show(bool show = true) override;
     void SetPath(const wxString& path) override;
 
     // Implementation only.
@@ -56,7 +55,7 @@ protected:
 
 private:
     void GTKAccept();
-    GtkFileChooser* m_fileChooserNative = nullptr;
+    GtkFileChooser* m_fileChooser = nullptr;
 
     wxDECLARE_DYNAMIC_CLASS(wxDirDialog);
 };

--- a/include/wx/gtk/filedlg.h
+++ b/include/wx/gtk/filedlg.h
@@ -11,12 +11,15 @@
 
 #include "wx/gtk/filectrl.h"    // for wxGtkFileChooser
 
+typedef struct _GtkFileChooser GtkFileChooser;
+
 //-------------------------------------------------------------------------
 // wxFileDialog
 //-------------------------------------------------------------------------
 
 class WXDLLIMPEXP_CORE wxFileDialog: public wxFileDialogBase
 {
+    typedef wxFileDialogBase BaseType;
 public:
     wxFileDialog() = default;
 
@@ -54,6 +57,7 @@ public:
     virtual void SetFilterIndex(int filterIndex) override;
 
     virtual int ShowModal() override;
+    virtual bool Show(bool show = true) override;
 
     virtual bool AddShortcut(const wxString& directory, int flags = 0) override;
     virtual bool SupportsExtraControl() const override { return true; }
@@ -76,6 +80,8 @@ private:
     virtual void AddChildGTK(wxWindowGTK* child) override;
 
     wxGtkFileChooser    m_fc;
+    wxGtkFileChooser* m_fcNative = nullptr;
+    GtkFileChooser* m_fileChooserNative = nullptr;
 
     wxDECLARE_DYNAMIC_CLASS(wxFileDialog);
     wxDECLARE_EVENT_TABLE();

--- a/include/wx/gtk/filedlg.h
+++ b/include/wx/gtk/filedlg.h
@@ -57,7 +57,6 @@ public:
     virtual void SetFilterIndex(int filterIndex) override;
 
     virtual int ShowModal() override;
-    virtual bool Show(bool show = true) override;
 
     virtual bool AddShortcut(const wxString& directory, int flags = 0) override;
     virtual bool SupportsExtraControl() const override { return true; }

--- a/src/gtk/dirdlg.cpp
+++ b/src/gtk/dirdlg.cpp
@@ -28,8 +28,10 @@
     #include "wx/filedlg.h"
 #endif
 
+#include "wx/modalhook.h"
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/mnemonics.h"
+#include "wx/gtk/private/gtk3-compat.h"
 #include "wx/stockitem.h"
 
 extern "C" {
@@ -107,23 +109,41 @@ bool wxDirDialog::Create(wxWindow* parent,
                    nullptr);
 
     g_object_ref(m_widget);
+    GtkFileChooser* const chooser = GTK_FILE_CHOOSER(m_widget);
+
+#if GTK_CHECK_VERSION(3,20,0)
+    if (wx_is_at_least_gtk3(20))
+    {
+        m_fileChooserNative = GTK_FILE_CHOOSER(gtk_file_chooser_native_new(
+            m_message.utf8_str(),
+            gtk_parent,
+            GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
+            nullptr, nullptr));
+    }
+#endif
 
     gtk_dialog_set_default_response(GTK_DIALOG(m_widget), GTK_RESPONSE_ACCEPT);
 #if GTK_CHECK_VERSION(2,18,0)
     if (wx_is_at_least_gtk2(18))
     {
-        gtk_file_chooser_set_create_folders(
-            GTK_FILE_CHOOSER(m_widget), !HasFlag(wxDD_DIR_MUST_EXIST) );
+        const bool create = !HasFlag(wxDD_DIR_MUST_EXIST);
+        gtk_file_chooser_set_create_folders(chooser, create);
+        if (m_fileChooserNative)
+            gtk_file_chooser_set_create_folders(m_fileChooserNative, create);
     }
 #endif
 
     // Enable multiple selection if desired
-    gtk_file_chooser_set_select_multiple(
-        GTK_FILE_CHOOSER(m_widget), HasFlag(wxDD_MULTIPLE) );
+    const bool multiple = HasFlag(wxDD_MULTIPLE);
+    gtk_file_chooser_set_select_multiple(chooser, multiple);
+    if (m_fileChooserNative)
+        gtk_file_chooser_set_select_multiple(m_fileChooserNative, multiple);
 
     // Enable show hidden folders if desired
-    gtk_file_chooser_set_show_hidden(
-        GTK_FILE_CHOOSER(m_widget), HasFlag(wxDD_SHOW_HIDDEN) );
+    const bool hidden = HasFlag(wxDD_SHOW_HIDDEN);
+    gtk_file_chooser_set_show_hidden(chooser, hidden);
+    if (m_fileChooserNative)
+        gtk_file_chooser_set_show_hidden(m_fileChooserNative, hidden);
 
     // local-only property could be set to false to allow non-local files to be loaded.
     // In that case get/set_uri(s) should be used instead of get/set_filename(s) everywhere
@@ -141,9 +161,16 @@ bool wxDirDialog::Create(wxWindow* parent,
     return true;
 }
 
-void wxDirDialog::GTKOnAccept()
+wxDirDialog::~wxDirDialog()
 {
-    GSList *fnamesi = gtk_file_chooser_get_filenames(GTK_FILE_CHOOSER(m_widget));
+    if (m_fileChooserNative)
+        g_object_unref(m_fileChooserNative);
+}
+
+void wxDirDialog::GTKAccept()
+{
+    GtkFileChooser* chooser = m_fileChooserNative ? m_fileChooserNative : GTK_FILE_CHOOSER(m_widget);
+    GSList *fnamesi = gtk_file_chooser_get_filenames(chooser);
     GSList *fnames = fnamesi;
 
     while ( fnamesi )
@@ -167,13 +194,46 @@ void wxDirDialog::GTKOnAccept()
     {
         m_path = m_paths.Last();
     }
+}
 
+void wxDirDialog::GTKOnAccept()
+{
+    GTKAccept();
     EndDialog(wxID_OK);
 }
 
 void wxDirDialog::GTKOnCancel()
 {
     EndDialog(wxID_CANCEL);
+}
+
+int wxDirDialog::ShowModal()
+{
+    WX_HOOK_MODAL_DIALOG();
+
+#if GTK_CHECK_VERSION(3,20,0)
+    if (m_fileChooserNative)
+    {
+        int res = gtk_native_dialog_run(GTK_NATIVE_DIALOG(m_fileChooserNative));
+        if (res == GTK_RESPONSE_ACCEPT)
+        {
+            GTKAccept();
+            return wxID_OK;
+        }
+        return wxID_CANCEL;
+    }
+#endif
+    return BaseType::ShowModal();
+}
+
+bool wxDirDialog::Show(bool show)
+{
+    if (show && m_fileChooserNative)
+    {
+        g_object_unref(m_fileChooserNative);
+        m_fileChooserNative = nullptr;
+    }
+    return BaseType::Show(show);
 }
 
 void wxDirDialog::DoSetSize(int x, int y, int width, int height, int sizeFlags)
@@ -188,8 +248,10 @@ void wxDirDialog::SetPath(const wxString& dir)
 {
     if (wxDirExists(dir))
     {
-        gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(m_widget),
-                                            wxGTK_CONV_FN(dir));
+        const auto folder(wxGTK_CONV_FN(dir));
+        gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(m_widget), folder);
+        if (m_fileChooserNative)
+            gtk_file_chooser_set_current_folder(m_fileChooserNative, folder);
     }
 }
 

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -443,18 +443,6 @@ int wxFileDialog::ShowModal()
     return wxDialog::ShowModal();
 }
 
-bool wxFileDialog::Show(bool show)
-{
-    if (show && m_fileChooserNative)
-    {
-        delete m_fcNative;
-        m_fcNative = nullptr;
-        g_object_unref(m_fileChooserNative);
-        m_fileChooserNative = nullptr;
-    }
-    return BaseType::Show(show);
-}
-
 void wxFileDialog::DoSetSize(int WXUNUSED(x), int WXUNUSED(y),
                              int WXUNUSED(width), int WXUNUSED(height),
                              int WXUNUSED(sizeFlags))

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -22,6 +22,7 @@
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/error.h"
 #include "wx/gtk/private/mnemonics.h"
+#include "wx/gtk/private/gtk3-compat.h"
 
 #ifdef __UNIX__
 #include <unistd.h> // chdir
@@ -252,10 +253,24 @@ bool wxFileDialog::Create(wxWindow *parent, const wxString& message,
 
     m_fc.SetWidget(file_chooser);
 
+#if GTK_CHECK_VERSION(3,20,0)
+    if (wx_is_at_least_gtk3(20) && (style & wxFD_PREVIEW) == 0)
+    {
+        m_fileChooserNative = GTK_FILE_CHOOSER(gtk_file_chooser_native_new(
+            m_message.utf8_str(), gtk_parent, gtk_action, nullptr, nullptr));
+        m_fcNative = new wxGtkFileChooser;
+        m_fcNative->SetWidget(m_fileChooserNative);
+    }
+#endif
+
     gtk_dialog_set_default_response(GTK_DIALOG(m_widget), GTK_RESPONSE_ACCEPT);
 
     if ( style & wxFD_MULTIPLE )
+    {
         gtk_file_chooser_set_select_multiple(file_chooser, true);
+        if (m_fileChooserNative)
+            gtk_file_chooser_set_select_multiple(m_fileChooserNative, true);
+    }
 
     // local-only property could be set to false to allow non-local files to be
     // loaded. In that case get/set_uri(s) should be used instead of
@@ -309,7 +324,10 @@ bool wxFileDialog::Create(wxWindow *parent, const wxString& message,
     const wxString dir = fn.GetPath();
     if ( !dir.empty() )
     {
-        gtk_file_chooser_set_current_folder(file_chooser, wxGTK_CONV_FN(dir));
+        const auto folder(wxGTK_CONV_FN(dir));
+        gtk_file_chooser_set_current_folder(file_chooser, folder);
+        if (m_fileChooserNative)
+            gtk_file_chooser_set_current_folder(m_fileChooserNative, folder);
     }
 
     const wxString fname = fn.GetFullName();
@@ -317,13 +335,18 @@ bool wxFileDialog::Create(wxWindow *parent, const wxString& message,
     {
         if ( !fname.empty() )
         {
-            gtk_file_chooser_set_current_name(file_chooser, wxGTK_CONV_FN(fname));
+            const auto curName(wxGTK_CONV_FN(fname));
+            gtk_file_chooser_set_current_name(file_chooser, curName);
+            if (m_fileChooserNative)
+                gtk_file_chooser_set_current_name(m_fileChooserNative, curName);
         }
 
 #if GTK_CHECK_VERSION(2,7,3)
         if ((style & wxFD_OVERWRITE_PROMPT) && wx_is_at_least_gtk2(8))
         {
             gtk_file_chooser_set_do_overwrite_confirmation(file_chooser, true);
+            if (m_fileChooserNative)
+                gtk_file_chooser_set_do_overwrite_confirmation(m_fileChooserNative, true);
         }
 #endif
     }
@@ -331,8 +354,10 @@ bool wxFileDialog::Create(wxWindow *parent, const wxString& message,
     {
         if ( !fname.empty() )
         {
-            gtk_file_chooser_set_filename(file_chooser,
-                                          wxGTK_CONV_FN(fn.GetFullPath()));
+            const auto filename(wxGTK_CONV_FN(fn.GetFullPath()));
+            gtk_file_chooser_set_filename(file_chooser, filename);
+            if (m_fileChooserNative)
+                gtk_file_chooser_set_filename(m_fileChooserNative, filename);
         }
     }
 
@@ -346,8 +371,12 @@ bool wxFileDialog::Create(wxWindow *parent, const wxString& message,
                          previewImage);
     }
 
-    gtk_file_chooser_set_show_hidden(file_chooser,
-                                     style & wxFD_SHOW_HIDDEN ? TRUE : FALSE);
+    if (style & wxFD_SHOW_HIDDEN)
+    {
+        gtk_file_chooser_set_show_hidden(file_chooser, true);
+        if (m_fileChooserNative)
+            gtk_file_chooser_set_show_hidden(m_fileChooserNative, true);
+    }
 
     return true;
 }
@@ -361,6 +390,9 @@ wxFileDialog::~wxFileDialog()
         gtk_file_chooser_set_extra_widget(
             GTK_FILE_CHOOSER(m_widget), nullptr);
     }
+    delete m_fcNative;
+    if (m_fileChooserNative)
+        g_object_unref(m_fileChooserNative);
 }
 
 void wxFileDialog::OnFakeOk(wxCommandEvent& WXUNUSED(event))
@@ -382,7 +414,45 @@ int wxFileDialog::ShowModal()
 
     CreateExtraControl();
 
+#if GTK_CHECK_VERSION(3,20,0)
+    if (m_fileChooserNative && m_extraControl)
+    {
+        // GtkFileChooserNative does not support extra controls
+        delete m_fcNative;
+        m_fcNative = nullptr;
+        g_object_unref(m_fileChooserNative);
+        m_fileChooserNative = nullptr;
+    }
+    if (m_fileChooserNative)
+    {
+        int res = gtk_native_dialog_run(GTK_NATIVE_DIALOG(m_fileChooserNative));
+        if (res == GTK_RESPONSE_ACCEPT)
+        {
+            if (HasFlag(wxFD_CHANGE_DIR))
+            {
+                wxGtkString filename(gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(m_fileChooserNative)));
+                wxGtkString dir(g_path_get_dirname(filename));
+                chdir(dir);
+            }
+            return wxID_OK;
+        }
+        return wxID_CANCEL;
+    }
+#endif
+
     return wxDialog::ShowModal();
+}
+
+bool wxFileDialog::Show(bool show)
+{
+    if (show && m_fileChooserNative)
+    {
+        delete m_fcNative;
+        m_fcNative = nullptr;
+        g_object_unref(m_fileChooserNative);
+        m_fileChooserNative = nullptr;
+    }
+    return BaseType::Show(show);
 }
 
 void wxFileDialog::DoSetSize(int WXUNUSED(x), int WXUNUSED(y),
@@ -400,17 +470,20 @@ void wxFileDialog::OnSize(wxSizeEvent&)
 wxString wxFileDialog::GetPath() const
 {
     wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetPaths() instead" );
-    return m_fc.GetPath();
+    const wxGtkFileChooser& fc = m_fcNative ? *m_fcNative : m_fc;
+    return fc.GetPath();
 }
 
 void wxFileDialog::GetFilenames(wxArrayString& files) const
 {
-    m_fc.GetFilenames( files );
+    const wxGtkFileChooser& fc = m_fcNative ? *m_fcNative : m_fc;
+    fc.GetFilenames(files);
 }
 
 void wxFileDialog::GetPaths(wxArrayString& paths) const
 {
-    m_fc.GetPaths( paths );
+    const wxGtkFileChooser& fc = m_fcNative ? *m_fcNative : m_fc;
+    fc.GetPaths(paths);
 }
 
 void wxFileDialog::SetMessage(const wxString& message)
@@ -432,7 +505,10 @@ void wxFileDialog::SetPath(const wxString& path)
     // we need an absolute path for GTK native chooser so ensure that we have
     // it: use the initial directory if it was set or just CWD otherwise (this
     // is the default behaviour if m_dir is empty)
-    m_fc.SetPath(wxFileName(path).GetAbsolutePath(m_dir));
+    const wxString str(wxFileName(path).GetAbsolutePath(m_dir));
+    m_fc.SetPath(str);
+    if (m_fcNative)
+        m_fcNative->SetPath(str);
 }
 
 void wxFileDialog::SetDirectory(const wxString& dir)
@@ -440,6 +516,8 @@ void wxFileDialog::SetDirectory(const wxString& dir)
     wxFileDialogBase::SetDirectory(dir);
 
     m_fc.SetDirectory(dir);
+    if (m_fcNative)
+        m_fcNative->SetDirectory(dir);
 }
 
 void wxFileDialog::SetFilename(const wxString& name)
@@ -448,7 +526,10 @@ void wxFileDialog::SetFilename(const wxString& name)
 
     if (HasFdFlag(wxFD_SAVE))
     {
-        gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(m_widget), name.utf8_str());
+        const auto curName(name.utf8_str());
+        gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(m_widget), curName);
+        if (m_fileChooserNative)
+            gtk_file_chooser_set_current_name(m_fileChooserNative, curName);
     }
 
     else
@@ -467,7 +548,8 @@ wxString wxFileDialog::GetFilename() const
 {
     wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetFilenames() instead" );
 
-    wxString currentFilename( m_fc.GetFilename() );
+    const wxGtkFileChooser& fc = m_fcNative ? *m_fcNative : m_fc;
+    wxString currentFilename(fc.GetFilename());
     if (currentFilename.empty())
     {
         // m_fc.GetFilename() will return empty until the dialog has been shown
@@ -481,16 +563,21 @@ void wxFileDialog::SetWildcard(const wxString& wildCard)
 {
     wxFileDialogBase::SetWildcard(wildCard);
     m_fc.SetWildcard( GetWildcard() );
+    if (m_fcNative)
+        m_fcNative->SetWildcard(wildCard);
 }
 
 void wxFileDialog::SetFilterIndex(int filterIndex)
 {
     m_fc.SetFilterIndex( filterIndex);
+    if (m_fcNative)
+        m_fcNative->SetFilterIndex(filterIndex);
 }
 
 int wxFileDialog::GetFilterIndex() const
 {
-    return m_fc.GetFilterIndex();
+    const wxGtkFileChooser& fc = m_fcNative ? *m_fcNative : m_fc;
+    return fc.GetFilterIndex();
 }
 
 void wxFileDialog::GTKSelectionChanged(const wxString& filename)
@@ -504,14 +591,20 @@ bool wxFileDialog::AddShortcut(const wxString& directory, int WXUNUSED(flags))
 {
     wxGtkError error;
 
+    const auto folder(directory.utf8_str());
     if ( !gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(m_widget),
-                                               directory.utf8_str(),
+                                               folder,
                                                error.Out()) )
     {
         wxLogDebug("Failed to add shortcut \"%s\": %s",
                    directory, error.GetMessage());
 
         return false;
+    }
+    if (m_fileChooserNative)
+    {
+        gtk_file_chooser_add_shortcut_folder(
+            GTK_FILE_CHOOSER(m_fileChooserNative), folder, nullptr);
     }
 
     return true;


### PR DESCRIPTION
This allows "native" dialogs with KDE. Not supported for extra control or wxFD_PREVIEW. See #24486, #25104