### PR TITLE
Use SVG bitmaps for the generic `wxSearchCtrl`

### DIFF
--- a/include/wx/generic/srchctlg.h
+++ b/include/wx/generic/srchctlg.h
@@ -187,8 +187,8 @@ private:
 #endif // wxUSE_MENUS
 
     void RecalcBitmaps();
-    wxBitmap RenderSearchBitmap( int x, int y, bool renderDrop );
-    wxBitmap RenderCancelBitmap( int x, int y );
+    wxBitmap RenderSearchBitmap(const wxSize& size, bool renderDrop);
+    wxBitmap RenderCancelBitmap(const wxSize& size);
 
     // the subcontrols
     wxSearchTextCtrl *m_text;

--- a/include/wx/generic/srchctlg.h
+++ b/include/wx/generic/srchctlg.h
@@ -187,8 +187,17 @@ private:
 #endif // wxUSE_MENUS
 
     void RecalcBitmaps();
-    wxBitmap RenderSearchBitmap(const wxSize& size, bool renderDrop);
-    wxBitmap RenderCancelBitmap(const wxSize& size);
+
+    enum class BitmapType
+    {
+        Search,
+        Cancel,
+#if wxUSE_MENUS
+        Menu
+#endif // wxUSE_MENUS
+    };
+
+    wxBitmap RenderBitmap(const wxSize& size, BitmapType bitmapType);
 
     // the subcontrols
     wxSearchTextCtrl *m_text;

--- a/include/wx/generic/srchctlg.h
+++ b/include/wx/generic/srchctlg.h
@@ -150,12 +150,7 @@ protected:
     // override the base class virtuals involved into geometry calculations
     virtual wxSize DoGetBestClientSize() const override;
 
-    virtual void RecalcBitmaps();
-
     void Init();
-
-    virtual wxBitmap RenderSearchBitmap( int x, int y, bool renderDrop );
-    virtual wxBitmap RenderCancelBitmap( int x, int y );
 
     void OnCancelButton( wxCommandEvent& event );
 
@@ -190,6 +185,10 @@ private:
 #if wxUSE_MENUS
     void PopupSearchMenu();
 #endif // wxUSE_MENUS
+
+    void RecalcBitmaps();
+    wxBitmap RenderSearchBitmap( int x, int y, bool renderDrop );
+    wxBitmap RenderCancelBitmap( int x, int y );
 
     // the subcontrols
     wxSearchTextCtrl *m_text;

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -825,8 +825,11 @@ static int GetMultiplier()
     return 6;
 }
 
-wxBitmap wxSearchCtrl::RenderSearchBitmap( int x, int y, bool renderDrop )
+wxBitmap wxSearchCtrl::RenderSearchBitmap(const wxSize& size, bool renderDrop)
 {
+    int x = size.x;
+    int y = size.y;
+
     wxColour bg = GetBackgroundColour();
     wxColour fg = GetForegroundColour().ChangeLightness(SEARCH_BITMAP_LIGHTNESS);
 
@@ -928,8 +931,11 @@ wxBitmap wxSearchCtrl::RenderSearchBitmap( int x, int y, bool renderDrop )
     return bitmap;
 }
 
-wxBitmap wxSearchCtrl::RenderCancelBitmap( int x, int y )
+wxBitmap wxSearchCtrl::RenderCancelBitmap(const wxSize& size)
 {
+    int x = size.x;
+    int y = size.y;
+
     wxColour bg = GetBackgroundColour();
     wxColour fg = GetForegroundColour().ChangeLightness(CANCEL_BITMAP_LIGHTNESS);
 
@@ -1023,18 +1029,17 @@ void wxSearchCtrl::RecalcBitmaps()
     }
     wxSize sizeText = m_text->GetBestSize();
 
-    int bitmapHeight = sizeText.y - FromDIP(4);
-    int bitmapWidth  = sizeText.y * 20 / 14;
+    const wxSize
+        bitmapSize = wxSize(sizeText.y * 20 / 14, sizeText.y - FromDIP(4));
 
     if ( !m_searchBitmapUser )
     {
         if (
             !m_searchBitmap.IsOk() ||
-            m_searchBitmap.GetHeight() != bitmapHeight ||
-            m_searchBitmap.GetWidth() != bitmapWidth
+            m_searchBitmap.GetSize() != bitmapSize
             )
         {
-            m_searchBitmap = RenderSearchBitmap(bitmapWidth,bitmapHeight,false);
+            m_searchBitmap = RenderSearchBitmap(bitmapSize, false);
             if ( !HasMenu() )
             {
                 m_searchButton->SetBitmapLabel(m_searchBitmap);
@@ -1048,11 +1053,10 @@ void wxSearchCtrl::RecalcBitmaps()
     {
         if (
             !m_searchMenuBitmap.IsOk() ||
-            m_searchMenuBitmap.GetHeight() != bitmapHeight ||
-            m_searchMenuBitmap.GetWidth() != bitmapWidth
+            m_searchMenuBitmap.GetSize() != bitmapSize
             )
         {
-            m_searchMenuBitmap = RenderSearchBitmap(bitmapWidth,bitmapHeight,true);
+            m_searchMenuBitmap = RenderSearchBitmap(bitmapSize, true);
             if ( m_menu )
             {
                 m_searchButton->SetBitmapLabel(m_searchMenuBitmap);
@@ -1066,11 +1070,10 @@ void wxSearchCtrl::RecalcBitmaps()
     {
         if (
             !m_cancelBitmap.IsOk() ||
-            m_cancelBitmap.GetHeight() != bitmapHeight ||
-            m_cancelBitmap.GetWidth() != bitmapWidth
+            m_cancelBitmap.GetSize() != bitmapSize
             )
         {
-            m_cancelBitmap = RenderCancelBitmap(bitmapWidth,bitmapHeight);
+            m_cancelBitmap = RenderCancelBitmap(bitmapSize);
             m_cancelButton->SetBitmapLabel(m_cancelBitmap);
         }
         // else this bitmap was set by user, don't alter

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -838,20 +838,6 @@ wxBitmap wxSearchCtrl::RenderBitmap(const wxSize& size, BitmapType bitmapType)
         {
             wxColour fg = GetForegroundColour().ChangeLightness(SEARCH_BITMAP_LIGHTNESS);
 
-            // image stats
-
-            // force width:height ratio
-            if ( 14*x > y*20 )
-            {
-                // x is too big
-                x = y*20/14;
-            }
-            else
-            {
-                // y is too big
-                y = x*14/20;
-            }
-
             // glass 11x11, top left corner
             // handle (9,9)-(13,13)
             // drop (13,16)-(19,6)-(16,9)
@@ -925,20 +911,6 @@ wxBitmap wxSearchCtrl::RenderBitmap(const wxSize& size, BitmapType bitmapType)
             //===============================================================================
             // begin drawing code
             //===============================================================================
-            // image stats
-
-            // total size 14x14
-            // force 1:1 ratio
-            if ( x > y )
-            {
-                // x is too big
-                x = y;
-            }
-            else
-            {
-                // y is too big
-                y = x;
-            }
 
             // 14x14 circle
             // cross line starts (4,4)-(10,10)
@@ -1015,8 +987,19 @@ void wxSearchCtrl::RecalcBitmaps()
     }
     wxSize sizeText = m_text->GetBestSize();
 
-    const wxSize
-        bitmapSize = wxSize(sizeText.y * 20 / 14, sizeText.y - FromDIP(4));
+    // We use rectangular shape for the search bitmap to accommodate a possible
+    // menu drop down indicator in the menu bitmap.
+    wxSize bitmapSize = wxSize(sizeText.y * 20 / 14, sizeText.y - FromDIP(4));
+    if ( 14*bitmapSize.x > bitmapSize.y*20 )
+    {
+        // x is too big
+        bitmapSize.x = bitmapSize.y*20/14;
+    }
+    else
+    {
+        // y is too big
+        bitmapSize.y = bitmapSize.x*14/20;
+    }
 
     if ( !m_searchBitmapUser )
     {
@@ -1051,6 +1034,19 @@ void wxSearchCtrl::RecalcBitmaps()
         // else this bitmap was set by user, don't alter
     }
 #endif // wxUSE_MENUS
+
+    // But the cancel button is square, so force 1:1 ratio.
+    if ( bitmapSize.x > bitmapSize.y )
+    {
+        // x is too big
+        bitmapSize.x = bitmapSize.y;
+    }
+    else
+    {
+        // y is too big
+        bitmapSize.y = bitmapSize.x;
+    }
+
 
     if ( m_cancelButton && !m_cancelBitmapUser )
     {

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -812,19 +812,6 @@ bool wxSearchCtrl::ShouldInheritColours() const
     return true;
 }
 
-// icons are rendered at 3-8 times larger than necessary and downscaled for
-// antialiasing
-static int GetMultiplier()
-{
-    int depth = ::wxDisplayDepth();
-
-    if  ( depth >= 24 )
-    {
-        return 8;
-    }
-    return 6;
-}
-
 wxBitmap wxSearchCtrl::RenderBitmap(const wxSize& size, BitmapType bitmapType)
 {
     int x = size.x;
@@ -834,7 +821,9 @@ wxBitmap wxSearchCtrl::RenderBitmap(const wxSize& size, BitmapType bitmapType)
 
     wxBitmap bitmap;
 
-    int multiplier = GetMultiplier();
+    // icons are rendered at 6-8 times larger than necessary and downscaled for
+    // antialiasing
+    const int multiplier = ::wxDisplayDepth() >= 24 ? 8 : 6;
 
     //===============================================================================
     // begin drawing code

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -153,7 +153,7 @@ public:
           m_eventType(eventType),
           m_bmp(bmp)
     {
-        SetBackgroundStyle(wxBG_STYLE_PAINT);
+        SetBackgroundColour(search->GetBackgroundColour());
     }
 
     void SetBitmapLabel(const wxBitmap& label)
@@ -210,10 +210,6 @@ protected:
     void OnPaint(wxPaintEvent&)
     {
         wxPaintDC dc(this);
-
-        // Clear the background in case of a user bitmap with alpha channel
-        dc.SetBrush(m_search->GetBackgroundColour());
-        dc.Clear();
 
         // Draw the bitmap
         dc.DrawBitmap(m_bmp, 0,0, true);

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -825,94 +825,180 @@ static int GetMultiplier()
     return 6;
 }
 
-wxBitmap wxSearchCtrl::RenderSearchBitmap(const wxSize& size, bool renderDrop)
+wxBitmap wxSearchCtrl::RenderBitmap(const wxSize& size, BitmapType bitmapType)
 {
     int x = size.x;
     int y = size.y;
 
     wxColour bg = GetBackgroundColour();
-    wxColour fg = GetForegroundColour().ChangeLightness(SEARCH_BITMAP_LIGHTNESS);
+
+    wxBitmap bitmap;
+
+    int multiplier = GetMultiplier();
 
     //===============================================================================
     // begin drawing code
     //===============================================================================
-    // image stats
 
-    // force width:height ratio
-    if ( 14*x > y*20 )
+    switch ( bitmapType )
     {
-        // x is too big
-        x = y*20/14;
-    }
-    else
-    {
-        // y is too big
-        y = x*14/20;
-    }
-
-    // glass 11x11, top left corner
-    // handle (9,9)-(13,13)
-    // drop (13,16)-(19,6)-(16,9)
-
-    int multiplier = GetMultiplier();
-    int penWidth = multiplier * 2;
-
-    penWidth = penWidth * x / 20;
-
-    wxBitmap bitmap( multiplier*x, multiplier*y );
-    wxMemoryDC mem;
-    mem.SelectObject(bitmap);
-
-    // clear background
-    mem.SetBrush( wxBrush(bg) );
-    mem.SetPen( wxPen(bg) );
-    mem.DrawRectangle(0,0,bitmap.GetWidth(),bitmap.GetHeight());
-
-    // draw drop glass
-    mem.SetBrush( wxBrush(fg) );
-    mem.SetPen( wxPen(fg) );
-    int glassBase = 5 * x / 20;
-    int glassFactor = 2*glassBase + 1;
-    int radius = multiplier*glassFactor/2;
-    mem.DrawCircle(radius,radius,radius);
-    mem.SetBrush( wxBrush(bg) );
-    mem.SetPen( wxPen(bg) );
-    mem.DrawCircle(radius,radius,radius-penWidth);
-
-    // draw handle
-    int lineStart = radius + (radius-penWidth/2) * 707 / 1000; // 707 / 1000 = 0.707 = 1/sqrt(2);
-
-    mem.SetPen( wxPen(fg) );
-    mem.SetBrush( wxBrush(fg) );
-    int handleCornerShift = penWidth * 707 / 1000 / 2; // 707 / 1000 = 0.707 = 1/sqrt(2);
-    handleCornerShift = wxMax( handleCornerShift, 1 );
-    int handleBase = 4 * x / 20;
-    int handleLength = 2*handleBase+1;
-    wxPoint handlePolygon[] =
-    {
-        wxPoint(-handleCornerShift,+handleCornerShift),
-        wxPoint(+handleCornerShift,-handleCornerShift),
-        wxPoint(multiplier*handleLength/2+handleCornerShift,multiplier*handleLength/2-handleCornerShift),
-        wxPoint(multiplier*handleLength/2-handleCornerShift,multiplier*handleLength/2+handleCornerShift),
-    };
-    mem.DrawPolygon(WXSIZEOF(handlePolygon),handlePolygon,lineStart,lineStart);
-
-    // draw drop triangle
-    int triangleX = 13 * x / 20;
-    int triangleY = 5 * x / 20;
-    int triangleBase = 3 * x / 20;
-    int triangleFactor = triangleBase*2+1;
-    if ( renderDrop )
-    {
-        wxPoint dropPolygon[] =
+    case BitmapType::Search:
+#if wxUSE_MENUS
+    case BitmapType::Menu:
+#endif // wxUSE_MENUS
         {
-            wxPoint(multiplier*0,multiplier*0), // triangle left
-            wxPoint(multiplier*triangleFactor-1,multiplier*0), // triangle right
-            wxPoint(multiplier*triangleFactor/2,multiplier*triangleFactor/2), // triangle bottom
-        };
-        mem.DrawPolygon(WXSIZEOF(dropPolygon),dropPolygon,multiplier*triangleX,multiplier*triangleY);
+            wxColour fg = GetForegroundColour().ChangeLightness(SEARCH_BITMAP_LIGHTNESS);
+
+            // image stats
+
+            // force width:height ratio
+            if ( 14*x > y*20 )
+            {
+                // x is too big
+                x = y*20/14;
+            }
+            else
+            {
+                // y is too big
+                y = x*14/20;
+            }
+
+            // glass 11x11, top left corner
+            // handle (9,9)-(13,13)
+            // drop (13,16)-(19,6)-(16,9)
+
+            int penWidth = multiplier * 2;
+
+            penWidth = penWidth * x / 20;
+
+            bitmap.Create( multiplier*x, multiplier*y );
+            wxMemoryDC mem;
+            mem.SelectObject(bitmap);
+
+            // clear background
+            mem.SetBrush( wxBrush(bg) );
+            mem.SetPen( wxPen(bg) );
+            mem.DrawRectangle(0,0,bitmap.GetWidth(),bitmap.GetHeight());
+
+            // draw drop glass
+            mem.SetBrush( wxBrush(fg) );
+            mem.SetPen( wxPen(fg) );
+            int glassBase = 5 * x / 20;
+            int glassFactor = 2*glassBase + 1;
+            int radius = multiplier*glassFactor/2;
+            mem.DrawCircle(radius,radius,radius);
+            mem.SetBrush( wxBrush(bg) );
+            mem.SetPen( wxPen(bg) );
+            mem.DrawCircle(radius,radius,radius-penWidth);
+
+            // draw handle
+            int lineStart = radius + (radius-penWidth/2) * 707 / 1000; // 707 / 1000 = 0.707 = 1/sqrt(2);
+
+            mem.SetPen( wxPen(fg) );
+            mem.SetBrush( wxBrush(fg) );
+            int handleCornerShift = penWidth * 707 / 1000 / 2; // 707 / 1000 = 0.707 = 1/sqrt(2);
+            handleCornerShift = wxMax( handleCornerShift, 1 );
+            int handleBase = 4 * x / 20;
+            int handleLength = 2*handleBase+1;
+            wxPoint handlePolygon[] =
+            {
+                wxPoint(-handleCornerShift,+handleCornerShift),
+                wxPoint(+handleCornerShift,-handleCornerShift),
+                wxPoint(multiplier*handleLength/2+handleCornerShift,multiplier*handleLength/2-handleCornerShift),
+                wxPoint(multiplier*handleLength/2-handleCornerShift,multiplier*handleLength/2+handleCornerShift),
+            };
+            mem.DrawPolygon(WXSIZEOF(handlePolygon),handlePolygon,lineStart,lineStart);
+
+            // draw drop triangle
+            int triangleX = 13 * x / 20;
+            int triangleY = 5 * x / 20;
+            int triangleBase = 3 * x / 20;
+            int triangleFactor = triangleBase*2+1;
+#if wxUSE_MENUS
+            if ( bitmapType == BitmapType::Menu )
+            {
+                wxPoint dropPolygon[] =
+                {
+                    wxPoint(multiplier*0,multiplier*0), // triangle left
+                    wxPoint(multiplier*triangleFactor-1,multiplier*0), // triangle right
+                    wxPoint(multiplier*triangleFactor/2,multiplier*triangleFactor/2), // triangle bottom
+                };
+                mem.DrawPolygon(WXSIZEOF(dropPolygon),dropPolygon,multiplier*triangleX,multiplier*triangleY);
+            }
+#endif // wxUSE_MENUS
+        }
+        break;
+
+    case BitmapType::Cancel:
+        {
+            wxColour fg = GetForegroundColour().ChangeLightness(CANCEL_BITMAP_LIGHTNESS);
+
+            //===============================================================================
+            // begin drawing code
+            //===============================================================================
+            // image stats
+
+            // total size 14x14
+            // force 1:1 ratio
+            if ( x > y )
+            {
+                // x is too big
+                x = y;
+            }
+            else
+            {
+                // y is too big
+                y = x;
+            }
+
+            // 14x14 circle
+            // cross line starts (4,4)-(10,10)
+            // drop (13,16)-(19,6)-(16,9)
+
+            int penWidth = multiplier * x / 14;
+
+            bitmap.Create( multiplier*x, multiplier*y );
+            wxMemoryDC mem;
+            mem.SelectObject(bitmap);
+
+            // clear background
+            mem.SetBrush( wxBrush(bg) );
+            mem.SetPen( wxPen(bg) );
+            mem.DrawRectangle(0,0,bitmap.GetWidth(),bitmap.GetHeight());
+
+            // draw drop glass
+            mem.SetBrush( wxBrush(fg) );
+            mem.SetPen( wxPen(fg) );
+            int radius = multiplier*x/2;
+            mem.DrawCircle(radius,radius,radius);
+
+            // draw cross
+            int lineStartBase = 4 * x / 14;
+            int lineLength = x - 2*lineStartBase;
+
+            mem.SetPen( wxPen(bg) );
+            mem.SetBrush( wxBrush(bg) );
+            int handleCornerShift = penWidth/2;
+            handleCornerShift = wxMax( handleCornerShift, 1 );
+            wxPoint handlePolygon[] =
+            {
+                wxPoint(-handleCornerShift,+handleCornerShift),
+                wxPoint(+handleCornerShift,-handleCornerShift),
+                wxPoint(multiplier*lineLength+handleCornerShift,multiplier*lineLength-handleCornerShift),
+                wxPoint(multiplier*lineLength-handleCornerShift,multiplier*lineLength+handleCornerShift),
+            };
+            mem.DrawPolygon(WXSIZEOF(handlePolygon),handlePolygon,multiplier*lineStartBase,multiplier*lineStartBase);
+            wxPoint handlePolygon2[] =
+            {
+                wxPoint(+handleCornerShift,+handleCornerShift),
+                wxPoint(-handleCornerShift,-handleCornerShift),
+                wxPoint(multiplier*lineLength-handleCornerShift,-multiplier*lineLength-handleCornerShift),
+                wxPoint(multiplier*lineLength+handleCornerShift,-multiplier*lineLength+handleCornerShift),
+            };
+            mem.DrawPolygon(WXSIZEOF(handlePolygon2),handlePolygon2,multiplier*lineStartBase,multiplier*(x-lineStartBase));
+        }
+        break;
     }
-    mem.SelectObject(wxNullBitmap);
 
     //===============================================================================
     // end drawing code
@@ -922,100 +1008,11 @@ wxBitmap wxSearchCtrl::RenderSearchBitmap(const wxSize& size, bool renderDrop)
     {
         wxBitmap::Rescale(bitmap, wxSize(x, y));
     }
-    if ( !renderDrop )
+
+    if ( bitmapType == BitmapType::Search )
     {
         // Trim the edge where the arrow would have gone
         bitmap = bitmap.GetSubBitmap(wxRect(0,0, y,y));
-    }
-
-    return bitmap;
-}
-
-wxBitmap wxSearchCtrl::RenderCancelBitmap(const wxSize& size)
-{
-    int x = size.x;
-    int y = size.y;
-
-    wxColour bg = GetBackgroundColour();
-    wxColour fg = GetForegroundColour().ChangeLightness(CANCEL_BITMAP_LIGHTNESS);
-
-    //===============================================================================
-    // begin drawing code
-    //===============================================================================
-    // image stats
-
-    // total size 14x14
-    // force 1:1 ratio
-    if ( x > y )
-    {
-        // x is too big
-        x = y;
-    }
-    else
-    {
-        // y is too big
-        y = x;
-    }
-
-    // 14x14 circle
-    // cross line starts (4,4)-(10,10)
-    // drop (13,16)-(19,6)-(16,9)
-
-    int multiplier = GetMultiplier();
-
-    int penWidth = multiplier * x / 14;
-
-    wxBitmap bitmap( multiplier*x, multiplier*y );
-    wxMemoryDC mem;
-    mem.SelectObject(bitmap);
-
-    // clear background
-    mem.SetBrush( wxBrush(bg) );
-    mem.SetPen( wxPen(bg) );
-    mem.DrawRectangle(0,0,bitmap.GetWidth(),bitmap.GetHeight());
-
-    // draw drop glass
-    mem.SetBrush( wxBrush(fg) );
-    mem.SetPen( wxPen(fg) );
-    int radius = multiplier*x/2;
-    mem.DrawCircle(radius,radius,radius);
-
-    // draw cross
-    int lineStartBase = 4 * x / 14;
-    int lineLength = x - 2*lineStartBase;
-
-    mem.SetPen( wxPen(bg) );
-    mem.SetBrush( wxBrush(bg) );
-    int handleCornerShift = penWidth/2;
-    handleCornerShift = wxMax( handleCornerShift, 1 );
-    wxPoint handlePolygon[] =
-    {
-        wxPoint(-handleCornerShift,+handleCornerShift),
-        wxPoint(+handleCornerShift,-handleCornerShift),
-        wxPoint(multiplier*lineLength+handleCornerShift,multiplier*lineLength-handleCornerShift),
-        wxPoint(multiplier*lineLength-handleCornerShift,multiplier*lineLength+handleCornerShift),
-    };
-    mem.DrawPolygon(WXSIZEOF(handlePolygon),handlePolygon,multiplier*lineStartBase,multiplier*lineStartBase);
-    wxPoint handlePolygon2[] =
-    {
-        wxPoint(+handleCornerShift,+handleCornerShift),
-        wxPoint(-handleCornerShift,-handleCornerShift),
-        wxPoint(multiplier*lineLength-handleCornerShift,-multiplier*lineLength-handleCornerShift),
-        wxPoint(multiplier*lineLength+handleCornerShift,-multiplier*lineLength+handleCornerShift),
-    };
-    mem.DrawPolygon(WXSIZEOF(handlePolygon2),handlePolygon2,multiplier*lineStartBase,multiplier*(x-lineStartBase));
-
-    // Stop drawing on the bitmap before possibly calling wxBitmap::Rescale()
-    // below.
-    mem.SelectObject(wxNullBitmap);
-
-    //===============================================================================
-    // end drawing code
-    //===============================================================================
-
-    if ( multiplier != 1 )
-    {
-        wxBitmap::Rescale(bitmap, wxSize(x, y));
     }
 
     return bitmap;
@@ -1039,7 +1036,7 @@ void wxSearchCtrl::RecalcBitmaps()
             m_searchBitmap.GetSize() != bitmapSize
             )
         {
-            m_searchBitmap = RenderSearchBitmap(bitmapSize, false);
+            m_searchBitmap = RenderBitmap(bitmapSize, BitmapType::Search);
             if ( !HasMenu() )
             {
                 m_searchButton->SetBitmapLabel(m_searchBitmap);
@@ -1056,7 +1053,7 @@ void wxSearchCtrl::RecalcBitmaps()
             m_searchMenuBitmap.GetSize() != bitmapSize
             )
         {
-            m_searchMenuBitmap = RenderSearchBitmap(bitmapSize, true);
+            m_searchMenuBitmap = RenderBitmap(bitmapSize, BitmapType::Menu);
             if ( m_menu )
             {
                 m_searchButton->SetBitmapLabel(m_searchMenuBitmap);
@@ -1073,7 +1070,7 @@ void wxSearchCtrl::RecalcBitmaps()
             m_cancelBitmap.GetSize() != bitmapSize
             )
         {
-            m_cancelBitmap = RenderCancelBitmap(bitmapSize);
+            m_cancelBitmap = RenderBitmap(bitmapSize, BitmapType::Cancel);
             m_cancelButton->SetBitmapLabel(m_cancelBitmap);
         }
         // else this bitmap was set by user, don't alter


### PR DESCRIPTION
The main commit here is the last but one, the previous ones are just refactoring/cleanup and the last one is a hack which I had to make to get the correct background for the "cancel" button: I have no idea why, but without this it showed greyish (`#f0f0f0`) background instead of white in light mode.

Speaking of light/dark, I'm also not proud of black/white replacement, but I don't see how else can the bitmaps be adjusted for the dark mode. Any better ideas?