### PR TITLE
Fix confusion between `wxNotebook` pages text and label

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -127,6 +127,10 @@ Changes in behaviour not resulting in compilation errors
   the page on screen, which doesn't make sense without reference to the tab
   control containing it, use GetPagePosition() to retrieve both of them.
 
+- wxListbook and wxChoicebook now interpret (but ignore) mnemonics in their
+  page titles, just as the other wx*book classes already did. Double "&"
+  in the page text if it should be interpreted as a literal "&".
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/osx/notebook.h
+++ b/include/wx/osx/notebook.h
@@ -14,6 +14,8 @@
 // ----------------------------------------------------------------------------
 #include "wx/event.h"
 
+#include <vector>
+
 // ----------------------------------------------------------------------------
 // types
 // ----------------------------------------------------------------------------
@@ -128,8 +130,25 @@ protected:
 
   int DoSetSelection(size_t nPage, int flags = 0) override;
 
-  // the icon indices
-  wxArrayInt m_images;
+private:
+  // this vector is synchronized with m_pages in the base class
+  struct PageData
+  {
+      PageData(const wxString& text_, int image_)
+          : text{text_}, image{image_}
+      {
+      }
+
+      PageData(const PageData&) = default;
+      PageData& operator=(const PageData&) = default;
+
+      PageData(PageData&&) = default;
+      PageData& operator=(PageData&&) = default;
+
+      wxString text;
+      int image = wxNOT_FOUND;
+  };
+  std::vector<PageData> m_pagesData;
 
   wxDECLARE_DYNAMIC_CLASS(wxNotebook);
   wxDECLARE_EVENT_TABLE();

--- a/interface/wx/bookctrl.h
+++ b/interface/wx/bookctrl.h
@@ -139,6 +139,10 @@ public:
 
     /**
         Sets the text for the given page.
+
+        The text may contain mnemonics, i.e. accelerator characters preceded by
+        the ampersand (`&`) character. If you need to include a literal
+        ampersand in the text, you need to double it, i.e. use `&&`.
     */
     virtual bool SetPageText(size_t page, const wxString& text) = 0;
     ///@}
@@ -257,7 +261,8 @@ public:
         @param page
             Specifies the new page.
         @param text
-            Specifies the text for the new page.
+            Specifies the text of the new page. Note that it may contain
+            mnemonic characters, see SetPageText() for more information.
         @param select
             Specifies whether the page should be selected.
         @param imageId
@@ -297,7 +302,8 @@ public:
         @param page
             Specifies the new page.
         @param text
-            Specifies the text for the new page.
+            Specifies the text of the new page. Note that it may contain
+            mnemonic characters, see SetPageText() for more information.
         @param select
             Specifies whether the page should be selected.
         @param imageId

--- a/samples/notebook/notebook.h
+++ b/samples/notebook/notebook.h
@@ -187,7 +187,7 @@ enum ID_COMMANDS
 */
 
 #define I_WAS_INSERTED_PAGE_NAME        "Inserted"
-#define RADIOBUTTONS_PAGE_NAME          "Radiobuttons"
+#define RADIOBUTTONS_PAGE_NAME          "Radio &buttons"
 #define VETO_PAGE_NAME                  "Veto"
 #define TEXT_PAGE_NAME                  "Text"
 

--- a/src/generic/choicbkg.cpp
+++ b/src/generic/choicbkg.cpp
@@ -106,7 +106,7 @@ wxChoicebook::Create(wxWindow *parent,
 
 bool wxChoicebook::SetPageText(size_t n, const wxString& strText)
 {
-    GetChoiceCtrl()->SetString(n, strText);
+    GetChoiceCtrl()->SetString(n, RemoveMnemonics(strText));
 
     return true;
 }
@@ -178,7 +178,7 @@ wxChoicebook::InsertPage(size_t n,
     if ( !wxBookCtrlBase::InsertPage(n, page, text, bSelect, imageId) )
         return false;
 
-    GetChoiceCtrl()->Insert(text, n);
+    GetChoiceCtrl()->Insert(RemoveMnemonics(text), n);
 
     // if the inserted page is before the selected one, we must update the
     // index of the selected page

--- a/src/generic/listbkg.cpp
+++ b/src/generic/listbkg.cpp
@@ -219,7 +219,7 @@ void wxListbook::UpdateSize()
 
 bool wxListbook::SetPageText(size_t n, const wxString& strText)
 {
-    GetListView()->SetItemText(n, strText);
+    GetListView()->SetItemText(n, RemoveMnemonics(strText));
 
     return true;
 }
@@ -320,7 +320,7 @@ wxListbook::InsertPage(size_t n,
     if ( !wxBookCtrlBase::InsertPage(n, page, text, bSelect, imageId) )
         return false;
 
-    GetListView()->InsertItem(n, text, imageId);
+    GetListView()->InsertItem(n, RemoveMnemonics(text), imageId);
 
     // if the inserted page is before the selected one, we must update the
     // index of the selected page

--- a/src/gtk/notebook.cpp
+++ b/src/gtk/notebook.cpp
@@ -16,7 +16,6 @@
 #ifndef WX_PRECOMP
     #include "wx/intl.h"
     #include "wx/log.h"
-    #include "wx/utils.h"
     #include "wx/msgdlg.h"
     #include "wx/bitmap.h"
 #endif
@@ -500,8 +499,9 @@ bool wxNotebook::InsertPage( size_t position,
         pageData->m_image = nullptr;
     }
 
-    /* set the label text */
-    pageData->m_label = gtk_label_new(wxStripMenuCodes(text).utf8_str());
+    // Set the label text: we don't support mnemonics here, but we still need
+    // to strip them if there are any.
+    pageData->m_label = gtk_label_new(RemoveMnemonics(text).utf8_str());
 
     if (m_windowStyle & wxBK_LEFT)
         gtk_label_set_angle(GTK_LABEL(pageData->m_label), 90);

--- a/src/osx/cocoa/notebook.mm
+++ b/src/osx/cocoa/notebook.mm
@@ -291,7 +291,7 @@ private:
     {
         wxNotebookPage* page = notebook.GetPage(i);
         [item setView:page->GetHandle() ];
-        wxCFStringRef cf( page->GetLabel() );
+        wxCFStringRef cf( wxControl::RemoveMnemonics(notebook.GetPageText(i)) );
         [item setLabel:cf.AsNSString()];
 
         const wxBitmapBundle bitmap = notebook.GetPageBitmapBundle(i);

--- a/src/osx/cocoa/notebook.mm
+++ b/src/osx/cocoa/notebook.mm
@@ -236,18 +236,9 @@ public:
         const int maximum = notebook.GetPageCount();
         for ( int i = 0; i < wxMin(maximum, cocoacount); ++i )
         {
-            NSTabViewItem* item = [(wxNSTabView*) m_osxView tabViewItemAtIndex:i];
+            SetupTabItem(notebook, i,
+                         [(wxNSTabView*) m_osxView tabViewItemAtIndex:i]);
 
-            wxNotebookPage* page = notebook.GetPage(i);
-            [item setView:page->GetHandle() ];
-            wxCFStringRef cf( page->GetLabel() );
-            [item setLabel:cf.AsNSString()];
-
-            const wxBitmapBundle bitmap = notebook.GetPageBitmapBundle(i);
-            if ( bitmap.IsOk() )
-            {
-                [(WXCTabViewImageItem*) item setImage: wxOSXGetImageFromBundle(bitmap)];
-            }
         }
 
         // Next also add new pages or delete the no more existing ones.
@@ -256,17 +247,7 @@ public:
             for ( int i = cocoacount ; i < maximum ; ++i )
             {
                 NSTabViewItem* item = [[WXCTabViewImageItem alloc] init];
-
-                wxNotebookPage* page = notebook.GetPage(i);
-                [item setView:page->GetHandle() ];
-                wxCFStringRef cf( page->GetLabel() );
-                [item setLabel:cf.AsNSString()];
-
-                const wxBitmapBundle bitmap = notebook.GetPageBitmapBundle(i);
-                if ( bitmap.IsOk() )
-                {
-                    [(WXCTabViewImageItem*) item setImage: wxOSXGetImageFromBundle(bitmap)];
-                }
+                SetupTabItem(notebook, i, item);
 
                 [slf addTabViewItem:item];
                 [item release];
@@ -303,6 +284,21 @@ public:
         }
         
         return retval; 
+    }
+
+private:
+    void SetupTabItem(const wxNotebook& notebook, int i, NSTabViewItem* item)
+    {
+        wxNotebookPage* page = notebook.GetPage(i);
+        [item setView:page->GetHandle() ];
+        wxCFStringRef cf( page->GetLabel() );
+        [item setLabel:cf.AsNSString()];
+
+        const wxBitmapBundle bitmap = notebook.GetPageBitmapBundle(i);
+        if ( bitmap.IsOk() )
+        {
+            [(WXCTabViewImageItem*) item setImage: wxOSXGetImageFromBundle(bitmap)];
+        }
     }
 };
 

--- a/src/osx/notebook_osx.cpp
+++ b/src/osx/notebook_osx.cpp
@@ -118,9 +118,11 @@ bool wxNotebook::SetPageText(size_t nPage, const wxString& strText)
 {
     wxCHECK_MSG( IS_VALID_PAGE(nPage), false, wxT("SetPageText: invalid notebook page") );
 
-    wxNotebookPage *page = m_pages[nPage];
-    page->SetLabel(wxStripMenuCodes(strText));
-    MacSetupTabs();
+    if ( m_pagesData[nPage].text != strText )
+    {
+        m_pagesData[nPage].text = strText;
+        MacSetupTabs();
+    }
 
     return true;
 }
@@ -129,16 +131,14 @@ wxString wxNotebook::GetPageText(size_t nPage) const
 {
     wxCHECK_MSG( IS_VALID_PAGE(nPage), wxEmptyString, wxT("GetPageText: invalid notebook page") );
 
-    wxNotebookPage *page = m_pages[nPage];
-
-    return page->GetLabel();
+    return m_pagesData[nPage].text;
 }
 
 int wxNotebook::GetPageImage(size_t nPage) const
 {
     wxCHECK_MSG( IS_VALID_PAGE(nPage), wxNOT_FOUND, wxT("GetPageImage: invalid notebook page") );
 
-    return m_images[nPage];
+    return m_pagesData[nPage].image;
 }
 
 bool wxNotebook::SetPageImage(size_t nPage, int nImage)
@@ -148,12 +148,12 @@ bool wxNotebook::SetPageImage(size_t nPage, int nImage)
     wxCHECK_MSG( HasImageList() && nImage < GetImageList()->GetImageCount(), false,
         wxT("SetPageImage: invalid image index") );
 
-    if ( nImage != m_images[nPage] )
+    if ( nImage != m_pagesData[nPage].image )
     {
         // if the item didn't have an icon before or, on the contrary, did have
         // it but has lost it now, its size will change - but if the icon just
         // changes, it won't
-        m_images[nPage] = nImage;
+        m_pagesData[nPage].image = nImage;
 
         MacSetupTabs() ;
     }
@@ -173,7 +173,7 @@ wxNotebookPage* wxNotebook::DoRemovePage(size_t nPage)
 
     wxNotebookPage* page = m_pages[nPage] ;
     m_pages.erase(m_pages.begin() + nPage);
-    m_images.RemoveAt(nPage);
+    m_pagesData.erase(m_pagesData.begin() + nPage);
 
     MacSetupTabs();
 
@@ -200,7 +200,7 @@ bool wxNotebook::DeleteAllPages()
 {
     wxBookCtrlBase::DeleteAllPages();
 
-    m_images.clear();
+    m_pagesData.clear();
     MacSetupTabs();
 
     return true;
@@ -221,9 +221,7 @@ bool wxNotebook::InsertPage(size_t nPage,
     // don't show pages by default (we'll need to adjust their size first)
     pPage->Show( false ) ;
 
-    pPage->SetLabel( wxStripMenuCodes(strText) );
-
-    m_images.Insert( imageId, nPage );
+    m_pagesData.insert( m_pagesData.begin() + nPage, {strText, imageId} );
 
     MacSetupTabs();
 

--- a/tests/controls/bookctrlbasetest.cpp
+++ b/tests/controls/bookctrlbasetest.cpp
@@ -80,9 +80,9 @@ void BookCtrlBaseTestCase::Text()
 
     CPPUNIT_ASSERT_EQUAL("Some other string", base->GetPageText(1));
 
-    base->SetPageText(2, "string with /nline break");
+    base->SetPageText(2, "string with\nline break");
 
-    CPPUNIT_ASSERT_EQUAL("string with /nline break", base->GetPageText(2));
+    CPPUNIT_ASSERT_EQUAL("string with\nline break", base->GetPageText(2));
 }
 
 void BookCtrlBaseTestCase::PageManagement()

--- a/tests/controls/bookctrlbasetest.cpp
+++ b/tests/controls/bookctrlbasetest.cpp
@@ -40,7 +40,7 @@ void BookCtrlBaseTestCase::AddPanels()
     m_panel2 = new wxPanel(base);
     m_panel3 = new wxPanel(base);
 
-    base->AddPage(m_panel1, "Panel 1", false, 0);
+    base->AddPage(m_panel1, "Panel &1", false, 0);
     base->AddPage(m_panel2, "Panel 2", false, 1);
     base->AddPage(m_panel3, "Panel 3", false, 2);
 }
@@ -74,7 +74,8 @@ void BookCtrlBaseTestCase::Text()
 {
     wxBookCtrlBase * const base = GetBase();
 
-    CPPUNIT_ASSERT_EQUAL("Panel 1", base->GetPageText(0));
+    const wxString expected(HasBrokenMnemonics() ? "Panel 1" : "Panel &1");
+    CPPUNIT_ASSERT_EQUAL(expected, base->GetPageText(0));
 
     base->SetPageText(1, "Some other string");
 
@@ -83,6 +84,12 @@ void BookCtrlBaseTestCase::Text()
     base->SetPageText(2, "string with\nline break");
 
     CPPUNIT_ASSERT_EQUAL("string with\nline break", base->GetPageText(2));
+
+    if ( !HasBrokenMnemonics() )
+    {
+        base->SetPageText(0, "With &mnemonic");
+        CPPUNIT_ASSERT_EQUAL("With &mnemonic", base->GetPageText(0));
+    }
 }
 
 void BookCtrlBaseTestCase::PageManagement()

--- a/tests/controls/bookctrlbasetest.h
+++ b/tests/controls/bookctrlbasetest.h
@@ -26,6 +26,10 @@ protected:
 
     virtual wxEventType GetChangingEvent() const = 0;
 
+    // Some wxBookCtrlBase-derived classes strip mnemonics and don't return
+    // them from their GetPageText(), allow them to just return true from here.
+    virtual bool HasBrokenMnemonics() const { return false; }
+
     // this should be inserted in the derived class CPPUNIT_TEST_SUITE
     // definition to run all wxBookCtrlBase tests as part of it
     #define wxBOOK_CTRL_BASE_TESTS() \

--- a/tests/controls/choicebooktest.cpp
+++ b/tests/controls/choicebooktest.cpp
@@ -36,6 +36,8 @@ private:
     virtual wxEventType GetChangingEvent() const override
     { return wxEVT_CHOICEBOOK_PAGE_CHANGING; }
 
+    virtual bool HasBrokenMnemonics() const override { return true; }
+
     CPPUNIT_TEST_SUITE( ChoicebookTestCase );
         wxBOOK_CTRL_BASE_TESTS();
         CPPUNIT_TEST( Choice );

--- a/tests/controls/listbooktest.cpp
+++ b/tests/controls/listbooktest.cpp
@@ -37,6 +37,8 @@ private:
     virtual wxEventType GetChangingEvent() const override
     { return wxEVT_LISTBOOK_PAGE_CHANGING; }
 
+    virtual bool HasBrokenMnemonics() const override { return true; }
+
     CPPUNIT_TEST_SUITE( ListbookTestCase );
         wxBOOK_CTRL_BASE_TESTS();
         CPPUNIT_TEST( ListView );


### PR DESCRIPTION
Return the original text used for the page, with mnemonics, if any, in all ports.