### PR TITLE
wxOSX: Implement clipboard events for single-line wxTextCtrl

### DIFF
--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -48,6 +48,20 @@
 - (void)setSelectable:(BOOL)flag;
 @end
 
+
+static BOOL HandleClipboardEvent(NSView *view, wxEventType type)
+{
+    wxWidgetImpl *impl = wxWidgetImpl::FindFromWXWidget(view);
+    wxWindow* wxpeer = impl ? impl->GetWXPeer() : NULL;
+    if ( wxpeer )
+    {
+        wxClipboardTextEvent evt(type, wxpeer->GetId());
+        evt.SetEventObject(wxpeer);
+        return wxpeer->HandleWindowEvent(evt);
+    }
+    return false;
+}
+
 // An object of this class is created before the text is modified
 // programmatically and destroyed as soon as this is done. It does several
 // things, like ensuring that the control is editable to allow setting its text
@@ -433,6 +447,23 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
     textField = field;
 }
 
+- (void)copy:(id)sender
+{
+    if ( !HandleClipboardEvent(textField, wxEVT_TEXT_COPY) )
+        [super copy:sender];
+}
+
+- (void)cut:(id)sender
+{
+    if ( !HandleClipboardEvent(textField, wxEVT_TEXT_CUT) )
+        [super cut:sender];
+}
+
+- (void)paste:(id)sender
+{
+    if ( !HandleClipboardEvent(textField, wxEVT_TEXT_PASTE) )
+        [super paste:sender];
+}
 
 @end
 
@@ -535,34 +566,21 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
     return NO;
 }
 
-- (BOOL)_handleClipboardEvent:(wxEventType)type
-{
-    wxWidgetImpl *impl = wxWidgetImpl::FindFromWXWidget(self);
-    wxWindow* wxpeer = impl ? impl->GetWXPeer() : nullptr;
-    if ( wxpeer )
-    {
-        wxClipboardTextEvent evt(type, wxpeer->GetId());
-        evt.SetEventObject(wxpeer);
-        return wxpeer->HandleWindowEvent(evt);
-    }
-    return false;
-}
-
 - (void)copy:(id)sender
 {
-    if ( ![self _handleClipboardEvent:wxEVT_TEXT_COPY] )
+    if ( !HandleClipboardEvent(self, wxEVT_TEXT_COPY) )
         [super copy:sender];
 }
 
 - (void)cut:(id)sender
 {
-    if ( ![self _handleClipboardEvent:wxEVT_TEXT_CUT] )
+    if ( !HandleClipboardEvent(self, wxEVT_TEXT_CUT) )
         [super cut:sender];
 }
 
 - (void)paste:(id)sender
 {
-    if ( ![self _handleClipboardEvent:wxEVT_TEXT_PASTE] )
+    if ( !HandleClipboardEvent(self, wxEVT_TEXT_PASTE) )
         [super paste:sender];
 }
 


### PR DESCRIPTION
Implement wxClipboardEvent sending from wxTextCtrl for NSTextField-based controls too. Previously they were only sent from NSTextView-based (i.e. multiline) controls.