### PR TITLE
Leave PCH enabled just for one wxGTK build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           - name: Ubuntu 18.04 wxGTK 3 compatible 3.0
             runner: ubuntu-latest
             container: ubuntu:18.04
-            configure_flags: --enable-compat30
+            configure_flags: --enable-compat30 --enable-pch
             use_xvfb: true
           - name: Ubuntu 20.04 wxGTK 3 with clang
             runner: ubuntu-latest
@@ -126,18 +126,18 @@ jobs:
           - name: Ubuntu 18.04 wxX11
             runner: ubuntu-latest
             container: ubuntu:18.04
-            configure_flags: --with-x11 --enable-pch --disable-stc
+            configure_flags: --with-x11 --disable-stc
             skip_samples: true
           - name: Ubuntu 18.04 wxDFB
             runner: ubuntu-latest
             container: ubuntu:18.04
-            configure_flags: --with-directfb --enable-pch --disable-stc
+            configure_flags: --with-directfb --disable-stc
             skip_samples: true
             allow_warnings: true
           - name: Ubuntu 18.04 wxQt
             runner: ubuntu-latest
             container: ubuntu:18.04
-            configure_flags: --with-qt --enable-pch --without-opengl
+            configure_flags: --with-qt --without-opengl
             skip_samples: true
             use_xvfb: true
 

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1997,8 +1997,7 @@ void MyFrame::OnNotebookPageChanging(wxAuiNotebookEvent& evt)
 
 void MyFrame::OnNotebookTabRightClick(wxAuiNotebookEvent& evt)
 {
-    wxPoint pt;
-    wxGetMousePosition(&pt.x, &pt.y);
+    wxPoint pt = wxGetMousePosition();
 
     auto* const book =
         wxCheckCast<wxAuiNotebook>(m_mgr.GetPane("notebook_content").window);

--- a/src/common/cshelp.cpp
+++ b/src/common/cshelp.cpp
@@ -31,7 +31,6 @@
 
 #if wxUSE_MS_HTML_HELP
     #include "wx/msw/helpchm.h"     // for ShowContextHelpPopup
-    #include "wx/utils.h"           // for wxGetMousePosition()
 #endif
 
 // ----------------------------------------------------------------------------

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -43,6 +43,7 @@
     #include "wx/sizer.h"
     #include "wx/menu.h"
     #include "wx/button.h"
+    #include "wx/utils.h"
 #endif //WX_PRECOMP
 
 #if wxUSE_DRAG_AND_DROP
@@ -3702,6 +3703,13 @@ wxString wxDumpWindow(const wxWindowBase* win)
     s += ")";
 
     return s;
+}
+
+wxPoint wxGetMousePosition()
+{
+    wxPoint pt;
+    wxGetMousePosition(&pt.x, &pt.y);
+    return pt;
 }
 
 #if wxUSE_ACCESSIBILITY

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3712,6 +3712,12 @@ wxPoint wxGetMousePosition()
     return pt;
 }
 
+wxWindow* wxFindWindowAtPointer(wxPoint& pt)
+{
+    pt = wxGetMousePosition();
+    return wxFindWindowAtPoint(pt);
+}
+
 #if wxUSE_ACCESSIBILITY
 // ----------------------------------------------------------------------------
 // accessible object for windows

--- a/src/dfb/utils.cpp
+++ b/src/dfb/utils.cpp
@@ -104,13 +104,6 @@ void wxGetMousePosition(int *x, int *y)
         layer->GetCursorPosition(x, y);
 }
 
-wxPoint wxGetMousePosition()
-{
-    wxPoint pt;
-    wxGetMousePosition(&pt.x, &pt.y);
-    return pt;
-}
-
 //-----------------------------------------------------------------------------
 // keyboard
 //-----------------------------------------------------------------------------

--- a/src/dfb/window.cpp
+++ b/src/dfb/window.cpp
@@ -1039,13 +1039,6 @@ void wxWindowDFB::HandleKeyEvent(const wxDFBWindowEvent& event_)
     }
 }
 
-// Find the wxWindow at the current mouse position, returning the mouse
-// position.
-wxWindow* wxFindWindowAtPointer(wxPoint& pt)
-{
-    return wxFindWindowAtPoint(pt = wxGetMousePosition());
-}
-
 wxWindow* wxFindWindowAtPoint(const wxPoint& WXUNUSED(pt))
 {
     wxFAIL_MSG( "wxFindWindowAtPoint not implemented" );

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6922,13 +6922,6 @@ void wxGetMousePosition(int* x, int* y)
 #endif
 }
 
-wxPoint wxGetMousePosition()
-{
-    wxPoint pt;
-    wxGetMousePosition(&pt.x, &pt.y);
-    return pt;
-}
-
 GdkWindow* wxWindowGTK::GTKGetDrawingWindow() const
 {
     GdkWindow* window = nullptr;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6893,15 +6893,6 @@ void wxWindowGTK::GTKScrolledWindowSetBorder(GtkWidget* w, int wxstyle)
     }
 }
 
-// Find the wxWindow at the current mouse position, also returning the mouse
-// position.
-wxWindow* wxFindWindowAtPointer(wxPoint& pt)
-{
-    pt = wxGetMousePosition();
-    wxWindow* found = wxFindWindowAtPoint(pt);
-    return found;
-}
-
 // Get the current mouse position.
 void wxGetMousePosition(int* x, int* y)
 {

--- a/src/msw/utilsgui.cpp
+++ b/src/msw/utilsgui.cpp
@@ -102,11 +102,9 @@ bool wxCheckForInterrupt(wxWindow *wnd)
 }
 
 // ----------------------------------------------------------------------------
-// get display info
+// get mouse position
 // ----------------------------------------------------------------------------
 
-// See also the wxGetMousePosition in window.cpp
-// Deprecated: use wxPoint wxGetMousePosition() instead
 void wxGetMousePosition( int* x, int* y )
 {
     POINT pt;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -7801,14 +7801,6 @@ static TEXTMETRIC wxGetTextMetrics(const wxWindowMSW *win)
     return tm;
 }
 
-// Find the wxWindow at the current mouse position, returning the mouse
-// position.
-wxWindow* wxFindWindowAtPointer(wxPoint& pt)
-{
-    pt = wxGetMousePosition();
-    return wxFindWindowAtPoint(pt);
-}
-
 wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
 {
     POINT pt2;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -7840,15 +7840,6 @@ wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
     return wxGetWindowFromHWND((WXHWND)hWnd);
 }
 
-// Get the current mouse position.
-wxPoint wxGetMousePosition()
-{
-    POINT pt;
-    wxGetCursorPosMSW(&pt);
-
-    return wxPoint(pt.x, pt.y);
-}
-
 #if wxUSE_HOTKEY
 
 bool wxWindowMSW::RegisterHotKey(int hotkeyId, int modifiers, int keycode)

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2307,16 +2307,6 @@ long wxWindowMac::MacRemoveBordersFromStyle( long style )
     return style & ~wxBORDER_MASK ;
 }
 
-// Find the wxWindowMac at the current mouse position, returning the mouse
-// position.
-wxWindow * wxFindWindowAtPointer( wxPoint& pt )
-{
-    pt = wxGetMousePosition();
-    wxWindowMac* found = wxFindWindowAtPoint(pt);
-
-    return (wxWindow*) found;
-}
-
 void wxWindowMac::OnMouseEvent( wxMouseEvent &event )
 {
     if ( event.GetEventType() == wxEVT_RIGHT_DOWN )

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2317,16 +2317,6 @@ wxWindow * wxFindWindowAtPointer( wxPoint& pt )
     return (wxWindow*) found;
 }
 
-// Get the current mouse position.
-wxPoint wxGetMousePosition()
-{
-    int x, y;
-
-    wxGetMousePosition( &x, &y );
-
-    return wxPoint(x, y);
-}
-
 void wxWindowMac::OnMouseEvent( wxMouseEvent &event )
 {
     if ( event.GetEventType() == wxEVT_RIGHT_DOWN )

--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -44,17 +44,14 @@ void wxQtFillMouseButtons( Qt::MouseButtons buttons, wxMouseState *state )
 }
 
 #if wxUSE_GUI
-wxPoint wxGetMousePosition()
-{
-    return wxQtConvertPoint( QCursor::pos() );
-}
-
 void wxGetMousePosition( int *x, int *y )
 {
-    wxPoint position = wxGetMousePosition();
+    const auto position = QCursor::pos();
 
-    *x = position.x;
-    *y = position.y;
+    if ( x )
+        *x = position.x();
+    if ( y )
+        *y = position.y();
 }
 #endif
 

--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -76,13 +76,6 @@ wxWindow *wxFindWindowAtPoint(const wxPoint& pt)
     return wxGenericFindWindowAtPoint( pt );
 }
 
-wxWindow *wxFindWindowAtPointer(wxPoint& pt)
-{
-    pt = wxQtConvertPoint( QCursor::pos() );
-
-    return wxFindWindowAtPoint( pt );
-}
-
 bool wxGetKeyState(wxKeyCode key)
 {
     /* FIXME: Qt doesn't provide a method to check the state of keys others

--- a/src/x11/window.cpp
+++ b/src/x11/window.cpp
@@ -1654,14 +1654,6 @@ wxWindow *wxWindowBase::GetCapture()
 }
 
 
-// Find the wxWindow at the current mouse position, returning the mouse
-// position.
-wxWindow* wxFindWindowAtPointer(wxPoint& pt)
-{
-    pt = wxGetMousePosition();
-    return wxFindWindowAtPoint(pt);
-}
-
 void wxGetMouseState(int& rootX, int& rootY, unsigned& maskReturn)
 {
 #if wxUSE_NANOX

--- a/src/x11/window.cpp
+++ b/src/x11/window.cpp
@@ -1682,16 +1682,6 @@ void wxGetMouseState(int& rootX, int& rootY, unsigned& maskReturn)
 #endif
 }
 
-// Get the current mouse position.
-wxPoint wxGetMousePosition()
-{
-    int x, y;
-    unsigned mask;
-
-    wxGetMouseState(x, y, mask);
-    return wxPoint(x, y);
-}
-
 wxMouseState wxGetMouseState()
 {
     wxMouseState ms;

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -12,10 +12,10 @@
 
 #include "testprec.h"
 
+#include "wx/bitmap.h"
+
 #ifdef wxHAS_RAW_BITMAP
 
-
-#include "wx/bitmap.h"
 #include "wx/rawbmp.h"
 #include "wx/dcmemory.h"
 #include "wx/dcsvg.h"


### PR DESCRIPTION
Disable it for wxX11, wxDFB and wxQt builds as this helps to catch
errors hidden when using PCH.

See #25176.
