### PR TITLE
Improve default wxImage scaling quality.

### DIFF
--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -464,14 +464,21 @@ wxImage::Scale( int width, int height, wxImageResizeQuality quality ) const
     switch ( quality )
     {
         case wxIMAGE_QUALITY_NORMAL:
-            // When downscaling, we prefer to use bilinear resampling as it
-            // results in better quality at reasonable speed.
-            if ( width <= old_width && height <= old_height )
             {
-                image = ResampleBilinear(width, height);
-                break;
-            }
+                double shrinkFactorX = double(old_width) / width;
+                double shrinkFactorY = double(old_height) / height;
 
+                // When downsampling, use bilinear algorithm for pre-scaling and
+                // box average for integer part
+                if ( shrinkFactorX >= 1 && shrinkFactorY >= 1 )
+                {
+                    int shrinkInt(wxMin(shrinkFactorX, shrinkFactorY));
+
+                    image = ResampleBilinear(width * shrinkInt, height * shrinkInt);
+                    image = image.ResampleBox(width, height);
+                    break;
+                }
+            }
             // Otherwise use NEAREST for upscaling.
             wxFALLTHROUGH;
 

--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -476,11 +476,14 @@ wxImage::Scale( int width, int height, wxImageResizeQuality quality ) const
 
                     image = ResampleBilinear(width * shrinkInt, height * shrinkInt);
                     image = image.ResampleBox(width, height);
-                    break;
                 }
+                else
+                {
+                    image = ResampleBox(width, height);
+                }
+
+                break;
             }
-            // Otherwise use NEAREST for upscaling.
-            wxFALLTHROUGH;
 
         case wxIMAGE_QUALITY_FAST:
         case wxIMAGE_QUALITY_NEAREST:


### PR DESCRIPTION
For downscaling, using just ResampleBilinear produces too sharp details if the shrink factor is significant.
Using bilinear then box-averaging produces the best results.

For non-integer upscaling, ResampleBox produces less jagged edges than ResampleNearest

Closes https://github.com/wxWidgets/wxWidgets/issues/24774

See https://github.com/wxWidgets/wxWidgets/pull/24567

This PR: 
![image](https://github.com/user-attachments/assets/24ae3501-eecc-453f-8c04-1a19f622a398)


Current `master` code:
![image](https://github.com/user-attachments/assets/dbe12a4d-5fa9-4775-a1c2-f1357ce16af3)

For the test setup see https://github.com/wxWidgets/wxWidgets/issues/24774#issuecomment-2659068729




