### PR TITLE
Restore support for years > 3000 in wxDateTime with MSVC

### DIFF
--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -1280,7 +1280,14 @@ wxDateTime& wxDateTime::Set(wxDateTime_t day,
 
     // test only the year instead of testing for the exact end of the Unix
     // time_t range - it doesn't bring anything to do more precise checks
-    if ( year >= yearMinInRange && (sizeof(time_t) > 4 || year <= yearMaxInRange) )
+    if ( year >= yearMinInRange &&
+            ((sizeof(time_t) > 4
+#if defined(__VISUALC__) || defined(__MINGW64__)
+              // MSVC CRT (also used by MinGW) is documented not to support
+              // years > 3000, even when using 64-bit time_t.
+              && year <= 3000
+#endif // Using MSVC CRT
+             ) || year <= yearMaxInRange) )
     {
         // use the standard library version if the date is in range - this is
         // probably more efficient than our code

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1419,6 +1419,14 @@ TEST_CASE("wxDateTime::ParseDateTime", "[datetime]")
         },
 
         {
+            "4242-04-02 4:20",
+            {  2, wxDateTime::Apr, 4242, 4, 20,  0 },
+            true,
+            "",
+            false
+        },
+
+        {
             "2010-01-04 14:30",
             {  4, wxDateTime::Jan, 2010, 14, 30,  0 },
             true,


### PR DESCRIPTION
Changes of a08c710b38 (Merge branch 'y2k38-fixes', 2024-04-14) broke support for dates with year > 3000 when using MSVC with 64-bit time_t as its CRT still doesn't support such dates even if they fit into the type range.

Fix this by restoring the use of our own code instead of using CRT in this case.

See #24464.

Closes #25228.

----

cc @lanurmi FYI