### PR TITLE
Assume all strings use UTF-8 encoding if wxUSE_UTF8_LOCALE_ONLY=1

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -405,8 +405,10 @@ more details.
 @itemdef{wxNO_IMPLICIT_WXSTRING_ENCODING,
         this symbol is not defined by wxWidgets itself, but can be defined by
         the applications using the library to disable implicit
-        conversions from and to <tt>const char*</tt> in wxString class.
-        Support for this option appeared in wxWidgets 3.1.4.}
+        conversions from and to <tt>const char*</tt> without specifying its
+        encoding in wxString class. Note that this option is incompatible with
+        @c wxUSE_UTF8_LOCALE_ONLY, as all strings are implicitly assumed to use
+        UTF-8 then. Support for this option appeared in wxWidgets 3.1.4.}
 @itemdef{wxNO_REQUIRE_LITERAL_MSGIDS,
         this symbol is not defined by wxWidgets itself, but can be defined by
         the applications using the library to allow variables as string arguments to

--- a/include/wx/strconv.h
+++ b/include/wx/strconv.h
@@ -704,17 +704,24 @@ inline wxCharBuffer wxSafeConvertWX2MB(const wchar_t *ws)
 }
 
 // Macro that indicates the default encoding for converting C strings
-// to wxString. It provides a default value for a const wxMBConv&
-// parameter (i.e. wxConvLibc) unless wxNO_IMPLICIT_WXSTRING_ENCODING
-// is defined.
+// to wxString. There are 3 possible cases:
 //
-// Intended use:
+//  - In UTF-8-only build, all strings are supposed to use UTF-8.
+//  - If wxNO_IMPLICIT_WXSTRING_ENCODING is defined, the conversion must be
+//    always specified explicitly. This forbids error prone implicit
+//    conversions (note that this is incompatible with UTF-8-only build).
+//  - Otherwise strings are considered to use current locale encoding.
+//
+// It is used to provide a default value for const wxMBConv& parameters, i.e.
+// its intended use is:
 // wxString(const char *data, ...,
 //          const wxMBConv &conv wxSTRING_DEFAULT_CONV_ARG);
-#ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
-#define wxSTRING_DEFAULT_CONV_ARG = wxConvLibc
-#else
+#if wxUSE_UTF8_LOCALE_ONLY
+#define wxSTRING_DEFAULT_CONV_ARG = wxConvUTF8
+#elif defined(wxNO_IMPLICIT_WXSTRING_ENCODING)
 #define wxSTRING_DEFAULT_CONV_ARG
+#else
+#define wxSTRING_DEFAULT_CONV_ARG = wxConvLibc
 #endif
 
 #endif // _WX_STRCONV_H_


### PR DESCRIPTION
In UTF-8-only build it makes more sense to assume that all strings are in UTF-8 and not the current locale encoding (even if it will often be UTF-8 too anyhow), this is consistent with the existing documentation of this build option.

See #25127.