### PR TITLE
Move wxGetLibraryVersionInfo() to core from base

### DIFF
--- a/include/wx/apptrait.h
+++ b/include/wx/apptrait.h
@@ -171,6 +171,10 @@ public:
     virtual wxString GetAssertStackTrace();
 #endif // wxUSE_STACKWALKER
 
+    // Text to be appended to the description. Currently used for getting
+    // compile-time versions of GTK+ and Qt.
+    virtual wxString GetLibversionExtraText() const = 0;
+
 private:
     static wxSocketManager *ms_manager;
 };
@@ -238,6 +242,7 @@ public:
 
     virtual bool IsUsingUniversalWidgets() const override { return false; }
     virtual wxString GetDesktopEnvironment() const override { return wxEmptyString; }
+    virtual wxString GetLibversionExtraText() const override { return wxEmptyString; }
 };
 
 // ----------------------------------------------------------------------------
@@ -278,6 +283,7 @@ public:
     }
 
     virtual wxString GetDesktopEnvironment() const override { return wxEmptyString; }
+    virtual wxString GetLibversionExtraText() const override { return wxEmptyString; }
 };
 
 #endif // wxUSE_GUI

--- a/include/wx/apptrait.h
+++ b/include/wx/apptrait.h
@@ -171,9 +171,9 @@ public:
     virtual wxString GetAssertStackTrace();
 #endif // wxUSE_STACKWALKER
 
-    // Text to be appended to the description. Currently used for getting
-    // compile-time versions of GTK+ and Qt.
-    virtual wxString GetLibVersionExtraText() const = 0;
+    // Text to be appended to the description returned by wxGetLibraryVersionInfo().
+    // Currently used for getting compile-time versions of GTK+ and Qt.
+    virtual wxString GetPlatformDescription() const = 0;
 
 private:
     static wxSocketManager *ms_manager;
@@ -242,7 +242,7 @@ public:
 
     virtual bool IsUsingUniversalWidgets() const override { return false; }
     virtual wxString GetDesktopEnvironment() const override { return wxEmptyString; }
-    virtual wxString GetLibVersionExtraText() const override { return wxEmptyString; }
+    virtual wxString GetPlatformDescription() const override { return wxEmptyString; }
 };
 
 // ----------------------------------------------------------------------------
@@ -283,7 +283,7 @@ public:
     }
 
     virtual wxString GetDesktopEnvironment() const override { return wxEmptyString; }
-    virtual wxString GetLibVersionExtraText() const override { return wxEmptyString; }
+    virtual wxString GetPlatformDescription() const override { return wxEmptyString; }
 };
 
 #endif // wxUSE_GUI

--- a/include/wx/apptrait.h
+++ b/include/wx/apptrait.h
@@ -173,7 +173,7 @@ public:
 
     // Text to be appended to the description. Currently used for getting
     // compile-time versions of GTK+ and Qt.
-    virtual wxString GetLibversionExtraText() const = 0;
+    virtual wxString GetLibVersionExtraText() const = 0;
 
 private:
     static wxSocketManager *ms_manager;
@@ -242,7 +242,7 @@ public:
 
     virtual bool IsUsingUniversalWidgets() const override { return false; }
     virtual wxString GetDesktopEnvironment() const override { return wxEmptyString; }
-    virtual wxString GetLibversionExtraText() const override { return wxEmptyString; }
+    virtual wxString GetLibVersionExtraText() const override { return wxEmptyString; }
 };
 
 // ----------------------------------------------------------------------------
@@ -283,7 +283,7 @@ public:
     }
 
     virtual wxString GetDesktopEnvironment() const override { return wxEmptyString; }
-    virtual wxString GetLibversionExtraText() const override { return wxEmptyString; }
+    virtual wxString GetLibVersionExtraText() const override { return wxEmptyString; }
 };
 
 #endif // wxUSE_GUI

--- a/include/wx/msw/apptrait.h
+++ b/include/wx/msw/apptrait.h
@@ -88,7 +88,7 @@ public:
     virtual bool WriteToStderr(const wxString& WXUNUSED(text)) override
         { return false; }
     virtual WXHWND GetMainHWND() const override { return nullptr; }
-    virtual wxString GetLibversionExtraText() const override;
+    virtual wxString GetLibVersionExtraText() const override;
 };
 
 #elif defined(__WXQT__)
@@ -115,7 +115,7 @@ public:
     virtual bool CanUseStderr() override { return false; }
     virtual bool WriteToStderr(const wxString&) override { return false; }
     virtual WXHWND GetMainHWND() const override { return nullptr; }
-    virtual wxString GetLibversionExtraText() const override;
+    virtual wxString GetLibVersionExtraText() const override;
 };
 
 #endif

--- a/include/wx/msw/apptrait.h
+++ b/include/wx/msw/apptrait.h
@@ -88,6 +88,7 @@ public:
     virtual bool WriteToStderr(const wxString& WXUNUSED(text)) override
         { return false; }
     virtual WXHWND GetMainHWND() const override { return nullptr; }
+    virtual wxString GetLibversionExtraText() const override;
 };
 
 #elif defined(__WXQT__)
@@ -114,6 +115,7 @@ public:
     virtual bool CanUseStderr() override { return false; }
     virtual bool WriteToStderr(const wxString&) override { return false; }
     virtual WXHWND GetMainHWND() const override { return nullptr; }
+    virtual wxString GetLibversionExtraText() const override;
 };
 
 #endif

--- a/include/wx/msw/apptrait.h
+++ b/include/wx/msw/apptrait.h
@@ -88,7 +88,7 @@ public:
     virtual bool WriteToStderr(const wxString& WXUNUSED(text)) override
         { return false; }
     virtual WXHWND GetMainHWND() const override { return nullptr; }
-    virtual wxString GetLibVersionExtraText() const override;
+    virtual wxString GetPlatformDescription() const override;
 };
 
 #elif defined(__WXQT__)
@@ -115,7 +115,7 @@ public:
     virtual bool CanUseStderr() override { return false; }
     virtual bool WriteToStderr(const wxString&) override { return false; }
     virtual WXHWND GetMainHWND() const override { return nullptr; }
-    virtual wxString GetLibVersionExtraText() const override;
+    virtual wxString GetPlatformDescription() const override;
 };
 
 #endif

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -249,6 +249,9 @@ public:
     int GetToolkitMicroVersion() const
         { return m_tkVersionMicro; }
 
+    wxString GetLibversionExtraText() const
+        { return m_libversionExtraText; }
+
     bool CheckToolkitVersion(int major, int minor, int micro = 0) const
     {
         return DoCheckVersion(GetToolkitMajorVersion(),
@@ -435,6 +438,9 @@ protected:
 
     // native CPU architecture family name, possibly empty if unknown
     wxString m_nativeCpuArch;
+
+    // e.g. compile-time version of toolkit, possibly empty
+    wxString m_libversionExtraText;
 };
 
 // Return true if running under Wine and fills the provided pointer with

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -249,8 +249,8 @@ public:
     int GetToolkitMicroVersion() const
         { return m_tkVersionMicro; }
 
-    wxString GetLibversionExtraText() const
-        { return m_libversionExtraText; }
+    wxString GetLibVersionExtraText() const
+        { return m_libVersionExtraText; }
 
     bool CheckToolkitVersion(int major, int minor, int micro = 0) const
     {
@@ -440,7 +440,7 @@ protected:
     wxString m_nativeCpuArch;
 
     // e.g. compile-time version of toolkit, possibly empty
-    wxString m_libversionExtraText;
+    wxString m_libVersionExtraText;
 };
 
 // Return true if running under Wine and fills the provided pointer with

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -249,8 +249,8 @@ public:
     int GetToolkitMicroVersion() const
         { return m_tkVersionMicro; }
 
-    wxString GetLibVersionExtraText() const
-        { return m_libVersionExtraText; }
+    wxString GetPlatformDescription() const
+        { return m_platformDescription; }
 
     bool CheckToolkitVersion(int major, int minor, int micro = 0) const
     {
@@ -440,7 +440,7 @@ protected:
     wxString m_nativeCpuArch;
 
     // e.g. compile-time version of toolkit, possibly empty
-    wxString m_libVersionExtraText;
+    wxString m_platformDescription;
 };
 
 // Return true if running under Wine and fills the provided pointer with

--- a/include/wx/unix/apptrait.h
+++ b/include/wx/unix/apptrait.h
@@ -65,6 +65,10 @@ public:
     virtual wxString GetDesktopEnvironment() const override;
 #endif // __WXGTK____
 
+#if defined(__WXGTK__) || defined(__WXQT__)
+    virtual wxString GetLibversionExtraText() const override;
+#endif
+
 #if defined(__WXGTK__)
     virtual bool ShowAssertDialog(const wxString& msg) override;
 #endif

--- a/include/wx/unix/apptrait.h
+++ b/include/wx/unix/apptrait.h
@@ -66,7 +66,7 @@ public:
 #endif // __WXGTK____
 
 #if defined(__WXGTK__) || defined(__WXQT__)
-    virtual wxString GetLibversionExtraText() const override;
+    virtual wxString GetLibVersionExtraText() const override;
 #endif
 
 #if defined(__WXGTK__)

--- a/include/wx/unix/apptrait.h
+++ b/include/wx/unix/apptrait.h
@@ -66,7 +66,7 @@ public:
 #endif // __WXGTK____
 
 #if defined(__WXGTK__) || defined(__WXQT__)
-    virtual wxString GetLibVersionExtraText() const override;
+    virtual wxString GetPlatformDescription() const override;
 #endif
 
 #if defined(__WXGTK__)

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -118,7 +118,7 @@ WXDLLIMPEXP_CORE void wxBell();
 WXDLLIMPEXP_CORE void wxInfoMessageBox(wxWindow* parent);
 #endif // wxUSE_MSGDLG
 
-WXDLLIMPEXP_CORE wxVersionInfo wxGetLibraryVersionInfo();
+WXDLLIMPEXP_BASE wxVersionInfo wxGetLibraryVersionInfo();
 
 // Get OS description as a user-readable string
 WXDLLIMPEXP_BASE wxString wxGetOsDescription();

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -231,8 +231,6 @@ void wxInfoMessageBox(wxWindow* parent);
     @see wxVersionInfo
 
     @header{wx/utils.h}
-
-    @library{wxcore}
 */
 wxVersionInfo wxGetLibraryVersionInfo();
 

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -231,6 +231,8 @@ void wxInfoMessageBox(wxWindow* parent);
     @see wxVersionInfo
 
     @header{wx/utils.h}
+
+    @library{wxbase}
 */
 wxVersionInfo wxGetLibraryVersionInfo();
 

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -171,7 +171,7 @@ bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
            m_usingUniversal == t.m_usingUniversal &&
            m_bitness == t.m_bitness &&
            m_endian == t.m_endian &&
-           m_libVersionExtraText == t.m_libVersionExtraText;
+           m_platformDescription == t.m_platformDescription;
 }
 
 void wxPlatformInfo::InitForCurrentPlatform()
@@ -196,7 +196,7 @@ void wxPlatformInfo::InitForCurrentPlatform()
                                            &m_tkVersionMicro);
         m_usingUniversal = traits->IsUsingUniversalWidgets();
         m_desktopEnv = traits->GetDesktopEnvironment();
-        m_libVersionExtraText = traits->GetLibVersionExtraText();
+        m_platformDescription = traits->GetPlatformDescription();
     }
 
     m_os = wxGetOsVersion(&m_osVersionMajor, &m_osVersionMinor, &m_osVersionMicro);

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -170,7 +170,8 @@ bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
            m_port == t.m_port &&
            m_usingUniversal == t.m_usingUniversal &&
            m_bitness == t.m_bitness &&
-           m_endian == t.m_endian;
+           m_endian == t.m_endian &&
+           m_libversionExtraText == t.m_libversionExtraText;
 }
 
 void wxPlatformInfo::InitForCurrentPlatform()
@@ -195,6 +196,7 @@ void wxPlatformInfo::InitForCurrentPlatform()
                                            &m_tkVersionMicro);
         m_usingUniversal = traits->IsUsingUniversalWidgets();
         m_desktopEnv = traits->GetDesktopEnvironment();
+        m_libversionExtraText = traits->GetLibversionExtraText();
     }
 
     m_os = wxGetOsVersion(&m_osVersionMajor, &m_osVersionMinor, &m_osVersionMicro);

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -171,7 +171,7 @@ bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
            m_usingUniversal == t.m_usingUniversal &&
            m_bitness == t.m_bitness &&
            m_endian == t.m_endian &&
-           m_libversionExtraText == t.m_libversionExtraText;
+           m_libVersionExtraText == t.m_libVersionExtraText;
 }
 
 void wxPlatformInfo::InitForCurrentPlatform()
@@ -196,7 +196,7 @@ void wxPlatformInfo::InitForCurrentPlatform()
                                            &m_tkVersionMicro);
         m_usingUniversal = traits->IsUsingUniversalWidgets();
         m_desktopEnv = traits->GetDesktopEnvironment();
-        m_libversionExtraText = traits->GetLibversionExtraText();
+        m_libVersionExtraText = traits->GetLibVersionExtraText();
     }
 
     m_os = wxGetOsVersion(&m_osVersionMajor, &m_osVersionMinor, &m_osVersionMicro);

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1067,7 +1067,7 @@ wxVersionInfo wxGetLibraryVersionInfo()
                wxPlatformInfo::Get().GetToolkitMicroVersion()
               );
 
-    msg += wxPlatformInfo::Get().GetLibversionExtraText();
+    msg += wxPlatformInfo::Get().GetLibVersionExtraText();
 
     const wxString copyrightSign = wxString::FromUTF8("\xc2\xa9");
 

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1022,6 +1022,64 @@ unsigned int wxCTZ(wxUint32 x)
 #endif
 }
 
+wxVersionInfo wxGetLibraryVersionInfo()
+{
+    // Only add the last build component to the version if it's non-zero, it's
+    // pretty useless otherwise.
+    wxString ver = wxString::Format
+                   (
+                        wxS("%d.%d.%d"),
+                        wxMAJOR_VERSION,
+                        wxMINOR_VERSION,
+                        wxRELEASE_NUMBER
+                   );
+    if ( wxSUBRELEASE_NUMBER )
+        ver += wxString::Format(wxS(".%d"), wxSUBRELEASE_NUMBER);
+
+    // don't translate these strings, they're for diagnostics purposes only
+    wxString msg;
+    msg.Printf(wxS("wxWidgets Library (%s port)\n")
+               wxS("Version %s (Unicode: %s, debug level: %d),\n")
+#if !wxUSE_REPRODUCIBLE_BUILD
+               wxS("compiled at %s %s\n\n")
+#endif
+               wxS("Runtime version of toolkit used is %d.%d.%d.\n"),
+               wxPlatformInfo::Get().GetPortIdName(),
+               ver,
+#if wxUSE_UNICODE_UTF8
+               "UTF-8",
+#else
+               "wchar_t",
+#endif
+               wxDEBUG_LEVEL,
+#if !wxUSE_REPRODUCIBLE_BUILD
+               // As explained in the comment near these macros definitions,
+               // ccache has special logic for detecting the use of __DATE__
+               // and __TIME__ macros, which doesn't apply to our own versions
+               // of them, hence this comment is needed just to mention the
+               // standard macro names and to ensure that ccache does _not_
+               // cache the results of compiling this file.
+               __TDATE__,
+               __TTIME__,
+#endif
+               wxPlatformInfo::Get().GetToolkitMajorVersion(),
+               wxPlatformInfo::Get().GetToolkitMinorVersion(),
+               wxPlatformInfo::Get().GetToolkitMicroVersion()
+              );
+
+    msg += wxPlatformInfo::Get().GetLibversionExtraText();
+
+    const wxString copyrightSign = wxString::FromUTF8("\xc2\xa9");
+
+    return wxVersionInfo(wxS("wxWidgets"),
+                         wxMAJOR_VERSION,
+                         wxMINOR_VERSION,
+                         wxRELEASE_NUMBER,
+                         msg,
+                         wxString::Format(wxS("Copyright %s 1992-2025 wxWidgets team"),
+                                          copyrightSign));
+}
+
 
 #endif // wxUSE_BASE
 
@@ -1372,74 +1430,6 @@ int wxMessageBox(const wxString& message, const wxString& caption, long style,
     wxFAIL_MSG( wxT("unexpected return code from wxMessageDialog") );
 
     return wxCANCEL;
-}
-
-wxVersionInfo wxGetLibraryVersionInfo()
-{
-    // Only add the last build component to the version if it's non-zero, it's
-    // pretty useless otherwise.
-    wxString ver = wxString::Format
-                   (
-                        wxS("%d.%d.%d"),
-                        wxMAJOR_VERSION,
-                        wxMINOR_VERSION,
-                        wxRELEASE_NUMBER
-                   );
-    if ( wxSUBRELEASE_NUMBER )
-        ver += wxString::Format(wxS(".%d"), wxSUBRELEASE_NUMBER);
-
-    // don't translate these strings, they're for diagnostics purposes only
-    wxString msg;
-    msg.Printf(wxS("wxWidgets Library (%s port)\n")
-               wxS("Version %s (Unicode: %s, debug level: %d),\n")
-#if !wxUSE_REPRODUCIBLE_BUILD
-               wxS("compiled at %s %s\n\n")
-#endif
-               wxS("Runtime version of toolkit used is %d.%d.%d.\n"),
-               wxPlatformInfo::Get().GetPortIdName(),
-               ver,
-#if wxUSE_UNICODE_UTF8
-               "UTF-8",
-#else
-               "wchar_t",
-#endif
-               wxDEBUG_LEVEL,
-#if !wxUSE_REPRODUCIBLE_BUILD
-               // As explained in the comment near these macros definitions,
-               // ccache has special logic for detecting the use of __DATE__
-               // and __TIME__ macros, which doesn't apply to our own versions
-               // of them, hence this comment is needed just to mention the
-               // standard macro names and to ensure that ccache does _not_
-               // cache the results of compiling this file.
-               __TDATE__,
-               __TTIME__,
-#endif
-               wxPlatformInfo::Get().GetToolkitMajorVersion(),
-               wxPlatformInfo::Get().GetToolkitMinorVersion(),
-               wxPlatformInfo::Get().GetToolkitMicroVersion()
-              );
-
-#ifdef __WXGTK__
-    msg += wxString::Format("Compile-time GTK+ version is %d.%d.%d.\n",
-                            GTK_MAJOR_VERSION,
-                            GTK_MINOR_VERSION,
-                            GTK_MICRO_VERSION);
-#endif // __WXGTK__
-
-#ifdef __WXQT__
-    msg += wxString::Format("Compile-time QT version is %s.\n",
-                            QT_VERSION_STR);
-#endif // __WXQT__
-
-    const wxString copyrightSign = wxString::FromUTF8("\xc2\xa9");
-
-    return wxVersionInfo(wxS("wxWidgets"),
-                         wxMAJOR_VERSION,
-                         wxMINOR_VERSION,
-                         wxRELEASE_NUMBER,
-                         msg,
-                         wxString::Format(wxS("Copyright %s 1992-2025 wxWidgets team"),
-                                          copyrightSign));
 }
 
 void wxInfoMessageBox(wxWindow* parent)

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1067,7 +1067,7 @@ wxVersionInfo wxGetLibraryVersionInfo()
                wxPlatformInfo::Get().GetToolkitMicroVersion()
               );
 
-    msg += wxPlatformInfo::Get().GetLibVersionExtraText();
+    msg += wxPlatformInfo::Get().GetPlatformDescription();
 
     const wxString copyrightSign = wxString::FromUTF8("\xc2\xa9");
 

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -165,6 +165,13 @@ wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
     return wxPORT_GTK;
 }
 
+wxString wxGUIAppTraits::GetLibversionExtraText() const {
+    return wxString::Format("Compile-time GTK+ version is %d.%d.%d.\n",
+                            GTK_MAJOR_VERSION,
+                            GTK_MINOR_VERSION,
+                            GTK_MICRO_VERSION);
+}
+
 #if wxUSE_TIMER
 
 wxTimerImpl *wxGUIAppTraits::CreateTimerImpl(wxTimer *timer)

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -165,7 +165,7 @@ wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
     return wxPORT_GTK;
 }
 
-wxString wxGUIAppTraits::GetLibversionExtraText() const {
+wxString wxGUIAppTraits::GetPlatformDescription() const {
     return wxString::Format("Compile-time GTK+ version is %d.%d.%d.\n",
                             GTK_MAJOR_VERSION,
                             GTK_MINOR_VERSION,

--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -125,7 +125,7 @@ bool wxLaunchDefaultApplication(const wxString& path, int WXUNUSED( flags ) )
     return QDesktopServices::openUrl( QUrl::fromLocalFile( wxQtConvertString( path ) ) );
 }
 
-wxString wxGUIAppTraits::GetLibversionExtraText() const {
+wxString wxGUIAppTraits::GetPlatformDescription() const {
     return wxString::Format("Compile-time QT version is %s.\n",
                             QT_VERSION_STR);
 }

--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -21,6 +21,7 @@
     #include "wx/window.h"
 #endif // WX_PRECOMP
 
+#include "wx/apptrait.h"
 #include "wx/utils.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
@@ -122,4 +123,9 @@ wxWindow *wxGetActiveWindow()
 bool wxLaunchDefaultApplication(const wxString& path, int WXUNUSED( flags ) )
 {
     return QDesktopServices::openUrl( QUrl::fromLocalFile( wxQtConvertString( path ) ) );
+}
+
+wxString wxGUIAppTraits::GetLibversionExtraText() const {
+    return wxString::Format("Compile-time QT version is %s.\n",
+                            QT_VERSION_STR);
 }

--- a/tests/misc/misctests.cpp
+++ b/tests/misc/misctests.cpp
@@ -19,6 +19,7 @@
 #include "wx/math.h"
 #include "wx/mimetype.h"
 #include "wx/versioninfo.h"
+#include "wx/utils.h"
 
 #include "wx/private/wordwrap.h"
 
@@ -255,6 +256,14 @@ TEST_CASE("wxVersionInfo", "[version]")
     CHECK_FALSE( ver120.AtLeast(1, 2, 1) );
     CHECK_FALSE( ver120.AtLeast(1, 3) );
     CHECK_FALSE( ver120.AtLeast(2, 0) );
+}
+
+TEST_CASE("wxGetLibraryVersionInfo", "[libraryversion]")
+{
+    // We especially want to ensure that wxGetLibraryVersionInfo()
+    // is available in wxBase, and successfully links, too.
+    wxVersionInfo libver = wxGetLibraryVersionInfo();
+    CHECK( libver.GetNumericVersionString().starts_with("3.") );
 }
 
 TEST_CASE("wxWordWrap", "[wordwrap]")


### PR DESCRIPTION
Move determining compile-time GTK+/QT versions to wxAppTraits, which is presumably the only reason why wxGetLibraryVersionInfo() needed to be in core.

Revert "Move wxGetLibraryVersionInfo() to core from base." This reverts commit 9aea2510431d7109ff7055bce02576ebd80f593b.