### PR TITLE
Fix compilation of Qt port

### DIFF
--- a/include/wx/qt/private/converter.h
+++ b/include/wx/qt/private/converter.h
@@ -16,6 +16,7 @@
 #include "wx/kbdstate.h"
 #include "wx/gdicmn.h"
 #include "wx/colour.h"
+#include "wx/geometry.h"
 
 #include <QtCore/QRect>
 #include <QtCore/QSize>


### PR DESCRIPTION
Add missing `#include "wx/geometry.h"`.

Broken by 734face (Add support for raw touch events, 2025-01-08).