### PR TITLE
Implement subitem for wxGenericListCtrl::HitTest()

### DIFF
--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -905,9 +905,10 @@ public:
 
         If @a ptrSubItem is not @NULL and the wxListCtrl is in the report
         mode the subitem (or column) number will also be provided.
-        This feature is only available in version 2.7.0 or higher and is currently only
-        implemented under wxMSW and requires at least comctl32.dll of version 4.70 on
-        the host system or the value stored in @a ptrSubItem will be always -1.
+        This feature is available since version 3.2.7 in the generic control;
+        in earlier versions the value stored in @a ptrSubItem will be always -1.
+        Under wxMSW, the feature is available since version 2.7.0, and requires
+        at least comctl32.dll of version 4.70 on the host system.
         To compile this feature into wxWidgets library you need to have access to
         commctrl.h of version 4.70 that is provided by Microsoft.
 

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1580,7 +1580,9 @@ void MyListCtrl::OnContextMenu(wxContextMenuEvent& event)
             point = ScreenToClient(point);
         }
         int flags;
-        ShowContextMenu(point, HitTest(point, flags));
+        long sub;
+        long hitItem = HitTest(point, flags, &sub);
+        ShowContextMenu(point, hitItem, sub);
     }
     else
     {
@@ -1592,10 +1594,10 @@ void MyListCtrl::OnContextMenu(wxContextMenuEvent& event)
 }
 #endif
 
-void MyListCtrl::ShowContextMenu(const wxPoint& pos, long item)
+void MyListCtrl::ShowContextMenu(const wxPoint& pos, long item, long sub)
 {
     wxMenu menu;
-    menu.Append(wxID_ANY, wxString::Format("Menu for item %ld", item));
+    menu.Append(wxID_ANY, wxString::Format("Menu for item %ld, subitem %ld", item, sub));
     menu.Append(wxID_ABOUT, "&About");
     menu.AppendSeparator();
     menu.Append(wxID_EXIT, "E&xit");

--- a/samples/listctrl/listtest.h
+++ b/samples/listctrl/listtest.h
@@ -75,7 +75,7 @@ public:
     void OnRightClick(wxMouseEvent& event);
 
 private:
-    void ShowContextMenu(const wxPoint& pos, long item);
+    void ShowContextMenu(const wxPoint& pos, long item, long sub);
     void SetColumnImage(int col, int image);
 
     void LogEvent(const wxListEvent& event, const wxString& eventName);

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -5482,9 +5482,26 @@ long wxGenericListCtrl::FindItem( long WXUNUSED(start), const wxPoint& pt,
 
 long wxGenericListCtrl::HitTest(const wxPoint& point, int& flags, long *col) const
 {
-    // TODO: sub item hit testing
     if ( col )
+    {
         *col = -1;
+        if ( InReportView() )
+        {
+            const wxPoint unscrolled = CalcUnscrolledPosition( point );
+
+            for ( int c = 0, wsum = 0, cols = GetColumnCount();
+                  c < cols;
+                  ++c )
+            {
+                wsum += GetColumnWidth(c);
+                if ( wsum > unscrolled.x )
+                {
+                    *col = c;
+                    break;
+                }
+            }
+        }
+    }
 
     return m_mainWin->HitTest( (int)point.x, (int)point.y, flags );
 }


### PR DESCRIPTION
(I'm not sure if I'm missing something. It is surprising that something that can be implemented in literally 5 lines of code has remained unimplemented for 19 years.)

Pre-emptively assumed to be backported to 3.2.