### PR TITLE
provide better default size for wxXRCPreviewVListBox

### DIFF
--- a/include/wx/vlbox.h
+++ b/include/wx/vlbox.h
@@ -360,6 +360,9 @@ public:
                 const wxString& name = wxASCII_STR(wxXRCPreviewVListBoxNameStr));
 
 protected:
+    // avoid defaulting to tiny window
+    wxSize DoGetBestClientSize() const override;
+
     // the derived class must implement this function to actually draw the item
     // with the given index on the provided DC
     void OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const override;

--- a/src/generic/vlbox.cpp
+++ b/src/generic/vlbox.cpp
@@ -766,6 +766,16 @@ bool wxXRCPreviewVListBox::Create(wxWindow *parent,
     return retval;
 }
 
+// avoid defaulting to tiny window
+wxSize wxXRCPreviewVListBox::DoGetBestClientSize() const
+{
+    // safe to const_cast since we're just using GetTextExtent()
+    wxInfoDC dc(const_cast<wxXRCPreviewVListBox*>(this));
+    wxSize item99Size = dc.GetTextExtent(GetItem(99));
+    return wxSize(item99Size.x + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, this),
+                    5 * item99Size.y);
+}
+
 void wxXRCPreviewVListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const
 {
     dc.DrawText(GetItem(n), rect.GetLeftTop());


### PR DESCRIPTION
Without this change, the default size is really tiny (wxSize(1, 1)?)