### PR TITLE
Make wxGetGtkPaperSize accessible

### DIFF
--- a/include/wx/gtk/print.h
+++ b/include/wx/gtk/print.h
@@ -26,6 +26,8 @@ typedef struct _GtkPageSetup GtkPageSetup;
 
 typedef struct _cairo cairo_t;
 
+GtkPaperSize* wxGetGtkPaperSize(wxPaperSize paperId, const wxSize& size);
+
 //----------------------------------------------------------------------------
 // wxGtkPrintFactory
 //----------------------------------------------------------------------------

--- a/include/wx/gtk/print.h
+++ b/include/wx/gtk/print.h
@@ -26,6 +26,7 @@ typedef struct _GtkPageSetup GtkPageSetup;
 
 typedef struct _cairo cairo_t;
 
+typedef struct _GtkPaperSize GtkPaperSize;
 GtkPaperSize* wxGetGtkPaperSize(wxPaperSize paperId, const wxSize& size);
 
 //----------------------------------------------------------------------------

--- a/src/gtk/print.cpp
+++ b/src/gtk/print.cpp
@@ -174,7 +174,7 @@ static const char* const gs_paperList[] = {
     "iso_a1"  // wxPAPER_A1
 };
 
-static GtkPaperSize* wxGetGtkPaperSize(wxPaperSize paperId, const wxSize& size)
+GtkPaperSize* wxGetGtkPaperSize(wxPaperSize paperId, const wxSize& size)
 {
     // if wxPaperSize is valid, get corresponding GtkPaperSize
     if (paperId > 0 && size_t(paperId) < WXSIZEOF(gs_paperList))


### PR DESCRIPTION
Move `wxGetGtkPaperSize()` declaration into header file. This can be useful for those doing low-level printing code under wxGTK.