### PR TITLE
Improve serializing dock proportion in wxAUI

### DIFF
--- a/interface/wx/aui/serializer.h
+++ b/interface/wx/aui/serializer.h
@@ -14,6 +14,11 @@
     wxAuiTabLayoutInfo and contain information about the layout of a docked
     pane or tab layout.
 
+    Note that when saving the objects of this type, fields that have the value
+    of 0 can be omitted, as this is their default value in any case (except for
+    `dock_direction` which is never 0), to make the serialized representation
+    more compact.
+
     @since 3.3.0
 */
 struct wxAuiDockLayoutInfo

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1621,7 +1621,9 @@ private:
 
     void AddChild(wxXmlNode* parent, const wxString& name, int value)
     {
-        AddChild(parent, name, wxString::Format("%u", value));
+        // Don't save 0 values, they're the default.
+        if ( value )
+            AddChild(parent, name, wxString::Format("%u", value));
     }
 
     void AddChild(wxXmlNode* parent, const wxString& name, const wxRect& rect)
@@ -1644,10 +1646,7 @@ private:
         AddChild(node, "row", layout.dock_row);
         AddChild(node, "position", layout.dock_pos);
         AddChild(node, "proportion", layout.dock_proportion);
-
-        // Saving dock size of 0 is harmless but unnecessary, so don't do it.
-        if ( layout.dock_size )
-            AddChild(node, "size", layout.dock_size);
+        AddChild(node, "size", layout.dock_size);
     }
 
 

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -1392,6 +1392,12 @@ wxAuiManager::CopyDockLayoutFrom(wxAuiDockLayoutInfo& dockInfo,
     dockInfo.dock_pos = paneInfo.dock_pos;
     dockInfo.dock_proportion = paneInfo.dock_proportion;
 
+    // Storing the default proportion is not really useful and it looks weird
+    // as it's an arbitrary huge number, so replace it with 0 in serialized
+    // representation, it will be mapped back to maxDockProportion after load.
+    if ( dockInfo.dock_proportion == maxDockProportion )
+        dockInfo.dock_proportion = 0;
+
     // The dock size is typically not set in the pane itself, but set in its
     // containing dock, so find it and copy it from there, as we do need to
     // save it when serializing.

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -70,12 +70,12 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxAuiManagerEvent, wxEvent);
 wxIMPLEMENT_CLASS(wxAuiManager, wxEvtHandler);
 
 
-
-const int auiToolBarLayer = 10;
-
-// -- static utility functions --
+// -- local constants and helper functions --
 namespace
 {
+
+// Index of the outermost layer used for all toolbars.
+constexpr int auiToolBarLayer = 10;
 
 wxBitmap wxCreateVenetianBlindsBitmap(wxByte r, wxByte g, wxByte b, wxByte a)
 {

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -77,6 +77,10 @@ namespace
 // Index of the outermost layer used for all toolbars.
 constexpr int auiToolBarLayer = 10;
 
+// Default proportion which is "infinitely" greater than anything else.
+constexpr int maxDockProportion = 100000;
+
+
 wxBitmap wxCreateVenetianBlindsBitmap(wxByte r, wxByte g, wxByte b, wxByte a)
 {
     const unsigned char c = wxSystemSettings::GetAppearance().IsDark() ? 220 : 5;
@@ -779,7 +783,7 @@ bool wxAuiManager::AddPane(wxWindow* window, const wxAuiPaneInfo& paneInfo)
 
     // set initial proportion (if not already set)
     if (pinfo.dock_proportion == 0)
-        pinfo.dock_proportion = 100000;
+        pinfo.dock_proportion = maxDockProportion;
 
     if (pinfo.HasGripper())
     {


### PR DESCRIPTION
This allows to skip serializing default proportion (but also layer, row and position) value of 0.