### PR TITLE
Use smart pointers in wxGTK code instead of manual memory management

### DIFF
--- a/include/wx/gtk/private/error.h
+++ b/include/wx/gtk/private/error.h
@@ -43,6 +43,11 @@ public:
         return m_error;
     }
 
+    const gchar* GetMessageStr() const
+    {
+        return m_error->message;
+    }
+
     wxString GetMessage() const
     {
         wxCHECK( m_error, wxASCII_STR("missing error object") );

--- a/include/wx/gtk/private/glibptr.h
+++ b/include/wx/gtk/private/glibptr.h
@@ -20,7 +20,20 @@ class wxGlibPtr
 public:
     wxGlibPtr() = default;
     explicit wxGlibPtr(const T *p) : m_ptr(const_cast<T*>(p)) { }
+    wxGlibPtr(wxGlibPtr&& other) : m_ptr(other.m_ptr) { other.m_ptr = nullptr; }
     ~wxGlibPtr() { g_free(m_ptr); }
+
+    wxGlibPtr& operator=(wxGlibPtr&& other)
+    {
+        if ( &other != this )
+        {
+            g_free(m_ptr);
+            m_ptr = other.m_ptr;
+            other.m_ptr = nullptr;
+        }
+
+        return *this;
+    }
 
     const T* get() const { return m_ptr; }
 

--- a/include/wx/gtk/private/glibptr.h
+++ b/include/wx/gtk/private/glibptr.h
@@ -1,0 +1,44 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/gtk/private/glibptr.h
+// Purpose:     Simple RAII helper for calling g_free() automatically
+// Author:      Vadim Zeitlin
+// Created:     2024-12-28
+// Copyright:   (c) 2024 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_GTK_PRIVATE_OWNEDPTR_H_
+#define _WX_GTK_PRIVATE_OWNEDPTR_H_
+
+// ----------------------------------------------------------------------------
+// Convenience class for calling g_free() automatically
+// ----------------------------------------------------------------------------
+
+template <typename T>
+class wxGlibPtr
+{
+public:
+    wxGlibPtr() = default;
+    explicit wxGlibPtr(const T *p) : m_ptr(const_cast<T*>(p)) { }
+    ~wxGlibPtr() { g_free(m_ptr); }
+
+    const T* get() const { return m_ptr; }
+
+    operator const T*() const { return m_ptr; }
+
+    T** Out()
+    {
+        wxASSERT_MSG( !m_ptr, wxS("Can't reuse the same object.") );
+
+        return &m_ptr;
+    }
+
+private:
+    // We store the pointer as non-const because it avoids casts in the dtor
+    // and Out(), but it's actually always handled as a const one.
+    T* m_ptr = nullptr;
+
+    wxDECLARE_NO_COPY_CLASS(wxGlibPtr);
+};
+
+#endif // _WX_GTK_PRIVATE_OWNEDPTR_H_

--- a/include/wx/gtk/private/string.h
+++ b/include/wx/gtk/private/string.h
@@ -10,24 +10,19 @@
 #ifndef _WX_GTK_PRIVATE_STRING_H_
 #define _WX_GTK_PRIVATE_STRING_H_
 
+#include "wx/gtk/private/glibptr.h"
+
 // ----------------------------------------------------------------------------
 // Convenience class for g_freeing a gchar* on scope exit automatically
 // ----------------------------------------------------------------------------
 
-class wxGtkString
+class wxGtkString : public wxGlibPtr<gchar>
 {
 public:
-    explicit wxGtkString(gchar *s) : m_str(s) { }
-    ~wxGtkString() { g_free(m_str); }
+    explicit wxGtkString(const gchar *s) : wxGlibPtr<gchar>(s) { }
 
-    const gchar *c_str() const { return m_str; }
-
-    operator gchar *() const { return m_str; }
-
-private:
-    gchar *m_str;
-
-    wxDECLARE_NO_COPY_CLASS(wxGtkString);
+    // More string-like accessor.
+    const gchar *c_str() const { return get(); }
 };
 
 

--- a/include/wx/gtk/private/string.h
+++ b/include/wx/gtk/private/string.h
@@ -31,8 +31,9 @@ public:
 // ----------------------------------------------------------------------------
 
 #include "wx/string.h"
-#include "wx/vector.h"
 #include "wx/sharedptr.h"
+
+#include <vector>
 
 class wxGtkCollatableString
 {
@@ -60,8 +61,7 @@ public:
 
         wxSharedPtr<wxGtkCollatableString> new_ptr( new wxGtkCollatableString( new_label, new_key ) );
 
-        wxVector< wxSharedPtr<wxGtkCollatableString> >::iterator iter;
-        for (iter = m_list.begin(); iter != m_list.end(); ++iter)
+        for (auto iter = m_list.begin(); iter != m_list.end(); ++iter)
         {
             wxSharedPtr<wxGtkCollatableString> ptr = *iter;
 
@@ -99,7 +99,7 @@ public:
     }
 
 private:
-    wxVector< wxSharedPtr<wxGtkCollatableString> > m_list;
+    std::vector< wxSharedPtr<wxGtkCollatableString> > m_list;
 };
 
 

--- a/include/wx/gtk/private/string.h
+++ b/include/wx/gtk/private/string.h
@@ -50,8 +50,7 @@ public:
 
     ~wxGtkCollatableString()
     {
-        if (m_key)
-            g_free( m_key );
+        g_free( m_key );
     }
 
     wxString     m_label;

--- a/include/wx/gtk/private/string.h
+++ b/include/wx/gtk/private/string.h
@@ -42,19 +42,13 @@ private:
 class wxGtkCollatableString
 {
 public:
-    wxGtkCollatableString( const wxString &label, gchar *key )
-        : m_label(label)
+    wxGtkCollatableString( const wxString &label, const gchar *key )
+        : m_label(label), m_key(key)
     {
-        m_key = key;
-    }
-
-    ~wxGtkCollatableString()
-    {
-        g_free( m_key );
     }
 
     wxString     m_label;
-    gchar       *m_key;
+    wxGtkString  m_key;
 };
 
 class wxGtkCollatedArrayString
@@ -66,9 +60,8 @@ public:
     {
         int index = 0;
 
-        gchar *new_key_lower = g_utf8_casefold( new_label.utf8_str(), -1);
+        wxGtkString new_key_lower(g_utf8_casefold( new_label.utf8_str(), -1));
         gchar *new_key = g_utf8_collate_key( new_key_lower, -1);
-        g_free( new_key_lower );
 
         wxSharedPtr<wxGtkCollatableString> new_ptr( new wxGtkCollatableString( new_label, new_key ) );
 
@@ -77,7 +70,7 @@ public:
         {
             wxSharedPtr<wxGtkCollatableString> ptr = *iter;
 
-            gchar *key = ptr->m_key;
+            const gchar* key = ptr->m_key;
             if (strcmp(key,new_key) >= 0)
             {
                 m_list.insert( iter, new_ptr );

--- a/src/gtk/colordlg.cpp
+++ b/src/gtk/colordlg.cpp
@@ -160,21 +160,19 @@ void wxColourDialog::DialogToColourData()
     // Extract custom palette:
 
     GtkSettings *settings = gtk_widget_get_settings(GTK_WIDGET(sel));
-    gchar *pal;
-    g_object_get(settings, "gtk-color-palette", &pal, nullptr);
+    wxGlibPtr<gchar> pal;
+    g_object_get(settings, "gtk-color-palette", pal.Out(), nullptr);
 
-    GdkColor *colors;
+    wxGlibPtr<GdkColor> colors;
     gint n_colors;
-    if (gtk_color_selection_palette_from_string(pal, &colors, &n_colors))
+    if (gtk_color_selection_palette_from_string(pal, colors.Out(), &n_colors))
     {
         for (int i = 0; i < n_colors && i < wxColourData::NUM_CUSTOM; i++)
         {
             m_data.SetCustomColour(i, wxColour(colors[i]));
         }
-        g_free(colors);
     }
 
-    g_free(pal);
     wxGCC_WARNING_RESTORE()
 #endif // !__WXGTK4__
 }

--- a/src/gtk/control.cpp
+++ b/src/gtk/control.cpp
@@ -311,18 +311,15 @@ wxControl::GetDefaultAttributesFromGTKWidget(GtkWidget* widget,
     if (!attr.font.IsOk())
     {
         GtkSettings *settings = gtk_settings_get_default();
-        gchar *font_name = nullptr;
+        wxGlibPtr<gchar> font_name;
         g_object_get ( settings,
                        "gtk-font-name",
-                       &font_name,
+                       font_name.Out(),
                        nullptr);
         if (!font_name)
             attr.font = wxSystemSettings::GetFont( wxSYS_DEFAULT_GUI_FONT );
         else
-        {
             attr.font = wxFont(wxString::FromUTF8(font_name));
-            g_free(font_name);
-        }
     }
 
     if (tlw)

--- a/src/gtk/dataobj.cpp
+++ b/src/gtk/dataobj.cpp
@@ -253,7 +253,7 @@ bool wxFileDataObject::GetDataHere(void *buf) const
 
     for (size_t i = 0; i < m_filenames.GetCount(); i++)
     {
-        char* uri = g_filename_to_uri(m_filenames[i].mbc_str(), nullptr, nullptr);
+        wxGtkString uri(g_filename_to_uri(m_filenames[i].mbc_str(), nullptr, nullptr));
         if (uri)
         {
             size_t const len = strlen(uri);
@@ -261,7 +261,6 @@ bool wxFileDataObject::GetDataHere(void *buf) const
             out += len;
             *(out++) = '\r';
             *(out++) = '\n';
-            g_free(uri);
         }
     }
     *out = 0;
@@ -275,10 +274,10 @@ size_t wxFileDataObject::GetDataSize() const
 
     for (size_t i = 0; i < m_filenames.GetCount(); i++)
     {
-        char* uri = g_filename_to_uri(m_filenames[i].mbc_str(), nullptr, nullptr);
-        if (uri) {
+        wxGtkString uri(g_filename_to_uri(m_filenames[i].mbc_str(), nullptr, nullptr));
+        if (uri)
+        {
             res += strlen(uri) + 2; // Including "\r\n"
-            g_free(uri);
         }
     }
 
@@ -327,16 +326,13 @@ bool wxFileDataObject::SetData(size_t WXUNUSED(size), const void *buf)
             break;
 
         // required to give it a trailing zero
-        gchar *uri = g_strndup( temp, len );
+        wxGtkString uri(g_strndup( temp, len ));
 
-        gchar *fn = g_filename_from_uri( uri, nullptr, nullptr );
-
-        g_free( uri );
+        wxGtkString fn(g_filename_from_uri( uri, nullptr, nullptr ));
 
         if (fn)
         {
             AddFile( wxConvFileName->cMB2WX( fn ) );
-            g_free( fn );
         }
     }
 

--- a/src/gtk/filepicker.cpp
+++ b/src/gtk/filepicker.cpp
@@ -270,14 +270,12 @@ static void file_set(GtkFileChooser* widget, wxDirButton* p)
 extern "C" {
 static void selection_changed(GtkFileChooser* chooser, wxDirButton* win)
 {
-    char* filename = gtk_file_chooser_get_filename(chooser);
+    wxGtkString filename(gtk_file_chooser_get_filename(chooser));
 
     if (wxString::FromUTF8(filename) == win->GetPath())
         win->m_bIgnoreNextChange = false;
     else if (!win->m_bIgnoreNextChange)
         file_set(chooser, win);
-
-    g_free(filename);
 }
 }
 

--- a/src/gtk/power.cpp
+++ b/src/gtk/power.cpp
@@ -33,6 +33,7 @@
 
 #include "wx/power.h"
 
+#include "wx/gtk/private/glibptr.h"
 #include "wx/gtk/private/error.h"
 #include "wx/gtk/private/object.h"
 #include "wx/gtk/private/variant.h"
@@ -265,9 +266,8 @@ wxGDBusLoginManagerProxy::StartInhibit(const wxString& reason,
         return false;
     }
 
-    gint* const fds = g_unix_fd_list_steal_fds(fd_list, nullptr);
+    wxGlibPtr<gint> fds(g_unix_fd_list_steal_fds(fd_list, nullptr));
     m_fdInhibit = fds[0];
-    g_free(fds);
 
     // Remember them so that we could call Inhibit() with the same arguments
     // again later from RestartInhibit().

--- a/src/gtk/print.cpp
+++ b/src/gtk/print.cpp
@@ -44,6 +44,7 @@
 #include "wx/link.h"
 wxFORCE_LINK_THIS_MODULE(gtk_print)
 
+#include "wx/gtk/private/glibptr.h"
 #include "wx/gtk/private/error.h"
 #include "wx/gtk/private/object.h"
 
@@ -998,8 +999,7 @@ void wxGtkPrinter::BeginPrint(wxPrintout *printout, GtkPrintOperation *operation
             GtkPageRange* range;
             range = gtk_print_settings_get_page_ranges (newSettings, &num_ranges);
 
-            std::unique_ptr<GtkPageRange, void (*)(void*)>
-                rangePtrDeleter(range, g_free);
+            wxGlibPtr<GtkPageRange> rangePtrDeleter(range);
 
             pageRanges.resize(num_ranges);
             for ( auto& pageRange : pageRanges )

--- a/src/gtk/print.cpp
+++ b/src/gtk/print.cpp
@@ -47,6 +47,8 @@ wxFORCE_LINK_THIS_MODULE(gtk_print)
 #include "wx/gtk/private/error.h"
 #include "wx/gtk/private/object.h"
 
+#include <vector>
+
 // Useful to convert angles from degrees to radians.
 static const double DEG2RAD  = M_PI / 180.0;
 
@@ -1917,12 +1919,11 @@ void wxGtkPrinterDCImpl::SetPen( const wxPen& pen )
         {
             wxDash *wx_dashes;
             int num = m_pen.GetDashes (&wx_dashes);
-            gdouble *g_dashes = g_new( gdouble, num );
-            int i;
-            for (i = 0; i < num; ++i)
+
+            std::vector<gdouble> g_dashes(num);
+            for (int i = 0; i < num; ++i)
                 g_dashes[i] = (gdouble) wx_dashes[i];
-            cairo_set_dash( m_cairo, g_dashes, num, 0);
-            g_free( g_dashes );
+            cairo_set_dash( m_cairo, &g_dashes[0], num, 0);
         }
         break;
         case wxPENSTYLE_SOLID:

--- a/src/gtk/region.cpp
+++ b/src/gtk/region.cpp
@@ -22,6 +22,8 @@
 
 #include <gdk/gdk.h>
 
+#include "wx/gtk/private/glibptr.h"
+
 // ----------------------------------------------------------------------------
 // wxRegionRefData: private class containing the information about the region
 // ----------------------------------------------------------------------------
@@ -508,15 +510,15 @@ void wxRegionIterator::CreateRects( const wxRegion& region )
     if (!gdkregion)
         return;
 
-    GdkRectangle* gdkrects;
-    gdk_region_get_rectangles(gdkregion, &gdkrects, &m_numRects);
+    wxGlibPtr<GdkRectangle> gdkrects;
+    gdk_region_get_rectangles(gdkregion, gdkrects.Out(), &m_numRects);
 
     if (m_numRects)
     {
         m_rects = new wxRect[m_numRects];
         for (int i = 0; i < m_numRects; ++i)
         {
-            GdkRectangle &gr = gdkrects[i];
+            const GdkRectangle &gr = gdkrects[i];
             wxRect &wr = m_rects[i];
             wr.x = gr.x;
             wr.y = gr.y;
@@ -524,7 +526,6 @@ void wxRegionIterator::CreateRects( const wxRegion& region )
             wr.height = gr.height;
         }
     }
-    g_free( gdkrects );
 #endif
 }
 

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -29,6 +29,7 @@
 
 #ifdef __WXGTK3__
     #include "wx/gtk/private/appearance.h"
+    #include "wx/gtk/private/glibptr.h"
     #include "wx/gtk/private/variant.h"
 #endif
 
@@ -256,10 +257,10 @@ void DoUpdateColorScheme(wxGTKImpl::ColorScheme colorScheme)
         return;
     }
 
-    char* themeName = nullptr;
+    wxGlibPtr<char> themeName;
     gboolean preferDarkPrev = FALSE;
     g_object_get(settings,
-        "gtk-theme-name", &themeName,
+        "gtk-theme-name", themeName.Out(),
         "gtk-application-prefer-dark-theme", &preferDarkPrev, nullptr);
 
     // This is not supposed to happen neither, but don't crash if it does.
@@ -269,10 +270,9 @@ void DoUpdateColorScheme(wxGTKImpl::ColorScheme colorScheme)
         return;
     }
 
-    wxLogTrace(TRACE_DARKMODE, "Current GTK theme is \"%s\"", themeName);
-
     const wxString theme = wxString::FromUTF8(themeName);
-    g_free(themeName);
+
+    wxLogTrace(TRACE_DARKMODE, "Current GTK theme is \"%s\"", theme);
 
     // Check if the current theme is a dark variant.
     constexpr const char* darkVariant = "-dark";

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -50,14 +50,12 @@ static void wxGtkOnRemoveTag(GtkTextBuffer *buffer,
                              GtkTextIter * WXUNUSED(end),
                              char *prefix)
 {
-    gchar *name;
-    g_object_get (tag, "name", &name, nullptr);
+    wxGlibPtr<gchar> name;
+    g_object_get (tag, "name", name.Out(), nullptr);
 
     if (!name || strncmp(name, prefix, strlen(prefix)))
         // anonymous tag or not starting with prefix - don't remove
         g_signal_stop_emission_by_name (buffer, "remove_tag");
-
-    g_free(name);
 }
 }
 

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -459,8 +459,8 @@ wxgtk_webview_webkit_title_changed(GtkWidget* widget,
                                    GParamSpec *,
                                    wxWebViewWebKit *webKitCtrl)
 {
-    gchar *title;
-    g_object_get(G_OBJECT(widget), "title", &title, nullptr);
+    wxGlibPtr<gchar> title;
+    g_object_get(G_OBJECT(widget), "title", title.Out(), nullptr);
 
     wxWebViewEvent event(wxEVT_WEBVIEW_TITLE_CHANGED,
                          webKitCtrl->GetId(),
@@ -470,8 +470,6 @@ wxgtk_webview_webkit_title_changed(GtkWidget* widget,
     event.SetString(wxString::FromUTF8(title));
 
     webKitCtrl->HandleWindowEvent(event);
-
-    g_free(title);
 }
 
 static void
@@ -1908,8 +1906,8 @@ wxWebViewWebKit::GetClassDefaultAttributes(wxWindowVariant WXUNUSED(variant))
 
 void wxWebViewWebKit::SetupWebExtensionServer()
 {
-    char *address = g_strdup_printf("unix:tmpdir=%s", g_get_tmp_dir());
-    char *guid = g_dbus_generate_guid();
+    wxGtkString address(g_strdup_printf("unix:tmpdir=%s", g_get_tmp_dir()));
+    wxGtkString guid(g_dbus_generate_guid());
     wxGtkObject<GDBusAuthObserver> observer(g_dbus_auth_observer_new());
     wxGtkError error;
 
@@ -1926,7 +1924,7 @@ void wxWebViewWebKit::SetupWebExtensionServer()
     if (error)
     {
         g_warning("Failed to start web extension server on %s: %s",
-                  address, error.GetMessageStr());
+                  address.c_str(), error.GetMessageStr());
     }
     else
     {
@@ -1934,9 +1932,6 @@ void wxWebViewWebKit::SetupWebExtensionServer()
                          G_CALLBACK(wxgtk_new_connection_cb), &m_extension);
         g_dbus_server_start(m_dbusServer);
     }
-
-    g_free(address);
-    g_free(guid);
 }
 
 GDBusProxy *wxWebViewWebKit::GetExtensionProxy() const

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -1910,7 +1910,7 @@ void wxWebViewWebKit::SetupWebExtensionServer()
     char *address = g_strdup_printf("unix:tmpdir=%s", g_get_tmp_dir());
     char *guid = g_dbus_generate_guid();
     GDBusAuthObserver *observer = g_dbus_auth_observer_new();
-    GError *error = nullptr;
+    wxGtkError error;
 
     g_signal_connect(observer, "authorize-authenticated-peer",
                      G_CALLBACK(wxgtk_authorize_authenticated_peer_cb), this);
@@ -1920,12 +1920,12 @@ void wxWebViewWebKit::SetupWebExtensionServer()
                                           guid,
                                           observer,
                                           nullptr,
-                                          &error);
+                                          error.Out());
 
     if (error)
     {
-        g_warning("Failed to start web extension server on %s: %s", address, error->message);
-        g_error_free(error);
+        g_warning("Failed to start web extension server on %s: %s",
+                  address, error.GetMessageStr());
     }
     else
     {

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -34,6 +34,7 @@
 #include "wx/gtk/private/string.h"
 #include "wx/gtk/private/webkit.h"
 #include "wx/gtk/private/error.h"
+#include "wx/gtk/private/object.h"
 #include "wx/gtk/private/variant.h"
 #include "wx/private/jsscriptwrapper.h"
 #include <webkit2/webkit2.h>
@@ -1909,7 +1910,7 @@ void wxWebViewWebKit::SetupWebExtensionServer()
 {
     char *address = g_strdup_printf("unix:tmpdir=%s", g_get_tmp_dir());
     char *guid = g_dbus_generate_guid();
-    GDBusAuthObserver *observer = g_dbus_auth_observer_new();
+    wxGtkObject<GDBusAuthObserver> observer(g_dbus_auth_observer_new());
     wxGtkError error;
 
     g_signal_connect(observer, "authorize-authenticated-peer",
@@ -1936,7 +1937,6 @@ void wxWebViewWebKit::SetupWebExtensionServer()
 
     g_free(address);
     g_free(guid);
-    g_object_unref(observer);
 }
 
 GDBusProxy *wxWebViewWebKit::GetExtensionProxy() const

--- a/src/unix/fontenum.cpp
+++ b/src/unix/fontenum.cpp
@@ -34,6 +34,8 @@
 #include "wx/fontutil.h"
 #include "wx/encinfo.h"
 
+#include "wx/gtk/private/object.h"
+
 // ----------------------------------------------------------------------------
 // Pango
 // ----------------------------------------------------------------------------
@@ -72,7 +74,7 @@ bool wxFontEnumerator::EnumerateFacenames(wxFontEncoding encoding,
 
     PangoFontFamily **families = nullptr;
     gint n_families = 0;
-    PangoContext* context = wxGetPangoContext();
+    wxGtkObject<PangoContext> context(wxGetPangoContext());
     pango_context_list_families(context, &families, &n_families);
     qsort (families, n_families, sizeof (PangoFontFamily *), wxCompareFamilies);
 
@@ -91,7 +93,6 @@ bool wxFontEnumerator::EnumerateFacenames(wxFontEncoding encoding,
         }
     }
     g_free(families);
-    g_object_unref(context);
 
     return true;
 }

--- a/src/unix/fontenum.cpp
+++ b/src/unix/fontenum.cpp
@@ -34,6 +34,7 @@
 #include "wx/fontutil.h"
 #include "wx/encinfo.h"
 
+#include "wx/gtk/private/glibptr.h"
 #include "wx/gtk/private/object.h"
 
 // ----------------------------------------------------------------------------
@@ -72,11 +73,14 @@ bool wxFontEnumerator::EnumerateFacenames(wxFontEncoding encoding,
         return false;
     }
 
-    PangoFontFamily **families = nullptr;
+    wxGlibPtr<PangoFontFamily*> families;
     gint n_families = 0;
     wxGtkObject<PangoContext> context(wxGetPangoContext());
-    pango_context_list_families(context, &families, &n_families);
-    qsort (families, n_families, sizeof (PangoFontFamily *), wxCompareFamilies);
+    pango_context_list_families(context, families.Out(), &n_families);
+    qsort (const_cast<PangoFontFamily**>(families.get()),
+           n_families,
+           sizeof (PangoFontFamily *),
+           wxCompareFamilies);
 
     for ( int i = 0; i < n_families; i++ )
     {
@@ -92,7 +96,6 @@ bool wxFontEnumerator::EnumerateFacenames(wxFontEncoding encoding,
             }
         }
     }
-    g_free(families);
 
     return true;
 }

--- a/src/unix/fontutil.cpp
+++ b/src/unix/fontutil.cpp
@@ -40,6 +40,7 @@ PangoContext* wxGetPangoContext();
 
 #ifdef __WXGTK__
     #include "wx/gtk/private.h"
+    #include "wx/gtk/private/object.h"
 #else
     #include "wx/x11/private.h"
     #include "wx/gtk/private/string.h"
@@ -158,7 +159,7 @@ wxFontFamily wxNativeFontInfo::GetFamily() const
         PangoFontFamily **families;
         PangoFontFamily  *family = nullptr;
         int n_families;
-        PangoContext* context = wxGetPangoContext();
+        wxGtkObject<PangoContext> context(wxGetPangoContext());
         pango_context_list_families(context, &families, &n_families);
 
         for (int i = 0; i < n_families; ++i)
@@ -172,7 +173,6 @@ wxFontFamily wxNativeFontInfo::GetFamily() const
         }
 
         g_free(families);
-        g_object_unref(context);
 
         // Some gtk+ systems might query for a non-existing font from
         // wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT) on initialization,

--- a/src/unix/fontutil.cpp
+++ b/src/unix/fontutil.cpp
@@ -156,11 +156,11 @@ wxFontFamily wxNativeFontInfo::GetFamily() const
 #if defined(__WXGTK__) || defined(HAVE_PANGO_FONT_FAMILY_IS_MONOSPACE)
     else
     {
-        PangoFontFamily **families;
+        wxGlibPtr<PangoFontFamily*> families;
         PangoFontFamily  *family = nullptr;
         int n_families;
         wxGtkObject<PangoContext> context(wxGetPangoContext());
-        pango_context_list_families(context, &families, &n_families);
+        pango_context_list_families(context, families.Out(), &n_families);
 
         for (int i = 0; i < n_families; ++i)
         {
@@ -171,8 +171,6 @@ wxFontFamily wxNativeFontInfo::GetFamily() const
                 break;
             }
         }
-
-        g_free(families);
 
         // Some gtk+ systems might query for a non-existing font from
         // wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT) on initialization,


### PR DESCRIPTION
No real changes here, just get rid of a number of `g_free()` and similar calls.

Also optimize `wxGtkCollatedArrayString` implementation a little.