### PR TITLE
Further improve wxURI tests and fix a bug in WinHTTP backend handling of reserved characters in the URLs

### DIFF
--- a/interface/wx/webrequest.h
+++ b/interface/wx/webrequest.h
@@ -554,6 +554,14 @@ public:
     To handle authentication with this class the username and password must be
     specified in the URL itself and wxWebAuthChallenge is not used with it.
 
+    @note Any reserved characters (see RFC 3986) in the username or password
+        must be percent encoded. wxURI::SetUserAndPassword() can be used to
+        ensure that this is done correctly.
+
+    @note macOS backend using NSURLSession doesn't handle encoded characters in
+        the password (but does handle them in the username). Async wxWebSession
+        must be used if you need to support them under this platform.
+
     @see wxWebRequest
 
     @since 3.3.0

--- a/src/common/webrequest.cpp
+++ b/src/common/webrequest.cpp
@@ -1117,10 +1117,11 @@ wxString wxWebSessionBase::GetFullURL(const wxString& url) const
     wxURI absURL(url);
     absURL.Resolve(*baseURL);
 
-    wxLogTrace(wxTRACE_WEBREQUEST, "Relative URL: %s -> %s",
-               url, absURL.BuildURI());
+    wxString fullURL = absURL.BuildURI();
+    if ( fullURL != url )
+        wxLogTrace(wxTRACE_WEBREQUEST, "Relative URL: %s -> %s", url, fullURL);
 
-    return absURL.BuildURI();
+    return fullURL;
 }
 
 wxWebRequest

--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -16,6 +16,8 @@
 
 #include "wx/mstream.h"
 #include "wx/dynlib.h"
+#include "wx/uri.h"
+
 #include "wx/msw/private.h"
 #include "wx/msw/private/webrequest_winhttp.h"
 
@@ -173,11 +175,12 @@ struct wxURLComponents : URL_COMPONENTS
 
     wxWebCredentials GetCredentials() const
     {
-        return wxWebCredentials
-               (
-                wxString(lpszUserName, dwUserNameLength),
-                wxSecretValue(wxString(lpszPassword, dwPasswordLength))
-               );
+        // WinHttpCrackUrl() leaves the URL components percent-encoded, but we
+        // need the actual username and password here, so decode them ourselves.
+        wxString user(wxURI::Unescape(wxString(lpszUserName, dwUserNameLength)));
+        wxString pass(wxURI::Unescape(wxString(lpszPassword, dwPasswordLength)));
+
+        return wxWebCredentials(user, wxSecretValue(pass));
     }
 };
 

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -21,6 +21,7 @@
 
 #include "wx/webrequest.h"
 #include "wx/filename.h"
+#include "wx/uri.h"
 #include "wx/wfstream.h"
 
 #include <memory>
@@ -140,23 +141,15 @@ protected:
                    const wxString& user,
                    const wxString& password)
     {
-        wxString schema;
-        wxString rest;
-        if ( baseURL.StartsWith("https://", &rest) )
-        {
-            schema = "https";
-        }
-        else if ( baseURL.StartsWith("http://", &rest) )
-        {
-            schema = "http";
-        }
-        else
-        {
-            FAIL("Base URL must be an HTTP(S) one: " << baseURL);
-        }
+        wxString url = baseURL;
+        if ( !url.EndsWith('/') && !relURL.StartsWith('/') )
+            url += '/';
+        url += relURL;
 
-        Create(wxString::Format("%s://%s:%s@%s/%s",
-                                schema, user, password, rest, relURL));
+        wxURI uri(url);
+        uri.SetUserAndPassword(user, password);
+
+        Create(uri.BuildURI());
     }
 
     virtual void Create(const wxString& url) = 0;

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -1128,6 +1128,17 @@ TEST_CASE_METHOD(SyncRequestFixture,
         CHECK( response.GetStatus() == 401 );
         CHECK( state == wxWebRequest::State_Unauthorized );
     }
+
+    SECTION("Reserved characters")
+    {
+        CreateWithAuth("basic-auth/u%40d/1%3d2%3f", "u@d", "1=2?");
+        REQUIRE( Execute() );
+        CHECK( response.GetStatus() == 200 );
+        CHECK( state == wxWebRequest::State_Completed );
+
+        CHECK_THAT( response.AsString().utf8_string(),
+                    Catch::Contains(AUTHORIZED_SUBSTRING) );
+    }
 }
 
 TEST_CASE_METHOD(SyncRequestFixture,

--- a/tests/uris/uris.cpp
+++ b/tests/uris/uris.cpp
@@ -28,11 +28,27 @@
 
 // apply the given accessor to the URI, check that the result is as expected
 #define URI_ASSERT_PART_EQUAL(uri, expected, accessor) \
-    CHECK(wxURI(uri).accessor == expected)
+    wxSTATEMENT_MACRO_BEGIN \
+        const wxURI u(uri); \
+        INFO(DumpURI(u)); \
+        CHECK(u.accessor == expected); \
+    wxSTATEMENT_MACRO_END
+
 #define URI_ASSERT_HOST_TEST(uri, expectedhost, expectedtype) \
-    CHECK(wxURI(uri).GetServer() == (expectedhost)); \
-    CHECK(wxURI(uri).GetHostType() == (expectedtype))
-#define URI_ASSERT_HOST_TESTBAD(uri, ne) CHECK(wxURI(uri).GetHostType() != (ne))
+    wxSTATEMENT_MACRO_BEGIN \
+        const wxURI u(uri); \
+        INFO(DumpURI(u)); \
+        CHECK(u.GetServer() == (expectedhost)); \
+        CHECK(u.GetHostType() == (expectedtype)); \
+    wxSTATEMENT_MACRO_END
+
+#define URI_ASSERT_HOST_TESTBAD(uri, ne) \
+    wxSTATEMENT_MACRO_BEGIN \
+        const wxURI u(uri); \
+        INFO(DumpURI(u)); \
+        CHECK(u.GetHostType() != (ne)); \
+    wxSTATEMENT_MACRO_END
+
 #define URI_ASSERT_HOST_EQUAL(uri, expected) \
     URI_ASSERT_PART_EQUAL((uri), (expected), GetServer())
 #define URI_ASSERT_PATH_EQUAL(uri, expected) \
@@ -41,7 +57,14 @@
     URI_ASSERT_PART_EQUAL((uri), (expected), GetHostType())
 #define URI_ASSERT_USER_EQUAL(uri, expected) \
     URI_ASSERT_PART_EQUAL((uri), (expected), GetUser())
-#define URI_ASSERT_BADPATH(uri) CHECK(!wxURI(uri).HasPath())
+
+#define URI_ASSERT_BADPATH(uri) \
+    wxSTATEMENT_MACRO_BEGIN \
+        const wxURI u(uri); \
+        INFO(DumpURI(u)); \
+        CHECK(!u.HasPath()); \
+    wxSTATEMENT_MACRO_END
+
 // IPv4
 #define URI_ASSERT_IPV4_TEST(ip, expected) \
     URI_ASSERT_HOST_TEST("http://user:password@" ip ":5050/path", expected, wxURI_IPV4ADDRESS)
@@ -54,11 +77,12 @@
     URI_ASSERT_HOST_TESTBAD("http://user:password@" ip ":5050/path", wxURI_IPV6ADDRESS)
 // Resolve
 #define URI_TEST_RESOLVE_IMPL(string, eq, strictness) \
-    {\
+    wxSTATEMENT_MACRO_BEGIN \
         wxURI uri(string); \
         uri.Resolve(masteruri, strictness); \
+        INFO(DumpURI(uri)); \
         CHECK(uri.BuildURI() == eq); \
-    }
+    wxSTATEMENT_MACRO_END
 #define URI_TEST_RESOLVE(string, eq) \
         URI_TEST_RESOLVE_IMPL(string, eq, wxURI_STRICT);
 #define URI_TEST_RESOLVE_LAX(string, eq) \
@@ -66,10 +90,14 @@
 
 // Normalization
 #define URI_ASSERT_NORMALIZEDENCODEDPATH_EQUAL(uri, expected) \
-    { wxURI nuri(uri); nuri.Resolve(wxURI("http://a/"));\
-      CHECK(nuri.GetPath() == expected); }
+    wxSTATEMENT_MACRO_BEGIN \
+      wxURI nuri(uri); \
+      nuri.Resolve(wxURI("http://a/")); \
+      INFO(DumpURI(nuri)); \
+      CHECK(nuri.GetPath() == expected); \
+    wxSTATEMENT_MACRO_END
 #define URI_ASSERT_NORMALIZEDPATH_EQUAL(uri, expected) \
-    { URI_ASSERT_NORMALIZEDENCODEDPATH_EQUAL(uri, expected); }
+    URI_ASSERT_NORMALIZEDENCODEDPATH_EQUAL(uri, expected);
 
 // Helper function used to show components of wxURI.
 static wxString DumpURI(const wxURI& uri)
@@ -328,7 +356,6 @@ TEST_CASE("URI::UserInfo", "[uri]")
     CHECK( uri.BuildURI() == "https://me%40here!@host/" );
 
     uri.SetUserAndPassword("you:", "?me");
-    INFO(DumpURI(uri));
     CHECK( uri.BuildURI() == "https://you%3a:%3fme@host/" );
 }
 

--- a/tests/uris/uris.cpp
+++ b/tests/uris/uris.cpp
@@ -57,6 +57,8 @@
     URI_ASSERT_PART_EQUAL(uri, expected, GetHostType())
 #define URI_ASSERT_USER_EQUAL(uri, expected) \
     URI_ASSERT_PART_EQUAL(uri, expected, GetUser())
+#define URI_ASSERT_USERINFO_EQUAL(uri, expected) \
+    URI_ASSERT_PART_EQUAL(uri, expected, GetUserInfo())
 
 #define URI_ASSERT_BADPATH(uri) \
     wxSTATEMENT_MACRO_BEGIN \
@@ -314,8 +316,8 @@ TEST_CASE("URI::UserInfo", "[uri]")
     wxURI uri;
 
     // Simple cases.
-    CHECK( wxURI("https://host/").GetUser() == "" );
-    CHECK( wxURI("https://user@host/").GetUser() == "user" );
+    URI_ASSERT_USER_EQUAL( "https://host/", "" );
+    URI_ASSERT_USER_EQUAL( "https://user@host/", "user" );
 
     CHECK( uri.Create("https://user:password@host/") );
     CHECK( uri.GetUser() == "user" );
@@ -340,15 +342,11 @@ TEST_CASE("URI::UserInfo", "[uri]")
 
     // But sub-delims (defined in the same section of the RFC) may be used
     // either in the encoded or raw form.
-    CHECK( wxURI("https://me!@host/").GetUser() == "me!" );
-    CHECK( wxURI::Unescape(wxURI("https://me%21@host/").GetUser()) == "me!" );
+    URI_ASSERT_USER_EQUAL( "https://me!@host/", "me!" );
+    URI_ASSERT_USER_EQUAL( "https://me%21@host/", "me%21" );
 
-    CHECK( uri.Create("https://u:pass=word@h/") );
-    CHECK( uri.GetUser() == "u" );
-    CHECK( wxURI::Unescape(uri.GetPassword()) == "pass=word" );
-
-    CHECK( uri.Create("https://u:pass%3Dword@h/") );
-    CHECK( wxURI::Unescape(uri.GetPassword()) == "pass=word" );
+    URI_ASSERT_USERINFO_EQUAL( "https://u:pass=word@h/", "u:pass=word" );
+    URI_ASSERT_USERINFO_EQUAL( "https://u:pass%3Dword@h/", "u:pass%3Dword" );
 
     // Also test that using SetUserAndPassword() works.
     uri = "https://host/";

--- a/tests/uris/uris.cpp
+++ b/tests/uris/uris.cpp
@@ -49,6 +49,8 @@
         CHECK(u.GetHostType() != ne); \
     wxSTATEMENT_MACRO_END
 
+#define URI_ASSERT_EQUAL(uri, expected) \
+    URI_ASSERT_PART_EQUAL(uri, expected, BuildURI())
 #define URI_ASSERT_HOST_EQUAL(uri, expected) \
     URI_ASSERT_PART_EQUAL(uri, expected, GetServer())
 #define URI_ASSERT_PATH_EQUAL(uri, expected) \
@@ -351,10 +353,10 @@ TEST_CASE("URI::UserInfo", "[uri]")
     // Also test that using SetUserAndPassword() works.
     uri = "https://host/";
     uri.SetUserAndPassword("me@here!");
-    CHECK( uri.BuildURI() == "https://me%40here!@host/" );
+    URI_ASSERT_EQUAL( uri, "https://me%40here!@host/" );
 
     uri.SetUserAndPassword("you:", "?me");
-    CHECK( uri.BuildURI() == "https://you%3a:%3fme@host/" );
+    URI_ASSERT_EQUAL( uri, "https://you%3a:%3fme@host/" );
 }
 
 //examples taken from RFC 2396.bis

--- a/tests/uris/uris.cpp
+++ b/tests/uris/uris.cpp
@@ -311,6 +311,9 @@ TEST_CASE("URI::Paths", "[uri]")
     URI_ASSERT_PATH_EQUAL("http://good.com:8042/GOODPATH", "/GOODPATH");
     //When authority is not present, the path cannot begin with two slash characters ("//").
     URI_ASSERT_BADPATH("http:////BADPATH");
+
+    // 8-bit characters in the path should be percent-encoded.
+    URI_ASSERT_PATH_EQUAL( wxString::FromUTF8("http://host/\xc3\xa9"), "/%c3%a9" );
 }
 
 TEST_CASE("URI::UserInfo", "[uri]")
@@ -357,6 +360,9 @@ TEST_CASE("URI::UserInfo", "[uri]")
 
     uri.SetUserAndPassword("you:", "?me");
     URI_ASSERT_EQUAL( uri, "https://you%3a:%3fme@host/" );
+
+    uri.SetUserAndPassword(wxString::FromUTF8("\xc3\xa7"));
+    URI_ASSERT_USER_EQUAL( uri, "%c3%a7");
 }
 
 //examples taken from RFC 2396.bis

--- a/tests/uris/uris.cpp
+++ b/tests/uris/uris.cpp
@@ -38,25 +38,25 @@
     wxSTATEMENT_MACRO_BEGIN \
         const wxURI u(uri); \
         INFO(DumpURI(u)); \
-        CHECK(u.GetServer() == (expectedhost)); \
-        CHECK(u.GetHostType() == (expectedtype)); \
+        CHECK(u.GetServer() == expectedhost); \
+        CHECK(u.GetHostType() == expectedtype); \
     wxSTATEMENT_MACRO_END
 
 #define URI_ASSERT_HOST_TESTBAD(uri, ne) \
     wxSTATEMENT_MACRO_BEGIN \
         const wxURI u(uri); \
         INFO(DumpURI(u)); \
-        CHECK(u.GetHostType() != (ne)); \
+        CHECK(u.GetHostType() != ne); \
     wxSTATEMENT_MACRO_END
 
 #define URI_ASSERT_HOST_EQUAL(uri, expected) \
-    URI_ASSERT_PART_EQUAL((uri), (expected), GetServer())
+    URI_ASSERT_PART_EQUAL(uri, expected, GetServer())
 #define URI_ASSERT_PATH_EQUAL(uri, expected) \
     URI_ASSERT_PART_EQUAL((uri), (expected), GetPath())
 #define URI_ASSERT_HOSTTYPE_EQUAL(uri, expected) \
-    URI_ASSERT_PART_EQUAL((uri), (expected), GetHostType())
+    URI_ASSERT_PART_EQUAL(uri, expected, GetHostType())
 #define URI_ASSERT_USER_EQUAL(uri, expected) \
-    URI_ASSERT_PART_EQUAL((uri), (expected), GetUser())
+    URI_ASSERT_PART_EQUAL(uri, expected, GetUser())
 
 #define URI_ASSERT_BADPATH(uri) \
     wxSTATEMENT_MACRO_BEGIN \


### PR DESCRIPTION
This is a continuation of #25240.