### PR TITLE
Add wxImage::Scale() and Rescale() overloads taking wxSize

### DIFF
--- a/include/wx/image.h
+++ b/include/wx/image.h
@@ -352,6 +352,9 @@ public:
     // return the new image with size width*height
     wxImage Scale( int width, int height,
                    wxImageResizeQuality quality = wxIMAGE_QUALITY_NORMAL ) const;
+    wxImage Scale(const wxSize& size,
+                  wxImageResizeQuality quality = wxIMAGE_QUALITY_NORMAL) const
+        { return Scale(size.GetWidth(), size.GetHeight(), quality); }
 
     // box averager and bicubic filters for up/down sampling
     wxImage ResampleNearest(int width, int height) const;
@@ -370,6 +373,9 @@ public:
     wxImage& Rescale( int width, int height,
                       wxImageResizeQuality quality = wxIMAGE_QUALITY_NORMAL )
         { return *this = Scale(width, height, quality); }
+    wxImage& Rescale( const wxSize& size,
+                      wxImageResizeQuality quality = wxIMAGE_QUALITY_NORMAL )
+        { return *this = Scale(size, quality); }
 
     // resizes the image in place
     wxImage& Resize( const wxSize& size, const wxPoint& pos,

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -877,9 +877,15 @@ public:
         For a description of the @a quality parameter, see the Scale() function.
         Returns the (modified) image itself.
 
+        Overload taking wxSize is only available since wxWidgets 3.3.0.
+
         @see Scale()
     */
     wxImage& Rescale(int width, int height,
+                     wxImageResizeQuality quality = wxIMAGE_QUALITY_NORMAL);
+
+    /// @overload
+    wxImage& Rescale(const wxSize& size,
                      wxImageResizeQuality quality = wxIMAGE_QUALITY_NORMAL);
 
     /**
@@ -1008,10 +1014,16 @@ public:
         for 32-bit programs. For 64-bit programs the limit is 2^48 and so not
         relevant in practice.
 
+        The overload taking a wxSize is only available since wxWidgets 3.3.0.
+
         @see Rescale()
     */
     wxImage Scale(int width, int height,
                    wxImageResizeQuality quality = wxIMAGE_QUALITY_NORMAL) const;
+
+    /// @overload
+    wxImage Scale(const wxSize& size,
+                  wxImageResizeQuality quality = wxIMAGE_QUALITY_NORMAL) const;
 
     /**
         Returns a resized version of this image without scaling it by adding either a

--- a/samples/image/image.cpp
+++ b/samples/image/image.cpp
@@ -462,9 +462,7 @@ private:
     void OnResize(wxCommandEvent& WXUNUSED(event))
     {
         wxImage img(m_bitmap.ConvertToImage());
-
-        const wxSize size = GetClientSize();
-        img.Rescale(size.x, size.y, wxIMAGE_QUALITY_HIGH);
+        img.Rescale(GetClientSize(), wxIMAGE_QUALITY_HIGH);
         m_bitmap = wxBitmap(img);
 
         UpdateStatusBar();

--- a/samples/splash/splash.cpp
+++ b/samples/splash/splash.cpp
@@ -263,7 +263,7 @@ void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
 
         // do not scale on already small screens
         if (!m_isPda)
-            image.Rescale( bitmap.GetWidth()/2, bitmap.GetHeight()/2 );
+            image.Rescale(bitmap.GetSize()/2);
 
         bitmap = wxBitmap(image);
         wxSplashScreen *splash = new wxSplashScreen(bitmap,

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -584,7 +584,7 @@ void MyFrame::PopulateToolbar(wxToolBarBase* toolBar)
                     // anything.
                     wxImage image = m_image;
                     if ( image.GetSize() != size )
-                        image.Rescale(size.x, size.y, wxIMAGE_QUALITY_HIGH);
+                        image.Rescale(size, wxIMAGE_QUALITY_HIGH);
 
                     // This is required under MSW in order to be able to draw
                     // over the bitmap using wxDC. For full alpha support,

--- a/src/common/animatecmn.cpp
+++ b/src/common/animatecmn.cpp
@@ -203,7 +203,7 @@ void wxAnimationCtrlBase::UpdateStaticImage()
         {
             // the user-provided bitmap is bigger than our control, strech it
             wxImage temp(bmpCurrent.ConvertToImage());
-            temp.Rescale(sz.GetWidth(), sz.GetHeight(), wxIMAGE_QUALITY_HIGH);
+            temp.Rescale(sz, wxIMAGE_QUALITY_HIGH);
             m_bmpStaticReal = wxBitmap(temp);
         }
     }

--- a/src/common/bmpbase.cpp
+++ b/src/common/bmpbase.cpp
@@ -76,7 +76,7 @@ void wxBitmapHelpers::Rescale(wxBitmap& bmp, const wxSize& sizeNeeded)
 
 #if wxUSE_IMAGE
     wxImage img = bmp.ConvertToImage();
-    img.Rescale(sizeNeeded.x, sizeNeeded.y);
+    img.Rescale(sizeNeeded);
     bmp = wxBitmap(img);
 #else // !wxUSE_IMAGE
     // Fallback method of scaling the bitmap

--- a/src/generic/dirctrlg.cpp
+++ b/src/generic/dirctrlg.cpp
@@ -1497,7 +1497,7 @@ int wxFileIconsTable::GetIconID(const wxString& extension, const wxString& mime)
 #endif
             {
                 // Double, using normal quality scaling.
-                img.Rescale(2*img.GetWidth(), 2*img.GetHeight());
+                img.Rescale(2*img.GetSize());
 
                 // Then scale to the desired size. This gives the best quality,
                 // and better than CreateAntialiasedBitmap.

--- a/src/propgrid/advprops.cpp
+++ b/src/propgrid/advprops.cpp
@@ -1964,7 +1964,7 @@ void wxImageFileProperty::OnCustomPaint( wxDC& dc,
         if ( !m_bitmap.IsOk() )
         {
             wxImage imgScaled = m_image;
-            imgScaled.Rescale(rect.width, rect.height);
+            imgScaled.Rescale(rect.GetSize());
             m_bitmap = wxBitmap(imgScaled, dc);
         }
     }

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -70,7 +70,7 @@ wxBitmap MakeResizedBitmap(const wxBitmap& original, wxSize size)
         scale = 2.0;
 
     wxImage img(original.ConvertToImage());
-    img.Rescale(int(scale * size.GetWidth()), int(scale * size.GetHeight()), wxIMAGE_QUALITY_HIGH);
+    img.Rescale(scale * size, wxIMAGE_QUALITY_HIGH);
     return wxBitmap(img, -1, scale);
 }
 

--- a/src/ribbon/panel.cpp
+++ b/src/ribbon/panel.cpp
@@ -711,9 +711,7 @@ bool wxRibbonPanel::Realize()
                 scale = 2.0;
 
             wxImage img(m_minimised_icon.ConvertToImage());
-            img.Rescale(wxRound(scale * bitmap_size.GetWidth()),
-                        wxRound(scale * bitmap_size.GetHeight()),
-                        wxIMAGE_QUALITY_HIGH);
+            img.Rescale(scale * bitmap_size, wxIMAGE_QUALITY_HIGH);
             m_minimised_icon_resized = wxBitmap(img, -1, scale);
         }
         else

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -12731,7 +12731,7 @@ bool wxRichTextImage::LoadAndScaleImageCache(wxImage& image, const wxSize& sz, w
             wxImage img;
             if (image.GetWidth() <= upscaleThreshold || image.GetHeight() <= upscaleThreshold)
             {
-                img = image.Scale(image.GetWidth()*2, image.GetHeight()*2);
+                img = image.Scale(2*image.GetSize());
                 img.Rescale(width*scaleFactor, height*scaleFactor, wxIMAGE_QUALITY_HIGH);
             }
             else

--- a/src/univ/topluniv.cpp
+++ b/src/univ/topluniv.cpp
@@ -337,7 +337,7 @@ void wxTopLevelWindow::SetIcons(const wxIconBundle& icons)
             else
             {
                 wxImage img = bmp1.ConvertToImage();
-                img.Rescale(size.x, size.y);
+                img.Rescale(size);
                 m_titlebarIcon.CopyFromBitmap(wxBitmap(img));
             }
 #endif // wxUSE_IMAGE

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -1900,7 +1900,8 @@ wxBitmap LoadBitmapFromFS(wxXmlResourceHandlerImpl* impl,
         );
         return wxNullBitmap;
     }
-    if (!(size == wxDefaultSize)) img.Rescale(size.x, size.y);
+    if (size != wxDefaultSize)
+        img.Rescale(size);
     return wxBitmap(img);
 }
 


### PR DESCRIPTION
Use them in the code where this is more convenient than using individual components.

No real changes, just make resizing the images a bit more convenient.