### PR TITLE
Improve wxAUI hint appearance and API

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -131,6 +131,8 @@ Changes in behaviour not resulting in compilation errors
   page titles, just as the other wx*book classes already did. Double "&"
   in the page text if it should be interpreted as a literal "&".
 
+- wxAUI_MGR_HINT_FADE is not included in default wxAuiManager style any longer,
+  please add it explicitly if you really want to use it.
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -334,6 +334,10 @@ public:
     // Also updates rowEnd for all pages in m_pages when using multiple rows.
     void DoApplyRect(const wxRect& rect, int tabCtrlHeight);
 
+    // Another internal helper: return the hint rectangle corresponding to this
+    // tab control in screen coordinates.
+    wxRect GetHintScreenRect() const;
+
 protected:
     // choose the default border for this window
     virtual wxBorder GetDefaultBorder() const override { return wxBORDER_NONE; }
@@ -377,6 +381,10 @@ private:
     wxDECLARE_CLASS(wxAuiTabCtrl);
     wxDECLARE_EVENT_TABLE();
 #endif
+
+    // Rectangle corresponding to the full tab control area, including both
+    // tabs (which is this window) and the page area.
+    wxRect m_fullRect;
 };
 
 

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -51,7 +51,6 @@ enum wxAuiManagerOption
 
     wxAUI_MGR_DEFAULT = wxAUI_MGR_ALLOW_FLOATING |
                         wxAUI_MGR_TRANSPARENT_HINT |
-                        wxAUI_MGR_HINT_FADE |
                         wxAUI_MGR_NO_VENETIAN_BLINDS_FADE |
                         wxAUI_MGR_LIVE_RESIZE
 };

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -46,12 +46,11 @@ enum wxAuiManagerOption
     wxAUI_MGR_VENETIAN_BLINDS_HINT     = 1 << 4,
     wxAUI_MGR_RECTANGLE_HINT           = 1 << 5,
     wxAUI_MGR_HINT_FADE                = 1 << 6,
-    wxAUI_MGR_NO_VENETIAN_BLINDS_FADE  = 1 << 7,
+    wxAUI_MGR_NO_VENETIAN_BLINDS_FADE  = 0, // For compatibility only.
     wxAUI_MGR_LIVE_RESIZE              = 1 << 8,
 
     wxAUI_MGR_DEFAULT = wxAUI_MGR_ALLOW_FLOATING |
                         wxAUI_MGR_TRANSPARENT_HINT |
-                        wxAUI_MGR_NO_VENETIAN_BLINDS_FADE |
                         wxAUI_MGR_LIVE_RESIZE
 };
 

--- a/interface/wx/aui/auibook.h
+++ b/interface/wx/aui/auibook.h
@@ -525,11 +525,11 @@ public:
         ones are simply ignored, so it is always possible to reuse the same
         flags for the main wxAuiManager and the one used by the notebook.
 
-        Example of using this function to disable the fade effect for the
-        notebook:
+        Example of using this function to enable the Venetian blinds effect for
+        the notebook:
         @code
             auiNotebook->SetManagerFlags(
-                wxAuiManager::GetManager()->GetFlags() & ~wxAUI_MGR_HINT_FADE
+                wxAuiManager::GetManager()->GetFlags() | ~wxAUI_MGR_VENETIAN_BLINDS_HINT
             );
         @endcode
 

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -48,8 +48,14 @@ enum wxAuiManagerOption
         wxAUI_MGR_DEFAULT.
      */
     wxAUI_MGR_HINT_FADE                = 1 << 6,
-    /// Used in complement of wxAUI_MGR_VENETIAN_BLINDS_HINT to show the hint immediately.
-    wxAUI_MGR_NO_VENETIAN_BLINDS_FADE  = 1 << 7,
+    /**
+        Style which disabled the fade-in effect for the docking hint when using
+        Venetian blinds hint.
+
+        This style is obsolete and doesn't do anything any longer, fade-in
+        effect is only enabled when wxAUI_MGR_HINT_FADE is used.
+     */
+    wxAUI_MGR_NO_VENETIAN_BLINDS_FADE  = 0,
     /// When a docked pane is resized, its content is refreshed in live (instead of moving
     /// the border alone and refreshing the content at the end).
     /// Since wxWidgets 3.3.0 this flag is included in the default flags.
@@ -57,7 +63,6 @@ enum wxAuiManagerOption
     /// Default behaviour.
     wxAUI_MGR_DEFAULT = wxAUI_MGR_ALLOW_FLOATING |
                         wxAUI_MGR_TRANSPARENT_HINT |
-                        wxAUI_MGR_NO_VENETIAN_BLINDS_FADE |
                         wxAUI_MGR_LIVE_RESIZE
 };
 
@@ -150,8 +155,8 @@ enum wxAuiManagerOption
            Note that this flag is not included in wxAUI_MGR_DEFAULT since
            wxWidgets 3.3.0 any longer.
     @style{wxAUI_MGR_NO_VENETIAN_BLINDS_FADE}
-           Used in complement of wxAUI_MGR_VENETIAN_BLINDS_HINT to show the
-           docking hint immediately.
+           This style is obsolete and doesn't do anything, it is only defined
+           as 0 for compatibility.
     @style{wxAUI_MGR_LIVE_RESIZE}
            When a docked pane is resized, its content is refreshed in live (instead of moving
            the border alone and refreshing the content at the end). Note that
@@ -161,7 +166,7 @@ enum wxAuiManagerOption
            implemented in them.
     @style{wxAUI_MGR_DEFAULT}
            Default behaviour, combines ::wxAUI_MGR_ALLOW_FLOATING,
-           ::wxAUI_MGR_TRANSPARENT_HINT and ::wxAUI_MGR_NO_VENETIAN_BLINDS_FADE.
+           ::wxAUI_MGR_TRANSPARENT_HINT and ::wxAUI_MGR_LIVE_RESIZE.
     @endStyleTable
 
     @beginEventEmissionTable{wxAuiManagerEvent}

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -39,7 +39,14 @@ enum wxAuiManagerOption
     wxAUI_MGR_VENETIAN_BLINDS_HINT     = 1 << 4,
     /// The possible location for docking is indicated by a rectangular outline.
     wxAUI_MGR_RECTANGLE_HINT           = 1 << 5,
-    /// The translucent area where the pane could be docked appears gradually.
+    /**
+        The translucent area where the pane could be docked appears gradually.
+
+        Note that this flag was included in the default flags until wxWidgets
+        3.3.0 but this is not the case in the newer versions. If you'd like to
+        still show the hint progressively, you need to explicitly add it to
+        wxAUI_MGR_DEFAULT.
+     */
     wxAUI_MGR_HINT_FADE                = 1 << 6,
     /// Used in complement of wxAUI_MGR_VENETIAN_BLINDS_HINT to show the hint immediately.
     wxAUI_MGR_NO_VENETIAN_BLINDS_FADE  = 1 << 7,
@@ -50,7 +57,6 @@ enum wxAuiManagerOption
     /// Default behaviour.
     wxAUI_MGR_DEFAULT = wxAUI_MGR_ALLOW_FLOATING |
                         wxAUI_MGR_TRANSPARENT_HINT |
-                        wxAUI_MGR_HINT_FADE |
                         wxAUI_MGR_NO_VENETIAN_BLINDS_FADE |
                         wxAUI_MGR_LIVE_RESIZE
 };
@@ -141,6 +147,8 @@ enum wxAuiManagerOption
            instead.
     @style{wxAUI_MGR_HINT_FADE}
            The translucent area where the pane could be docked appears gradually.
+           Note that this flag is not included in wxAUI_MGR_DEFAULT since
+           wxWidgets 3.3.0 any longer.
     @style{wxAUI_MGR_NO_VENETIAN_BLINDS_FADE}
            Used in complement of wxAUI_MGR_VENETIAN_BLINDS_HINT to show the
            docking hint immediately.
@@ -152,8 +160,8 @@ enum wxAuiManagerOption
            always enabled in wxGTK3 and wxOSX ports as non-live resizing is not
            implemented in them.
     @style{wxAUI_MGR_DEFAULT}
-           Default behaviour, combines: wxAUI_MGR_ALLOW_FLOATING | wxAUI_MGR_TRANSPARENT_HINT |
-           wxAUI_MGR_HINT_FADE | wxAUI_MGR_NO_VENETIAN_BLINDS_FADE.
+           Default behaviour, combines ::wxAUI_MGR_ALLOW_FLOATING,
+           ::wxAUI_MGR_TRANSPARENT_HINT and ::wxAUI_MGR_NO_VENETIAN_BLINDS_FADE.
     @endStyleTable
 
     @beginEventEmissionTable{wxAuiManagerEvent}

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -87,7 +87,6 @@ class MyFrame : public wxFrame
         ID_RectangleHint,
         ID_NoHint,
         ID_HintFade,
-        ID_NoVenetianFade,
         ID_TransparentDrag,
         ID_NoGradient,
         ID_VerticalGradient,
@@ -632,7 +631,6 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(ID_RectangleHint, MyFrame::OnManagerFlag)
     EVT_MENU(ID_NoHint, MyFrame::OnManagerFlag)
     EVT_MENU(ID_HintFade, MyFrame::OnManagerFlag)
-    EVT_MENU(ID_NoVenetianFade, MyFrame::OnManagerFlag)
     EVT_MENU(ID_TransparentDrag, MyFrame::OnManagerFlag)
     EVT_MENU(ID_LiveUpdate, MyFrame::OnManagerFlag)
     EVT_MENU(ID_AllowActivePane, MyFrame::OnManagerFlag)
@@ -688,7 +686,6 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_UPDATE_UI(ID_RectangleHint, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NoHint, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_HintFade, MyFrame::OnUpdateUI)
-    EVT_UPDATE_UI(ID_NoVenetianFade, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_TransparentDrag, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_LiveUpdate, MyFrame::OnUpdateUI)
     EVT_UPDATE_UI(ID_NoGradient, MyFrame::OnUpdateUI)
@@ -756,7 +753,6 @@ MyFrame::MyFrame(wxWindow* parent,
     options_menu->AppendSeparator();
     options_menu->AppendCheckItem(ID_HintFade, _("Hint Fade-in"));
     options_menu->AppendCheckItem(ID_AllowFloating, _("Allow Floating"));
-    options_menu->AppendCheckItem(ID_NoVenetianFade, _("Disable Venetian Blinds Hint Fade-in"));
     options_menu->AppendCheckItem(ID_TransparentDrag, _("Transparent Drag"));
     options_menu->AppendCheckItem(ID_AllowActivePane, _("Allow Active Pane"));
     // Only show "live resize" toggle if it's actually functional.
@@ -1205,7 +1201,6 @@ void MyFrame::OnManagerFlag(wxCommandEvent& event)
         case ID_AllowFloating: flag = wxAUI_MGR_ALLOW_FLOATING; break;
         case ID_TransparentDrag: flag = wxAUI_MGR_TRANSPARENT_DRAG; break;
         case ID_HintFade: flag = wxAUI_MGR_HINT_FADE; break;
-        case ID_NoVenetianFade: flag = wxAUI_MGR_NO_VENETIAN_BLINDS_FADE; break;
         case ID_AllowActivePane: flag = wxAUI_MGR_ALLOW_ACTIVE_PANE; break;
         case ID_TransparentHint: flag = wxAUI_MGR_TRANSPARENT_HINT; break;
         case ID_VenetianBlindsHint: flag = wxAUI_MGR_VENETIAN_BLINDS_HINT; break;
@@ -1372,9 +1367,6 @@ void MyFrame::OnUpdateUI(wxUpdateUIEvent& event)
             break;
         case ID_HintFade:
             event.Check((flags & wxAUI_MGR_HINT_FADE) != 0);
-            break;
-        case ID_NoVenetianFade:
-            event.Check((flags & wxAUI_MGR_NO_VENETIAN_BLINDS_FADE) != 0);
             break;
 
         case ID_NotebookNoCloseButton:

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3025,14 +3025,17 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
     }
 
 
+    wxRect hintRect;
     if (dest_tabs)
     {
-        m_mgr.UpdateHint(dest_tabs->GetHintScreenRect());
+        hintRect = dest_tabs->GetHintScreenRect();
     }
     else
     {
-        m_mgr.DrawHintRect(m_dummyWnd, client_pt);
+        hintRect = m_mgr.CalculateHintRect(m_dummyWnd, client_pt);
     }
+
+    m_mgr.UpdateHint(hintRect);
 }
 
 

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3446,21 +3446,22 @@ void wxAuiManager::DrawHintRect(wxWindow* pane_window,
                                 const wxPoint& pt,
                                 const wxPoint& offset)
 {
-    const wxRect rect = CalculateHintRect(pane_window, pt, offset);
-    if (rect != m_lastHint)
-        UpdateHint(rect);
+    UpdateHint(CalculateHintRect(pane_window, pt, offset));
 }
 
 void wxAuiManager::UpdateHint(const wxRect& rect)
 {
+    if (rect == m_lastHint)
+        return;
+
+    m_lastHint = rect;
+
     if (rect.IsEmpty())
     {
         HideHint();
     }
     else
     {
-        m_lastHint = rect;
-
         // Decide if we want to fade in the hint and set it to the end value if
         // we don't.
         if ((m_flags & wxAUI_MGR_HINT_FADE)

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3464,10 +3464,7 @@ void wxAuiManager::UpdateHint(const wxRect& rect)
     {
         // Decide if we want to fade in the hint and set it to the end value if
         // we don't.
-        if ((m_flags & wxAUI_MGR_HINT_FADE)
-            && !((m_flags & wxAUI_MGR_VENETIAN_BLINDS_HINT) &&
-                 (m_flags & wxAUI_MGR_NO_VENETIAN_BLINDS_FADE))
-            )
+        if (m_flags & wxAUI_MGR_HINT_FADE)
             m_hintFadeAmt = 0;
         else
             m_hintFadeAmt = m_hintFadeMax;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -427,7 +427,7 @@ wxAuiManager::wxAuiManager(wxWindow* managed_wnd, unsigned int flags)
     m_frame = nullptr;
     m_dockConstraintX = 0.3;
     m_dockConstraintY = 0.3;
-    m_hintFadeMax = 128;
+    m_hintFadeMax = 64;
 
     m_reserved = nullptr;
     m_currentDragItem = -1;


### PR DESCRIPTION
This PR disables fade-in effect by default, as proposed in [this thread](https://groups.google.com/g/wx-dev/c/WC_mZJWDBfI) but also shows the hints when dragging tabs between different tab controls in a better (IMO) way.

Any comments and, especially, testing of this PR would be welcome!