### PR TITLE
Add support for pinned and locked tabs to wxAUI

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -121,6 +121,13 @@ Changes in behaviour not resulting in compilation errors
   under all platforms instead of behaving as SetValue() under MSW and doing
   nothing elsewhere.
 
+- If you have a custom class deriving from wxAuiGenericTabArt, possibly
+  indirectly, e.g. via wxAuiMSWTabArt, you need to update it to override the
+  new virtual functions DrawPageTab() and GetPageTabSize() instead of
+  overriding the old DrawTab() and GetTabSize(). Note that this is not needed
+  if your class inherits directly from wxAuiTabArt, as it will continue to work
+  in this case (but switching to the new functions is still recommended).
+
 - The meaning of page index in wxAuiNotebook has changed if the pages have
   been reordered (see wxAUI_NB_TAB_MOVE) and now always refers to the page
   logical index, which is not affected by reordering. To get the position of

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -150,6 +150,7 @@ public:
     bool AddPage(const wxAuiNotebookPage& info);
     bool InsertPage(const wxAuiNotebookPage& info, size_t idx);
     bool MovePage(wxWindow* page, size_t newIdx);
+    bool MovePage(size_t oldIdx, size_t newIdx);
     bool RemovePage(wxWindow* page);
     void RemovePageAt(size_t idx);
     bool SetActivePage(wxWindow* page);

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -685,6 +685,13 @@ private:
 
     TabInfo FindTab(wxWindow* page) const;
 
+    // Return the index at which the given page should be inserted in this tab
+    // control if it's dropped at the given (in screen coordinates) point or
+    // wxNOT_FOUND if dropping it is not allowed.
+    int GetDropIndex(const wxAuiNotebookPage& srcPage,
+                     wxAuiTabCtrl* tabCtrl,
+                     const wxPoint& ptScreen) const;
+
 #ifndef SWIG
     wxDECLARE_CLASS(wxAuiNotebook);
     wxDECLARE_EVENT_TABLE();

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -52,6 +52,7 @@ enum wxAuiNotebookOption
     wxAUI_NB_MIDDLE_CLICK_CLOSE  = 1 << 13,
     wxAUI_NB_MULTILINE           = 1 << 14,
     wxAUI_NB_PIN_ON_ACTIVE_TAB   = 1 << 15,
+    wxAUI_NB_UNPIN_ON_ALL_PINNED = 1 << 16,
 
     wxAUI_NB_DEFAULT_STYLE = wxAUI_NB_TOP |
                              wxAUI_NB_TAB_SPLIT |

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -119,10 +119,19 @@ public:
 class WXDLLIMPEXP_AUI wxAuiTabContainerButton
 {
 public:
+    wxAuiTabContainerButton() = default;
 
-    int id;               // button's id
-    int curState;        // current state (normal, hover, pressed, etc.)
-    int location;         // buttons location (wxLEFT, wxRIGHT, or wxCENTER)
+    wxAuiTabContainerButton(
+            int id_,
+            int location_,
+            wxAuiPaneButtonState curState_ = wxAUI_BUTTON_STATE_NORMAL
+        ) : id(id_), curState(curState_), location(location_)
+    {
+    }
+
+    int id = 0;               // button's id
+    int curState = 0;         // current state (normal, hover, pressed, etc.)
+    int location = 0;         // buttons location (wxLEFT, wxRIGHT, or wxCENTER)
     wxBitmapBundle bitmap;    // button's hover bitmap
     wxBitmapBundle disBitmap; // button's disabled bitmap
     wxRect rect;          // button's hit rectangle

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -90,6 +90,15 @@ private:
 };
 
 
+// Possible tab states.
+enum class wxAuiTabKind
+{
+    Normal, // Can be closed and dragged by user.
+    Pinned, // Can be closed but can't be dragged. Can be unpinned by user.
+    Locked  // Can't be closed, dragged nor unlocked by user.
+};
+
+
 class WXDLLIMPEXP_AUI wxAuiNotebookPage
 {
 public:
@@ -97,7 +106,9 @@ public:
     wxString caption;     // caption displayed on the tab
     wxString tooltip;     // tooltip displayed when hovering over tab title
     wxBitmapBundle bitmap;// tab's bitmap
-    wxRect rect;          // tab's hit rectangle
+    wxAuiTabKind kind = wxAuiTabKind::Normal; // tab's kind
+
+    wxRect rect;          // tab's hit rectangle (only used internally)
     bool active = false;  // true if the page is currently active
 
     // These fields are internal, don't use them.
@@ -267,6 +278,11 @@ public:
         return LayoutMultiLineTabs(m_rect, wnd);
     }
 
+    // Get the index of the first tab of the given kind or of a different kind,
+    // returning GetPageCount() if there is no such tabs.
+    int GetFirstTabOfKind(wxAuiTabKind kind) const;
+    int GetFirstTabNotOfKind(wxAuiTabKind kind) const;
+
 protected:
 
     virtual void Render(wxDC* dc, wxWindow* wnd);
@@ -284,13 +300,12 @@ protected:
     size_t m_tabOffset;
     unsigned int m_flags;
 
-    int GetCloseButtonState(const wxAuiNotebookPage& page) const
-    {
-        return GetCloseButtonState(page.active);
-    }
+    // Return wxAUI_BUTTON_STATE_{NORMAL,HIDDEN} corresponding to the current
+    // flags and the kind and state of the page.
+    int GetCloseButtonState(const wxAuiNotebookPage& page) const;
 
     // Return wxAUI_BUTTON_STATE_{NORMAL,HIDDEN} corresponding to the current
-    // flags and the state of the page.
+    // flags and the given active state.
     int GetCloseButtonState(bool isPageActive) const;
 
 private:
@@ -459,6 +474,9 @@ public:
 
     bool SetPageBitmap(size_t page, const wxBitmapBundle& bitmap);
     wxBitmap GetPageBitmap(size_t pageIdx) const;
+
+    wxAuiTabKind GetPageKind(size_t pageIdx) const;
+    bool SetPageKind(size_t pageIdx, wxAuiTabKind kind);
 
     int SetSelection(size_t newPage) override;
     int GetSelection() const override;

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -302,11 +302,11 @@ protected:
 
     // Return wxAUI_BUTTON_STATE_{NORMAL,HIDDEN} corresponding to the current
     // flags and the kind and state of the page.
-    int GetCloseButtonState(const wxAuiNotebookPage& page) const;
+    wxAuiPaneButtonState GetCloseButtonState(const wxAuiNotebookPage& page) const;
 
     // Return wxAUI_BUTTON_STATE_{NORMAL,HIDDEN} corresponding to the current
     // flags and the given active state.
-    int GetCloseButtonState(bool isPageActive) const;
+    wxAuiPaneButtonState GetCloseButtonState(bool isPageActive) const;
 
 private:
     // Return the width that can be used for the tabs, i.e. without the space

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -294,7 +294,10 @@ protected:
     // Contains pages in the display order.
     wxAuiNotebookPageArray m_pages;
 
-    wxAuiTabContainerButtonArray m_buttons;
+    // This vector contains container-level buttons, e.g. left/right scroll
+    // buttons, close button if it's not per-tab, window list button etc.
+    std::vector<wxAuiTabContainerButton> m_buttons;
+
     wxAuiTabContainerButtonArray m_tabCloseButtons;
     wxRect m_rect;
     size_t m_tabOffset;

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -51,6 +51,7 @@ enum wxAuiNotebookOption
     wxAUI_NB_CLOSE_ON_ALL_TABS   = 1 << 12,
     wxAUI_NB_MIDDLE_CLICK_CLOSE  = 1 << 13,
     wxAUI_NB_MULTILINE           = 1 << 14,
+    wxAUI_NB_TAB_PIN             = 1 << 15,
 
     wxAUI_NB_DEFAULT_STYLE = wxAUI_NB_TOP |
                              wxAUI_NB_TAB_SPLIT |
@@ -136,6 +137,10 @@ public:
     // These fields are internal, don't use them.
     bool hover = false;   // true if mouse hovering over tab
     bool rowEnd = false;  // true if the tab is the last in the row
+
+    // This vector contains per-page buttons, i.e. "close" and, optionally,
+    // "pin" buttons. It can be empty if none are used.
+    std::vector<wxAuiTabContainerButton> buttons;
 };
 
 
@@ -308,18 +313,9 @@ protected:
     // buttons, close button if it's not per-tab, window list button etc.
     std::vector<wxAuiTabContainerButton> m_buttons;
 
-    wxAuiTabContainerButtonArray m_tabCloseButtons;
     wxRect m_rect;
     size_t m_tabOffset;
     unsigned int m_flags;
-
-    // Return wxAUI_BUTTON_STATE_{NORMAL,HIDDEN} corresponding to the current
-    // flags and the kind and state of the page.
-    wxAuiPaneButtonState GetCloseButtonState(const wxAuiNotebookPage& page) const;
-
-    // Return wxAUI_BUTTON_STATE_{NORMAL,HIDDEN} corresponding to the current
-    // flags and the given active state.
-    wxAuiPaneButtonState GetCloseButtonState(bool isPageActive) const;
 
 private:
     // Return the width that can be used for the tabs, i.e. without the space
@@ -330,6 +326,14 @@ private:
     // on the left and right side.
     void RenderButtons(wxDC& dc, wxWindow* wnd,
                        int& left_buttons_width, int& right_buttons_width);
+
+    // Update the state of the close button for the given page depending on its
+    // state and flags.
+    //
+    // If forceActive is true, the page is always considered as active, see the
+    // comment in LayoutMultiLineTabs() for the reason why this is needed.
+    void UpdateCloseButtonState(wxAuiNotebookPage& page,
+                                bool forceActive = false);
 
     int m_tabRowHeight;
 };

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -51,7 +51,7 @@ enum wxAuiNotebookOption
     wxAUI_NB_CLOSE_ON_ALL_TABS   = 1 << 12,
     wxAUI_NB_MIDDLE_CLICK_CLOSE  = 1 << 13,
     wxAUI_NB_MULTILINE           = 1 << 14,
-    wxAUI_NB_TAB_PIN             = 1 << 15,
+    wxAUI_NB_PIN_ON_ACTIVE_TAB   = 1 << 15,
 
     wxAUI_NB_DEFAULT_STYLE = wxAUI_NB_TOP |
                              wxAUI_NB_TAB_SPLIT |
@@ -327,13 +327,11 @@ private:
     void RenderButtons(wxDC& dc, wxWindow* wnd,
                        int& left_buttons_width, int& right_buttons_width);
 
-    // Update the state of the close button for the given page depending on its
-    // state and flags.
+    // Update the state of the page buttons depending on its state and flags.
     //
     // If forceActive is true, the page is always considered as active, see the
     // comment in LayoutMultiLineTabs() for the reason why this is needed.
-    void UpdateCloseButtonState(wxAuiNotebookPage& page,
-                                bool forceActive = false);
+    void UpdateButtonsState(wxAuiNotebookPage& page, bool forceActive = false);
 
     int m_tabRowHeight;
 };

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -90,6 +90,28 @@ private:
 };
 
 
+class WXDLLIMPEXP_AUI wxAuiTabContainerButton
+{
+public:
+    wxAuiTabContainerButton() = default;
+
+    wxAuiTabContainerButton(
+            int id_,
+            int location_,
+            wxAuiPaneButtonState curState_ = wxAUI_BUTTON_STATE_NORMAL
+        ) : id(id_), curState(curState_), location(location_)
+    {
+    }
+
+    int id = 0;               // button's id
+    int curState = 0;         // current state (normal, hover, pressed, etc.)
+    int location = 0;         // buttons location (wxLEFT, wxRIGHT, or wxCENTER)
+    wxBitmapBundle bitmap;    // button's hover bitmap
+    wxBitmapBundle disBitmap; // button's disabled bitmap
+    wxRect rect;          // button's hit rectangle
+};
+
+
 // Possible tab states.
 enum class wxAuiTabKind
 {
@@ -114,27 +136,6 @@ public:
     // These fields are internal, don't use them.
     bool hover = false;   // true if mouse hovering over tab
     bool rowEnd = false;  // true if the tab is the last in the row
-};
-
-class WXDLLIMPEXP_AUI wxAuiTabContainerButton
-{
-public:
-    wxAuiTabContainerButton() = default;
-
-    wxAuiTabContainerButton(
-            int id_,
-            int location_,
-            wxAuiPaneButtonState curState_ = wxAUI_BUTTON_STATE_NORMAL
-        ) : id(id_), curState(curState_), location(location_)
-    {
-    }
-
-    int id = 0;               // button's id
-    int curState = 0;         // current state (normal, hover, pressed, etc.)
-    int location = 0;         // buttons location (wxLEFT, wxRIGHT, or wxCENTER)
-    wxBitmapBundle bitmap;    // button's hover bitmap
-    wxBitmapBundle disBitmap; // button's disabled bitmap
-    wxRect rect;          // button's hit rectangle
 };
 
 

--- a/include/wx/aui/serializer.h
+++ b/include/wx/aui/serializer.h
@@ -47,6 +47,11 @@ struct wxAuiTabLayoutInfo : wxAuiDockLayoutInfo
     // If this vector is empty, it means that the tab control contains all
     // notebook pages in natural order.
     std::vector<int> pages;
+
+    // Vectors contain indices of locked and pinned pages, if any, i.e. both of
+    // them can be empty.
+    std::vector<int> locked;
+    std::vector<int> pinned;
 };
 
 // This struct contains the pane name and information about its layout that can

--- a/include/wx/aui/tabartmsw.h
+++ b/include/wx/aui/tabartmsw.h
@@ -34,14 +34,10 @@ public:
         wxWindow* wnd,
         const wxRect& rect) override;
 
-    void DrawTab(wxDC& dc,
+    int DrawPageTab(wxDC& dc,
         wxWindow* wnd,
-        const wxAuiNotebookPage& pane,
-        const wxRect& inRect,
-        int closeButtonState,
-        wxRect* outTabRect,
-        wxRect* outButtonRect,
-        int* xExtent) override;
+        wxAuiNotebookPage& page,
+        const wxRect& rect) override;
 
     void DrawButton(
         wxDC& dc,
@@ -60,13 +56,10 @@ public:
     int GetAdditionalBorderSpace(
         wxWindow* wnd) override;
 
-    wxSize GetTabSize(
+    wxSize GetPageTabSize(
         wxReadOnlyDC& dc,
         wxWindow* wnd,
-        const wxString& caption,
-        const wxBitmapBundle& bitmap,
-        bool active,
-        int closeButtonState,
+        const wxAuiNotebookPage& page,
         int* xExtent) override;
 
     int ShowDropDown(

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -30,14 +30,28 @@ enum wxAuiNotebookOption
 
         With this style, the active page shows either a "pin" icon allowing to
         pin it if it it's currently not pinned or an "unpin" icon if it is
-        already pinned.
+        already pinned. Note that "unpin" icon may be shown even if this style
+        is not specified, but ::wxAUI_NB_UNPIN_ON_ALL_PINNED is.
 
         Note that if this style is not specified, tabs can still be pinned
         programmatically using SetPageKind().
 
         @since 3.3.0
      */
-    wxAUI_NB_PIN_ON_ACTIVE_TAB    = 1 << 15
+    wxAUI_NB_PIN_ON_ACTIVE_TAB    = 1 << 15,
+
+    /**
+        Allow the user to unpin pinned tabs by using the unpin button.
+
+        Specifying this style shows "unpin" button on all currently pinned
+        tabs, allowing the user to unpin them, i.e. make them normal again.
+
+        This style can be combined with ::wxAUI_NB_PIN_ON_ACTIVE_TAB or used on
+        its own.
+
+        @since 3.3.0
+     */
+    wxAUI_NB_UNPIN_ON_ALL_PINNED  = 1 << 16,
 
     wxAUI_NB_DEFAULT_STYLE = wxAUI_NB_TOP |
                              wxAUI_NB_TAB_SPLIT |
@@ -197,6 +211,11 @@ struct wxAuiNotebookPosition
            to normal. This style is not included in the default notebook style
            and has to be explicitly specified for the user to be able to pin
            the tabs interactively. It is available in wxWidgets 3.3.0 or later.
+    @style{wxAUI_NB_UNPIN_ON_ALL_PINNED}
+           If this style is specified, "unpin" button is shown on all currently
+           pinned tabs, allowing the user to unpin them, i.e. make them normal
+           again. This style can be combined with ::wxAUI_NB_PIN_ON_ACTIVE_TAB
+           or used on its own. It is available in wxWidgets 3.3.0 or later.
     @endStyleTable
 
     @beginEventEmissionTable{wxAuiNotebookEvent}
@@ -604,12 +623,12 @@ public:
         different content from the normal (and pinned) tabs. These tabs are
         special, they're always shown and can't be closed nor moved, by
         dragging them, by the user.
-        - Next are pinned tabs: these tabs can be closed and, depending on the
-        presence of ::wxAUI_NB_PIN_ON_ACTIVE_TAB style, can also be unpinned
-        (i.e. made normal) by the user. If ::wxAUI_NB_TAB_MOVE is specified,
-        they can be moved by dragging them, however they are restricted to
-        remain in the pinned tabs group, i.e. only the order of the pinned tabs
-        can be changed.
+        - Next are pinned tabs: these tabs can be closed and, depending on
+        whether ::wxAUI_NB_PIN_ON_ACTIVE_TAB and ::wxAUI_NB_UNPIN_ON_ALL_PINNED
+        styles are specified, can also be unpinned (i.e. made normal) by the
+        user. If ::wxAUI_NB_TAB_MOVE is specified, they can be moved by
+        dragging them, however they are restricted to remain in the pinned tabs
+        group, i.e. only the order of the pinned tabs can be changed.
         - Finally, normal tabs are shown. These tabs can be closed and,
         depending on ::wxAUI_NB_PIN_ON_ACTIVE_TAB style, pinned by the user.
         They can also be moved by dragging them, but only inside the same

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -26,15 +26,18 @@ enum wxAuiNotebookOption
     wxAUI_NB_MULTILINE           = 1 << 14,
 
     /**
-        Allow the user to pin tabs and to use wxAuiNotebook::SetPageKind() to
-        do it programmatically.
+        Allow the user to pin tabs by using the pin button.
 
-        This style is not included in the default notebook style and has to be
-        explicitly specified when creating the control.
+        With this style, the active page shows either a "pin" icon allowing to
+        pin it if it it's currently not pinned or an "unpin" icon if it is
+        already pinned.
+
+        Note that if this style is not specified, tabs can still be pinned
+        programmatically using SetPageKind().
 
         @since 3.3.0
      */
-    wxAUI_NB_TAB_PIN             = 1 << 15
+    wxAUI_NB_PIN_ON_ACTIVE_TAB    = 1 << 15
 
     wxAUI_NB_DEFAULT_STYLE = wxAUI_NB_TOP |
                              wxAUI_NB_TAB_SPLIT |
@@ -187,12 +190,13 @@ struct wxAuiNotebookPosition
            area, multiple rows of tabs are used instead of adding a button
            allowing to scroll them. This style is only available in wxWidgets
            3.3.0 or later.
-    @style{wxAUI_NB_TAB_PIN}
-           If this style is specified, tabs show a "pin" icon allowing to
-           change their kind to wxAuiTabKind::Pinned and back to normal. This
-           style is not included in the default notebook style and has to be
-           explicitly specified for pinned tabs to be supported. It is
-           available in wxWidgets 3.3.0 or later.
+    @style{wxAUI_NB_PIN_ON_ACTIVE_TAB}
+           If this style is specified, the active tab shows either a "pin" icon
+           allowing to pin it (i.e. change its kind to wxAuiTabKind::Pinned) if
+           it's not currently pinned or an "unpin" icon to change the kind back
+           to normal. This style is not included in the default notebook style
+           and has to be explicitly specified for the user to be able to pin
+           the tabs interactively. It is available in wxWidgets 3.3.0 or later.
     @endStyleTable
 
     @beginEventEmissionTable{wxAuiNotebookEvent}
@@ -591,12 +595,25 @@ public:
     /**
         Set the tab kind.
 
-        Can be used to pin or lock a tab. Pinning, i.e. passing @a kind of
-        wxAuiTabKind::Pinned, requires the control to have ::wxAUI_NB_TAB_PIN
-        style, which also allows the user to unpin the tab later.
+        Can be used to pin or lock a tab.
 
-        Locking doesn't require any special styles because locked tabs can only
-        be unlocked programmatically by calling this function.
+        Tabs are are grouped in 3 subsets (each of which can possibly be
+        empty):
+
+        - Shown first are locked tabs which are typically used for showing some
+        different content from the normal (and pinned) tabs. These tabs are
+        special, they're always shown and can't be closed nor moved, by
+        dragging them, by the user.
+        - Next are pinned tabs: these tabs can be closed and, depending on the
+        presence of ::wxAUI_NB_PIN_ON_ACTIVE_TAB style, can also be unpinned
+        (i.e. made normal) by the user. If ::wxAUI_NB_TAB_MOVE is specified,
+        they can be moved by dragging them, however they are restricted to
+        remain in the pinned tabs group, i.e. only the order of the pinned tabs
+        can be changed.
+        - Finally, normal tabs are shown. These tabs can be closed and,
+        depending on ::wxAUI_NB_PIN_ON_ACTIVE_TAB style, pinned by the user.
+        They can also be moved by dragging them, but only inside the same
+        group.
 
         @param pageIdx
             The index of the page to change.
@@ -606,8 +623,7 @@ public:
             @true if the kind was changed, @false if it didn't change, either
             because the page already was of the specified @a kind or because
             the preconditions were not satisfied, e.g. the page index was
-            invalid or pinning was requested for a control without
-            ::wxAUI_NB_TAB_PIN style.
+            invalid.
 
         @since 3.3.0
      */
@@ -766,7 +782,7 @@ public:
 enum class wxAuiTabKind
 {
     Normal, ///< Can be closed and dragged by user.
-    Pinned, ///< Can be closed but can't be dragged, can be unpinned by user.
+    Pinned, ///< Can be closed and possibly unpinned by user.
     Locked  ///< Can't be closed, dragged nor unlocked by user.
 };
 

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -110,8 +110,12 @@ struct wxAuiNotebookPosition
     splitter configurations, and toggle through different themes to customize
     the control's look and feel.
 
-    The default theme that is used is wxAuiDefaultTabArt, which provides a modern,
-    glossy look and feel.
+    The default theme depends on the platform and styles used: in wxMSW port
+    native-like theme is used provided that none of ::wxAUI_NB_BOTTOM,
+    ::wxAUI_NB_PIN_ON_ACTIVE_TAB and ::wxAUI_NB_UNPIN_ON_ALL_PINNED styles is
+    used, because the native theme doesn't support them. In the other ports, or
+    when these styles are used with wxMSW, wxAuiDefaultTabArt, providing a
+    glossy-looking appearance, is used.
     The theme can be changed by calling wxAuiNotebook::SetArtProvider.
 
     @section auibook_tabs Multiple Tab Controls

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -349,6 +349,15 @@ public:
     int GetPageIndex(wxWindow* page_wnd) const;
 
     /**
+        Returns the tab kind for the page.
+
+        See SetPageKind().
+
+        @since 3.3.0
+     */
+    wxAuiTabKind GetPageKind(size_t pageIdx) const;
+
+    /**
         Returns the position of the page in the notebook.
 
         For example, to determine if one page is located immediately next to
@@ -563,6 +572,26 @@ public:
     virtual bool SetPageImage(size_t n, int imageId);
 
     /**
+        Set the tab kind.
+
+        Can be used to pin or lock a tab. Note that pinned tabs can be unpinned
+        by the user, but locked tabs can only be unlocked programmatically by
+        calling this function.
+
+        @param pageIdx
+            The index of the page to change.
+        @param kind
+            The new kind for the page.
+        @return
+            @true if the kind was changed, @false if it didn't change, either
+            because the page already was of the specified @a kind or because
+            the page index is invalid.
+
+        @since 3.3.0
+     */
+    bool SetPageKind(size_t pageIdx, wxAuiTabKind kind);
+
+    /**
         Sets the tab label for the page.
     */
     bool SetPageText(size_t page, const wxString& text);
@@ -703,6 +732,20 @@ public:
         @since 3.1.4
     */
     bool FindTab(wxWindow* page, wxAuiTabCtrl** ctrl, int* idx);
+};
+
+/**
+    Tab kind for wxAuiNotebook pages.
+
+    See wxAuiNotebook::SetTabKind().
+
+    @since 3.3.0
+ */
+enum class wxAuiTabKind
+{
+    Normal, ///< Can be closed and dragged by user.
+    Pinned, ///< Can be closed but can't be dragged, can be unpinned by user.
+    Locked  ///< Can't be closed, dragged nor unlocked by user.
 };
 
 

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -1031,7 +1031,7 @@ public:
     /**
         Returns the tab size for the given caption, bitmap and state.
     */
-    virtual wxSize GetTabSize(wxDC& dc, wxWindow* wnd, const wxString& caption,
+    virtual wxSize GetTabSize(wxReadOnlyDC& dc, wxWindow* wnd, const wxString& caption,
                               const wxBitmapBundle& bitmap, bool active,
                               int close_button_state, int* x_extent) = 0;
 
@@ -1238,7 +1238,7 @@ public:
     int GetIndentSize();
 
     wxSize GetTabSize(
-                 wxDC& dc,
+                 wxReadOnlyDC& dc,
                  wxWindow* wnd,
                  const wxString& caption,
                  const wxBitmapBundle& bitmap,
@@ -1344,7 +1344,7 @@ public:
     int GetIndentSize();
 
     wxSize GetTabSize(
-                 wxDC& dc,
+                 wxReadOnlyDC& dc,
                  wxWindow* wnd,
                  const wxString& caption,
                  const wxBitmap& bitmap,

--- a/interface/wx/aui/serializer.h
+++ b/interface/wx/aui/serializer.h
@@ -46,7 +46,8 @@ struct wxAuiDockLayoutInfo
     Contains information about the layout of a tab control in a wxAuiNotebook.
 
     This includes where it is docked, via the fields inherited from
-    wxAuiDockLayoutInfo, and the order of pages in it.
+    wxAuiDockLayoutInfo, and, optionally, the order of pages in it if it was
+    changed as well as locked and pinned pages indices, if any.
 
     @since 3.3.0
 */
@@ -59,6 +60,20 @@ struct wxAuiTabLayoutInfo : wxAuiDockLayoutInfo
         notebook pages in natural order.
     */
     std::vector<int> pages;
+
+    /**
+        Indices of the locked pages in this tab control.
+
+        This vector can be empty if there are no locked pages.
+     */
+    std::vector<int> locked;
+
+    /**
+        Indices of the pinned pages in this tab control.
+
+        This vector can be empty if there are no pinned pages.
+     */
+    std::vector<int> pinned;
 };
 
 /**

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -742,7 +742,11 @@ MyFrame::MyFrame(wxWindow* parent,
     SetIcon(wxIcon(sample_xpm));
 
     // set up default notebook style
-    m_notebook_style = wxAUI_NB_DEFAULT_STYLE | wxAUI_NB_TAB_EXTERNAL_MOVE | wxNO_BORDER;
+    m_notebook_style = wxAUI_NB_DEFAULT_STYLE |
+                       wxAUI_NB_TAB_EXTERNAL_MOVE |
+                       wxAUI_NB_PIN_ON_ACTIVE_TAB |
+                       wxAUI_NB_UNPIN_ON_ALL_PINNED |
+                       wxNO_BORDER;
 
     // create menu
     wxMenuBar* mb = new wxMenuBar;

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -108,6 +108,7 @@ class MyFrame : public wxFrame
         ID_NotebookScrollButtons,
         ID_NotebookTabFixedWidth,
         ID_NotebookTabPin,
+        ID_NotebookTabUnpin,
         ID_NotebookMultiLine,
         ID_NotebookNextTab,
         ID_NotebookPrevTab,
@@ -644,6 +645,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(ID_AllowActivePane, MyFrame::OnManagerFlag)
     EVT_MENU(ID_NotebookTabFixedWidth, MyFrame::OnNotebookFlag)
     EVT_MENU(ID_NotebookTabPin, MyFrame::OnNotebookFlag)
+    EVT_MENU(ID_NotebookTabUnpin, MyFrame::OnNotebookFlag)
     EVT_MENU(ID_NotebookMultiLine, MyFrame::OnNotebookFlag)
     EVT_MENU(ID_NotebookNoCloseButton, MyFrame::OnNotebookFlag)
     EVT_MENU(ID_NotebookCloseButton, MyFrame::OnNotebookFlag)
@@ -683,6 +685,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(wxID_ABOUT, MyFrame::OnAbout)
     EVT_UPDATE_UI(ID_NotebookTabFixedWidth, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NotebookTabPin, MyFrame::OnUpdateUI)
+    EVT_UPDATE_UI(ID_NotebookTabUnpin, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NotebookMultiLine, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NotebookNoCloseButton, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NotebookCloseButton, MyFrame::OnUpdateUI)
@@ -804,6 +807,7 @@ MyFrame::MyFrame(wxWindow* parent,
     notebook_menu->AppendCheckItem(ID_NotebookWindowList, _("Window List Button Visible"));
     notebook_menu->AppendCheckItem(ID_NotebookTabFixedWidth, _("Fixed-width Tabs"));
     notebook_menu->AppendCheckItem(ID_NotebookTabPin, _("Show &Pin Button"));
+    notebook_menu->AppendCheckItem(ID_NotebookTabUnpin, _("Show &Unpin Buttons"));
     notebook_menu->AppendCheckItem(ID_NotebookMultiLine, _("Tabs on &Multiple Lines"));
     notebook_menu->AppendSeparator();
     notebook_menu->Append(ID_NotebookNextTab, _("Switch to next tab\tCtrl-F6"));
@@ -1300,6 +1304,10 @@ void MyFrame::OnNotebookFlag(wxCommandEvent& event)
     {
         m_notebook_style ^= wxAUI_NB_PIN_ON_ACTIVE_TAB;
     }
+    else if (id == ID_NotebookTabUnpin)
+    {
+        m_notebook_style ^= wxAUI_NB_UNPIN_ON_ALL_PINNED;
+    }
     else if (id == ID_NotebookMultiLine)
     {
         m_notebook_style ^= wxAUI_NB_MULTILINE;
@@ -1432,6 +1440,9 @@ void MyFrame::OnUpdateUI(wxUpdateUIEvent& event)
             break;
         case ID_NotebookTabPin:
             event.Check((m_notebook_style & wxAUI_NB_PIN_ON_ACTIVE_TAB) != 0);
+            break;
+        case ID_NotebookTabUnpin:
+            event.Check((m_notebook_style & wxAUI_NB_UNPIN_ON_ALL_PINNED) != 0);
             break;
         case ID_NotebookMultiLine:
             event.Check((m_notebook_style & wxAUI_NB_MULTILINE) != 0);

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -803,7 +803,7 @@ MyFrame::MyFrame(wxWindow* parent,
     notebook_menu->AppendCheckItem(ID_NotebookScrollButtons, _("Scroll Buttons Visible"));
     notebook_menu->AppendCheckItem(ID_NotebookWindowList, _("Window List Button Visible"));
     notebook_menu->AppendCheckItem(ID_NotebookTabFixedWidth, _("Fixed-width Tabs"));
-    notebook_menu->AppendCheckItem(ID_NotebookTabPin, _("Allow to &Pin Tabs"));
+    notebook_menu->AppendCheckItem(ID_NotebookTabPin, _("Show &Pin Button"));
     notebook_menu->AppendCheckItem(ID_NotebookMultiLine, _("Tabs on &Multiple Lines"));
     notebook_menu->AppendSeparator();
     notebook_menu->Append(ID_NotebookNextTab, _("Switch to next tab\tCtrl-F6"));
@@ -1298,7 +1298,7 @@ void MyFrame::OnNotebookFlag(wxCommandEvent& event)
     }
     else if (id == ID_NotebookTabPin)
     {
-        m_notebook_style ^= wxAUI_NB_TAB_PIN;
+        m_notebook_style ^= wxAUI_NB_PIN_ON_ACTIVE_TAB;
     }
     else if (id == ID_NotebookMultiLine)
     {
@@ -1431,7 +1431,7 @@ void MyFrame::OnUpdateUI(wxUpdateUIEvent& event)
             event.Check((m_notebook_style & wxAUI_NB_TAB_FIXED_WIDTH) != 0);
             break;
         case ID_NotebookTabPin:
-            event.Check((m_notebook_style & wxAUI_NB_TAB_PIN) != 0);
+            event.Check((m_notebook_style & wxAUI_NB_PIN_ON_ACTIVE_TAB) != 0);
             break;
         case ID_NotebookMultiLine:
             event.Check((m_notebook_style & wxAUI_NB_MULTILINE) != 0);

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -107,6 +107,7 @@ class MyFrame : public wxFrame
         ID_NotebookWindowList,
         ID_NotebookScrollButtons,
         ID_NotebookTabFixedWidth,
+        ID_NotebookTabPin,
         ID_NotebookMultiLine,
         ID_NotebookNextTab,
         ID_NotebookPrevTab,
@@ -642,6 +643,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(ID_LiveUpdate, MyFrame::OnManagerFlag)
     EVT_MENU(ID_AllowActivePane, MyFrame::OnManagerFlag)
     EVT_MENU(ID_NotebookTabFixedWidth, MyFrame::OnNotebookFlag)
+    EVT_MENU(ID_NotebookTabPin, MyFrame::OnNotebookFlag)
     EVT_MENU(ID_NotebookMultiLine, MyFrame::OnNotebookFlag)
     EVT_MENU(ID_NotebookNoCloseButton, MyFrame::OnNotebookFlag)
     EVT_MENU(ID_NotebookCloseButton, MyFrame::OnNotebookFlag)
@@ -680,6 +682,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(wxID_EXIT, MyFrame::OnExit)
     EVT_MENU(wxID_ABOUT, MyFrame::OnAbout)
     EVT_UPDATE_UI(ID_NotebookTabFixedWidth, MyFrame::OnUpdateUI)
+    EVT_UPDATE_UI(ID_NotebookTabPin, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NotebookMultiLine, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NotebookNoCloseButton, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NotebookCloseButton, MyFrame::OnUpdateUI)
@@ -800,6 +803,7 @@ MyFrame::MyFrame(wxWindow* parent,
     notebook_menu->AppendCheckItem(ID_NotebookScrollButtons, _("Scroll Buttons Visible"));
     notebook_menu->AppendCheckItem(ID_NotebookWindowList, _("Window List Button Visible"));
     notebook_menu->AppendCheckItem(ID_NotebookTabFixedWidth, _("Fixed-width Tabs"));
+    notebook_menu->AppendCheckItem(ID_NotebookTabPin, _("Allow to &Pin Tabs"));
     notebook_menu->AppendCheckItem(ID_NotebookMultiLine, _("Tabs on &Multiple Lines"));
     notebook_menu->AppendSeparator();
     notebook_menu->Append(ID_NotebookNextTab, _("Switch to next tab\tCtrl-F6"));
@@ -1292,6 +1296,10 @@ void MyFrame::OnNotebookFlag(wxCommandEvent& event)
     {
         m_notebook_style ^= wxAUI_NB_TAB_FIXED_WIDTH;
     }
+    else if (id == ID_NotebookTabPin)
+    {
+        m_notebook_style ^= wxAUI_NB_TAB_PIN;
+    }
     else if (id == ID_NotebookMultiLine)
     {
         m_notebook_style ^= wxAUI_NB_MULTILINE;
@@ -1421,6 +1429,9 @@ void MyFrame::OnUpdateUI(wxUpdateUIEvent& event)
             break;
         case ID_NotebookTabFixedWidth:
             event.Check((m_notebook_style & wxAUI_NB_TAB_FIXED_WIDTH) != 0);
+            break;
+        case ID_NotebookTabPin:
+            event.Check((m_notebook_style & wxAUI_NB_TAB_PIN) != 0);
             break;
         case ID_NotebookMultiLine:
             event.Check((m_notebook_style & wxAUI_NB_MULTILINE) != 0);
@@ -2177,8 +2188,25 @@ void MyFrame::OnNotebookTabBackgroundDClick(wxAuiNotebookEvent& WXUNUSED(evt))
         int pos = 0;
         for ( auto idx : book->GetPagesInDisplayOrder(tabCtrl) )
         {
-            pages += wxString::Format("%s %d. %s\n",
+            wxString kind;
+            switch ( book->GetPageKind(idx) )
+            {
+                case wxAuiTabKind::Normal:
+                    kind = "   "; // Don't show anything for normal tabs.
+                    break;
+
+                case wxAuiTabKind::Pinned:
+                    kind = wxString::FromUTF8("\xf0\x9f\x93\x8c"); // U+1F4CC
+                    break;
+
+                case wxAuiTabKind::Locked:
+                    kind = wxString::FromUTF8("\xf0\x9f\x94\x92"); // U+1F512
+                    break;
+            }
+
+            pages += wxString::Format("%s%s%d. %s\n",
                                       idx == sel ? "*" : "  ",
+                                      kind,
                                       pos++,
                                       book->GetPageText(idx));
         }

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -615,7 +615,7 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
         }
     }
 
-    // determine whether left button should be enabled
+    // determine whether various buttons should be enabled
     for (i = 0; i < button_count; ++i)
     {
         wxAuiTabContainerButton& button = m_buttons.Item(i);
@@ -626,7 +626,7 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
             else
                 button.curState &= ~wxAUI_BUTTON_STATE_DISABLED;
         }
-        if (button.id == wxAUI_BUTTON_RIGHT)
+        else if (button.id == wxAUI_BUTTON_RIGHT)
         {
             int button_width = 0;
             for ( const auto& b : m_buttons )

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -629,8 +629,8 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
         if (button.id == wxAUI_BUTTON_RIGHT)
         {
             int button_width = 0;
-            for (i = 0; i < button_count; ++i)
-                button_width += m_buttons.Item(button_count - i - 1).rect.GetWidth();
+            for ( const auto& b : m_buttons )
+                button_width += b.rect.GetWidth();
 
             if (visible_width < m_rect.GetWidth() - button_width)
                 button.curState |= wxAUI_BUTTON_STATE_DISABLED;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -348,17 +348,11 @@ size_t wxAuiTabContainer::GetPageCount() const
 
 void wxAuiTabContainer::AddButton(int id,
                                   int location,
-                                  const wxBitmapBundle& normalBitmap,
-                                  const wxBitmapBundle& disabledBitmap)
+                                  const wxBitmapBundle& WXUNUSED(normalBitmap),
+                                  const wxBitmapBundle& WXUNUSED(disabledBitmap))
 {
-    wxAuiTabContainerButton button;
-    button.id = id;
-    button.bitmap = normalBitmap;
-    button.disBitmap = disabledBitmap;
-    button.location = location;
-    button.curState = wxAUI_BUTTON_STATE_NORMAL;
-
-    m_buttons.push_back(button);
+    // We ignore the bitmaps as they are never used currently.
+    m_buttons.push_back({id, location});
 }
 
 void wxAuiTabContainer::RemoveButton(int id)
@@ -746,11 +740,9 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
     // make sure there are enough tab button entries to accommodate all tabs
     while (m_tabCloseButtons.GetCount() < page_count)
     {
-        wxAuiTabContainerButton tempbtn;
-        tempbtn.id = wxAUI_BUTTON_CLOSE;
-        tempbtn.location = wxCENTER;
-        tempbtn.curState = wxAUI_BUTTON_STATE_HIDDEN;
-        m_tabCloseButtons.Add(tempbtn);
+        m_tabCloseButtons.push_back(
+            {wxAUI_BUTTON_CLOSE, wxCENTER, wxAUI_BUTTON_STATE_HIDDEN}
+        );
     }
 
 

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -393,7 +393,8 @@ void wxAuiTabContainer::SetTabOffset(size_t offset)
 
 
 
-int wxAuiTabContainer::GetCloseButtonState(const wxAuiNotebookPage& page) const
+wxAuiPaneButtonState
+wxAuiTabContainer::GetCloseButtonState(const wxAuiNotebookPage& page) const
 {
     switch ( page.kind )
     {
@@ -409,7 +410,8 @@ int wxAuiTabContainer::GetCloseButtonState(const wxAuiNotebookPage& page) const
     return GetCloseButtonState(page.active);
 }
 
-int wxAuiTabContainer::GetCloseButtonState(bool isPageActive) const
+wxAuiPaneButtonState
+wxAuiTabContainer::GetCloseButtonState(bool isPageActive) const
 {
     // determine if a close button is on this tab
     return ((m_flags & wxAUI_NB_CLOSE_ON_ALL_TABS) != 0 ||

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -70,9 +70,9 @@ std::vector<wxAuiTabContainerButton> MakePageButtons(unsigned int flags)
 {
     std::vector<wxAuiTabContainerButton> buttons;
 
-    // Pinned button is only shown if the corresponding style is used and only
-    // shown for the current tab, so make it hidden by default.
-    if (flags & wxAUI_NB_PIN_ON_ACTIVE_TAB)
+    // Pin/unpin button can be only shown if one of the styles enabling it is
+    // used and depends on the current tab state, so make it hidden by default.
+    if (flags & (wxAUI_NB_PIN_ON_ACTIVE_TAB | wxAUI_NB_UNPIN_ON_ALL_PINNED))
         buttons.push_back({wxAUI_BUTTON_PIN, wxRIGHT, wxAUI_BUTTON_STATE_HIDDEN});
 
     // Close button is hidden by default, it will be shown depending on the
@@ -162,6 +162,7 @@ void wxAuiTabContainer::SetFlags(unsigned int flags)
     // flags affecting them changed.
     const auto flagsAffectingButtons =
         wxAUI_NB_PIN_ON_ACTIVE_TAB |
+        wxAUI_NB_UNPIN_ON_ALL_PINNED |
         wxAUI_NB_CLOSE_ON_ALL_TABS |
         wxAUI_NB_CLOSE_ON_ACTIVE_TAB;
     if ((m_flags & flagsAffectingButtons) != (flags & flagsAffectingButtons))
@@ -462,6 +463,20 @@ wxAuiTabContainer::UpdateButtonsState(wxAuiNotebookPage& page, bool forceActive)
                                     button.curState |= wxAUI_BUTTON_STATE_CHECKED;
                                 else
                                     button.curState &= ~wxAUI_BUTTON_STATE_CHECKED;
+                            }
+                        }
+
+                        // This is not an "else" of the above "if" as when both
+                        // styles are used, we show "pin" button only on the
+                        // active tab, but also show "unpin" on all the pinned
+                        // tabs.
+                        if (IsFlagSet(wxAUI_NB_UNPIN_ON_ALL_PINNED))
+                        {
+                            if ( page.kind == wxAuiTabKind::Pinned )
+                            {
+                                shown = true;
+
+                                button.curState |= wxAUI_BUTTON_STATE_CHECKED;
                             }
                         }
                         break;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -845,10 +845,11 @@ void wxAuiTabContainer::Render(wxDC* raw_dc, wxWindow* wnd)
         wxAuiTabContainerButton& tab_button = m_tabCloseButtons.Item(i);
 
         // determine if a close button is on this tab
-        const auto prevState = tab_button.curState;
-        tab_button.curState = GetCloseButtonState(page);
-        if ( tab_button.curState == wxAUI_BUTTON_STATE_NORMAL &&
-                prevState == wxAUI_BUTTON_STATE_HIDDEN )
+        const auto wasHidden = tab_button.curState & wxAUI_BUTTON_STATE_HIDDEN;
+        tab_button.curState &= ~wxAUI_BUTTON_STATE_HIDDEN;
+        tab_button.curState |= GetCloseButtonState(page);
+        if ( !(tab_button.curState & wxAUI_BUTTON_STATE_HIDDEN) &&
+                wasHidden )
         {
             tab_button.id = wxAUI_BUTTON_CLOSE;
             tab_button.location = wxCENTER;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -802,19 +802,13 @@ void wxAuiTabContainer::Render(wxDC* raw_dc, wxWindow* wnd)
         wxAuiTabContainerButton& tab_button = m_tabCloseButtons.Item(i);
 
         // determine if a close button is on this tab
-        if ((m_flags & wxAUI_NB_CLOSE_ON_ALL_TABS) != 0 ||
-            ((m_flags & wxAUI_NB_CLOSE_ON_ACTIVE_TAB) != 0 && page.active))
+        const auto prevState = tab_button.curState;
+        tab_button.curState = GetCloseButtonState(page);
+        if ( tab_button.curState == wxAUI_BUTTON_STATE_NORMAL &&
+                prevState == wxAUI_BUTTON_STATE_HIDDEN )
         {
-            if (tab_button.curState == wxAUI_BUTTON_STATE_HIDDEN)
-            {
-                tab_button.id = wxAUI_BUTTON_CLOSE;
-                tab_button.curState = wxAUI_BUTTON_STATE_NORMAL;
-                tab_button.location = wxCENTER;
-            }
-        }
-        else
-        {
-            tab_button.curState = wxAUI_BUTTON_STATE_HIDDEN;
+            tab_button.id = wxAUI_BUTTON_CLOSE;
+            tab_button.location = wxCENTER;
         }
 
         // Check if this tab is at least partially visible when using a single

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -596,12 +596,20 @@ int wxAuiTabContainer::LayoutMultiLineTabs(const wxRect& rect, wxWindow* wnd)
         // Note that for non-wxAUI_NB_CLOSE_ON_ACTIVE_TAB cases, it doesn't
         // matter, as "Close" is either never shown at all or always shown
         // regardless of the page active status.
-        UpdateCloseButtonState(page, firstTabInRow);
+        //
+        // Also note that we don't need to update the buttons state for the
+        // locked pages as they never change, so the layout doesn't depend on
+        // whether they're active or not and if the entire row consists of only
+        // locked tabs, we never have to add any extra space.
+        if ( page.kind != wxAuiTabKind::Locked )
+        {
+            UpdateCloseButtonState(page, firstTabInRow);
+            firstTabInRow = false;
+        }
 
         const auto size = m_art->GetPageTabSize(dc, wnd, page);
 
         widthRow += size.x;
-        firstTabInRow = false;
 
         // Reset it by default, it will be set during the next loop
         // iteration or after the loop if it's the last tab in the row.

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -358,18 +358,16 @@ void wxAuiTabContainer::AddButton(int id,
     button.location = location;
     button.curState = wxAUI_BUTTON_STATE_NORMAL;
 
-    m_buttons.Add(button);
+    m_buttons.push_back(button);
 }
 
 void wxAuiTabContainer::RemoveButton(int id)
 {
-    size_t i, button_count = m_buttons.GetCount();
-
-    for (i = 0; i < button_count; ++i)
+    for (auto it = m_buttons.begin(); it != m_buttons.end(); ++it)
     {
-        if (m_buttons.Item(i).id == id)
+        if (it->id == id)
         {
-            m_buttons.RemoveAt(i);
+            m_buttons.erase(it);
             return;
         }
     }
@@ -432,14 +430,14 @@ int wxAuiTabContainer::GetAvailableForTabs(const wxRect& rect,
     // the other functions, notable we can assume that all tabs are visible.
 
     size_t i;
-    const size_t button_count = m_buttons.GetCount();
+    const size_t button_count = m_buttons.size();
 
     int right_buttons_width = 0;
 
     // measure the buttons on the right side
     for (i = 0; i < button_count; ++i)
     {
-        wxAuiTabContainerButton& button = m_buttons.Item(button_count - i - 1);
+        wxAuiTabContainerButton& button = m_buttons.at(button_count - i - 1);
 
         if (button.location != wxRIGHT)
             continue;
@@ -469,7 +467,7 @@ int wxAuiTabContainer::GetAvailableForTabs(const wxRect& rect,
 
     for (i = 0; i < button_count; ++i)
     {
-        wxAuiTabContainerButton& button = m_buttons.Item(button_count - i - 1);
+        wxAuiTabContainerButton& button = m_buttons.at(button_count - i - 1);
 
         if (button.location != wxLEFT)
             continue;
@@ -569,7 +567,7 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
 {
     size_t i;
     const size_t page_count = m_pages.GetCount();
-    const size_t button_count = m_buttons.GetCount();
+    const size_t button_count = m_buttons.size();
 
     // ensure we show as many tabs as possible
     while (m_tabOffset > 0 && IsTabVisible(page_count-1, m_tabOffset-1, &dc, wnd))
@@ -611,7 +609,7 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
         // show left/right buttons
         for (i = 0; i < button_count; ++i)
         {
-            wxAuiTabContainerButton& button = m_buttons.Item(i);
+            wxAuiTabContainerButton& button = m_buttons.at(i);
             if (button.id == wxAUI_BUTTON_LEFT ||
                 button.id == wxAUI_BUTTON_RIGHT)
             {
@@ -624,7 +622,7 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
         // hide left/right buttons
         for (i = 0; i < button_count; ++i)
         {
-            wxAuiTabContainerButton& button = m_buttons.Item(i);
+            wxAuiTabContainerButton& button = m_buttons.at(i);
             if (button.id == wxAUI_BUTTON_LEFT ||
                 button.id == wxAUI_BUTTON_RIGHT)
             {
@@ -636,7 +634,7 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
     // determine whether various buttons should be enabled
     for (i = 0; i < button_count; ++i)
     {
-        wxAuiTabContainerButton& button = m_buttons.Item(i);
+        wxAuiTabContainerButton& button = m_buttons.at(i);
         if (button.id == wxAUI_BUTTON_LEFT)
         {
             if (m_tabOffset == 0)
@@ -686,7 +684,7 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
     // draw the buttons on the right side
     for (i = 0; i < button_count; ++i)
     {
-        wxAuiTabContainerButton& button = m_buttons.Item(button_count - i - 1);
+        wxAuiTabContainerButton& button = m_buttons.at(button_count - i - 1);
 
         if (button.location != wxRIGHT)
             continue;
@@ -716,7 +714,7 @@ void wxAuiTabContainer::RenderButtons(wxDC& dc, wxWindow* wnd,
 
     for (i = 0; i < button_count; ++i)
     {
-        wxAuiTabContainerButton& button = m_buttons.Item(button_count - i - 1);
+        wxAuiTabContainerButton& button = m_buttons.at(button_count - i - 1);
 
         if (button.location != wxLEFT)
             continue;
@@ -940,7 +938,7 @@ bool wxAuiTabContainer::IsTabVisible(int tabPage, int tabOffset, wxReadOnlyDC* d
 
     size_t i;
     size_t page_count = m_pages.GetCount();
-    size_t button_count = m_buttons.GetCount();
+    size_t button_count = m_buttons.size();
 
     // Hasn't been rendered yet; assume it's visible
     if (m_tabCloseButtons.GetCount() < page_count)
@@ -951,7 +949,7 @@ bool wxAuiTabContainer::IsTabVisible(int tabPage, int tabOffset, wxReadOnlyDC* d
     int arrowButtonVisibleCount = 0;
     for (i = 0; i < button_count; ++i)
     {
-        wxAuiTabContainerButton& button = m_buttons.Item(i);
+        wxAuiTabContainerButton& button = m_buttons.at(i);
         if (button.id == wxAUI_BUTTON_LEFT ||
             button.id == wxAUI_BUTTON_RIGHT)
         {
@@ -976,7 +974,7 @@ bool wxAuiTabContainer::IsTabVisible(int tabPage, int tabOffset, wxReadOnlyDC* d
     int offset = m_rect.x + m_rect.width;
     for (i = 0; i < button_count; ++i)
     {
-        wxAuiTabContainerButton& button = m_buttons.Item(button_count - i - 1);
+        wxAuiTabContainerButton& button = m_buttons.at(button_count - i - 1);
 
         if (button.location != wxRIGHT)
             continue;
@@ -992,7 +990,7 @@ bool wxAuiTabContainer::IsTabVisible(int tabPage, int tabOffset, wxReadOnlyDC* d
     // calculate size of the buttons on the left side
     for (i = 0; i < button_count; ++i)
     {
-        wxAuiTabContainerButton& button = m_buttons.Item(button_count - i - 1);
+        wxAuiTabContainerButton& button = m_buttons.at(button_count - i - 1);
 
         if (button.location != wxLEFT)
             continue;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -206,8 +206,11 @@ bool wxAuiTabContainer::MovePage(wxWindow* page,
     if (idx == -1)
         return false;
 
-    const size_t old_idx = static_cast<size_t>(idx);
+    return MovePage(static_cast<size_t>(idx), new_idx);
+}
 
+bool wxAuiTabContainer::MovePage(size_t old_idx, size_t new_idx)
+{
     const auto b = m_pages.begin();
     if (old_idx < new_idx)
         std::rotate(b + old_idx, b + old_idx + 1, b + new_idx + 1);

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -163,7 +163,15 @@ static const unsigned char list_bits[] = {
    0x0f, 0xf8, 0xff, 0xff, 0x0f, 0xf8, 0x1f, 0xfc, 0x3f, 0xfe, 0x7f, 0xff,
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
+static const unsigned char pin_bits[] = {
+   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xbf, 0xff, 0x3f, 0xe0,
+   0xbf, 0xef, 0x87, 0xef, 0x3f, 0xe0, 0x3f, 0xe0, 0xbf, 0xff, 0xff, 0xff,
+   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
+static const unsigned char unpin_bits[]={
+   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0xfc, 0xdf, 0xfc, 0xdf, 0xfc,
+   0xdf, 0xfc, 0xdf, 0xfc, 0xdf, 0xfc, 0x0f, 0xf8, 0x7f, 0xff, 0x7f, 0xff,
+   0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
 
 // wxAuiTabArt implementation
@@ -182,6 +190,92 @@ int wxAuiTabArt::GetButtonRect(
     return 0;
 }
 
+void wxAuiTabArt::DrawTab(
+                         wxDC& WXUNUSED(dc),
+                         wxWindow* WXUNUSED(wnd),
+                         const wxAuiNotebookPage& WXUNUSED(pane),
+                         const wxRect& WXUNUSED(inRect),
+                         int WXUNUSED(closeButtonState),
+                         wxRect* WXUNUSED(outTabRect),
+                         wxRect* WXUNUSED(outButtonRect),
+                         int* WXUNUSED(xExtent))
+{
+    // This can only be called from the default implementation of
+    // DrawPageTab(), which means that that function is not overridden
+    // in the derived class -- but then this one must be.
+    wxFAIL_MSG("Did you forget to override DrawPageTab()?");
+}
+
+int wxAuiTabArt::DrawPageTab(
+                         wxDC& dc,
+                         wxWindow* wnd,
+                         wxAuiNotebookPage& page,
+                         const wxRect& rect)
+{
+    wxRect* closeRect = nullptr;
+    int closeState = wxAUI_BUTTON_STATE_HIDDEN;
+
+    for ( auto& button : page.buttons )
+    {
+        if ( button.id == wxAUI_BUTTON_CLOSE )
+        {
+            closeRect = &button.rect;
+            closeState = button.curState;
+        }
+        else
+        {
+            wxFAIL_MSG("Must be overridden if using buttons other than close");
+        }
+    }
+
+    int xExtent = 0;
+
+    DrawTab(dc, wnd, page, rect, closeState, &page.rect, closeRect, &xExtent);
+
+    return xExtent;
+}
+
+wxSize wxAuiTabArt::GetTabSize(
+                         wxReadOnlyDC& WXUNUSED(dc),
+                         wxWindow* WXUNUSED(wnd),
+                         const wxString& WXUNUSED(caption),
+                         const wxBitmapBundle& WXUNUSED(bitmap),
+                         bool WXUNUSED(active),
+                         int WXUNUSED(closeButtonState),
+                         int* WXUNUSED(xExtent))
+{
+    wxFAIL_MSG("Did you forget to override GetPageTabSize()?");
+
+    return wxSize{};
+}
+
+wxSize wxAuiTabArt::GetPageTabSize(
+                         wxReadOnlyDC& dc,
+                         wxWindow* wnd,
+                         const wxAuiNotebookPage& page,
+                         int* xExtent)
+{
+    int closeState = wxAUI_BUTTON_STATE_HIDDEN;
+
+    for ( const auto& button : page.buttons )
+    {
+        if ( button.id == wxAUI_BUTTON_CLOSE )
+        {
+            closeState = button.curState;
+        }
+        else
+        {
+            wxFAIL_MSG("Must be overridden if using buttons other than close");
+        }
+    }
+
+    // This function allows passing null pointer for the extent, but
+    // GetTabSize() doesn't, so give it something if necessary.
+    int dummyExtent;
+
+    return GetTabSize(dc, wnd, page.caption, page.bitmap, page.active,
+                      closeState, xExtent ? xExtent : &dummyExtent);
+}
 
 // -- wxAuiGenericTabArt class implementation --
 
@@ -233,6 +327,10 @@ void wxAuiGenericTabArt::UpdateColoursFromSystem()
     m_disabledRightBmp = wxAuiBitmapFromBits(right_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
     m_activeWindowListBmp = wxAuiBitmapFromBits(list_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
     m_disabledWindowListBmp = wxAuiBitmapFromBits(list_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    m_activePinBmp = wxAuiBitmapFromBits(pin_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledPinBmp = wxAuiBitmapFromBits(pin_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    m_activeUnpinBmp = wxAuiBitmapFromBits(unpin_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledUnpinBmp = wxAuiBitmapFromBits(unpin_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
 }
 
 wxAuiTabArt* wxAuiGenericTabArt::Clone()
@@ -346,23 +444,39 @@ void wxAuiGenericTabArt::DrawBackground(wxDC& dc,
 }
 
 
-// DrawTab() draws an individual tab.
-//
-// dc       - output dc
-// in_rect  - rectangle the tab should be confined to
-// caption  - tab's caption
-// active   - whether or not the tab is active
-// out_rect - actual output rectangle
-// x_extent - the advance x; where the next tab should start
+const wxBitmapBundle*
+wxAuiGenericTabArt::GetButtonBitmapBundle(const wxAuiTabContainerButton& button) const
+{
+    if (button.curState & wxAUI_BUTTON_STATE_HIDDEN)
+        return nullptr;
 
-void wxAuiGenericTabArt::DrawTab(wxDC& dc,
+    const auto active = button.curState & (wxAUI_BUTTON_STATE_HOVER |
+                                           wxAUI_BUTTON_STATE_PRESSED);
+
+    switch (button.id)
+    {
+        case wxAUI_BUTTON_CLOSE:
+            return active ? &m_activeCloseBmp : &m_disabledCloseBmp;
+
+        case wxAUI_BUTTON_PIN:
+            return button.curState & wxAUI_BUTTON_STATE_CHECKED
+                    ? (active ? &m_activeUnpinBmp : &m_disabledUnpinBmp)
+                    : (active ? &m_activePinBmp : &m_disabledPinBmp);
+    }
+
+    return nullptr;
+}
+
+// DrawPageTab() draws the tab for the given page.
+//
+// It updates the page rectangle and returns the amount to advance by to the
+// start of the next tab.
+
+int wxAuiGenericTabArt::DrawPageTab(
+                                 wxDC& dc,
                                  wxWindow* wnd,
-                                 const wxAuiNotebookPage& page,
-                                 const wxRect& in_rect,
-                                 int close_button_state,
-                                 wxRect* out_tab_rect,
-                                 wxRect* out_button_rect,
-                                 int* x_extent)
+                                 wxAuiNotebookPage& page,
+                                 const wxRect& in_rect)
 {
     wxCoord normal_textx, normal_texty;
     wxCoord selected_textx, selected_texty;
@@ -380,13 +494,8 @@ void wxAuiGenericTabArt::DrawTab(wxDC& dc,
     dc.GetTextExtent(caption, &normal_textx, &normal_texty);
 
     // figure out the size of the tab
-    wxSize tab_size = GetTabSize(dc,
-                                 wnd,
-                                 page.caption,
-                                 page.bitmap,
-                                 page.active,
-                                 close_button_state,
-                                 x_extent);
+    int xExtent = 0;
+    wxSize tab_size = GetPageTabSize(dc, wnd, page, &xExtent);
 
     wxCoord tab_height = in_rect.height - 3;
     wxCoord tab_width = tab_size.x;
@@ -568,39 +677,49 @@ void wxAuiGenericTabArt::DrawTab(wxDC& dc,
         text_offset = tab_x + wnd->FromDIP(8);
     }
 
-    // draw close button if necessary
-    int close_button_width = 0;
-    if (close_button_state != wxAUI_BUTTON_STATE_HIDDEN)
+    // draw buttons: start by computing their total width (note that we don't
+    // use any padding between them currently because the current bitmaps don't
+    // need it)
+    int buttonsWidth = 0;
+    for (auto& button : page.buttons)
     {
-        wxBitmapBundle bb = m_disabledCloseBmp;
+        const wxBitmapBundle* const bb = GetButtonBitmapBundle(button);
+        if (!bb)
+            continue;
 
-        if (close_button_state == wxAUI_BUTTON_STATE_HOVER ||
-            close_button_state == wxAUI_BUTTON_STATE_PRESSED)
-        {
-            bb = m_activeCloseBmp;
-        }
+        const wxBitmap bmp = bb->GetBitmapFor(wnd);
+        buttonsWidth += bmp.GetLogicalWidth();
+    }
 
-        const wxBitmap bmp = bb.GetBitmapFor(wnd);
+    // now draw them
+    int buttonX = tab_x + tab_width - buttonsWidth - wnd->FromDIP(1);
+    for (auto& button : page.buttons)
+    {
+        const wxBitmapBundle* const bb = GetButtonBitmapBundle(button);
+        if (!bb)
+            continue;
+
+        const wxBitmap bmp = bb->GetBitmapFor(wnd);
 
         int offsetY = tab_y-1;
         if (m_flags & wxAUI_NB_BOTTOM)
             offsetY = 1;
 
-        wxRect rect(tab_x + tab_width - bmp.GetLogicalWidth() - wnd->FromDIP(1),
+        wxRect rect(buttonX,
                     offsetY + (tab_height/2) - (bmp.GetLogicalHeight()/2),
                     bmp.GetLogicalWidth(),
                     tab_height);
 
-        IndentPressedBitmap(wnd->FromDIP(wxSize(1, 1)), &rect, close_button_state);
+        IndentPressedBitmap(wnd->FromDIP(wxSize(1, 1)), &rect, button.curState);
         dc.DrawBitmap(bmp, rect.x, rect.y, true);
 
-        *out_button_rect = rect;
-        close_button_width = bmp.GetLogicalWidth();
+        button.rect = rect;
+        buttonX += bmp.GetLogicalWidth();
     }
 
     wxString draw_text = wxAuiChopText(dc,
                           caption,
-                          tab_width - (text_offset-tab_x) - close_button_width);
+                          tab_width - (text_offset-tab_x) - buttonsWidth);
 
     // draw tab text
     wxColor sys_color = wxSystemSettings::GetColour(
@@ -643,7 +762,9 @@ void wxAuiGenericTabArt::DrawTab(wxDC& dc,
     }
 #endif // !__WXOSX__
 
-    *out_tab_rect = wxRect(tab_x, tab_y, tab_width, tab_height);
+    page.rect = wxRect(tab_x, tab_y, tab_width, tab_height);
+
+    return xExtent;
 }
 
 int wxAuiGenericTabArt::GetIndentSize()
@@ -668,18 +789,16 @@ int wxAuiGenericTabArt::GetAdditionalBorderSpace(wxWindow* WXUNUSED(wnd))
     return 0;
 }
 
-wxSize wxAuiGenericTabArt::GetTabSize(wxReadOnlyDC& dc,
+wxSize wxAuiGenericTabArt::GetPageTabSize(
+                                      wxReadOnlyDC& dc,
                                       wxWindow* wnd,
-                                      const wxString& caption,
-                                      const wxBitmapBundle& bitmap,
-                                      bool WXUNUSED(active),
-                                      int close_button_state,
+                                      const wxAuiNotebookPage& page,
                                       int* x_extent)
 {
     wxCoord measured_textx, measured_texty, tmp;
 
     dc.SetFont(m_measuringFont);
-    dc.GetTextExtent(caption, &measured_textx, &measured_texty);
+    dc.GetTextExtent(page.caption, &measured_textx, &measured_texty);
 
     dc.GetTextExtent(wxT("ABCDEFXj"), &tmp, &measured_texty);
 
@@ -687,19 +806,21 @@ wxSize wxAuiGenericTabArt::GetTabSize(wxReadOnlyDC& dc,
     wxCoord tab_width = measured_textx;
     wxCoord tab_height = measured_texty;
 
-    // if the close button is showing, add space for it
-    if (close_button_state != wxAUI_BUTTON_STATE_HIDDEN)
+    // add space for the buttons, if any
+    for (const auto& button : page.buttons)
     {
-        // increase by button size plus the padding
-        tab_width += m_activeCloseBmp.GetBitmapFor(wnd).GetLogicalWidth() + wnd->FromDIP(3);
+        if (const wxBitmapBundle* bmp = GetButtonBitmapBundle(button))
+        {
+            tab_width += bmp->GetBitmapFor(wnd).GetLogicalWidth() + wnd->FromDIP(3);
+        }
     }
 
     // if there's a bitmap, add space for it
-    if (bitmap.IsOk())
+    if (page.bitmap.IsOk())
     {
         // we need the correct size of the bitmap to be used on this window in
         // logical dimensions for drawing
-        const wxSize bitmapSize = bitmap.GetPreferredLogicalSizeFor(wnd);
+        const wxSize bitmapSize = page.bitmap.GetPreferredLogicalSizeFor(wnd);
 
         // increase by bitmap plus right side bitmap padding
         tab_width += bitmapSize.x + wnd->FromDIP(3);
@@ -716,7 +837,8 @@ wxSize wxAuiGenericTabArt::GetTabSize(wxReadOnlyDC& dc,
         tab_width = m_fixedTabWidth;
     }
 
-    *x_extent = tab_width;
+    if (x_extent)
+        *x_extent = tab_width;
 
     return wxSize(tab_width, tab_height);
 }
@@ -894,31 +1016,27 @@ int wxAuiGenericTabArt::GetBestTabCtrlSize(wxWindow* wnd,
                            requiredBmp_size.y);
     }
 
+    // we don't use the caption text because we don't
+    // want tab heights to be different in the case
+    // of a very short piece of text on one tab and a very
+    // tall piece of text on another tab
+    const wxString measureText(wxT("ABCDEFGHIj"));
 
     int max_y = 0;
     size_t i, page_count = pages.GetCount();
     for (i = 0; i < page_count; ++i)
     {
-        wxAuiNotebookPage& page = pages.Item(i);
+        // Make a copy of the page as we modify it below.
+        wxAuiNotebookPage page = pages.Item(i);
 
         wxBitmapBundle bmp;
         if (measureBmp.IsOk())
-            bmp = measureBmp;
-        else
-            bmp = page.bitmap;
+            page.bitmap = measureBmp;
 
-        // we don't use the caption text because we don't
-        // want tab heights to be different in the case
-        // of a very short piece of text on one tab and a very
-        // tall piece of text on another tab
-        int x_ext = 0;
-        wxSize s = GetTabSize(dc,
-                              wnd,
-                              wxT("ABCDEFGHIj"),
-                              bmp,
-                              true,
-                              wxAUI_BUTTON_STATE_HIDDEN,
-                              &x_ext);
+        page.caption = measureText;
+        page.active = true;
+
+        wxSize s = GetPageTabSize(dc, wnd, page);
 
         max_y = wxMax(max_y, s.y);
     }

--- a/src/aui/tabartmsw.cpp
+++ b/src/aui/tabartmsw.cpp
@@ -445,7 +445,8 @@ bool wxAuiMSWTabArt::IsThemed() const
 {
     return
         m_themed &&
-        !(m_flags & wxAUI_NB_PIN_ON_ACTIVE_TAB) && // We don't draw pin button yet
+        !(m_flags & wxAUI_NB_PIN_ON_ACTIVE_TAB) && // We don't draw pin
+        !(m_flags & wxAUI_NB_UNPIN_ON_ALL_PINNED) && // ...and unpin buttons yet
         !(m_flags & wxAUI_NB_BOTTOM); // Native theme does not support bottom tabs
 }
 

--- a/src/aui/tabartmsw.cpp
+++ b/src/aui/tabartmsw.cpp
@@ -445,7 +445,7 @@ bool wxAuiMSWTabArt::IsThemed() const
 {
     return
         m_themed &&
-        !(m_flags & wxAUI_NB_TAB_PIN) && // We don't draw pin button yet
+        !(m_flags & wxAUI_NB_PIN_ON_ACTIVE_TAB) && // We don't draw pin button yet
         !(m_flags & wxAUI_NB_BOTTOM); // Native theme does not support bottom tabs
 }
 

--- a/src/aui/tabartmsw.cpp
+++ b/src/aui/tabartmsw.cpp
@@ -103,37 +103,27 @@ void wxAuiMSWTabArt::DrawBackground(wxDC& dc,
     );
 }
 
-void wxAuiMSWTabArt::DrawTab(wxDC& dc,
+int wxAuiMSWTabArt::DrawPageTab(wxDC& dc,
     wxWindow* wnd,
-    const wxAuiNotebookPage& page,
-    const wxRect& in_rect,
-    int close_button_state,
-    wxRect* out_tab_rect,
-    wxRect* out_button_rect,
-    int* x_extent)
+    wxAuiNotebookPage& page,
+    const wxRect& rect)
 {
     if ( !IsThemed() )
     {
-        wxAuiGenericTabArt::DrawTab(dc, wnd, page, in_rect, close_button_state, out_tab_rect, out_button_rect, x_extent);
-        return;
+        return wxAuiGenericTabArt::DrawPageTab(dc, wnd, page, rect);
     }
 
     if ( !m_closeBtnSize.IsFullySpecified() )
         InitSizes(wnd, dc);
 
     // figure out the size of the tab
-    wxSize tabSize = GetTabSize(dc,
-        wnd,
-        page.caption,
-        page.bitmap,
-        page.active,
-        close_button_state,
-        x_extent);
+    int x_extent = 0;
+    wxSize tabSize = GetPageTabSize(dc, wnd, page, &x_extent);
 
     wxCoord tabHeight = tabSize.y;
     wxCoord tabWidth = tabSize.x;
-    wxCoord tabX = in_rect.x;
-    wxCoord tabY = in_rect.y;
+    wxCoord tabX = rect.x;
+    wxCoord tabY = rect.y;
 
     if (!page.active)
     {
@@ -148,8 +138,8 @@ void wxAuiMSWTabArt::DrawTab(wxDC& dc,
     }
 
     int clipWidth = tabWidth;
-    if ( tabX + clipWidth > in_rect.x + in_rect.width )
-        clipWidth = (in_rect.x + in_rect.width) - tabX;
+    if ( tabX + clipWidth > rect.x + rect.width )
+        clipWidth = (rect.x + rect.width) - tabX;
 
     wxDCClipper clipper(dc, tabX - wnd->FromDIP(2), tabY, clipWidth + wnd->FromDIP(4), tabHeight);
 
@@ -189,8 +179,43 @@ void wxAuiMSWTabArt::DrawTab(wxDC& dc,
     wxRect textRect = tabRect;
     if ( !page.active )
         textRect.Offset(0, wnd->FromDIP(1));
-    if ( close_button_state != wxAUI_BUTTON_STATE_HIDDEN )
-        textRect.width -= m_closeBtnSize.x + wnd->FromDIP(3);
+
+    for ( auto& button : page.buttons )
+    {
+        if ( button.curState & wxAUI_BUTTON_STATE_HIDDEN )
+            continue;
+
+        switch ( button.id )
+        {
+            case wxAUI_BUTTON_CLOSE:
+                {
+                    wxUxThemeHandle hToolTipTheme(wnd, L"TOOLTIP");
+
+                    int btnState;
+                    if ( button.curState & wxAUI_BUTTON_STATE_HOVER )
+                        btnState = TTCS_HOT;
+                    else if ( button.curState & wxAUI_BUTTON_STATE_PRESSED )
+                        btnState = TTCS_PRESSED;
+                    else
+                        btnState = TTCS_NORMAL;
+
+                    button.rect = wxRect(tabX + tabWidth - m_closeBtnSize.x - wnd->FromDIP(4),
+                        tabY + (tabHeight / 2) - (m_closeBtnSize.y / 2),
+                        m_closeBtnSize.x,
+                        m_closeBtnSize.y);
+
+                    hToolTipTheme.DrawBackground(
+                        GetHdcOf(dc.GetTempHDC()),
+                        button.rect,
+                        TTP_CLOSE,
+                        btnState
+                    );
+                }
+
+                textRect.width -= m_closeBtnSize.x + wnd->FromDIP(3);
+                break;
+        }
+    }
 
     dc.SetFont(wnd->GetFont());
     dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
@@ -205,36 +230,9 @@ void wxAuiMSWTabArt::DrawTab(wxDC& dc,
         wxRendererNative::Get().DrawFocusRect(wnd, dc, focusRect, 0);
     }
 
-    // draw close button
-    if ( close_button_state != wxAUI_BUTTON_STATE_HIDDEN )
-    {
-        wxUxThemeHandle hToolTipTheme(wnd, L"TOOLTIP");
+    page.rect = wxRect(tabX, tabY, tabWidth, tabHeight);
 
-        int btnState;
-        if ( close_button_state == wxAUI_BUTTON_STATE_HOVER )
-            btnState = TTCS_HOT;
-        else if ( close_button_state == wxAUI_BUTTON_STATE_PRESSED )
-            btnState = TTCS_PRESSED;
-        else
-            btnState = TTCS_NORMAL;
-
-        wxRect rect(tabX + tabWidth - m_closeBtnSize.x - wnd->FromDIP(4),
-            tabY + (tabHeight / 2) - (m_closeBtnSize.y / 2),
-            m_closeBtnSize.x,
-            m_closeBtnSize.y);
-
-        hToolTipTheme.DrawBackground(
-            GetHdcOf(dc.GetTempHDC()),
-            rect,
-            TTP_CLOSE,
-            btnState
-        );
-
-        if ( out_button_rect )
-            *out_button_rect = rect;
-    }
-
-    *out_tab_rect = wxRect(tabX, tabY, tabWidth, tabHeight);
+    return x_extent;
 }
 
 int wxAuiMSWTabArt::GetIndentSize()
@@ -260,16 +258,13 @@ int wxAuiMSWTabArt::GetAdditionalBorderSpace(wxWindow* wnd)
         return wxAuiGenericTabArt::GetAdditionalBorderSpace(wnd);
 }
 
-wxSize wxAuiMSWTabArt::GetTabSize(wxReadOnlyDC& dc,
+wxSize wxAuiMSWTabArt::GetPageTabSize(wxReadOnlyDC& dc,
     wxWindow* wnd,
-    const wxString& caption,
-    const wxBitmapBundle& bitmap,
-    bool active,
-    int close_button_state,
+    const wxAuiNotebookPage& page,
     int* x_extent)
 {
     if ( !IsThemed() )
-        return wxAuiGenericTabArt::GetTabSize(dc, wnd, caption, bitmap, active, close_button_state, x_extent);
+        return wxAuiGenericTabArt::GetPageTabSize(dc, wnd, page, x_extent);
 
     if ( !m_closeBtnSize.IsFullySpecified() )
         InitSizes(wnd, dc);
@@ -277,23 +272,31 @@ wxSize wxAuiMSWTabArt::GetTabSize(wxReadOnlyDC& dc,
     wxCoord textWidth, textHeight, tmp;
 
     dc.SetFont(wnd->GetFont());
-    dc.GetTextExtent(caption, &textWidth, &tmp);
+    dc.GetTextExtent(page.caption, &textWidth, &tmp);
     dc.GetTextExtent("ABCDEFXj", &tmp, &textHeight);
 
     wxCoord tabWidth = wxMax(m_tabSize.x, textWidth);
     wxCoord tabHeight = wxMax(m_tabSize.y, textHeight);
 
     // if the close button is showing, add space for it
-    if ( close_button_state != wxAUI_BUTTON_STATE_HIDDEN )
+    for ( const auto& button : page.buttons )
     {
-        tabWidth += m_closeBtnSize.x;
-        tabHeight = wxMax(tabHeight, m_closeBtnSize.y);
+        if ( button.curState & wxAUI_BUTTON_STATE_HIDDEN )
+            continue;
+
+        switch ( button.id )
+        {
+            case wxAUI_BUTTON_CLOSE:
+                tabWidth += m_closeBtnSize.x;
+                tabHeight = wxMax(tabHeight, m_closeBtnSize.y);
+                break;
+        }
     }
 
     // if there's a bitmap, add space for it
-    if ( bitmap.IsOk() )
+    if ( page.bitmap.IsOk() )
     {
-        const wxSize bitmapSize = bitmap.GetPreferredLogicalSizeFor(wnd);
+        const wxSize bitmapSize = page.bitmap.GetPreferredLogicalSizeFor(wnd);
 
         tabWidth += bitmapSize.x + wnd->FromDIP(3); // bitmap padding
         tabHeight = wxMax(tabHeight, bitmapSize.y + wnd->FromDIP(2));
@@ -314,7 +317,8 @@ wxSize wxAuiMSWTabArt::GetTabSize(wxReadOnlyDC& dc,
             tabWidth = minTabWidth;
     }
 
-    *x_extent = tabWidth;
+    if ( x_extent )
+        *x_extent = tabWidth;
 
     if (tabHeight > m_maxTabHeight)
         m_maxTabHeight = tabHeight;
@@ -441,6 +445,7 @@ bool wxAuiMSWTabArt::IsThemed() const
 {
     return
         m_themed &&
+        !(m_flags & wxAUI_NB_TAB_PIN) && // We don't draw pin button yet
         !(m_flags & wxAUI_NB_BOTTOM); // Native theme does not support bottom tabs
 }
 


### PR DESCRIPTION
This implements support for the usual concept of pinned tabs (shown before all the other normal tabs) as well as the locked tabs from #25072 (shown even before the pinned tabs and can't be closed nor drag-moved by the user, even among the tabs of the given group).

After reviewing handling of the pinned tabs in different programs, I've discovered that there are quite a few different ways in which they're handled:

- Some programs don't show any special button for them at all, only allow [un]pinning them from a menu.
- Some programs show the pin/unpin button only on the current tab.
- Some programs show the pin button only on the current tab, but unpin button on all pinned tabs.

And this is why we have `wxAUI_NB_PIN_ON_ACTIVE_TAB` and `wxAUI_NB_UNPIN_ON_ALL_PINNED` styles that provide support for all of the possibilities above. Note that I couldn't find any program that always showed pin button on all tabs and experimenting with it showed why: this just makes the display too visually busy. OTOH MSVS shows pin/unpin buttons on all tabs, but only when the mouse is hovering over it and this looks quite nice (but wastes space on the not shown buttons) and is something we could implement later.

As always, any comments/remarks/suggestions are welcome!