### PR TITLE
Allow serializing layout of just `wxAuiNotebook`

### DIFF
--- a/docs/doxygen/mainpages/samples.h
+++ b/docs/doxygen/mainpages/samples.h
@@ -127,7 +127,10 @@ get stock bitmaps for use in your application.
 
 @section page_samples_aui Advanced User Interface Sample
 
-@sampleabout{@ref overview_aui "AUI classes"}
+This sample shows how to use wxAuiManager and other
+@ref overview_aui "AUI classes", such as wxAuiToolBar and wxAuiNotebook. It
+allows to change wxAuiNotebook styles and save and reload the layout of either
+the entire wxAuiManager or just the notebook part.
 
 @sampledir{aui}
 

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -26,8 +26,8 @@
 #include "wx/compositebookctrl.h"
 
 
-class wxAuiSerializer;
-class wxAuiDeserializer;
+class wxAuiBookSerializer;
+class wxAuiBookDeserializer;
 
 class wxAuiNotebook;
 class wxAuiTabFrame;
@@ -435,10 +435,10 @@ public:
     // Internal, don't use: use GetPagePosition() instead.
     bool FindTab(wxWindow* page, wxAuiTabCtrl** ctrl, int* idx) const;
 
-    // Serialization support: this is only used by wxAuiManager, don't use
-    // directly.
-    void SaveLayout(const wxString& name, wxAuiSerializer& serializer) const;
-    void LoadLayout(const wxString& name, wxAuiDeserializer& deserializer);
+    // Serialization support: this is used by wxAuiManager but can also be
+    // called directly to save/load layout of just this notebook.
+    void SaveLayout(const wxString& name, wxAuiBookSerializer& serializer) const;
+    void LoadLayout(const wxString& name, wxAuiBookDeserializer& deserializer);
 
 protected:
     // Common part of all ctors.

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -68,10 +68,10 @@ struct wxAuiNotebookPosition
     @section auibook_tabs Multiple Tab Controls
 
     By default, wxAuiNotebook uses a single tab control for all tabs, however
-    when wxAUI_NB_TAB_SPLIT style is used (which is the case by default), the
+    when ::wxAUI_NB_TAB_SPLIT style is used (which is the case by default), the
     user will be able to drag pages out of it and create new tab controls, that
     can then themselves be dragged to be docked in a different place inside the
-    notebook. Also, whether wxAUI_NB_TAB_SPLIT is specified or not, Split()
+    notebook. Also, whether ::wxAUI_NB_TAB_SPLIT is specified or not, Split()
     function can always be used to create new tab controls programmatically.
 
     When using multiple tab controls, exactly one of them is active at any
@@ -84,11 +84,29 @@ struct wxAuiNotebookPosition
     The logical order of the pages in the notebook is determined by the order
     in which they are added to it, i.e. the first page added has index 0, the
     second one has index 1, and so on. Since wxWidgets 3.3.0 this order is not
-    affected any longer by reodering the visual order of the pages in the UI,
-    which can be done by dragging them around if the wxAUI_NB_TAB_MOVE style is
-    used (which is the case by default).
+    affected any longer by changing the visual order of the pages in the UI,
+    which can be done by dragging them around if the ::wxAUI_NB_TAB_MOVE style
+    is used (which is the case by default).
 
     To get the visual position of the page, GetPagePosition() can be used.
+
+
+    @section auibook_layout Pages Layout
+
+    When the user can change the notebook layout interactively, i.e. when
+    ::wxAUI_NB_TAB_MOVE and/or ::wxAUI_NB_TAB_SPLIT styles are used, it can be
+    useful to remember the current layout on program exit and restore it when
+    it is restarted. This can be done by saving, and reloading, the layout of
+    the entire wxAuiManager containing this notebook using
+    wxAuiManager::SaveLayout() and wxAuiManager::LoadLayout(), but it can also
+    be done just for the given notebook, without affecting the other panes,
+    using SaveLayout() and LoadLayout() functions of this class.
+
+    Using them is similar to using wxAuiManager functions, except they only
+    require implementing wxAuiBookSerializer or wxAuiBookDeserializer
+    interface, which is a subset of the full wxAuiSerializer or
+    wxAuiDeserializer. The @ref page_samples_aui shows how to use them.
+
 
     @beginStyleTable
     @style{wxAUI_NB_DEFAULT_STYLE}
@@ -378,9 +396,50 @@ public:
                             bool select, int imageId);
 
     /**
+        Load the previously saved layout of the notebook.
+
+        This function is used to restore the layout previously saved by
+        SaveLayout().
+
+        @param name
+            Used as argument for wxAuiBookDeserializer::LoadNotebookTabs()
+            call.
+        @param deserializer
+            The object to use for restoring the layout.
+
+        @see wxAuiManager::LoadLayout()
+
+        @since 3.3.0
+     */
+    void LoadLayout(const wxString& name, wxAuiBookDeserializer& deserializer);
+
+    /**
         Removes a page, without deleting the window pointer.
     */
     bool RemovePage(size_t page);
+
+    /**
+        Save the layout of the notebook using the provided serializer.
+
+        The notebook layout includes the number and positions of all the tab
+        controls as well as the pages contained in each of them and their
+        order.
+
+        The serializer defines how exactly this information is saved: it can
+        use any form of serialization, e.g. XML or JSON, to do it, with the
+        only requirement being that LoadLayout() should be able to restore it
+        from the same @a name.
+
+        @param name
+            Used as argument for wxAuiBookSerializer::BeforeSaveNotebook() call.
+        @param serializer
+            The object to use for saving the layout.
+
+        @see wxAuiManager::SaveLayout()
+
+        @since 3.3.0
+     */
+    void SaveLayout(const wxString& name, wxAuiBookSerializer& serializer) const;
 
     /**
         Sets the art provider to be used by the notebook.

--- a/interface/wx/aui/serializer.h
+++ b/interface/wx/aui/serializer.h
@@ -89,17 +89,82 @@ struct wxAuiPaneLayoutInfo : wxAuiDockLayoutInfo
 };
 
 /**
+    @class wxAuiBookSerializer
+
+    wxAuiBookSerializer is used for serializing wxAuiNotebook layout.
+
+    This includes the tab controls layout and the order of pages in them.
+
+    It can be used standalone with wxAuiNotebook::SaveLayout() or as base class
+    of wxAuiSerializer for saving and restoring the entire layout.
+
+    @library{wxaui}
+    @category{aui}
+
+    @since 3.3.0
+ */
+class wxAuiBookSerializer
+{
+public:
+    /// Trivial default ctor.
+    wxAuiBookSerializer() = default;
+
+    /// Trivial but virtual destructor.
+    virtual ~wxAuiBookSerializer() = default;
+
+    /**
+        Called before starting to save information about the tabs in the
+        notebook in the AUI pane with the given name.
+
+        This function needs to be overridden to keep record of the notebook for
+        which SaveNotebookTabControl() will be called next.
+
+        If this class is used as a base class of wxAuiSerializer, saving
+        notebook layout may be unnecessary, e.g. because the program doesn't
+        use wxAuiNotebook at all, and the implementation can be trivial and
+        just do nothing because it is not going to be called at all if there
+        are no notebooks in the full layout.
+
+        When using wxAuiNotebook::SaveLayout() directly, this function is
+        always called and is the first function of this class to be called.
+     */
+    virtual void BeforeSaveNotebook(const wxString& name) = 0;
+
+    /**
+        Called to save information about a single tab control in the given
+        notebook.
+
+        This function will be called for all tab controls in the notebook after
+        BeforeSaveNotebook().
+
+        As with that function, it has to be implemented, but can simply do
+        nothing if saving notebook layout is not necessary.
+     */
+    virtual void SaveNotebookTabControl(const wxAuiTabLayoutInfo& tab) = 0;
+
+    /**
+        Called after saving information about all the pages of the notebook in
+        the AUI pane with the given name.
+
+        Does nothing by default.
+     */
+    virtual void AfterSaveNotebook();
+
+};
+
+/**
     @class wxAuiSerializer
 
     wxAuiSerializer is used by wxAuiManager::SaveLayout() to store layout
     information.
 
     This is an abstract base class, you need to inherit from it and override its
-    pure virtual functions in your derived class.
+    pure virtual functions, including those inherited from its base
+    wxAuiBookSerializer class, in your derived class.
 
-    SavePane() and SaveDock() must be overridden and will be called by
-    wxAuiManager for each pane and dock present in the layout. The other
-    functions don't need to be overridden, but it is often convenient to
+    In particular, SavePane() must be overridden and will be called by
+    wxAuiManager for each pane and dock present in the layout. Most of the
+    other functions don't need to be overridden, but it is often convenient to
     perform some actions before or after starting to save the objects of the
     given type or at the beginning or end of the whole saving process, so this
     class provides hooks for doing it.
@@ -113,14 +178,11 @@ struct wxAuiPaneLayoutInfo : wxAuiDockLayoutInfo
 
     @since 3.3.0
  */
-class wxAuiSerializer
+class wxAuiSerializer : public wxAuiBookSerializer
 {
 public:
     /// Trivial default ctor.
     wxAuiSerializer() = default;
-
-    /// Trivial but virtual destructor.
-    virtual ~wxAuiSerializer() = default;
 
     /**
         Called before doing anything else.
@@ -164,47 +226,18 @@ public:
 
         Note that this function is called after AfterSavePanes() but may not be
         called at all if there are no panes containing wxAuiNotebook.
+
+        wxAuiBookSerializer member functions will be called after this function
+        if it is called at all.
      */
     virtual void BeforeSaveNotebooks();
-
-    /**
-        Called before starting to save information about the tabs in the
-        notebook in the AUI pane with the given name.
-
-        This function needs to be overridden to keep record of the notebook for
-        which SaveNotebookTabControl() will be called next. Of course, if
-        saving notebook layout is unnecessary, e.g. because the program doesn't
-        use wxAuiNotebook at all, the implementation can be trivial and just do
-        nothing.
-
-        This function is called one or more times after BeforeSaveNotebooks().
-     */
-    virtual void BeforeSaveNotebook(const wxString& name) = 0;
-
-    /**
-        Called to save information about a single tab control in the given
-        notebook.
-
-        This function will be called for all tab controls in the notebook after
-        BeforeSaveNotebook().
-
-        As with that function, it has to be implemented, but can simply do
-        nothing if saving notebook layout is not necessary.
-     */
-    virtual void SaveNotebookTabControl(const wxAuiTabLayoutInfo& tab) = 0;
-
-    /**
-        Called after saving information about all the pages of the notebook in
-        the AUI pane with the given name.
-
-        Does nothing by default.
-     */
-    virtual void AfterSaveNotebook();
 
     /**
         Called after the last call to SaveNotebook().
 
         Does nothing by default.
+
+        This function is called after all wxAuiBookSerializer member functions
      */
     virtual void AfterSaveNotebooks();
 
@@ -214,6 +247,44 @@ public:
         Does nothing by default.
      */
     virtual void AfterSave();
+};
+
+/**
+    wxAuiBookDeserializer is used for deserializing wxAuiNotebook layout.
+
+    Similarly to wxAuiBookSerializer, it can be used standalone with
+    wxAuiNotebook::LoadLayout() or as base class of wxAuiDeserializer.
+
+    @library{wxaui}
+    @category{aui}
+
+    @since 3.3.0
+ */
+class wxAuiBookDeserializer
+{
+public:
+    /// Trivial default ctor.
+    wxAuiBookDeserializer() = default;
+
+    /// Trivial but virtual destructor.
+    virtual ~wxAuiBookDeserializer() = default;
+
+    /**
+        Load information about the notebook tabs previously saved by
+        wxAuiBookSerializer::SaveNotebookTabControl().
+
+        When using this class as a base class of wxAuiDeserializer, this
+        function is called by wxAuiManager::LoadLayout() after loading the pane
+        with the name @a name if it is a wxAuiNotebook. Otherwise, i.e. when
+        using wxAuiNotebook::LoadLayout() directly, this function is called
+        with the same @a name as was passed to that function.
+
+        If restoring the notebook layout is not necessary, this function can
+        just return an empty vector which is interpreted as meaning that the
+        default notebook layout should be used.
+     */
+    virtual std::vector<wxAuiTabLayoutInfo>
+    LoadNotebookTabs(const wxString& name) = 0;
 };
 
 /**
@@ -271,19 +342,6 @@ public:
         allow creating it on the fly.
      */
     virtual std::vector<wxAuiPaneLayoutInfo> LoadPanes() = 0;
-
-    /**
-        Load information about the notebook tabs previously saved by
-        wxAuiSerializer::SaveNotebookTabControl().
-
-        The pane with the name @a name is guaranteed to exist in the layout and
-        have wxAuiNotebook as the associated window.
-
-        If restoring the notebook layout is not necessary, this function can
-        just return an empty vector.
-     */
-    virtual std::vector<wxAuiTabLayoutInfo>
-    LoadNotebookTabs(const wxString& name) = 0;
 
     /**
         Create the window to be managed by the given pane if necessary.

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -79,6 +79,7 @@ class MyFrame : public wxFrame
         ID_CreatePerspective,
         ID_CopyLayout,
         ID_PasteLayout,
+        ID_EditNotebookLayout,
         ID_AllowFloating,
         ID_AllowActivePane,
         ID_TransparentHint,
@@ -161,6 +162,7 @@ private:
     void OnCreatePerspective(wxCommandEvent& evt);
     void OnCopyLayout(wxCommandEvent& evt);
     void OnPasteLayout(wxCommandEvent& evt);
+    void OnEditNotebookLayout(wxCommandEvent& evt);
     void OnRestorePerspective(wxCommandEvent& evt);
     void OnSettings(wxCommandEvent& evt);
     void OnCustomizeToolbar(wxCommandEvent& evt);
@@ -619,6 +621,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(MyFrame::ID_CreatePerspective, MyFrame::OnCreatePerspective)
     EVT_MENU(MyFrame::ID_CopyLayout, MyFrame::OnCopyLayout)
     EVT_MENU(MyFrame::ID_PasteLayout, MyFrame::OnPasteLayout)
+    EVT_MENU(MyFrame::ID_EditNotebookLayout, MyFrame::OnEditNotebookLayout)
     EVT_MENU(ID_AllowFloating, MyFrame::OnManagerFlag)
     EVT_MENU(ID_TransparentHint, MyFrame::OnManagerFlag)
     EVT_MENU(ID_VenetianBlindsHint, MyFrame::OnManagerFlag)
@@ -788,6 +791,8 @@ MyFrame::MyFrame(wxWindow* parent,
     m_perspectives_menu->Append(ID_CreatePerspective, _("Create Perspective"));
     m_perspectives_menu->Append(ID_CopyLayout, _("Copy Layout to Clipboard as XML\tCtrl-C"));
     m_perspectives_menu->Append(ID_PasteLayout, _("Paste XML Layout from Clipboard\tCtrl-V"));
+    m_perspectives_menu->AppendSeparator();
+    m_perspectives_menu->Append(ID_EditNotebookLayout, _("Edit &Notebook Layout..."));
     m_perspectives_menu->AppendSeparator();
     m_perspectives_menu->Append(ID_FirstPerspective+0, _("Default Startup"));
     m_perspectives_menu->Append(ID_FirstPerspective+1, _("All Panes"));
@@ -1713,9 +1718,6 @@ public:
                 throw std::runtime_error("Unexpected node name");
             }
         }
-
-        if ( !m_panes )
-            throw std::runtime_error("Missing panes node");
     }
 
     // Implement wxAuiDeserializer methods.
@@ -1945,6 +1947,51 @@ void MyFrame::OnPasteLayout(wxCommandEvent& WXUNUSED(evt))
 #else
     wxLogError("This menu command requires wxUSE_CLIPBOARD.");
 #endif
+}
+
+void MyFrame::OnEditNotebookLayout(wxCommandEvent& WXUNUSED(event))
+{
+    auto* const book =
+        wxCheckCast<wxAuiNotebook>(m_mgr.GetPane("notebook_content").window);
+
+    MyXmlSerializer ser;
+
+    // This is a hack, but it allows us to reuse the full serializer without
+    // duplicating its code.
+    ser.BeforeSave();
+    ser.BeforeSaveNotebooks();
+
+    // The name here doesn't need to be the same as the notebook name, even
+    // though it usually would be.
+    book->SaveLayout("notebook", ser);
+
+    // Second part of the hack above.
+    ser.AfterSaveNotebooks();
+    ser.AfterSave();
+
+    // In a real application, we would save this XML string somewhere and
+    // restore it during the next run, but here we just show it and allow
+    // editing it interactively to test how changing it affect the layout.
+    wxTextEntryDialog dlg(
+        this,
+        "Current notebook layout (edit and press OK to apply):",
+        "wxAUI Sample",
+        ser.GetXML(),
+        wxOK | wxCANCEL | wxTE_MULTILINE
+    );
+
+    if ( dlg.ShowModal() != wxID_OK )
+        return;
+
+    try
+    {
+        MyXmlDeserializer deser(m_mgr, dlg.GetValue());
+        book->LoadLayout("notebook", deser);
+    }
+    catch ( const std::exception& e )
+    {
+        wxLogError("Failed to load notebook layout: %s", e.what());
+    }
 }
 
 void MyFrame::OnRestorePerspective(wxCommandEvent& evt)

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3696,7 +3696,7 @@ void wxAuiTabCtrl::SetHoverTab(wxWindow* wnd)
 
 void
 wxAuiNotebook::SaveLayout(const wxString& name,
-                          wxAuiSerializer& serializer) const
+                          wxAuiBookSerializer& serializer) const
 {
     serializer.BeforeSaveNotebook(name);
 
@@ -3757,7 +3757,8 @@ wxAuiNotebook::SaveLayout(const wxString& name,
 }
 
 void
-wxAuiNotebook::LoadLayout(const wxString& name, wxAuiDeserializer& deserializer)
+wxAuiNotebook::LoadLayout(const wxString& name,
+                          wxAuiBookDeserializer& deserializer)
 {
     const auto tabs = deserializer.LoadNotebookTabs(name);
 


### PR DESCRIPTION
In addition to allowing to save and reload the entire wxAuiManager layout, also allow doing it for just the given wxAuiNotebook.

This doesn't cost much, as all the required code is already present, and just had to be refactored to extract wxAuiBookSerializer/Deserializer classes from wxAuiSerializer/Deserializer and change wxAuiNotebook functions to take them instead of the full [de]serializer.

Update the sample to allow editing notebook layout in XML format interactively.