### PR TITLE
Improve wxBitmap scaling quality. (3.2)

### DIFF
--- a/src/common/bmpbase.cpp
+++ b/src/common/bmpbase.cpp
@@ -92,7 +92,7 @@ void wxBitmapHelpers::Rescale(wxBitmap& bmp, const wxSize& sizeNeeded)
     }
     else
     {
-        img.Rescale(sizeNeeded.x, sizeNeeded.y, wxIMAGE_QUALITY_NEAREST);
+        img.Rescale(sizeNeeded.x, sizeNeeded.y, wxIMAGE_QUALITY_BOX_AVERAGE);
     }
 
     bmp = wxBitmap(img);


### PR DESCRIPTION
For downscaling, using just Bilinear produces too sharp details if the shrink factor is significant. Using Bilinear then Box-averaging produces the best results.

For non-integer upscaling, Box-averaging produces less jagged edges than Nearest-neighbor.

See #24567

This PR:
![image](https://github.com/user-attachments/assets/fe970fcf-2f04-4acb-a43a-a0d8ff372c86)

Current 3.2:
![image](https://github.com/user-attachments/assets/8c77ac37-2f50-481f-b1b7-b58a02d37200)

---

For the test setup see https://github.com/wxWidgets/wxWidgets/issues/24774#issuecomment-2659068729
