### PR TITLE
Serialize and restore wxAUI pane visibility too

### DIFF
--- a/include/wx/aui/serializer.h
+++ b/include/wx/aui/serializer.h
@@ -65,11 +65,16 @@ struct wxAuiPaneLayoutInfo : wxAuiDockLayoutInfo
     wxSize floating_size = wxDefaultSize;
 
 
+    // The remaining fields correspond to individual bits of the pane state
+    // flags instead of corresponding to wxAuiPaneInfo fields directly because
+    // we prefer not storing the entire state -- this would be less readable
+    // and extensible.
+
     // True if the pane is currently maximized.
-    //
-    // Note that it's the only field of this struct which doesn't directly
-    // correspond to a field of wxAuiPaneInfo.
     bool is_maximized   = false;
+
+    // True if the pane is currently hidden.
+    bool is_hidden      = false;
 };
 
 // wxAuiBookSerializer is used for serializing wxAuiNotebook layout.

--- a/interface/wx/aui/serializer.h
+++ b/interface/wx/aui/serializer.h
@@ -67,8 +67,9 @@ struct wxAuiTabLayoutInfo : wxAuiDockLayoutInfo
     This struct is used with wxAuiSerializer and wxAuiDeserializer to store the
     pane layout. Its fields, including the inherited ones from
     wxAuiDockLayoutInfo, have the same meaning as the corresponding fields in
-    wxAuiPaneInfo (with the exception of `is_maximized`), but it doesn't
-    contain the fields that it wouldn't make sense to serialize.
+    wxAuiPaneInfo (with the exception of `is_maximized` and `is_hidden`, which
+    rather correspond to the individual bits of its state field), but it
+    doesn't contain the fields that it wouldn't make sense to serialize.
 
     @since 3.3.0
  */
@@ -91,6 +92,9 @@ struct wxAuiPaneLayoutInfo : wxAuiDockLayoutInfo
 
     /// True if the pane is currently maximized.
     bool is_maximized   = false;
+
+    /// True if the pane is currently hidden.
+    bool is_hidden      = false;
 };
 
 /**

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -1587,6 +1587,10 @@ public:
         if ( pane.is_maximized )
             AddChild(node, "maximized", 1);
 
+        // Also don't mark visible pages (as most of them are) as being so.
+        if ( pane.is_hidden )
+            AddChild(node, "hidden", 1);
+
         m_panes->AddChild(node);
     }
 
@@ -1778,6 +1782,10 @@ public:
                     else if ( name == "maximized" )
                     {
                         pane.is_maximized = GetInt(content) != 0;
+                    }
+                    else if ( name == "hidden" )
+                    {
+                        pane.is_hidden = GetInt(content) != 0;
                     }
                     else
                     {

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -1438,6 +1438,7 @@ wxAuiManager::CopyLayoutFrom(wxAuiPaneLayoutInfo& layoutInfo,
     layoutInfo.floating_size = pane.floating_size;
 
     layoutInfo.is_maximized = pane.HasFlag(wxAuiPaneInfo::optionMaximized);
+    layoutInfo.is_hidden = pane.HasFlag(wxAuiPaneInfo::optionHidden);
 }
 
 void
@@ -1450,6 +1451,7 @@ wxAuiManager::CopyLayoutTo(const wxAuiPaneLayoutInfo& layoutInfo,
     pane.floating_size = layoutInfo.floating_size;
 
     pane.SetFlag(wxAuiPaneInfo::optionMaximized, layoutInfo.is_maximized);
+    pane.SetFlag(wxAuiPaneInfo::optionHidden, layoutInfo.is_hidden);
 }
 
 void wxAuiManager::SaveLayout(wxAuiSerializer& serializer) const


### PR DESCRIPTION
Panes may be hidden by user, so it makes sense to store their visibility as part of the serialized representation to be able to restore the same visual layout later.