### PR TITLE
Try to make code operating with `GdkWindow` more clear

### DIFF
--- a/include/wx/gtk/bmpcbox.h
+++ b/include/wx/gtk/bmpcbox.h
@@ -124,7 +124,7 @@ public:
     virtual bool IsEditable() const override;
     virtual void SetEditable(bool editable) override;
 
-    virtual GtkWidget* GetConnectWidget() override;
+    virtual GtkWidget* GetConnectWidget() const override;
 
 protected:
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const override;

--- a/include/wx/gtk/combobox.h
+++ b/include/wx/gtk/combobox.h
@@ -123,7 +123,7 @@ public:
 
     virtual void GTKDisableEvents() override;
     virtual void GTKEnableEvents() override;
-    GtkWidget* GetConnectWidget() override;
+    GtkWidget* GetConnectWidget() const override;
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);

--- a/include/wx/gtk/listbox.h
+++ b/include/wx/gtk/listbox.h
@@ -84,7 +84,7 @@ public:
 
     // implementation from now on
 
-    virtual GtkWidget *GetConnectWidget() override;
+    virtual GtkWidget *GetConnectWidget() const override;
 
     struct _GtkTreeView   *m_treeview;
     struct _GtkListStore  *m_liststore;

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -141,7 +141,7 @@ public:
     bool SetForegroundColour(const wxColour& colour) override;
     bool SetBackgroundColour(const wxColour& colour) override;
 
-    GtkWidget* GetConnectWidget() override;
+    GtkWidget* GetConnectWidget() const override;
 
     void SetUpdateFont(bool WXUNUSED(update)) { }
 

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -173,7 +173,7 @@ public:
     // also, it is not clear which native widget is the top
     // widget where (most of) the input goes. even tooltips have
     // to be applied to all subwidgets.
-    virtual GtkWidget* GetConnectWidget();
+    virtual GtkWidget* GetConnectWidget() const;
     void ConnectWidget( GtkWidget *widget );
 
 

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -243,6 +243,18 @@ protected:
     // Check if the given window makes part of this widget
     bool GTKIsOwnWindow(GdkWindow *window) const;
 
+    // Return the GdkWindow associated with either m_wxwindow or m_widget.
+    //
+    // This may be different from GTKGetConnectWindow() for the native widgets
+    // using a different "connect widget".
+    //
+    // Unlike GTKGetDrawingWindow(), this function always returns something
+    // non-null for a mapped window.
+    GdkWindow* GTKGetMainWindow() const;
+
+    // Return the GdkWindow associated with GetConnectWidget().
+    GdkWindow* GTKGetConnectWindow() const;
+
 public:
     // Returns the default context which usually is anti-aliased
     PangoContext   *GTKGetPangoDefaultContext();

--- a/src/gtk/bmpcbox.cpp
+++ b/src/gtk/bmpcbox.cpp
@@ -169,7 +169,7 @@ wxBitmapComboBox::~wxBitmapComboBox()
 {
 }
 
-GtkWidget* wxBitmapComboBox::GetConnectWidget()
+GtkWidget* wxBitmapComboBox::GetConnectWidget() const
 {
     if ( GetEntry() )
         return wxComboBox::GetConnectWidget();

--- a/src/gtk/combobox.cpp
+++ b/src/gtk/combobox.cpp
@@ -264,7 +264,7 @@ void wxComboBox::GTKEnableEvents()
         (gpointer)gtkcombobox_popupshown_callback, this);
 }
 
-GtkWidget* wxComboBox::GetConnectWidget()
+GtkWidget* wxComboBox::GetConnectWidget() const
 {
     return GTK_WIDGET( GetEntry() );
 }

--- a/src/gtk/listbox.cpp
+++ b/src/gtk/listbox.cpp
@@ -862,7 +862,7 @@ int wxListBox::DoListHitTest(const wxPoint& point) const
 // helpers
 // ----------------------------------------------------------------------------
 
-GtkWidget *wxListBox::GetConnectWidget()
+GtkWidget *wxListBox::GetConnectWidget() const
 {
     // the correct widget for listbox events (such as mouse clicks for example)
     // is m_treeview, not the parent scrolled window

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1898,7 +1898,7 @@ void wxTextCtrl::OnChar( wxKeyEvent &key_event )
     key_event.Skip();
 }
 
-GtkWidget* wxTextCtrl::GetConnectWidget()
+GtkWidget* wxTextCtrl::GetConnectWidget() const
 {
     return GTK_WIDGET(m_text);
 }

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6923,10 +6923,7 @@ void wxGetMousePosition(int* x, int* y)
 
 GdkWindow* wxWindowGTK::GTKGetDrawingWindow() const
 {
-    GdkWindow* window = nullptr;
-    if (m_wxwindow)
-        window = gtk_widget_get_window(m_wxwindow);
-    return window;
+    return m_wxwindow ? gtk_widget_get_window(m_wxwindow) : nullptr;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4609,10 +4609,7 @@ void wxWindowGTK::DoClientToScreen( int *x, int *y ) const
 {
     wxCHECK_RET( (m_widget != nullptr), wxT("invalid window") );
 
-    GtkWidget* widget = m_widget;
-    if (m_wxwindow)
-        widget = m_wxwindow;
-    GdkWindow* source = gtk_widget_get_window(widget);
+    GdkWindow* const source = GTKGetMainWindow();
 
     if ((!m_isGtkPositionValid || source == nullptr) && !IsTopLevel() && m_parent)
     {
@@ -4683,10 +4680,7 @@ void wxWindowGTK::DoScreenToClient( int *x, int *y ) const
 {
     wxCHECK_RET( (m_widget != nullptr), wxT("invalid window") );
 
-    GtkWidget* widget = m_widget;
-    if (m_wxwindow)
-        widget = m_wxwindow;
-    GdkWindow* source = gtk_widget_get_window(widget);
+    GdkWindow* const source = GTKGetMainWindow();
 
     if ((!m_isGtkPositionValid || source == nullptr) && !IsTopLevel() && m_parent)
     {
@@ -5421,13 +5415,9 @@ void wxWindowGTK::Raise()
 {
     wxCHECK_RET( (m_widget != nullptr), wxT("invalid window") );
 
-    if (m_wxwindow && gtk_widget_get_window(m_wxwindow))
+    if (auto const window = GTKGetMainWindow())
     {
-        gdk_window_raise(gtk_widget_get_window(m_wxwindow));
-    }
-    else if (gtk_widget_get_window(m_widget))
-    {
-        gdk_window_raise(gtk_widget_get_window(m_widget));
+        gdk_window_raise(window);
     }
 }
 
@@ -5435,13 +5425,9 @@ void wxWindowGTK::Lower()
 {
     wxCHECK_RET( (m_widget != nullptr), wxT("invalid window") );
 
-    if (m_wxwindow && gtk_widget_get_window(m_wxwindow))
+    if (auto const window = GTKGetMainWindow())
     {
-        gdk_window_lower(gtk_widget_get_window(m_wxwindow));
-    }
-    else if (gtk_widget_get_window(m_widget))
-    {
-        gdk_window_lower(gtk_widget_get_window(m_widget));
+        gdk_window_lower(window);
     }
 }
 
@@ -5617,9 +5603,7 @@ void wxWindowGTK::Update()
 {
     if (m_widget && gtk_widget_get_mapped(m_widget) && m_width > 0 && m_height > 0)
     {
-        GdkWindow* window = GTKGetDrawingWindow();
-        if (window == nullptr)
-            window = gtk_widget_get_window(m_widget);
+        GdkWindow* const window = GTKGetMainWindow();
 
 #ifdef GDK_WINDOWING_WAYLAND
         if (wxGTKImpl::IsWayland(window))
@@ -6400,7 +6384,7 @@ bool wxWindowGTK::DoPopupMenu( wxMenu *menu, int x, int y )
 
     menu->m_popupShown = true;
 #if GTK_CHECK_VERSION(3,22,0)
-    GdkWindow* window = gtk_widget_get_window(m_wxwindow ? m_wxwindow : m_widget);
+    GdkWindow* const window = GTKGetMainWindow();
     if (wxGTKImpl::IsWayland(window) && wx_is_at_least_gtk3(22))
     {
         GdkEvent* currentEvent = gtk_get_current_event();
@@ -6514,7 +6498,17 @@ bool wxWindowGTK::GTKIsOwnWindow(GdkWindow *window) const
 
 GdkWindow *wxWindowGTK::GTKGetWindow(wxArrayGdkWindows& WXUNUSED(windows)) const
 {
-    return m_wxwindow ? GTKGetDrawingWindow() : gtk_widget_get_window(m_widget);
+    return GTKGetMainWindow();
+}
+
+GdkWindow* wxWindowGTK::GTKGetMainWindow() const
+{
+    return gtk_widget_get_window(m_wxwindow ? m_wxwindow : m_widget);
+}
+
+GdkWindow* wxWindowGTK::GTKGetConnectWindow() const
+{
+    return gtk_widget_get_window(GetConnectWidget());
 }
 
 #ifdef __WXGTK3__
@@ -6603,12 +6597,7 @@ void wxWindowGTK::DoCaptureMouse()
 {
     wxCHECK_RET( m_widget != nullptr, wxT("invalid window") );
 
-    GdkWindow *window = nullptr;
-    if (m_wxwindow)
-        window = GTKGetDrawingWindow();
-    else
-        window = gtk_widget_get_window(GetConnectWidget());
-
+    GdkWindow* const window = GTKGetConnectWindow();
     wxCHECK_RET( window, wxT("CaptureMouse() failed") );
 
 #if GTK_CHECK_VERSION(3,20,0)
@@ -6648,11 +6637,7 @@ void wxWindowGTK::DoReleaseMouse()
 
     g_captureWindow = nullptr;
 
-    GdkWindow *window = nullptr;
-    if (m_wxwindow)
-        window = GTKGetDrawingWindow();
-    else
-        window = gtk_widget_get_window(GetConnectWidget());
+    GdkWindow* const window = GTKGetConnectWindow();
 
     if (!window)
         return;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6498,7 +6498,7 @@ void wxWindowGTK::SetDropTarget( wxDropTarget *dropTarget )
 
 #endif // wxUSE_DRAG_AND_DROP
 
-GtkWidget* wxWindowGTK::GetConnectWidget()
+GtkWidget* wxWindowGTK::GetConnectWidget() const
 {
     return m_wxwindow ? m_wxwindow : m_widget;
 }

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -6500,10 +6500,7 @@ void wxWindowGTK::SetDropTarget( wxDropTarget *dropTarget )
 
 GtkWidget* wxWindowGTK::GetConnectWidget()
 {
-    GtkWidget *connect_widget = m_widget;
-    if (m_wxwindow) connect_widget = m_wxwindow;
-
-    return connect_widget;
+    return m_wxwindow ? m_wxwindow : m_widget;
 }
 
 bool wxWindowGTK::GTKIsOwnWindow(GdkWindow *window) const


### PR DESCRIPTION
There are no real changes here, but this hopefully makes it more clear to understand which widget is used where.