### PR TITLE
Fix wxSearchCtrl best size with GTK

### DIFF
--- a/include/wx/gtk/srchctrl.h
+++ b/include/wx/gtk/srchctrl.h
@@ -97,6 +97,8 @@ private:
     }
 
 protected:
+    virtual wxSize DoGetBestSize() const override;
+    virtual wxSize DoGetSizeFromTextSize(int xlen, int ylen = -1) const override;
     virtual GdkWindow* GTKGetWindow(wxArrayGdkWindows& windows) const override;
 
 private:

--- a/src/gtk/srchctrl.cpp
+++ b/src/gtk/srchctrl.cpp
@@ -16,12 +16,13 @@
 
 #ifndef WX_PRECOMP
     #include "wx/menu.h"
+    #include "wx/utils.h"
 #endif //WX_PRECOMP
 
-#include "wx/utils.h"
-#include "wx/gtk/private.h"
+#include "wx/gtk/private/wrapgtk.h"
 #include "wx/gtk/private/event.h"
 #include "wx/gtk/private/gtk3-compat.h"
+#include "wx/gtk/private/stylecontext.h"
 
 
 #if GTK_CHECK_VERSION(3,6,0)
@@ -198,9 +199,9 @@ bool wxSearchCtrl::Create(wxWindow *parent, wxWindowID id,
 
     m_focusWidget = GTK_WIDGET(entry);
 
-    PostCreation(size);
-
     gtk_entry_set_text(entry, value.utf8_str());
+
+    PostCreation(size);
 
     SetHint(_("Search"));
 
@@ -383,6 +384,43 @@ void wxSearchCtrl::PopupSearchMenu()
 }
 
 #endif // wxUSE_MENUS
+
+wxSize wxSearchCtrl::DoGetBestSize() const
+{
+    int w;
+    GetTextExtent(wxS("0"), &w, nullptr);
+    return DoGetSizeFromTextSize(w * 8);
+}
+
+wxSize wxSearchCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
+{
+    wxSize size(GTKGetPreferredSize(m_widget));
+    size.x += xlen;
+    if (size.y < ylen)
+        size.y = ylen;
+
+#ifdef wxHAS_GTK_SEARCH_ENTRY
+    if (HasGtkSearchEntry() &&
+        gtk_entry_get_icon_storage_type(m_entry, GTK_ENTRY_ICON_SECONDARY) == GTK_IMAGE_EMPTY)
+    {
+        // If text is empty, there is no "clear" icon, and GtkEntry preferred size
+        // does not account for it. So add in size of primary icon as a substitute.
+        GdkPixbuf* pixbuf = gtk_entry_get_icon_pixbuf(m_entry, GTK_ENTRY_ICON_PRIMARY);
+        if (pixbuf)
+            size.x += gdk_pixbuf_get_width(pixbuf);
+
+        // Also account for secondary icon margin
+        wxGtkStyleContext sc(GetContentScaleFactor());
+        sc.Add(GTK_TYPE_ENTRY, "entry", "entry", nullptr);
+        sc.Add(GTK_TYPE_IMAGE, "image", "right", nullptr);
+        GtkBorder margin;
+        gtk_style_context_get_margin(sc, GTK_STATE_FLAG_NORMAL, &margin);
+        size.x += margin.left + margin.right;
+    }
+#endif // wxHAS_GTK_SEARCH_ENTRY
+
+    return size;
+}
 
 GdkWindow* wxSearchCtrl::GTKGetWindow(wxArrayGdkWindows& windows) const
 {


### PR DESCRIPTION
Implement GetSizeFromTextSize() and use that to get a reasonable width.
See #25210