### PR TITLE
Move wxPowerEvent and wxPowerResource to core library

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -540,7 +540,6 @@ ALL_BASE_HEADERS =  \
 	wx/object.h \
 	wx/platform.h \
 	wx/platinfo.h \
-	wx/power.h \
 	wx/process.h \
 	wx/ptr_scpd.h \
 	wx/ptr_shrd.h \
@@ -727,7 +726,6 @@ ALL_PORTS_BASE_HEADERS =  \
 	wx/object.h \
 	wx/platform.h \
 	wx/platinfo.h \
-	wx/power.h \
 	wx/process.h \
 	wx/ptr_scpd.h \
 	wx/ptr_shrd.h \
@@ -904,7 +902,6 @@ ALL_BASE_SOURCES =  \
 	src/common/numformatter.cpp \
 	src/common/object.cpp \
 	src/common/platinfo.cpp \
-	src/common/powercmn.cpp \
 	src/common/process.cpp \
 	src/common/regex.cpp \
 	src/common/stdpbase.cpp \
@@ -972,7 +969,6 @@ ALL_BASE_SOURCES =  \
 	src/msw/dlmsw.cpp \
 	src/msw/evtloopconsole.cpp \
 	src/msw/mimetype.cpp \
-	src/msw/power.cpp \
 	src/msw/regconf.cpp \
 	src/msw/registry.cpp \
 	src/msw/snglinst.cpp \
@@ -990,7 +986,6 @@ ALL_BASE_SOURCES =  \
 	src/common/fs_mem.cpp \
 	src/common/msgout.cpp \
 	src/common/utilscmn.cpp \
-	src/osx/cocoa/power.mm \
 	src/osx/cocoa/utils.mm \
 	src/osx/volume.mm \
 	src/msw/main.cpp \
@@ -1110,7 +1105,6 @@ MONODLL_OBJECTS =  \
 	monodll_numformatter.o \
 	monodll_object.o \
 	monodll_platinfo.o \
-	monodll_powercmn.o \
 	monodll_process.o \
 	monodll_regex.o \
 	monodll_stdpbase.o \
@@ -1270,7 +1264,6 @@ MONOLIB_OBJECTS =  \
 	monolib_numformatter.o \
 	monolib_object.o \
 	monolib_platinfo.o \
-	monolib_powercmn.o \
 	monolib_process.o \
 	monolib_regex.o \
 	monolib_stdpbase.o \
@@ -1399,7 +1392,6 @@ BASEDLL_OBJECTS =  \
 	basedll_numformatter.o \
 	basedll_object.o \
 	basedll_platinfo.o \
-	basedll_powercmn.o \
 	basedll_process.o \
 	basedll_regex.o \
 	basedll_stdpbase.o \
@@ -1510,7 +1502,6 @@ BASELIB_OBJECTS =  \
 	baselib_numformatter.o \
 	baselib_object.o \
 	baselib_platinfo.o \
-	baselib_powercmn.o \
 	baselib_process.o \
 	baselib_regex.o \
 	baselib_stdpbase.o \
@@ -3922,6 +3913,7 @@ COND_USE_GUI_1_ALL_GUI_HEADERS =  \
 	wx/filedlgcustomize.h \
 	wx/compositebookctrl.h \
 	wx/persist/combobox.h \
+	wx/power.h \
 	$(LOWLEVEL_HDR) \
 	$(GUI_CORE_HEADERS) \
 	wx/mediactrl.h \
@@ -4208,7 +4200,6 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS =  \
 	monodll_dlmsw.o \
 	monodll_evtloopconsole.o \
 	monodll_msw_mimetype.o \
-	monodll_msw_power.o \
 	monodll_regconf.o \
 	monodll_registry.o \
 	monodll_msw_snglinst.o \
@@ -4225,8 +4216,7 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS =  \
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS \
 @COND_PLATFORM_WIN32_1@	= monodll_main.o monodll_msw_volume.o
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS \
-@COND_TOOLKIT_OSX_COCOA@	= monodll_cocoa_power.o monodll_cocoa_utils.o \
-@COND_TOOLKIT_OSX_COCOA@	monodll_osx_volume.o
+@COND_TOOLKIT_OSX_COCOA@	= monodll_cocoa_utils.o monodll_osx_volume.o
 COND_PLATFORM_MACOSX_1___NET_PLATFORM_SRC_OBJECTS =  \
 	monodll_socketiohandler.o \
 	monodll_sockunix.o \
@@ -4596,7 +4586,8 @@ COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS =  \
 	monodll_creddlgg.o \
 	monodll_rowheightcache.o \
 	monodll_common_bmpbndl.o \
-	monodll_bmpsvg.o
+	monodll_bmpsvg.o \
+	monodll_powercmn.o
 @COND_USE_GUI_1_WXUNIV_0@__CORE_SRC_OBJECTS = $(COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS)
 COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS =  \
 	$(__LOWLEVEL_SRC_OBJECTS_1) \
@@ -4860,7 +4851,8 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS =  \
 	monodll_creddlgg.o \
 	monodll_rowheightcache.o \
 	monodll_common_bmpbndl.o \
-	monodll_bmpsvg.o
+	monodll_bmpsvg.o \
+	monodll_powercmn.o
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS =  \
 	monodll_fontmgrcmn.o \
@@ -5079,7 +5071,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS =  \
 	monodll_msw_overlay.o \
 	monodll_darkmode.o \
 	monodll_msw_appprogress.o \
-	monodll_taskbarbutton.o
+	monodll_taskbarbutton.o \
+	monodll_msw_power.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS)
@@ -5450,7 +5443,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS =  \
 	monodll_cocoa_activityindicator.o \
 	monodll_cocoa_statbmp.o \
 	monodll_core_display.o \
-	monodll_cocoa_renderer.o
+	monodll_cocoa_renderer.o \
+	monodll_cocoa_power.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS =  \
 	$(__OSX_COMMON_SRC_OBJECTS) \
@@ -5809,7 +5803,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_1 =  \
 	monodll_msw_overlay.o \
 	monodll_darkmode.o \
 	monodll_msw_appprogress.o \
-	monodll_taskbarbutton.o
+	monodll_taskbarbutton.o \
+	monodll_msw_power.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_1 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_1)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_1 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS)
@@ -5970,7 +5965,6 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_1 =  \
 	monolib_dlmsw.o \
 	monolib_evtloopconsole.o \
 	monolib_msw_mimetype.o \
-	monolib_msw_power.o \
 	monolib_regconf.o \
 	monolib_registry.o \
 	monolib_msw_snglinst.o \
@@ -5987,8 +5981,7 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_1 =  \
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_1 \
 @COND_PLATFORM_WIN32_1@	= monolib_main.o monolib_msw_volume.o
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_1 \
-@COND_TOOLKIT_OSX_COCOA@	= monolib_cocoa_power.o monolib_cocoa_utils.o \
-@COND_TOOLKIT_OSX_COCOA@	monolib_osx_volume.o
+@COND_TOOLKIT_OSX_COCOA@	= monolib_cocoa_utils.o monolib_osx_volume.o
 COND_PLATFORM_MACOSX_1___NET_PLATFORM_SRC_OBJECTS_1 =  \
 	monolib_socketiohandler.o \
 	monolib_sockunix.o \
@@ -6358,7 +6351,8 @@ COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_1 =  \
 	monolib_creddlgg.o \
 	monolib_rowheightcache.o \
 	monolib_common_bmpbndl.o \
-	monolib_bmpsvg.o
+	monolib_bmpsvg.o \
+	monolib_powercmn.o
 @COND_USE_GUI_1_WXUNIV_0@__CORE_SRC_OBJECTS_1 = $(COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_1)
 COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_1 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_3) \
@@ -6622,7 +6616,8 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_1 =  \
 	monolib_creddlgg.o \
 	monolib_rowheightcache.o \
 	monolib_common_bmpbndl.o \
-	monolib_bmpsvg.o
+	monolib_bmpsvg.o \
+	monolib_powercmn.o
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_1 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_1)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_2 =  \
 	monolib_fontmgrcmn.o \
@@ -6841,7 +6836,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_2 =  \
 	monolib_msw_overlay.o \
 	monolib_darkmode.o \
 	monolib_msw_appprogress.o \
-	monolib_taskbarbutton.o
+	monolib_taskbarbutton.o \
+	monolib_msw_power.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_2 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_2)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_2 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_17)
@@ -7212,7 +7208,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_1 =  \
 	monolib_cocoa_activityindicator.o \
 	monolib_cocoa_statbmp.o \
 	monolib_core_display.o \
-	monolib_cocoa_renderer.o
+	monolib_cocoa_renderer.o \
+	monolib_cocoa_power.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_1)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_1 =  \
 	$(__OSX_COMMON_SRC_OBJECTS_0) \
@@ -7571,7 +7568,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_3 =  \
 	monolib_msw_overlay.o \
 	monolib_darkmode.o \
 	monolib_msw_appprogress.o \
-	monolib_taskbarbutton.o
+	monolib_taskbarbutton.o \
+	monolib_msw_power.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_3 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_3)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_3 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_17)
@@ -7782,7 +7780,6 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_2 =  \
 	basedll_dlmsw.o \
 	basedll_evtloopconsole.o \
 	basedll_msw_mimetype.o \
-	basedll_msw_power.o \
 	basedll_regconf.o \
 	basedll_registry.o \
 	basedll_msw_snglinst.o \
@@ -7799,8 +7796,7 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_2 =  \
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_2 \
 @COND_PLATFORM_WIN32_1@	= basedll_main.o basedll_msw_volume.o
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_2 \
-@COND_TOOLKIT_OSX_COCOA@	= basedll_cocoa_power.o basedll_cocoa_utils.o \
-@COND_TOOLKIT_OSX_COCOA@	basedll_osx_volume.o
+@COND_TOOLKIT_OSX_COCOA@	= basedll_cocoa_utils.o basedll_osx_volume.o
 COND_MONOLITHIC_0_SHARED_0___baselib___depname = \
 	$(LIBDIRNAME)/$(LIBPREFIX)wx_base$(WXBASEPORT)u$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)-$(WX_RELEASE)$(HOST_SUFFIX)$(LIBEXT)
 @COND_MONOLITHIC_0_SHARED_0@__baselib___depname = $(COND_MONOLITHIC_0_SHARED_0___baselib___depname)
@@ -7869,7 +7865,6 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_3 =  \
 	baselib_dlmsw.o \
 	baselib_evtloopconsole.o \
 	baselib_msw_mimetype.o \
-	baselib_msw_power.o \
 	baselib_regconf.o \
 	baselib_registry.o \
 	baselib_msw_snglinst.o \
@@ -7886,8 +7881,7 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_3 =  \
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_3 \
 @COND_PLATFORM_WIN32_1@	= baselib_main.o baselib_msw_volume.o
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_3 \
-@COND_TOOLKIT_OSX_COCOA@	= baselib_cocoa_power.o baselib_cocoa_utils.o \
-@COND_TOOLKIT_OSX_COCOA@	baselib_osx_volume.o
+@COND_TOOLKIT_OSX_COCOA@	= baselib_cocoa_utils.o baselib_osx_volume.o
 @COND_SHARED_1@____wxbase_namedll_DEP = $(__basedll___depname)
 @COND_SHARED_0@____wxbase_namelib_DEP = $(__baselib___depname)
 COND_MONOLITHIC_0_SHARED_1___netdll___depname = \
@@ -8060,8 +8054,7 @@ COND_USE_SOVERSOLARIS_1___coredll___so_symlinks_uninst_cmd = rm -f \
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_4 \
 @COND_PLATFORM_WIN32_1@	= coredll_main.o coredll_msw_volume.o
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_4 \
-@COND_TOOLKIT_OSX_COCOA@	= coredll_cocoa_power.o coredll_cocoa_utils.o \
-@COND_TOOLKIT_OSX_COCOA@	coredll_osx_volume.o
+@COND_TOOLKIT_OSX_COCOA@	= coredll_cocoa_utils.o coredll_osx_volume.o
 COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_2 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_4) \
 	$(__PLATFORM_SRC_OBJECTS_8) \
@@ -8269,7 +8262,8 @@ COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_2 =  \
 	coredll_creddlgg.o \
 	coredll_rowheightcache.o \
 	coredll_common_bmpbndl.o \
-	coredll_bmpsvg.o
+	coredll_bmpsvg.o \
+	coredll_powercmn.o
 @COND_USE_GUI_1_WXUNIV_0@__CORE_SRC_OBJECTS_2 = $(COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_2)
 COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_2 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_5) \
@@ -8533,7 +8527,8 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_2 =  \
 	coredll_creddlgg.o \
 	coredll_rowheightcache.o \
 	coredll_common_bmpbndl.o \
-	coredll_bmpsvg.o
+	coredll_bmpsvg.o \
+	coredll_powercmn.o
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_2 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_2)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_4 =  \
 	coredll_fontmgrcmn.o \
@@ -8752,7 +8747,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_4 =  \
 	coredll_msw_overlay.o \
 	coredll_darkmode.o \
 	coredll_msw_appprogress.o \
-	coredll_taskbarbutton.o
+	coredll_taskbarbutton.o \
+	coredll_msw_power.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_4 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_4)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_4 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_1_1)
@@ -9123,7 +9119,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_2 =  \
 	coredll_cocoa_activityindicator.o \
 	coredll_cocoa_statbmp.o \
 	coredll_core_display.o \
-	coredll_cocoa_renderer.o
+	coredll_cocoa_renderer.o \
+	coredll_cocoa_power.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_2)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_2 =  \
 	$(__OSX_COMMON_SRC_OBJECTS_8) \
@@ -9482,7 +9479,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_5 =  \
 	coredll_msw_overlay.o \
 	coredll_darkmode.o \
 	coredll_msw_appprogress.o \
-	coredll_taskbarbutton.o
+	coredll_taskbarbutton.o \
+	coredll_msw_power.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_5 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_5)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_5 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_1_1)
@@ -9546,8 +9544,7 @@ COND_MONOLITHIC_0_SHARED_0_USE_GUI_1___corelib___depname = \
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_5 \
 @COND_PLATFORM_WIN32_1@	= corelib_main.o corelib_msw_volume.o
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_5 \
-@COND_TOOLKIT_OSX_COCOA@	= corelib_cocoa_power.o corelib_cocoa_utils.o \
-@COND_TOOLKIT_OSX_COCOA@	corelib_osx_volume.o
+@COND_TOOLKIT_OSX_COCOA@	= corelib_cocoa_utils.o corelib_osx_volume.o
 COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_3 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_6) \
 	$(__PLATFORM_SRC_OBJECTS_9) \
@@ -9755,7 +9752,8 @@ COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_3 =  \
 	corelib_creddlgg.o \
 	corelib_rowheightcache.o \
 	corelib_common_bmpbndl.o \
-	corelib_bmpsvg.o
+	corelib_bmpsvg.o \
+	corelib_powercmn.o
 @COND_USE_GUI_1_WXUNIV_0@__CORE_SRC_OBJECTS_3 = $(COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_3)
 COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_3 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_7) \
@@ -10019,7 +10017,8 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_3 =  \
 	corelib_creddlgg.o \
 	corelib_rowheightcache.o \
 	corelib_common_bmpbndl.o \
-	corelib_bmpsvg.o
+	corelib_bmpsvg.o \
+	corelib_powercmn.o
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_3 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_3)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_6 =  \
 	corelib_fontmgrcmn.o \
@@ -10238,7 +10237,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_6 =  \
 	corelib_msw_overlay.o \
 	corelib_darkmode.o \
 	corelib_msw_appprogress.o \
-	corelib_taskbarbutton.o
+	corelib_taskbarbutton.o \
+	corelib_msw_power.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_6 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_6)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_6 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_1_4)
@@ -10609,7 +10609,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_3 =  \
 	corelib_cocoa_activityindicator.o \
 	corelib_cocoa_statbmp.o \
 	corelib_core_display.o \
-	corelib_cocoa_renderer.o
+	corelib_cocoa_renderer.o \
+	corelib_cocoa_power.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_3)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_3 =  \
 	$(__OSX_COMMON_SRC_OBJECTS_9) \
@@ -10968,7 +10969,8 @@ COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_7 =  \
 	corelib_msw_overlay.o \
 	corelib_darkmode.o \
 	corelib_msw_appprogress.o \
-	corelib_taskbarbutton.o
+	corelib_taskbarbutton.o \
+	corelib_msw_power.o
 @COND_TOOLKIT_MSW@__LOWLEVEL_SRC_OBJECTS_7 = $(COND_TOOLKIT_MSW___LOWLEVEL_SRC_OBJECTS_7)
 @COND_TOOLKIT_OSX_COCOA@__LOWLEVEL_SRC_OBJECTS_7 = \
 @COND_TOOLKIT_OSX_COCOA@	$(__OSX_LOWLEVEL_SRC_OBJECTS_1_4)
@@ -14914,9 +14916,6 @@ monodll_object.o: $(srcdir)/src/common/object.cpp $(MONODLL_ODEP)
 monodll_platinfo.o: $(srcdir)/src/common/platinfo.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/common/platinfo.cpp
 
-monodll_powercmn.o: $(srcdir)/src/common/powercmn.cpp $(MONODLL_ODEP)
-	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/common/powercmn.cpp
-
 monodll_process.o: $(srcdir)/src/common/process.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/common/process.cpp
 
@@ -15073,9 +15072,6 @@ monodll_evtloopconsole.o: $(srcdir)/src/msw/evtloopconsole.cpp $(MONODLL_ODEP)
 monodll_msw_mimetype.o: $(srcdir)/src/msw/mimetype.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/mimetype.cpp
 
-monodll_msw_power.o: $(srcdir)/src/msw/power.cpp $(MONODLL_ODEP)
-	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/power.cpp
-
 monodll_regconf.o: $(srcdir)/src/msw/regconf.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/regconf.cpp
 
@@ -15156,9 +15152,6 @@ monodll_main.o: $(srcdir)/src/msw/main.cpp $(MONODLL_ODEP)
 
 monodll_msw_volume.o: $(srcdir)/src/msw/volume.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/volume.cpp
-
-monodll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(MONODLL_ODEP)
-	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 monodll_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
@@ -15561,6 +15554,9 @@ monodll_core_display.o: $(srcdir)/src/osx/core/display.cpp $(MONODLL_ODEP)
 
 monodll_cocoa_renderer.o: $(srcdir)/src/osx/cocoa/renderer.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/renderer.mm
+
+monodll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 monodll_regiong.o: $(srcdir)/src/generic/regiong.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/regiong.cpp
@@ -17523,6 +17519,9 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 
 @COND_TOOLKIT_MSW_USE_GUI_1@monodll_taskbarbutton.o: $(srcdir)/src/msw/taskbarbutton.cpp $(MONODLL_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/taskbarbutton.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@monodll_msw_power.o: $(srcdir)/src/msw/power.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/power.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@monodll_artmac.o: $(srcdir)/src/osx/artmac.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/artmac.cpp
@@ -19489,6 +19488,9 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 @COND_USE_GUI_1@monodll_bmpsvg.o: $(srcdir)/src/generic/bmpsvg.cpp $(MONODLL_ODEP)
 @COND_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/bmpsvg.cpp
 
+@COND_USE_GUI_1@monodll_powercmn.o: $(srcdir)/src/common/powercmn.cpp $(MONODLL_ODEP)
+@COND_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/common/powercmn.cpp
+
 @COND_TOOLKIT_OSX_COCOA_USE_GUI_1@monodll_osx_cocoa_mediactrl.o: $(srcdir)/src/osx/cocoa/mediactrl.mm $(MONODLL_ODEP)
 @COND_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/mediactrl.mm
 
@@ -19660,9 +19662,6 @@ monolib_object.o: $(srcdir)/src/common/object.cpp $(MONOLIB_ODEP)
 monolib_platinfo.o: $(srcdir)/src/common/platinfo.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/common/platinfo.cpp
 
-monolib_powercmn.o: $(srcdir)/src/common/powercmn.cpp $(MONOLIB_ODEP)
-	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/common/powercmn.cpp
-
 monolib_process.o: $(srcdir)/src/common/process.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/common/process.cpp
 
@@ -19819,9 +19818,6 @@ monolib_evtloopconsole.o: $(srcdir)/src/msw/evtloopconsole.cpp $(MONOLIB_ODEP)
 monolib_msw_mimetype.o: $(srcdir)/src/msw/mimetype.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/mimetype.cpp
 
-monolib_msw_power.o: $(srcdir)/src/msw/power.cpp $(MONOLIB_ODEP)
-	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/power.cpp
-
 monolib_regconf.o: $(srcdir)/src/msw/regconf.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/regconf.cpp
 
@@ -19902,9 +19898,6 @@ monolib_main.o: $(srcdir)/src/msw/main.cpp $(MONOLIB_ODEP)
 
 monolib_msw_volume.o: $(srcdir)/src/msw/volume.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/volume.cpp
-
-monolib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(MONOLIB_ODEP)
-	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 monolib_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
@@ -20307,6 +20300,9 @@ monolib_core_display.o: $(srcdir)/src/osx/core/display.cpp $(MONOLIB_ODEP)
 
 monolib_cocoa_renderer.o: $(srcdir)/src/osx/cocoa/renderer.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/renderer.mm
+
+monolib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 monolib_regiong.o: $(srcdir)/src/generic/regiong.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/regiong.cpp
@@ -22269,6 +22265,9 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 
 @COND_TOOLKIT_MSW_USE_GUI_1@monolib_taskbarbutton.o: $(srcdir)/src/msw/taskbarbutton.cpp $(MONOLIB_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/taskbarbutton.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@monolib_msw_power.o: $(srcdir)/src/msw/power.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/power.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@monolib_artmac.o: $(srcdir)/src/osx/artmac.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/artmac.cpp
@@ -24235,6 +24234,9 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 @COND_USE_GUI_1@monolib_bmpsvg.o: $(srcdir)/src/generic/bmpsvg.cpp $(MONOLIB_ODEP)
 @COND_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/bmpsvg.cpp
 
+@COND_USE_GUI_1@monolib_powercmn.o: $(srcdir)/src/common/powercmn.cpp $(MONOLIB_ODEP)
+@COND_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/common/powercmn.cpp
+
 @COND_TOOLKIT_OSX_COCOA_USE_GUI_1@monolib_osx_cocoa_mediactrl.o: $(srcdir)/src/osx/cocoa/mediactrl.mm $(MONOLIB_ODEP)
 @COND_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/mediactrl.mm
 
@@ -24406,9 +24408,6 @@ basedll_object.o: $(srcdir)/src/common/object.cpp $(BASEDLL_ODEP)
 basedll_platinfo.o: $(srcdir)/src/common/platinfo.cpp $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/common/platinfo.cpp
 
-basedll_powercmn.o: $(srcdir)/src/common/powercmn.cpp $(BASEDLL_ODEP)
-	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/common/powercmn.cpp
-
 basedll_process.o: $(srcdir)/src/common/process.cpp $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/common/process.cpp
 
@@ -24565,9 +24564,6 @@ basedll_evtloopconsole.o: $(srcdir)/src/msw/evtloopconsole.cpp $(BASEDLL_ODEP)
 basedll_msw_mimetype.o: $(srcdir)/src/msw/mimetype.cpp $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/msw/mimetype.cpp
 
-basedll_msw_power.o: $(srcdir)/src/msw/power.cpp $(BASEDLL_ODEP)
-	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/msw/power.cpp
-
 basedll_regconf.o: $(srcdir)/src/msw/regconf.cpp $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/msw/regconf.cpp
 
@@ -24648,9 +24644,6 @@ basedll_main.o: $(srcdir)/src/msw/main.cpp $(BASEDLL_ODEP)
 
 basedll_msw_volume.o: $(srcdir)/src/msw/volume.cpp $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/msw/volume.cpp
-
-basedll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(BASEDLL_ODEP)
-	$(CXXC) -c -o $@ $(BASEDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 basedll_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
@@ -24889,9 +24882,6 @@ baselib_object.o: $(srcdir)/src/common/object.cpp $(BASELIB_ODEP)
 baselib_platinfo.o: $(srcdir)/src/common/platinfo.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/common/platinfo.cpp
 
-baselib_powercmn.o: $(srcdir)/src/common/powercmn.cpp $(BASELIB_ODEP)
-	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/common/powercmn.cpp
-
 baselib_process.o: $(srcdir)/src/common/process.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/common/process.cpp
 
@@ -25048,9 +25038,6 @@ baselib_evtloopconsole.o: $(srcdir)/src/msw/evtloopconsole.cpp $(BASELIB_ODEP)
 baselib_msw_mimetype.o: $(srcdir)/src/msw/mimetype.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/msw/mimetype.cpp
 
-baselib_msw_power.o: $(srcdir)/src/msw/power.cpp $(BASELIB_ODEP)
-	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/msw/power.cpp
-
 baselib_regconf.o: $(srcdir)/src/msw/regconf.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/msw/regconf.cpp
 
@@ -25131,9 +25118,6 @@ baselib_main.o: $(srcdir)/src/msw/main.cpp $(BASELIB_ODEP)
 
 baselib_msw_volume.o: $(srcdir)/src/msw/volume.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/msw/volume.cpp
-
-baselib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(BASELIB_ODEP)
-	$(CXXC) -c -o $@ $(BASELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 baselib_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
@@ -25380,9 +25364,6 @@ coredll_main.o: $(srcdir)/src/msw/main.cpp $(COREDLL_ODEP)
 
 coredll_msw_volume.o: $(srcdir)/src/msw/volume.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/volume.cpp
-
-coredll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(COREDLL_ODEP)
-	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 coredll_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
@@ -25734,6 +25715,9 @@ coredll_core_display.o: $(srcdir)/src/osx/core/display.cpp $(COREDLL_ODEP)
 
 coredll_cocoa_renderer.o: $(srcdir)/src/osx/cocoa/renderer.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/renderer.mm
+
+coredll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 coredll_regiong.o: $(srcdir)/src/generic/regiong.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/regiong.cpp
@@ -27102,6 +27086,9 @@ coredll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(COREDLL_ODEP)
 
 @COND_TOOLKIT_MSW_USE_GUI_1@coredll_taskbarbutton.o: $(srcdir)/src/msw/taskbarbutton.cpp $(COREDLL_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/taskbarbutton.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@coredll_msw_power.o: $(srcdir)/src/msw/power.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/power.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@coredll_artmac.o: $(srcdir)/src/osx/artmac.cpp $(COREDLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/artmac.cpp
@@ -29068,6 +29055,9 @@ coredll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(COREDLL_ODEP)
 @COND_USE_GUI_1@coredll_bmpsvg.o: $(srcdir)/src/generic/bmpsvg.cpp $(COREDLL_ODEP)
 @COND_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/bmpsvg.cpp
 
+@COND_USE_GUI_1@coredll_powercmn.o: $(srcdir)/src/common/powercmn.cpp $(COREDLL_ODEP)
+@COND_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/common/powercmn.cpp
+
 corelib_event.o: $(srcdir)/src/common/event.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/common/event.cpp
 
@@ -29085,9 +29075,6 @@ corelib_main.o: $(srcdir)/src/msw/main.cpp $(CORELIB_ODEP)
 
 corelib_msw_volume.o: $(srcdir)/src/msw/volume.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/volume.cpp
-
-corelib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(CORELIB_ODEP)
-	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 corelib_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
@@ -29439,6 +29426,9 @@ corelib_core_display.o: $(srcdir)/src/osx/core/display.cpp $(CORELIB_ODEP)
 
 corelib_cocoa_renderer.o: $(srcdir)/src/osx/cocoa/renderer.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/renderer.mm
+
+corelib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
 
 corelib_regiong.o: $(srcdir)/src/generic/regiong.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/regiong.cpp
@@ -30807,6 +30797,9 @@ corelib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(CORELIB_ODEP)
 
 @COND_TOOLKIT_MSW_USE_GUI_1@corelib_taskbarbutton.o: $(srcdir)/src/msw/taskbarbutton.cpp $(CORELIB_ODEP)
 @COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/taskbarbutton.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@corelib_msw_power.o: $(srcdir)/src/msw/power.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/power.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@corelib_artmac.o: $(srcdir)/src/osx/artmac.cpp $(CORELIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/artmac.cpp
@@ -32772,6 +32765,9 @@ corelib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(CORELIB_ODEP)
 
 @COND_USE_GUI_1@corelib_bmpsvg.o: $(srcdir)/src/generic/bmpsvg.cpp $(CORELIB_ODEP)
 @COND_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/bmpsvg.cpp
+
+@COND_USE_GUI_1@corelib_powercmn.o: $(srcdir)/src/common/powercmn.cpp $(CORELIB_ODEP)
+@COND_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/common/powercmn.cpp
 
 advdll_version_rc.o: $(srcdir)/src/msw/version.rc $(ADVDLL_ODEP)
 	$(WINDRES) -i$< -o$@  $(__INC_TIFF_BUILD_p_54) $(__INC_TIFF_p_54) $(__INC_JPEG_p_54) $(__INC_PNG_p_53) $(__INC_ZLIB_p_67) $(__INC_REGEX_p_65) $(__INC_EXPAT_p_65)   --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_67)  $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65) --define WXBUILDING --define WXDLLNAME=$(WXDLLNAMEPREFIXGUI)u$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_adv$(WXCOMPILER)$(VENDORTAG)$(WXDLLVERSIONTAG) $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include --define WXUSINGDLL --define WXMAKINGDLL_ADV

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -134,7 +134,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/msw/dlmsw.cpp
     src/msw/evtloopconsole.cpp
     src/msw/mimetype.cpp
-    src/msw/power.cpp
     src/msw/regconf.cpp
     src/msw/registry.cpp
     src/msw/snglinst.cpp
@@ -224,7 +223,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 <!-- Base and GUI files used by OS X -->
 
 <set var="BASE_AND_GUI_OSX_COCOA_SRC" hints="files">
-    src/osx/cocoa/power.mm
     src/osx/cocoa/utils.mm
     src/osx/volume.mm
 </set>
@@ -541,7 +539,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/common/numformatter.cpp
     src/common/object.cpp
     src/common/platinfo.cpp
-    src/common/powercmn.cpp
     src/common/process.cpp
     src/common/regex.cpp
     src/common/stdpbase.cpp
@@ -677,7 +674,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/object.h
     wx/platform.h
     wx/platinfo.h
-    wx/power.h
     wx/process.h
     wx/ptr_scpd.h
     wx/ptr_shrd.h
@@ -1032,6 +1028,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/generic/rowheightcache.cpp
     src/common/bmpbndl.cpp
     src/generic/bmpsvg.cpp
+    src/common/powercmn.cpp
 </set>
 <set var="GUI_CMN_HDR" hints="files">
     wx/affinematrix2dbase.h
@@ -1325,6 +1322,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/filedlgcustomize.h
     wx/compositebookctrl.h
     wx/persist/combobox.h
+    wx/power.h
 </set>
 
 <!-- ====================================================================== -->
@@ -1770,6 +1768,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/msw/darkmode.cpp
     src/msw/appprogress.cpp
     src/msw/taskbarbutton.cpp
+    src/msw/power.cpp
 </set>
 <set var="MSW_LOWLEVEL_HDR" hints="files">
     wx/msw/nonownedwnd.h
@@ -2339,6 +2338,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/osx/cocoa/statbmp.mm
     src/osx/core/display.cpp
     src/osx/cocoa/renderer.mm
+    src/osx/cocoa/power.mm
 </set>
 <set var="OSX_COCOA_HDR" hints="files">
     wx/osx/cocoa/chkconf.h

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -64,7 +64,6 @@ set(BASE_WIN32_SRC
     src/msw/dlmsw.cpp
     src/msw/evtloopconsole.cpp
     src/msw/mimetype.cpp
-    src/msw/power.cpp
     src/msw/regconf.cpp
     src/msw/registry.cpp
     src/msw/secretstore.cpp
@@ -152,7 +151,6 @@ set(BASE_OSX_SHARED_HDR
 
 set(BASE_AND_GUI_OSX_COCOA_SRC
     src/osx/cocoa/utils.mm
-    src/osx/cocoa/power.mm
     src/osx/volume.mm
 )
 
@@ -453,7 +451,6 @@ set(BASE_CMN_SRC
     src/common/numformatter.cpp
     src/common/object.cpp
     src/common/platinfo.cpp
-    src/common/powercmn.cpp
     src/common/process.cpp
     src/common/regex.cpp
     src/common/secretstore.cpp
@@ -591,7 +588,6 @@ set(BASE_CMN_HDR
     wx/object.h
     wx/platform.h
     wx/platinfo.h
-    wx/power.h
     wx/process.h
     wx/ptr_scpd.h
     wx/ptr_shrd.h
@@ -933,6 +929,7 @@ set(GUI_CMN_SRC
     src/generic/animateg.cpp
     src/common/bmpbndl.cpp
     src/generic/bmpsvg.cpp
+    src/common/powercmn.cpp
 )
 
 set(GUI_CMN_HDR
@@ -1226,6 +1223,7 @@ set(GUI_CMN_HDR
     wx/filedlgcustomize.h
     wx/compositebookctrl.h
     wx/persist/combobox.h
+    wx/power.h
 )
 
 set(UNIX_SRC
@@ -1646,6 +1644,7 @@ set(MSW_LOWLEVEL_SRC
     src/msw/darkmode.cpp
     src/msw/appprogress.cpp
     src/msw/taskbarbutton.cpp
+    src/msw/power.cpp
 )
 
 set(MSW_LOWLEVEL_HDR
@@ -2213,6 +2212,7 @@ set(OSX_COCOA_SRC
     src/osx/cocoa/statbmp.mm
     src/osx/core/display.cpp
     src/osx/cocoa/renderer.mm
+    src/osx/cocoa/power.mm
 )
 
 set(OSX_COCOA_HDR

--- a/build/files
+++ b/build/files
@@ -89,7 +89,6 @@ BASE_WIN32_SRC =
     src/msw/dlmsw.cpp
     src/msw/evtloopconsole.cpp
     src/msw/mimetype.cpp
-    src/msw/power.cpp
     src/msw/regconf.cpp
     src/msw/registry.cpp
     src/msw/secretstore.cpp
@@ -176,7 +175,6 @@ BASE_OSX_SHARED_HDR =
 # Base and GUI files used by OS X
 BASE_AND_GUI_OSX_COCOA_SRC =
     src/osx/cocoa/utils.mm
-    src/osx/cocoa/power.mm
     src/osx/volume.mm
 
 # files used by non-wxMac OS X builds
@@ -473,7 +471,6 @@ BASE_CMN_SRC =
     src/common/numformatter.cpp
     src/common/object.cpp
     src/common/platinfo.cpp
-    src/common/powercmn.cpp
     src/common/process.cpp
     src/common/regex.cpp
     src/common/secretstore.cpp
@@ -609,7 +606,6 @@ BASE_CMN_HDR =
     wx/object.h
     wx/platform.h
     wx/platinfo.h
-    wx/power.h
     wx/process.h
     wx/ptr_scpd.h
     wx/ptr_shrd.h
@@ -842,6 +838,7 @@ GUI_CMN_SRC =
     src/common/persist.cpp
     src/common/pickerbase.cpp
     src/common/popupcmn.cpp
+    src/common/powercmn.cpp
     src/common/preferencescmn.cpp
     src/common/prntbase.cpp
     src/common/quantize.cpp
@@ -1161,6 +1158,7 @@ GUI_CMN_HDR =
     wx/pickerbase.h
     wx/popupwin.h
     wx/position.h
+    wx/power.h
     wx/preferences.h
     wx/print.h
     wx/printdlg.h
@@ -1634,6 +1632,7 @@ MSW_LOWLEVEL_SRC =
     src/msw/palette.cpp
     src/msw/pen.cpp
     src/msw/popupwin.cpp
+    src/msw/power.cpp
     src/msw/printdlg.cpp
     src/msw/printwin.cpp
     src/msw/region.cpp
@@ -2170,6 +2169,7 @@ OSX_COCOA_SRC =
     src/osx/cocoa/notebook.mm
     src/osx/cocoa/notifmsg.mm
     src/osx/cocoa/overlay.mm
+    src/osx/cocoa/power.mm
     src/osx/cocoa/preferences.mm
     src/osx/cocoa/printdlg.mm
     src/osx/cocoa/radiobut.mm

--- a/build/msw/makefile.gcc
+++ b/build/msw/makefile.gcc
@@ -475,7 +475,6 @@ MONODLL_OBJECTS =  \
 	$(OBJS)\monodll_numformatter.o \
 	$(OBJS)\monodll_object.o \
 	$(OBJS)\monodll_platinfo.o \
-	$(OBJS)\monodll_powercmn.o \
 	$(OBJS)\monodll_process.o \
 	$(OBJS)\monodll_regex.o \
 	$(OBJS)\monodll_stdpbase.o \
@@ -523,7 +522,6 @@ MONODLL_OBJECTS =  \
 	$(OBJS)\monodll_dlmsw.o \
 	$(OBJS)\monodll_evtloopconsole.o \
 	$(OBJS)\monodll_mimetype.o \
-	$(OBJS)\monodll_power.o \
 	$(OBJS)\monodll_regconf.o \
 	$(OBJS)\monodll_registry.o \
 	$(OBJS)\monodll_snglinst.o \
@@ -637,7 +635,6 @@ MONOLIB_OBJECTS =  \
 	$(OBJS)\monolib_numformatter.o \
 	$(OBJS)\monolib_object.o \
 	$(OBJS)\monolib_platinfo.o \
-	$(OBJS)\monolib_powercmn.o \
 	$(OBJS)\monolib_process.o \
 	$(OBJS)\monolib_regex.o \
 	$(OBJS)\monolib_stdpbase.o \
@@ -685,7 +682,6 @@ MONOLIB_OBJECTS =  \
 	$(OBJS)\monolib_dlmsw.o \
 	$(OBJS)\monolib_evtloopconsole.o \
 	$(OBJS)\monolib_mimetype.o \
-	$(OBJS)\monolib_power.o \
 	$(OBJS)\monolib_regconf.o \
 	$(OBJS)\monolib_registry.o \
 	$(OBJS)\monolib_snglinst.o \
@@ -787,7 +783,6 @@ BASEDLL_OBJECTS =  \
 	$(OBJS)\basedll_numformatter.o \
 	$(OBJS)\basedll_object.o \
 	$(OBJS)\basedll_platinfo.o \
-	$(OBJS)\basedll_powercmn.o \
 	$(OBJS)\basedll_process.o \
 	$(OBJS)\basedll_regex.o \
 	$(OBJS)\basedll_stdpbase.o \
@@ -835,7 +830,6 @@ BASEDLL_OBJECTS =  \
 	$(OBJS)\basedll_dlmsw.o \
 	$(OBJS)\basedll_evtloopconsole.o \
 	$(OBJS)\basedll_mimetype.o \
-	$(OBJS)\basedll_power.o \
 	$(OBJS)\basedll_regconf.o \
 	$(OBJS)\basedll_registry.o \
 	$(OBJS)\basedll_snglinst.o \
@@ -918,7 +912,6 @@ BASELIB_OBJECTS =  \
 	$(OBJS)\baselib_numformatter.o \
 	$(OBJS)\baselib_object.o \
 	$(OBJS)\baselib_platinfo.o \
-	$(OBJS)\baselib_powercmn.o \
 	$(OBJS)\baselib_process.o \
 	$(OBJS)\baselib_regex.o \
 	$(OBJS)\baselib_stdpbase.o \
@@ -966,7 +959,6 @@ BASELIB_OBJECTS =  \
 	$(OBJS)\baselib_dlmsw.o \
 	$(OBJS)\baselib_evtloopconsole.o \
 	$(OBJS)\baselib_mimetype.o \
-	$(OBJS)\baselib_power.o \
 	$(OBJS)\baselib_regconf.o \
 	$(OBJS)\baselib_registry.o \
 	$(OBJS)\baselib_snglinst.o \
@@ -1966,6 +1958,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_darkmode.o \
 	$(OBJS)\monodll_appprogress.o \
 	$(OBJS)\monodll_taskbarbutton.o \
+	$(OBJS)\monodll_power.o \
 	$(OBJS)\monodll_clrpickerg.o \
 	$(OBJS)\monodll_collpaneg.o \
 	$(OBJS)\monodll_filepickerg.o \
@@ -2238,7 +2231,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_creddlgg.o \
 	$(OBJS)\monodll_rowheightcache.o \
 	$(OBJS)\monodll_common_bmpbndl.o \
-	$(OBJS)\monodll_bmpsvg.o
+	$(OBJS)\monodll_bmpsvg.o \
+	$(OBJS)\monodll_powercmn.o
 endif
 endif
 ifeq ($(USE_GUI),1)
@@ -2313,6 +2307,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_darkmode.o \
 	$(OBJS)\monodll_appprogress.o \
 	$(OBJS)\monodll_taskbarbutton.o \
+	$(OBJS)\monodll_power.o \
 	$(OBJS)\monodll_generic_accel.o \
 	$(OBJS)\monodll_clrpickerg.o \
 	$(OBJS)\monodll_collpaneg.o \
@@ -2572,7 +2567,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_creddlgg.o \
 	$(OBJS)\monodll_rowheightcache.o \
 	$(OBJS)\monodll_common_bmpbndl.o \
-	$(OBJS)\monodll_bmpsvg.o
+	$(OBJS)\monodll_bmpsvg.o \
+	$(OBJS)\monodll_powercmn.o
 endif
 endif
 ifeq ($(USE_STC),1)
@@ -2822,6 +2818,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_darkmode.o \
 	$(OBJS)\monolib_appprogress.o \
 	$(OBJS)\monolib_taskbarbutton.o \
+	$(OBJS)\monolib_power.o \
 	$(OBJS)\monolib_clrpickerg.o \
 	$(OBJS)\monolib_collpaneg.o \
 	$(OBJS)\monolib_filepickerg.o \
@@ -3094,7 +3091,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_creddlgg.o \
 	$(OBJS)\monolib_rowheightcache.o \
 	$(OBJS)\monolib_common_bmpbndl.o \
-	$(OBJS)\monolib_bmpsvg.o
+	$(OBJS)\monolib_bmpsvg.o \
+	$(OBJS)\monolib_powercmn.o
 endif
 endif
 ifeq ($(USE_GUI),1)
@@ -3169,6 +3167,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_darkmode.o \
 	$(OBJS)\monolib_appprogress.o \
 	$(OBJS)\monolib_taskbarbutton.o \
+	$(OBJS)\monolib_power.o \
 	$(OBJS)\monolib_generic_accel.o \
 	$(OBJS)\monolib_clrpickerg.o \
 	$(OBJS)\monolib_collpaneg.o \
@@ -3428,7 +3427,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_creddlgg.o \
 	$(OBJS)\monolib_rowheightcache.o \
 	$(OBJS)\monolib_common_bmpbndl.o \
-	$(OBJS)\monolib_bmpsvg.o
+	$(OBJS)\monolib_bmpsvg.o \
+	$(OBJS)\monolib_powercmn.o
 endif
 endif
 ifeq ($(USE_STC),1)
@@ -3554,6 +3554,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_darkmode.o \
 	$(OBJS)\coredll_appprogress.o \
 	$(OBJS)\coredll_taskbarbutton.o \
+	$(OBJS)\coredll_power.o \
 	$(OBJS)\coredll_clrpickerg.o \
 	$(OBJS)\coredll_collpaneg.o \
 	$(OBJS)\coredll_filepickerg.o \
@@ -3826,7 +3827,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_creddlgg.o \
 	$(OBJS)\coredll_rowheightcache.o \
 	$(OBJS)\coredll_common_bmpbndl.o \
-	$(OBJS)\coredll_bmpsvg.o
+	$(OBJS)\coredll_bmpsvg.o \
+	$(OBJS)\coredll_powercmn.o
 endif
 endif
 ifeq ($(USE_GUI),1)
@@ -3901,6 +3903,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_darkmode.o \
 	$(OBJS)\coredll_appprogress.o \
 	$(OBJS)\coredll_taskbarbutton.o \
+	$(OBJS)\coredll_power.o \
 	$(OBJS)\coredll_generic_accel.o \
 	$(OBJS)\coredll_clrpickerg.o \
 	$(OBJS)\coredll_collpaneg.o \
@@ -4160,7 +4163,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_creddlgg.o \
 	$(OBJS)\coredll_rowheightcache.o \
 	$(OBJS)\coredll_common_bmpbndl.o \
-	$(OBJS)\coredll_bmpsvg.o
+	$(OBJS)\coredll_bmpsvg.o \
+	$(OBJS)\coredll_powercmn.o
 endif
 endif
 ifeq ($(MONOLITHIC),0)
@@ -4243,6 +4247,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_darkmode.o \
 	$(OBJS)\corelib_appprogress.o \
 	$(OBJS)\corelib_taskbarbutton.o \
+	$(OBJS)\corelib_power.o \
 	$(OBJS)\corelib_clrpickerg.o \
 	$(OBJS)\corelib_collpaneg.o \
 	$(OBJS)\corelib_filepickerg.o \
@@ -4515,7 +4520,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_creddlgg.o \
 	$(OBJS)\corelib_rowheightcache.o \
 	$(OBJS)\corelib_common_bmpbndl.o \
-	$(OBJS)\corelib_bmpsvg.o
+	$(OBJS)\corelib_bmpsvg.o \
+	$(OBJS)\corelib_powercmn.o
 endif
 endif
 ifeq ($(USE_GUI),1)
@@ -4590,6 +4596,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_darkmode.o \
 	$(OBJS)\corelib_appprogress.o \
 	$(OBJS)\corelib_taskbarbutton.o \
+	$(OBJS)\corelib_power.o \
 	$(OBJS)\corelib_generic_accel.o \
 	$(OBJS)\corelib_clrpickerg.o \
 	$(OBJS)\corelib_collpaneg.o \
@@ -4849,7 +4856,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_creddlgg.o \
 	$(OBJS)\corelib_rowheightcache.o \
 	$(OBJS)\corelib_common_bmpbndl.o \
-	$(OBJS)\corelib_bmpsvg.o
+	$(OBJS)\corelib_bmpsvg.o \
+	$(OBJS)\corelib_powercmn.o
 endif
 endif
 ifeq ($(SHARED),1)
@@ -7186,9 +7194,6 @@ $(OBJS)\monodll_object.o: ../../src/common/object.cpp
 $(OBJS)\monodll_platinfo.o: ../../src/common/platinfo.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
-$(OBJS)\monodll_powercmn.o: ../../src/common/powercmn.cpp
-	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
-
 $(OBJS)\monodll_process.o: ../../src/common/process.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
@@ -7328,9 +7333,6 @@ $(OBJS)\monodll_evtloopconsole.o: ../../src/msw/evtloopconsole.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monodll_mimetype.o: ../../src/msw/mimetype.cpp
-	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
-
-$(OBJS)\monodll_power.o: ../../src/msw/power.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monodll_regconf.o: ../../src/msw/regconf.cpp
@@ -8588,6 +8590,11 @@ $(OBJS)\monodll_taskbarbutton.o: ../../src/msw/taskbarbutton.cpp
 endif
 
 ifeq ($(USE_GUI),1)
+$(OBJS)\monodll_power.o: ../../src/msw/power.cpp
+	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
 $(OBJS)\monodll_clrpickerg.o: ../../src/generic/clrpickerg.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 endif
@@ -9637,6 +9644,11 @@ $(OBJS)\monodll_bmpsvg.o: ../../src/generic/bmpsvg.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 endif
 
+ifeq ($(USE_GUI),1)
+$(OBJS)\monodll_powercmn.o: ../../src/common/powercmn.cpp
+	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
+endif
+
 $(OBJS)\monodll_version_rc.o: ../../src/msw/version.rc
 	$(WINDRES) -i$< -o$@   --include-dir ../../src/tiff/libtiff --include-dir ../../src/jpeg --include-dir ../../src/png --include-dir ../../src/zlib --include-dir ../../3rdparty/pcre/src/wx --include-dir ../../src/expat/expat/lib   --define __WXMSW__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_67) $(__NDEBUG_DEFINE_p_65) $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65) --include-dir $(SETUPHDIR) --include-dir ../../include $(__CAIRO_INCLUDEDIR_p) --define WXBUILDING --define WXDLLNAME=wx$(PORTNAME)$(WXUNIVNAME)$(WX_VERSION_NODOT)u$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)$(WXCOMPILER)$(VENDORTAG) --include-dir ../../src/stc/scintilla/include --include-dir ../../src/stc/scintilla/src --define __WX__ --include-dir ../../src/stc/lexilla/access --include-dir ../../src/stc/lexilla/include --include-dir ../../src/stc/lexilla/lexlib --include-dir ../../src/stc/lexilla/include --include-dir ../../src/stc/scintilla/include --include-dir ../../src/stc/scintilla/src --include-dir ../../include/wx/msw/wrl --include-dir ../../3rdparty/webview2/build/native/include --define wxUSE_BASE=1 --define WXMAKINGDLL
 
@@ -9784,9 +9796,6 @@ $(OBJS)\monolib_object.o: ../../src/common/object.cpp
 $(OBJS)\monolib_platinfo.o: ../../src/common/platinfo.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
-$(OBJS)\monolib_powercmn.o: ../../src/common/powercmn.cpp
-	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
-
 $(OBJS)\monolib_process.o: ../../src/common/process.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
@@ -9926,9 +9935,6 @@ $(OBJS)\monolib_evtloopconsole.o: ../../src/msw/evtloopconsole.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monolib_mimetype.o: ../../src/msw/mimetype.cpp
-	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
-
-$(OBJS)\monolib_power.o: ../../src/msw/power.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monolib_regconf.o: ../../src/msw/regconf.cpp
@@ -11186,6 +11192,11 @@ $(OBJS)\monolib_taskbarbutton.o: ../../src/msw/taskbarbutton.cpp
 endif
 
 ifeq ($(USE_GUI),1)
+$(OBJS)\monolib_power.o: ../../src/msw/power.cpp
+	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
 $(OBJS)\monolib_clrpickerg.o: ../../src/generic/clrpickerg.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 endif
@@ -12235,6 +12246,11 @@ $(OBJS)\monolib_bmpsvg.o: ../../src/generic/bmpsvg.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 endif
 
+ifeq ($(USE_GUI),1)
+$(OBJS)\monolib_powercmn.o: ../../src/common/powercmn.cpp
+	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
+endif
+
 $(OBJS)\basedll_dummy.o: ../../src/common/dummy.cpp
 	$(CXX) -c -o $@ $(BASEDLL_CXXFLAGS) $(CPPDEPS) $<
 
@@ -12382,9 +12398,6 @@ $(OBJS)\basedll_object.o: ../../src/common/object.cpp
 $(OBJS)\basedll_platinfo.o: ../../src/common/platinfo.cpp
 	$(CXX) -c -o $@ $(BASEDLL_CXXFLAGS) $(CPPDEPS) $<
 
-$(OBJS)\basedll_powercmn.o: ../../src/common/powercmn.cpp
-	$(CXX) -c -o $@ $(BASEDLL_CXXFLAGS) $(CPPDEPS) $<
-
 $(OBJS)\basedll_process.o: ../../src/common/process.cpp
 	$(CXX) -c -o $@ $(BASEDLL_CXXFLAGS) $(CPPDEPS) $<
 
@@ -12524,9 +12537,6 @@ $(OBJS)\basedll_evtloopconsole.o: ../../src/msw/evtloopconsole.cpp
 	$(CXX) -c -o $@ $(BASEDLL_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\basedll_mimetype.o: ../../src/msw/mimetype.cpp
-	$(CXX) -c -o $@ $(BASEDLL_CXXFLAGS) $(CPPDEPS) $<
-
-$(OBJS)\basedll_power.o: ../../src/msw/power.cpp
 	$(CXX) -c -o $@ $(BASEDLL_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\basedll_regconf.o: ../../src/msw/regconf.cpp
@@ -12727,9 +12737,6 @@ $(OBJS)\baselib_object.o: ../../src/common/object.cpp
 $(OBJS)\baselib_platinfo.o: ../../src/common/platinfo.cpp
 	$(CXX) -c -o $@ $(BASELIB_CXXFLAGS) $(CPPDEPS) $<
 
-$(OBJS)\baselib_powercmn.o: ../../src/common/powercmn.cpp
-	$(CXX) -c -o $@ $(BASELIB_CXXFLAGS) $(CPPDEPS) $<
-
 $(OBJS)\baselib_process.o: ../../src/common/process.cpp
 	$(CXX) -c -o $@ $(BASELIB_CXXFLAGS) $(CPPDEPS) $<
 
@@ -12869,9 +12876,6 @@ $(OBJS)\baselib_evtloopconsole.o: ../../src/msw/evtloopconsole.cpp
 	$(CXX) -c -o $@ $(BASELIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\baselib_mimetype.o: ../../src/msw/mimetype.cpp
-	$(CXX) -c -o $@ $(BASELIB_CXXFLAGS) $(CPPDEPS) $<
-
-$(OBJS)\baselib_power.o: ../../src/msw/power.cpp
 	$(CXX) -c -o $@ $(BASELIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\baselib_regconf.o: ../../src/msw/regconf.cpp
@@ -13732,6 +13736,11 @@ endif
 
 ifeq ($(USE_GUI),1)
 $(OBJS)\coredll_taskbarbutton.o: ../../src/msw/taskbarbutton.cpp
+	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
+$(OBJS)\coredll_power.o: ../../src/msw/power.cpp
 	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
 endif
 
@@ -14785,6 +14794,11 @@ $(OBJS)\coredll_bmpsvg.o: ../../src/generic/bmpsvg.cpp
 	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
 endif
 
+ifeq ($(USE_GUI),1)
+$(OBJS)\coredll_powercmn.o: ../../src/common/powercmn.cpp
+	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
+endif
+
 $(OBJS)\corelib_dummy.o: ../../src/common/dummy.cpp
 	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
 
@@ -15487,6 +15501,11 @@ endif
 
 ifeq ($(USE_GUI),1)
 $(OBJS)\corelib_taskbarbutton.o: ../../src/msw/taskbarbutton.cpp
+	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
+$(OBJS)\corelib_power.o: ../../src/msw/power.cpp
 	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
 endif
 
@@ -16537,6 +16556,11 @@ endif
 
 ifeq ($(USE_GUI),1)
 $(OBJS)\corelib_bmpsvg.o: ../../src/generic/bmpsvg.cpp
+	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
+$(OBJS)\corelib_powercmn.o: ../../src/common/powercmn.cpp
 	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
 endif
 

--- a/build/msw/makefile.vc
+++ b/build/msw/makefile.vc
@@ -511,7 +511,6 @@ MONODLL_OBJECTS =  \
 	$(OBJS)\monodll_numformatter.obj \
 	$(OBJS)\monodll_object.obj \
 	$(OBJS)\monodll_platinfo.obj \
-	$(OBJS)\monodll_powercmn.obj \
 	$(OBJS)\monodll_process.obj \
 	$(OBJS)\monodll_regex.obj \
 	$(OBJS)\monodll_stdpbase.obj \
@@ -559,7 +558,6 @@ MONODLL_OBJECTS =  \
 	$(OBJS)\monodll_dlmsw.obj \
 	$(OBJS)\monodll_evtloopconsole.obj \
 	$(OBJS)\monodll_mimetype.obj \
-	$(OBJS)\monodll_power.obj \
 	$(OBJS)\monodll_regconf.obj \
 	$(OBJS)\monodll_registry.obj \
 	$(OBJS)\monodll_snglinst.obj \
@@ -682,7 +680,6 @@ MONOLIB_OBJECTS =  \
 	$(OBJS)\monolib_numformatter.obj \
 	$(OBJS)\monolib_object.obj \
 	$(OBJS)\monolib_platinfo.obj \
-	$(OBJS)\monolib_powercmn.obj \
 	$(OBJS)\monolib_process.obj \
 	$(OBJS)\monolib_regex.obj \
 	$(OBJS)\monolib_stdpbase.obj \
@@ -730,7 +727,6 @@ MONOLIB_OBJECTS =  \
 	$(OBJS)\monolib_dlmsw.obj \
 	$(OBJS)\monolib_evtloopconsole.obj \
 	$(OBJS)\monolib_mimetype.obj \
-	$(OBJS)\monolib_power.obj \
 	$(OBJS)\monolib_regconf.obj \
 	$(OBJS)\monolib_registry.obj \
 	$(OBJS)\monolib_snglinst.obj \
@@ -841,7 +837,6 @@ BASEDLL_OBJECTS =  \
 	$(OBJS)\basedll_numformatter.obj \
 	$(OBJS)\basedll_object.obj \
 	$(OBJS)\basedll_platinfo.obj \
-	$(OBJS)\basedll_powercmn.obj \
 	$(OBJS)\basedll_process.obj \
 	$(OBJS)\basedll_regex.obj \
 	$(OBJS)\basedll_stdpbase.obj \
@@ -889,7 +884,6 @@ BASEDLL_OBJECTS =  \
 	$(OBJS)\basedll_dlmsw.obj \
 	$(OBJS)\basedll_evtloopconsole.obj \
 	$(OBJS)\basedll_mimetype.obj \
-	$(OBJS)\basedll_power.obj \
 	$(OBJS)\basedll_regconf.obj \
 	$(OBJS)\basedll_registry.obj \
 	$(OBJS)\basedll_snglinst.obj \
@@ -982,7 +976,6 @@ BASELIB_OBJECTS =  \
 	$(OBJS)\baselib_numformatter.obj \
 	$(OBJS)\baselib_object.obj \
 	$(OBJS)\baselib_platinfo.obj \
-	$(OBJS)\baselib_powercmn.obj \
 	$(OBJS)\baselib_process.obj \
 	$(OBJS)\baselib_regex.obj \
 	$(OBJS)\baselib_stdpbase.obj \
@@ -1030,7 +1023,6 @@ BASELIB_OBJECTS =  \
 	$(OBJS)\baselib_dlmsw.obj \
 	$(OBJS)\baselib_evtloopconsole.obj \
 	$(OBJS)\baselib_mimetype.obj \
-	$(OBJS)\baselib_power.obj \
 	$(OBJS)\baselib_regconf.obj \
 	$(OBJS)\baselib_registry.obj \
 	$(OBJS)\baselib_snglinst.obj \
@@ -2311,6 +2303,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_darkmode.obj \
 	$(OBJS)\monodll_appprogress.obj \
 	$(OBJS)\monodll_taskbarbutton.obj \
+	$(OBJS)\monodll_power.obj \
 	$(OBJS)\monodll_clrpickerg.obj \
 	$(OBJS)\monodll_collpaneg.obj \
 	$(OBJS)\monodll_filepickerg.obj \
@@ -2583,7 +2576,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_creddlgg.obj \
 	$(OBJS)\monodll_rowheightcache.obj \
 	$(OBJS)\monodll_common_bmpbndl.obj \
-	$(OBJS)\monodll_bmpsvg.obj
+	$(OBJS)\monodll_bmpsvg.obj \
+	$(OBJS)\monodll_powercmn.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_OBJECTS =  \
@@ -2656,6 +2650,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_darkmode.obj \
 	$(OBJS)\monodll_appprogress.obj \
 	$(OBJS)\monodll_taskbarbutton.obj \
+	$(OBJS)\monodll_power.obj \
 	$(OBJS)\monodll_generic_accel.obj \
 	$(OBJS)\monodll_clrpickerg.obj \
 	$(OBJS)\monodll_collpaneg.obj \
@@ -2915,7 +2910,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_creddlgg.obj \
 	$(OBJS)\monodll_rowheightcache.obj \
 	$(OBJS)\monodll_common_bmpbndl.obj \
-	$(OBJS)\monodll_bmpsvg.obj
+	$(OBJS)\monodll_bmpsvg.obj \
+	$(OBJS)\monodll_powercmn.obj
 !endif
 !if "$(USE_STC)" == "1"
 ____MONOLIB_STC_SRC_FILENAMES_OBJECTS =  \
@@ -3167,6 +3163,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_darkmode.obj \
 	$(OBJS)\monolib_appprogress.obj \
 	$(OBJS)\monolib_taskbarbutton.obj \
+	$(OBJS)\monolib_power.obj \
 	$(OBJS)\monolib_clrpickerg.obj \
 	$(OBJS)\monolib_collpaneg.obj \
 	$(OBJS)\monolib_filepickerg.obj \
@@ -3439,7 +3436,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_creddlgg.obj \
 	$(OBJS)\monolib_rowheightcache.obj \
 	$(OBJS)\monolib_common_bmpbndl.obj \
-	$(OBJS)\monolib_bmpsvg.obj
+	$(OBJS)\monolib_bmpsvg.obj \
+	$(OBJS)\monolib_powercmn.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_1_OBJECTS =  \
@@ -3512,6 +3510,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_darkmode.obj \
 	$(OBJS)\monolib_appprogress.obj \
 	$(OBJS)\monolib_taskbarbutton.obj \
+	$(OBJS)\monolib_power.obj \
 	$(OBJS)\monolib_generic_accel.obj \
 	$(OBJS)\monolib_clrpickerg.obj \
 	$(OBJS)\monolib_collpaneg.obj \
@@ -3771,7 +3770,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_creddlgg.obj \
 	$(OBJS)\monolib_rowheightcache.obj \
 	$(OBJS)\monolib_common_bmpbndl.obj \
-	$(OBJS)\monolib_bmpsvg.obj
+	$(OBJS)\monolib_bmpsvg.obj \
+	$(OBJS)\monolib_powercmn.obj
 !endif
 !if "$(USE_STC)" == "1"
 ____MONOLIB_STC_SRC_FILENAMES_1_OBJECTS =  \
@@ -3949,6 +3949,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_darkmode.obj \
 	$(OBJS)\coredll_appprogress.obj \
 	$(OBJS)\coredll_taskbarbutton.obj \
+	$(OBJS)\coredll_power.obj \
 	$(OBJS)\coredll_clrpickerg.obj \
 	$(OBJS)\coredll_collpaneg.obj \
 	$(OBJS)\coredll_filepickerg.obj \
@@ -4221,7 +4222,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_creddlgg.obj \
 	$(OBJS)\coredll_rowheightcache.obj \
 	$(OBJS)\coredll_common_bmpbndl.obj \
-	$(OBJS)\coredll_bmpsvg.obj
+	$(OBJS)\coredll_bmpsvg.obj \
+	$(OBJS)\coredll_powercmn.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_2_OBJECTS =  \
@@ -4294,6 +4296,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_darkmode.obj \
 	$(OBJS)\coredll_appprogress.obj \
 	$(OBJS)\coredll_taskbarbutton.obj \
+	$(OBJS)\coredll_power.obj \
 	$(OBJS)\coredll_generic_accel.obj \
 	$(OBJS)\coredll_clrpickerg.obj \
 	$(OBJS)\coredll_collpaneg.obj \
@@ -4553,7 +4556,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_creddlgg.obj \
 	$(OBJS)\coredll_rowheightcache.obj \
 	$(OBJS)\coredll_common_bmpbndl.obj \
-	$(OBJS)\coredll_bmpsvg.obj
+	$(OBJS)\coredll_bmpsvg.obj \
+	$(OBJS)\coredll_powercmn.obj
 !endif
 !if "$(MONOLITHIC)" == "0" && "$(SHARED)" == "0" && "$(USE_GUI)" == "1"
 __corelib___depname = \
@@ -4636,6 +4640,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_darkmode.obj \
 	$(OBJS)\corelib_appprogress.obj \
 	$(OBJS)\corelib_taskbarbutton.obj \
+	$(OBJS)\corelib_power.obj \
 	$(OBJS)\corelib_clrpickerg.obj \
 	$(OBJS)\corelib_collpaneg.obj \
 	$(OBJS)\corelib_filepickerg.obj \
@@ -4908,7 +4913,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_creddlgg.obj \
 	$(OBJS)\corelib_rowheightcache.obj \
 	$(OBJS)\corelib_common_bmpbndl.obj \
-	$(OBJS)\corelib_bmpsvg.obj
+	$(OBJS)\corelib_bmpsvg.obj \
+	$(OBJS)\corelib_powercmn.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_3_OBJECTS =  \
@@ -4981,6 +4987,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_darkmode.obj \
 	$(OBJS)\corelib_appprogress.obj \
 	$(OBJS)\corelib_taskbarbutton.obj \
+	$(OBJS)\corelib_power.obj \
 	$(OBJS)\corelib_generic_accel.obj \
 	$(OBJS)\corelib_clrpickerg.obj \
 	$(OBJS)\corelib_collpaneg.obj \
@@ -5240,7 +5247,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_creddlgg.obj \
 	$(OBJS)\corelib_rowheightcache.obj \
 	$(OBJS)\corelib_common_bmpbndl.obj \
-	$(OBJS)\corelib_bmpsvg.obj
+	$(OBJS)\corelib_bmpsvg.obj \
+	$(OBJS)\corelib_powercmn.obj
 !endif
 !if "$(SHARED)" == "1"
 ____wxcore_namedll_DEP = $(__coredll___depname)
@@ -7655,9 +7663,6 @@ $(OBJS)\monodll_object.obj: ..\..\src\common\object.cpp
 $(OBJS)\monodll_platinfo.obj: ..\..\src\common\platinfo.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\common\platinfo.cpp
 
-$(OBJS)\monodll_powercmn.obj: ..\..\src\common\powercmn.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\common\powercmn.cpp
-
 $(OBJS)\monodll_process.obj: ..\..\src\common\process.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\common\process.cpp
 
@@ -7798,9 +7803,6 @@ $(OBJS)\monodll_evtloopconsole.obj: ..\..\src\msw\evtloopconsole.cpp
 
 $(OBJS)\monodll_mimetype.obj: ..\..\src\msw\mimetype.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\msw\mimetype.cpp
-
-$(OBJS)\monodll_power.obj: ..\..\src\msw\power.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\msw\power.cpp
 
 $(OBJS)\monodll_regconf.obj: ..\..\src\msw\regconf.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\msw\regconf.cpp
@@ -9057,6 +9059,11 @@ $(OBJS)\monodll_taskbarbutton.obj: ..\..\src\msw\taskbarbutton.cpp
 !endif
 
 !if "$(USE_GUI)" == "1"
+$(OBJS)\monodll_power.obj: ..\..\src\msw\power.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\msw\power.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
 $(OBJS)\monodll_clrpickerg.obj: ..\..\src\generic\clrpickerg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\generic\clrpickerg.cpp
 !endif
@@ -10106,6 +10113,11 @@ $(OBJS)\monodll_bmpsvg.obj: ..\..\src\generic\bmpsvg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\generic\bmpsvg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\monodll_powercmn.obj: ..\..\src\common\powercmn.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\common\powercmn.cpp
+!endif
+
 $(OBJS)\monodll_version.res: ..\..\src\msw\version.rc
 	rc /fo$@  /d WIN32  /i ..\..\src\tiff\libtiff /i ..\..\src\jpeg /i ..\..\src\png /i ..\..\src\zlib /i ..\..\3rdparty\pcre\src\wx /i ..\..\src\expat\expat\lib $(____DEBUGRUNTIME_6) /d _CRT_SECURE_NO_DEPRECATE=1 /d _CRT_NON_CONFORMING_SWPRINTFS=1 /d _SCL_SECURE_NO_WARNINGS=1 $(__NO_VC_CRTDBG_p_73)  $(__TARGET_CPU_COMPFLAG_p_73) /d __WXMSW__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_67) $(__NDEBUG_DEFINE_p_65) $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65) /i $(SETUPHDIR) /i ..\..\include $(____CAIRO_INCLUDEDIR_FILENAMES_4) /d WXBUILDING /d WXDLLNAME=wx$(PORTNAME)$(WXUNIVNAME)$(WX_VERSION_NODOT)u$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)$(WXCOMPILER)$(VENDORTAG) /i ..\..\src\stc\scintilla\include /i ..\..\src\stc\scintilla\src /d __WX__ /i ..\..\src\stc\lexilla\access /i ..\..\src\stc\lexilla\include /i ..\..\src\stc\lexilla\lexlib /i ..\..\src\stc\lexilla\include /i ..\..\src\stc\scintilla\include /i ..\..\src\stc\scintilla\src  /i ..\..\3rdparty\webview2\build\native\include /d wxUSE_BASE=1 /d WXMAKINGDLL ..\..\src\msw\version.rc
 
@@ -10253,9 +10265,6 @@ $(OBJS)\monolib_object.obj: ..\..\src\common\object.cpp
 $(OBJS)\monolib_platinfo.obj: ..\..\src\common\platinfo.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\common\platinfo.cpp
 
-$(OBJS)\monolib_powercmn.obj: ..\..\src\common\powercmn.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\common\powercmn.cpp
-
 $(OBJS)\monolib_process.obj: ..\..\src\common\process.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\common\process.cpp
 
@@ -10396,9 +10405,6 @@ $(OBJS)\monolib_evtloopconsole.obj: ..\..\src\msw\evtloopconsole.cpp
 
 $(OBJS)\monolib_mimetype.obj: ..\..\src\msw\mimetype.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\msw\mimetype.cpp
-
-$(OBJS)\monolib_power.obj: ..\..\src\msw\power.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\msw\power.cpp
 
 $(OBJS)\monolib_regconf.obj: ..\..\src\msw\regconf.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\msw\regconf.cpp
@@ -11655,6 +11661,11 @@ $(OBJS)\monolib_taskbarbutton.obj: ..\..\src\msw\taskbarbutton.cpp
 !endif
 
 !if "$(USE_GUI)" == "1"
+$(OBJS)\monolib_power.obj: ..\..\src\msw\power.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\msw\power.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
 $(OBJS)\monolib_clrpickerg.obj: ..\..\src\generic\clrpickerg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\generic\clrpickerg.cpp
 !endif
@@ -12704,6 +12715,11 @@ $(OBJS)\monolib_bmpsvg.obj: ..\..\src\generic\bmpsvg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\generic\bmpsvg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\monolib_powercmn.obj: ..\..\src\common\powercmn.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\common\powercmn.cpp
+!endif
+
 $(OBJS)\basedll_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASEDLL_CXXFLAGS) /Ycwx/wxprec.h ..\..\src\common\dummy.cpp
 
@@ -12851,9 +12867,6 @@ $(OBJS)\basedll_object.obj: ..\..\src\common\object.cpp
 $(OBJS)\basedll_platinfo.obj: ..\..\src\common\platinfo.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASEDLL_CXXFLAGS) ..\..\src\common\platinfo.cpp
 
-$(OBJS)\basedll_powercmn.obj: ..\..\src\common\powercmn.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(BASEDLL_CXXFLAGS) ..\..\src\common\powercmn.cpp
-
 $(OBJS)\basedll_process.obj: ..\..\src\common\process.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASEDLL_CXXFLAGS) ..\..\src\common\process.cpp
 
@@ -12994,9 +13007,6 @@ $(OBJS)\basedll_evtloopconsole.obj: ..\..\src\msw\evtloopconsole.cpp
 
 $(OBJS)\basedll_mimetype.obj: ..\..\src\msw\mimetype.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASEDLL_CXXFLAGS) ..\..\src\msw\mimetype.cpp
-
-$(OBJS)\basedll_power.obj: ..\..\src\msw\power.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(BASEDLL_CXXFLAGS) ..\..\src\msw\power.cpp
 
 $(OBJS)\basedll_regconf.obj: ..\..\src\msw\regconf.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASEDLL_CXXFLAGS) ..\..\src\msw\regconf.cpp
@@ -13196,9 +13206,6 @@ $(OBJS)\baselib_object.obj: ..\..\src\common\object.cpp
 $(OBJS)\baselib_platinfo.obj: ..\..\src\common\platinfo.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASELIB_CXXFLAGS) ..\..\src\common\platinfo.cpp
 
-$(OBJS)\baselib_powercmn.obj: ..\..\src\common\powercmn.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(BASELIB_CXXFLAGS) ..\..\src\common\powercmn.cpp
-
 $(OBJS)\baselib_process.obj: ..\..\src\common\process.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASELIB_CXXFLAGS) ..\..\src\common\process.cpp
 
@@ -13339,9 +13346,6 @@ $(OBJS)\baselib_evtloopconsole.obj: ..\..\src\msw\evtloopconsole.cpp
 
 $(OBJS)\baselib_mimetype.obj: ..\..\src\msw\mimetype.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASELIB_CXXFLAGS) ..\..\src\msw\mimetype.cpp
-
-$(OBJS)\baselib_power.obj: ..\..\src\msw\power.cpp
-	$(CXX) /c /nologo /TP /Fo$@ $(BASELIB_CXXFLAGS) ..\..\src\msw\power.cpp
 
 $(OBJS)\baselib_regconf.obj: ..\..\src\msw\regconf.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASELIB_CXXFLAGS) ..\..\src\msw\regconf.cpp
@@ -14202,6 +14206,11 @@ $(OBJS)\coredll_appprogress.obj: ..\..\src\msw\appprogress.cpp
 !if "$(USE_GUI)" == "1"
 $(OBJS)\coredll_taskbarbutton.obj: ..\..\src\msw\taskbarbutton.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\msw\taskbarbutton.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
+$(OBJS)\coredll_power.obj: ..\..\src\msw\power.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\msw\power.cpp
 !endif
 
 !if "$(USE_GUI)" == "1"
@@ -15254,6 +15263,11 @@ $(OBJS)\coredll_bmpsvg.obj: ..\..\src\generic\bmpsvg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\generic\bmpsvg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\coredll_powercmn.obj: ..\..\src\common\powercmn.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\common\powercmn.cpp
+!endif
+
 $(OBJS)\corelib_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) /Ycwx/wxprec.h ..\..\src\common\dummy.cpp
 
@@ -15957,6 +15971,11 @@ $(OBJS)\corelib_appprogress.obj: ..\..\src\msw\appprogress.cpp
 !if "$(USE_GUI)" == "1"
 $(OBJS)\corelib_taskbarbutton.obj: ..\..\src\msw\taskbarbutton.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\msw\taskbarbutton.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
+$(OBJS)\corelib_power.obj: ..\..\src\msw\power.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\msw\power.cpp
 !endif
 
 !if "$(USE_GUI)" == "1"
@@ -17007,6 +17026,11 @@ $(OBJS)\corelib_common_bmpbndl.obj: ..\..\src\common\bmpbndl.cpp
 !if "$(USE_GUI)" == "1"
 $(OBJS)\corelib_bmpsvg.obj: ..\..\src\generic\bmpsvg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\generic\bmpsvg.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
+$(OBJS)\corelib_powercmn.obj: ..\..\src\common\powercmn.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\common\powercmn.cpp
 !endif
 
 $(OBJS)\advdll_dummy.obj: ..\..\src\common\dummy.cpp

--- a/build/msw/wx_base.vcxproj
+++ b/build/msw/wx_base.vcxproj
@@ -942,7 +942,6 @@
     <ClCompile Include="..\..\src\common\numformatter.cpp" />
     <ClCompile Include="..\..\src\common\object.cpp" />
     <ClCompile Include="..\..\src\common\platinfo.cpp" />
-    <ClCompile Include="..\..\src\common\powercmn.cpp" />
     <ClCompile Include="..\..\src\common\process.cpp" />
     <ClCompile Include="..\..\src\common\regex.cpp" />
     <ClCompile Include="..\..\src\common\sstream.cpp" />
@@ -987,7 +986,6 @@
     <ClCompile Include="..\..\src\msw\fswatcher.cpp" />
     <ClCompile Include="..\..\src\msw\main.cpp" />
     <ClCompile Include="..\..\src\msw\mimetype.cpp" />
-    <ClCompile Include="..\..\src\msw\power.cpp" />
     <ClCompile Include="..\..\src\msw\regconf.cpp" />
     <ClCompile Include="..\..\src\msw\registry.cpp" />
     <ClCompile Include="..\..\src\msw\snglinst.cpp" />
@@ -1237,7 +1235,6 @@
     <ClInclude Include="..\..\include\wx\platform.h" />
     <ClInclude Include="..\..\include\wx\platinfo.h" />
     <ClInclude Include="..\..\include\wx\meta\pod.h" />
-    <ClInclude Include="..\..\include\wx\power.h" />
     <ClInclude Include="..\..\include\wx\process.h" />
     <ClInclude Include="..\..\include\wx\ptr_scpd.h" />
     <ClInclude Include="..\..\include\wx\ptr_shrd.h" />

--- a/build/msw/wx_base.vcxproj.filters
+++ b/build/msw/wx_base.vcxproj.filters
@@ -186,9 +186,6 @@
     <ClCompile Include="..\..\src\common\platinfo.cpp">
       <Filter>Common Sources</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\common\powercmn.cpp">
-      <Filter>Common Sources</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\common\process.cpp">
       <Filter>Common Sources</Filter>
     </ClCompile>
@@ -328,9 +325,6 @@
       <Filter>MSW Sources</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\msw\mimetype.cpp">
-      <Filter>MSW Sources</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\msw\power.cpp">
       <Filter>MSW Sources</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\msw\regconf.cpp">
@@ -740,9 +734,6 @@
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\platinfo.h">
-      <Filter>Common Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\wx\power.h">
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\process.h">

--- a/build/msw/wx_core.vcxproj
+++ b/build/msw/wx_core.vcxproj
@@ -1724,6 +1724,8 @@
     <ClCompile Include="..\..\src\generic\rowheightcache.cpp" />
     <ClCompile Include="..\..\src\generic\creddlgg.cpp" />
     <ClCompile Include="..\..\src\msw\overlay.cpp" />
+    <ClCompile Include="..\..\src\msw\power.cpp" />
+    <ClCompile Include="..\..\src\common\powercmn.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\msw\version.rc">
@@ -2184,6 +2186,7 @@
     <ClInclude Include="..\..\include\wx\compositebookctrl.h" />
     <ClInclude Include="..\..\include\wx\msw\darkmode.h" />
     <ClInclude Include="..\..\include\wx\persist\combobox.h" />
+    <ClInclude Include="..\..\include\wx\power.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/msw/wx_core.vcxproj.filters
+++ b/build/msw/wx_core.vcxproj.filters
@@ -339,6 +339,9 @@
     <ClCompile Include="..\..\src\common\popupcmn.cpp">
       <Filter>Common Sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\common\powercmn.cpp">
+      <Filter>Common Sources</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\common\preferencescmn.cpp">
       <Filter>Common Sources</Filter>
     </ClCompile>
@@ -949,6 +952,9 @@
       <Filter>MSW Sources</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\msw\popupwin.cpp">
+      <Filter>MSW Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\msw\power.cpp">
       <Filter>MSW Sources</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\msw\printdlg.cpp">
@@ -2078,6 +2084,9 @@
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\position.h">
+      <Filter>Common Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\wx\power.h">
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\preferences.h">

--- a/include/wx/power.h
+++ b/include/wx/power.h
@@ -44,7 +44,7 @@ enum wxBatteryState
 
 #define wxHAS_POWER_EVENTS
 
-class WXDLLIMPEXP_BASE wxPowerEvent : public wxEvent
+class WXDLLIMPEXP_CORE wxPowerEvent : public wxEvent
 {
 public:
     wxPowerEvent()            // just for use by wxRTTI
@@ -71,10 +71,10 @@ private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(wxPowerEvent);
 };
 
-wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_BASE, wxEVT_POWER_SUSPENDING, wxPowerEvent );
-wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_BASE, wxEVT_POWER_SUSPENDED, wxPowerEvent );
-wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_BASE, wxEVT_POWER_SUSPEND_CANCEL, wxPowerEvent );
-wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_BASE, wxEVT_POWER_RESUME, wxPowerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_POWER_SUSPENDING, wxPowerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_POWER_SUSPENDED, wxPowerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_POWER_SUSPEND_CANCEL, wxPowerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_POWER_RESUME, wxPowerEvent );
 
 typedef void (wxEvtHandler::*wxPowerEventFunction)(wxPowerEvent&);
 
@@ -110,7 +110,7 @@ enum wxPowerBlockKind
     wxPOWER_DELAY
 };
 
-class WXDLLIMPEXP_BASE wxPowerResource
+class WXDLLIMPEXP_CORE wxPowerResource
 {
 public:
     static bool Acquire(wxPowerResourceKind kind,
@@ -150,9 +150,9 @@ private:
 // ----------------------------------------------------------------------------
 
 // return the current system power state: online or offline
-WXDLLIMPEXP_BASE wxPowerType wxGetPowerType();
+WXDLLIMPEXP_CORE wxPowerType wxGetPowerType();
 
 // return approximate battery state
-WXDLLIMPEXP_BASE wxBatteryState wxGetBatteryState();
+WXDLLIMPEXP_CORE wxBatteryState wxGetBatteryState();
 
 #endif // _WX_POWER_H_

--- a/interface/wx/power.h
+++ b/interface/wx/power.h
@@ -130,7 +130,7 @@ enum wxPowerBlockKind
            the state in which it had been before the suspension.
     @endEventTable
 
-    @library{wxbase}
+    @library{wxcore}
     @category{events}
 
     @see ::wxGetPowerType(), ::wxGetBatteryState()
@@ -174,7 +174,7 @@ wxEventType wxEVT_POWER_RESUME;
     called instead of calling it manually.
 
     @since 3.1.0
-    @library{wxbase}
+    @library{wxcore}
     @category{misc}
 
     @see wxPowerResourceBlocker
@@ -263,7 +263,7 @@ public:
     @endcode
 
     @since 3.1.0
-    @library{wxbase}
+    @library{wxcore}
     @category{misc}
 
     @see wxPowerResource


### PR DESCRIPTION
These classes can't be implemented in the base library any more as the Linux implementation uses glib and so can only be part of wxGTK.