### PR TITLE
Update GitHub Actions to stop using Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,11 +282,6 @@ jobs:
           df -h /
           echo
 
-      - name: Work around Ubuntu 22.04 runner problem
-        if: matrix.runner == 'ubuntu-22.04'
-        # See https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917
-        run: sudo sysctl vm.mmap_rnd_bits=28
-
       - name: Configuring
         run: |
           wxCONFIGURE_OPTIONS="--disable-optimise $wxCONFIGURE_FLAGS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,8 @@ jobs:
             configure_flags: --enable-compat30
             use_xvfb: true
           - name: Ubuntu 20.04 wxGTK 3 with clang
-            runner: ubuntu-20.04
+            runner: ubuntu-latest
+            container: ubuntu:20.04
             compiler: clang++-10
             configure_flags: --disable-sys-libs
             use_xvfb: true
@@ -165,12 +166,30 @@ jobs:
               fi
 
               compiler=${{ matrix.compiler }}
+              case "$compiler" in
+                clang++*)
+                  compiler_packages='clang libc++-dev libc++abi-dev'
+                  ;;
+
+                g++*)
+                  compiler_packages="${compiler}"
+                  ;;
+
+                '')
+                  # Assume gcc.
+                  compiler_packages='g++'
+                  ;;
+
+                *)
+                  echo '::error ::Unknown compiler kind.'
+                  exit 1
+              esac
 
               # Explanation for installing some less obvious packages:
               #   - coreutils contains nproc used in proc_count.sh called below.
               #   - xvfb is used for running the GUI tests.
               apt-get update -qq
-              apt-get install -qq coreutils ${compiler-g++} git make pkg-config sudo xvfb
+              apt-get install -qq coreutils ${compiler_packages} git make pkg-config sudo xvfb
 
               # Checkout action doesn't work under Ubuntu 18.04 any more, so
               # run checkout manually.
@@ -198,13 +217,13 @@ jobs:
           esac
 
       - name: Checkout
-        if: matrix.container == ''
+        if: matrix.container != 'ubuntu:18.04'
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
       - name: Install CCache
-        if: matrix.container == ''
+        if: matrix.container != 'ubuntu:18.04'
         uses: hendrikmuhs/ccache-action@v1.2.12
         with:
           key: ${{ matrix.name }}
@@ -228,6 +247,8 @@ jobs:
               echo LD=$compiler >> $GITHUB_ENV
 
               allow_warn_opt="-Wno-error=#warnings"
+
+              export WX_EXTRA_PACKAGES="libc++-dev"
               ;;
 
             g++*)
@@ -345,7 +366,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_tests }}
 
       - name: Setup Go
-        if: matrix.container == ''
+        if: matrix.container != 'ubuntu:18.04'
         uses: actions/setup-go@v5
         with:
           go-version: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,14 @@ jobs:
             configure_flags: --enable-compat30 --disable-std_containers
             use_xvfb: true
             check_headers: true
-          - name: Ubuntu 22.04 wxGTK with ASAN
-            runner: ubuntu-22.04
+          - name: Ubuntu 24.04 wxGTK with ASAN
+            runner: ubuntu-24.04
             configure_flags: --disable-compat32 --disable-sys-libs
             skip_samples: true
             use_asan: true
             use_xvfb: true
-          - name: Ubuntu 22.04 wxGTK with UBSAN
-            runner: ubuntu-22.04
+          - name: Ubuntu 24.04 wxGTK with UBSAN
+            runner: ubuntu-24.04
             configure_flags: --with-cxx=20
             use_ubsan: true
             use_xvfb: true

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   check-unix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Check Spelling
 
     steps:
@@ -31,7 +31,7 @@ jobs:
 
 
   check-whitespace:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Check Whitespace
 
     steps:
@@ -69,7 +69,7 @@ jobs:
 
 
   check-mixed-eol:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Check Mixed EOL
 
     steps:
@@ -85,7 +85,7 @@ jobs:
             ./misc/scripts/check_mixed_eol.sh
 
   check-cxx-style:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Check C++ Style
 
     steps:
@@ -103,7 +103,7 @@ jobs:
             fi
 
   check-allheaders:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Check All Headers In allheaders.h
 
     steps:

--- a/configure
+++ b/configure
@@ -26325,6 +26325,7 @@ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
       ax_args="--disable-option-checking $ax_args"
       # Options that must be added as they are provided.
       as_fn_append ax_args " '--disable-jbig'"
+      as_fn_append ax_args " '--disable-lerc'"
       as_fn_append ax_args " '--disable-libdeflate'"
       as_fn_append ax_args " '--disable-webp'"
       as_fn_append ax_args " '--disable-zstd'"

--- a/configure.ac
+++ b/configure.ac
@@ -2599,6 +2599,7 @@ if test "$wxUSE_LIBTIFF" != "no" ; then
 
         AX_SUBDIRS_CONFIGURE([src/tiff],
             [[--disable-jbig],
+             [--disable-lerc],
              [--disable-libdeflate],
              [--disable-webp],
              [--disable-zstd],

--- a/include/wx/ribbon/bar.h
+++ b/include/wx/ribbon/bar.h
@@ -62,6 +62,8 @@ public:
         , m_page(page)
     {
     }
+
+    wxRibbonBarEvent(const wxRibbonBarEvent& e) = default;
     wxEvent *Clone() const override { return new wxRibbonBarEvent(*this); }
 
     wxRibbonPage* GetPage() {return m_page;}

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -228,6 +228,8 @@ public:
         , m_bar(bar), m_button(button)
     {
     }
+
+    wxRibbonButtonBarEvent(const wxRibbonButtonBarEvent& e) = default;
     wxEvent *Clone() const override { return new wxRibbonButtonBarEvent(*this); }
 
     wxRibbonButtonBar* GetBar() {return m_bar;}

--- a/include/wx/ribbon/panel.h
+++ b/include/wx/ribbon/panel.h
@@ -149,6 +149,8 @@ public:
         , m_panel(panel)
     {
     }
+
+    wxRibbonPanelEvent(const wxRibbonPanelEvent& e) = default;
     wxEvent *Clone() const override { return new wxRibbonPanelEvent(*this); }
 
     wxRibbonPanel* GetPanel() {return m_panel;}

--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -210,6 +210,8 @@ public:
         , m_bar(bar)
     {
     }
+
+    wxRibbonToolBarEvent(const wxRibbonToolBarEvent& e) = default;
     wxEvent *Clone() const override { return new wxRibbonToolBarEvent(*this); }
 
     wxRibbonToolBar* GetBar() {return m_bar;}

--- a/tests/testprec.h
+++ b/tests/testprec.h
@@ -99,6 +99,8 @@ public:
     {
     }
 
+    TestAssertFailure(const TestAssertFailure&) = default;
+
     const wxString m_file;
     const int m_line;
     const wxString m_func;


### PR DESCRIPTION
GitHub Actions will drop Ubuntu 20.04 images on 2025-04-01, so stop using
them.
