### PR TITLE
Use SVG icons in wxAUI

### DIFF
--- a/include/wx/private/aui.h
+++ b/include/wx/private/aui.h
@@ -22,12 +22,12 @@
 // given colour.
 wxBitmapBundle wxAuiCreateBitmap(const char* svgData, int w, int h,
                                  const wxColour& color);
-#endif
-
+#else // !wxHAS_SVG
 // When using XBM, the black bits of the given monochrome bitmap define the
 // mask of the returned bitmap and white bits are mapped to the given colour.
 wxBitmap wxAuiCreateBitmap(const unsigned char bits[], int w, int h,
                            const wxColour& color);
+#endif // wxHAS_SVG/!wxHAS_SVG
 
 // Define some specialized functions to create bitmaps used in both dockart.cpp
 // and tabart.cpp.

--- a/include/wx/private/aui.h
+++ b/include/wx/private/aui.h
@@ -10,9 +10,22 @@
 #ifndef _WX_PRIVATE_AUI_H_
 #define _WX_PRIVATE_AUI_H_
 
-// This is a utility function that creates a bitmap with mask corresponding to
-// the black bits of the given (as raw bits in XBM format) monochrome bitmap
-// and white bits mapped to the given colour.
+#include "wx/bmpbndl.h"
+
+// wxAuiCreateBitmap() is a utility function that creates a bitmap using the
+// given colour from monochrome image defined by either SVG (if supported in
+// this build) or XBM data.
+
+#ifdef wxHAS_SVG
+// SVG data must start with a new line (this is convenient when embedding it as
+// a raw string) and use "currentColor" for the colour to be mapped to the
+// given colour.
+wxBitmapBundle wxAuiCreateBitmap(const char* svgData, int w, int h,
+                                 const wxColour& color);
+#endif
+
+// When using XBM, the black bits of the given monochrome bitmap define the
+// mask of the returned bitmap and white bits are mapped to the given colour.
 wxBitmap wxAuiCreateBitmap(const unsigned char bits[], int w, int h,
                            const wxColour& color);
 

--- a/include/wx/private/aui.h
+++ b/include/wx/private/aui.h
@@ -29,4 +29,9 @@ wxBitmapBundle wxAuiCreateBitmap(const char* svgData, int w, int h,
 wxBitmap wxAuiCreateBitmap(const unsigned char bits[], int w, int h,
                            const wxColour& color);
 
+// Define some specialized functions to create bitmaps used in both dockart.cpp
+// and tabart.cpp.
+wxBitmapBundle wxAuiCreateCloseButtonBitmap(const wxColour& color);
+wxBitmapBundle wxAuiCreatePinButtonBitmap(const wxColour& color);
+
 #endif // _WX_PRIVATE_AUI_H_

--- a/include/wx/private/aui.h
+++ b/include/wx/private/aui.h
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/aui.h
+// Purpose:     Private wxAUI declarations.
+// Author:      Vadim Zeitlin
+// Created:     2025-03-13
+// Copyright:   (c) 2025 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_AUI_H_
+#define _WX_PRIVATE_AUI_H_
+
+// This is a utility function that creates a bitmap with mask corresponding to
+// the black bits of the given (as raw bits in XBM format) monochrome bitmap
+// and white bits mapped to the given colour.
+wxBitmap wxAuiCreateBitmap(const unsigned char bits[], int w, int h,
+                           const wxColour& color);
+
+#endif // _WX_PRIVATE_AUI_H_

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -40,6 +40,8 @@
 #include "wx/osx/private.h"
 #endif
 
+#include "wx/private/aui.h"
+
 wxDEFINE_EVENT( wxEVT_AUITOOLBAR_TOOL_DROPDOWN, wxAuiToolBarEvent );
 wxDEFINE_EVENT( wxEVT_AUITOOLBAR_OVERFLOW_CLICK, wxAuiToolBarEvent );
 wxDEFINE_EVENT( wxEVT_AUITOOLBAR_RIGHT_CLICK, wxAuiToolBarEvent );
@@ -59,9 +61,6 @@ enum
     wxITEM_SPACER
 };
 
-
-wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
-                             const wxColour& color);
 
 static wxColor GetBaseColor()
 {
@@ -177,17 +176,17 @@ void wxAuiGenericToolBarArt::UpdateColoursFromSystem()
     // Note: update the bitmaps here as they depend on the system colours too.
 
     // TODO: Provide x1.5 and x2.0 versions or migrate to SVG.
-    static const unsigned char buttonDropdownBits[] = { 0xe0, 0xf1, 0xfb };
-    static const unsigned char overflowBits[] = { 0x80, 0xff, 0x80, 0xc1, 0xe3, 0xf7 };
+    static const unsigned char buttonDropdownBitmapData[] = { 0xe0, 0xf1, 0xfb };
+    static const unsigned char overflowBitmapData[] = { 0x80, 0xff, 0x80, 0xc1, 0xe3, 0xf7 };
 
-    m_buttonDropDownBmp = wxAuiBitmapFromBits(buttonDropdownBits, 5, 3,
+    m_buttonDropDownBmp = wxAuiCreateBitmap(buttonDropdownBitmapData, 5, 3,
                                               wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
-    m_disabledButtonDropDownBmp = wxAuiBitmapFromBits(
-                                                buttonDropdownBits, 5, 3,
+    m_disabledButtonDropDownBmp = wxAuiCreateBitmap(
+                                                buttonDropdownBitmapData, 5, 3,
                                                 wxColor(128,128,128));
-    m_overflowBmp = wxAuiBitmapFromBits(overflowBits, 7, 6,
+    m_overflowBmp = wxAuiCreateBitmap(overflowBitmapData, 7, 6,
                                         wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
-    m_disabledOverflowBmp = wxAuiBitmapFromBits(overflowBits, 7, 6, wxColor(128,128,128));
+    m_disabledOverflowBmp = wxAuiCreateBitmap(overflowBitmapData, 7, 6, wxColor(128,128,128));
 }
 
 void wxAuiGenericToolBarArt::SetFlags(unsigned int flags)

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -175,9 +175,23 @@ void wxAuiGenericToolBarArt::UpdateColoursFromSystem()
 
     // Note: update the bitmaps here as they depend on the system colours too.
 
-    // TODO: Provide x1.5 and x2.0 versions or migrate to SVG.
+#ifdef wxHAS_SVG
+    static const char* const buttonDropdownBitmapData = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="5" height="3">
+    <polygon points="0, 0 5 0 2.5, 2" stroke="currentColor" fill="currentColor" stroke-width="0"/>
+</svg>
+)svg";
+
+    static const char* const overflowBitmapData = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="7" height="6">
+    <rect x="0" y="0" width="7" height="1" stroke="currentColor" fill="currentColor" stroke-width="0"/>
+    <polygon points="0, 2 7 2 3.5, 6" stroke="currentColor" fill="currentColor" stroke-width="0"/>
+</svg>
+)svg";
+#else // !wxHAS_SVG
     static const unsigned char buttonDropdownBitmapData[] = { 0xe0, 0xf1, 0xfb };
     static const unsigned char overflowBitmapData[] = { 0x80, 0xff, 0x80, 0xc1, 0xe3, 0xf7 };
+#endif // wxHAS_SVG/!wxHAS_SVG
 
     m_buttonDropDownBmp = wxAuiCreateBitmap(buttonDropdownBitmapData, 5, 3,
                                               wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3213,22 +3213,22 @@ void wxAuiNotebook::OnTabDragMotion(wxAuiNotebookEvent& evt)
         // make sure we are not over the hint window
         if (!wxDynamicCast(tab_ctrl, wxFrame))
         {
-            wxAuiTabCtrl* dest_tabs = nullptr;
+            wxAuiTabCtrl* other_tabs = nullptr;
             while (tab_ctrl)
             {
-                dest_tabs = wxDynamicCast(tab_ctrl, wxAuiTabCtrl);
-                if (dest_tabs)
+                other_tabs = wxDynamicCast(tab_ctrl, wxAuiTabCtrl);
+                if (other_tabs)
                     break;
                 tab_ctrl = tab_ctrl->GetParent();
             }
 
-            if (dest_tabs)
+            if (other_tabs)
             {
                 wxAuiNotebook* nb = (wxAuiNotebook*)tab_ctrl->GetParent();
 
                 if (nb != this)
                 {
-                    m_mgr.UpdateHint(dest_tabs->GetHintScreenRect());
+                    m_mgr.UpdateHint(other_tabs->GetHintScreenRect());
                     return;
                 }
             }

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -84,8 +84,8 @@ float wxAuiGetColourContrast(const wxColour& c1, const wxColour& c2)
 
 // wxAuiBitmapFromBits() is a utility function that creates a
 // masked bitmap from raw bits (XBM format)
-wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
-                             const wxColour& color)
+wxBitmap wxAuiCreateBitmap(const unsigned char bits[], int w, int h,
+                           const wxColour& color)
 {
     wxImage img = wxBitmap((const char*)bits, w, h).ConvertToImage();
     img.InitAlpha();
@@ -261,17 +261,17 @@ wxAuiDefaultDockArt::InitBitmaps ()
     // some built in bitmaps
     // TODO: Provide x1.5 and x2.0 versions or migrate to SVG.
 #if defined( __WXMAC__ )
-     static const unsigned char close_bits[]={
+     static const unsigned char close_bitmap_data[]={
          0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0xFE, 0x03, 0xF8, 0x01, 0xF0, 0x19, 0xF3,
          0xB8, 0xE3, 0xF0, 0xE1, 0xE0, 0xE0, 0xF0, 0xE1, 0xB8, 0xE3, 0x19, 0xF3,
          0x01, 0xF0, 0x03, 0xF8, 0x0F, 0xFE, 0xFF, 0xFF };
 #elif defined(__WXGTK__)
-     static const unsigned char close_bits[]={
+     static const unsigned char close_bitmap_data[]={
          0xff, 0xff, 0xff, 0xff, 0x07, 0xf0, 0xfb, 0xef, 0xdb, 0xed, 0x8b, 0xe8,
          0x1b, 0xec, 0x3b, 0xee, 0x1b, 0xec, 0x8b, 0xe8, 0xdb, 0xed, 0xfb, 0xef,
          0x07, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 #else
-    static const unsigned char close_bits[]={
+    static const unsigned char close_bitmap_data[]={
          // reduced height, symmetric
          0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xcf, 0xf3, 0x9f, 0xf9,
          0x3f, 0xfc, 0x7f, 0xfe, 0x3f, 0xfc, 0x9f, 0xf9, 0xcf, 0xf3, 0xff, 0xff,
@@ -284,17 +284,17 @@ wxAuiDefaultDockArt::InitBitmaps ()
       */
 #endif
 
-    static const unsigned char maximize_bits[] = {
+    static const unsigned char maximize_bitmap_data[] = {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x07, 0xf0, 0xf7, 0xf7, 0x07, 0xf0,
         0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0x07, 0xf0,
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-    static const unsigned char restore_bits[]={
+    static const unsigned char restore_bitmap_data[]={
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0xf0, 0x1f, 0xf0, 0xdf, 0xf7,
         0x07, 0xf4, 0x07, 0xf4, 0xf7, 0xf5, 0xf7, 0xf1, 0xf7, 0xfd, 0xf7, 0xfd,
         0x07, 0xfc, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-    static const unsigned char pin_bits[]={
+    static const unsigned char pin_bitmap_data[]={
         0xff,0xff,0xff,0xff,0xff,0xff,0x1f,0xfc,0xdf,0xfc,0xdf,0xfc,
         0xdf,0xfc,0xdf,0xfc,0xdf,0xfc,0x0f,0xf8,0x7f,0xff,0x7f,0xff,
         0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff};
@@ -307,17 +307,17 @@ wxAuiDefaultDockArt::InitBitmaps ()
     const wxColor active = m_activeCaptionTextColour;
 #endif
 
-    m_inactiveCloseBitmap = wxAuiBitmapFromBits(close_bits, 16, 16, inactive);
-    m_activeCloseBitmap = wxAuiBitmapFromBits(close_bits, 16, 16, active);
+    m_inactiveCloseBitmap = wxAuiCreateBitmap(close_bitmap_data, 16, 16, inactive);
+    m_activeCloseBitmap = wxAuiCreateBitmap(close_bitmap_data, 16, 16, active);
 
-    m_inactiveMaximizeBitmap = wxAuiBitmapFromBits(maximize_bits, 16, 16, inactive);
-    m_activeMaximizeBitmap = wxAuiBitmapFromBits(maximize_bits, 16, 16, active);
+    m_inactiveMaximizeBitmap = wxAuiCreateBitmap(maximize_bitmap_data, 16, 16, inactive);
+    m_activeMaximizeBitmap = wxAuiCreateBitmap(maximize_bitmap_data, 16, 16, active);
 
-    m_inactiveRestoreBitmap = wxAuiBitmapFromBits(restore_bits, 16, 16, inactive);
-    m_activeRestoreBitmap = wxAuiBitmapFromBits(restore_bits, 16, 16, active);
+    m_inactiveRestoreBitmap = wxAuiCreateBitmap(restore_bitmap_data, 16, 16, inactive);
+    m_activeRestoreBitmap = wxAuiCreateBitmap(restore_bitmap_data, 16, 16, active);
 
-    m_inactivePinBitmap = wxAuiBitmapFromBits(pin_bits, 16, 16, inactive);
-    m_activePinBitmap = wxAuiBitmapFromBits(pin_bits, 16, 16, active);
+    m_inactivePinBitmap = wxAuiCreateBitmap(pin_bitmap_data, 16, 16, inactive);
+    m_activePinBitmap = wxAuiCreateBitmap(pin_bitmap_data, 16, 16, active);
 }
 
 void wxAuiDefaultDockArt::UpdateColoursFromSystem()

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -95,8 +95,7 @@ wxBitmapBundle wxAuiCreateBitmap(const char* svgData, int w, int h,
 
     return wxBitmapBundle::FromSVG(s.ToAscii(), wxSize(w, h));
 }
-#endif // wxHAS_SVG
-
+#else // !wxHAS_SVG
 wxBitmap wxAuiCreateBitmap(const unsigned char bits[], int w, int h,
                            const wxColour& color)
 {
@@ -126,6 +125,7 @@ wxBitmap wxAuiCreateBitmap(const unsigned char bits[], int w, int h,
     }
     return wxBitmap(img);
 }
+#endif // wxHAS_SVG/!wxHAS_SVG
 
 static void DrawGradientRectangle(wxDC& dc,
                                   const wxRect& rect,

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -268,34 +268,13 @@ wxAuiDockArt* wxAuiDefaultDockArt::Clone()
     return new wxAuiDefaultDockArt(*this);
 }
 
-void
-wxAuiDefaultDockArt::InitBitmaps ()
+wxBitmapBundle wxAuiCreateCloseButtonBitmap(const wxColour& color)
 {
-    // Initialize built in bitmaps, from SVG, if supported, or XBM otherwise.
 #ifdef wxHAS_SVG
     static const char* const close_bitmap_data = R"svg(
 <svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
     <line x1="4" y1="4" x2="11" y2="11" stroke="currentColor" fill="none" stroke-linecap="round" stroke-width="1.5"/>
     <line x1="4" y1="11" x2="11" y2="4" stroke="currentColor" fill="none" stroke-linecap="round" stroke-width="1.5"/>
-</svg>
-)svg";
-
-    static const char* const maximize_bitmap_data = R"svg(
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-    <rect x="3" y="3" width="9" height="9" stroke="currentColor" fill="none" stroke-width="1"/>
-    <line x1="3" y1="5.5" x2="12" y2="5.5" stroke="currentColor" stroke-width="1"/>
-</svg>
-)svg";
-
-    static const char* const restore_bitmap_data = R"svg(
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-    <path d="M 3 5 v 8 h 8 v -8 Z m 2 0 v -2 h 8 v 8 h -2" stroke="currentColor" fill="none" stroke-width="1"/>
-</svg>
-)svg";
-
-    static const char* const pin_bitmap_data = R"svg(
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-    <path d="M 5 9 h 6 h -1 v -6 h -1 v 6 v -6 h -3 v 6 h 2 v 4" stroke="currentColor" fill="none" stroke-width="1"/>
 </svg>
 )svg";
 #else // !wxHAS_SVG
@@ -322,7 +301,47 @@ wxAuiDefaultDockArt::InitBitmaps ()
          0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
       */
 #endif
+#endif // wxHAS_SVG/!wxHAS_SVG
 
+    return wxAuiCreateBitmap(close_bitmap_data, 16, 16, color);
+}
+
+wxBitmapBundle wxAuiCreatePinButtonBitmap(const wxColour& color)
+{
+#ifdef wxHAS_SVG
+    static const char* const pin_bitmap_data = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+    <path d="M 5 9 h 6 h -1 v -6 h -1 v 6 v -6 h -3 v 6 h 2 v 4" stroke="currentColor" fill="none" stroke-width="1"/>
+</svg>
+)svg";
+#else // !wxHAS_SVG
+    static const unsigned char pin_bitmap_data[]={
+        0xff,0xff,0xff,0xff,0xff,0xff,0x1f,0xfc,0xdf,0xfc,0xdf,0xfc,
+        0xdf,0xfc,0xdf,0xfc,0xdf,0xfc,0x0f,0xf8,0x7f,0xff,0x7f,0xff,
+        0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff};
+#endif // wxHAS_SVG/!wxHAS_SVG
+
+    return wxAuiCreateBitmap(pin_bitmap_data, 16, 16, color);
+}
+
+void
+wxAuiDefaultDockArt::InitBitmaps ()
+{
+    // Initialize built in bitmaps, from SVG, if supported, or XBM otherwise.
+#ifdef wxHAS_SVG
+    static const char* const maximize_bitmap_data = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+    <rect x="3" y="3" width="9" height="9" stroke="currentColor" fill="none" stroke-width="1"/>
+    <line x1="3" y1="5.5" x2="12" y2="5.5" stroke="currentColor" stroke-width="1"/>
+</svg>
+)svg";
+
+    static const char* const restore_bitmap_data = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+    <path d="M 3 5 v 8 h 8 v -8 Z m 2 0 v -2 h 8 v 8 h -2" stroke="currentColor" fill="none" stroke-width="1"/>
+</svg>
+)svg";
+#else // !wxHAS_SVG
     static const unsigned char maximize_bitmap_data[] = {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x07, 0xf0, 0xf7, 0xf7, 0x07, 0xf0,
         0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0xf7, 0x07, 0xf0,
@@ -332,11 +351,6 @@ wxAuiDefaultDockArt::InitBitmaps ()
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0xf0, 0x1f, 0xf0, 0xdf, 0xf7,
         0x07, 0xf4, 0x07, 0xf4, 0xf7, 0xf5, 0xf7, 0xf1, 0xf7, 0xfd, 0xf7, 0xfd,
         0x07, 0xfc, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-
-    static const unsigned char pin_bitmap_data[]={
-        0xff,0xff,0xff,0xff,0xff,0xff,0x1f,0xfc,0xdf,0xfc,0xdf,0xfc,
-        0xdf,0xfc,0xdf,0xfc,0xdf,0xfc,0x0f,0xf8,0x7f,0xff,0x7f,0xff,
-        0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff};
 #endif // wxHAS_SVG/!wxHAS_SVG
 
 #ifdef __WXMAC__
@@ -347,8 +361,8 @@ wxAuiDefaultDockArt::InitBitmaps ()
     const wxColor active = m_activeCaptionTextColour;
 #endif
 
-    m_inactiveCloseBitmap = wxAuiCreateBitmap(close_bitmap_data, 16, 16, inactive);
-    m_activeCloseBitmap = wxAuiCreateBitmap(close_bitmap_data, 16, 16, active);
+    m_inactiveCloseBitmap = wxAuiCreateCloseButtonBitmap(inactive);
+    m_activeCloseBitmap = wxAuiCreateCloseButtonBitmap(active);
 
     m_inactiveMaximizeBitmap = wxAuiCreateBitmap(maximize_bitmap_data, 16, 16, inactive);
     m_activeMaximizeBitmap = wxAuiCreateBitmap(maximize_bitmap_data, 16, 16, active);
@@ -356,8 +370,8 @@ wxAuiDefaultDockArt::InitBitmaps ()
     m_inactiveRestoreBitmap = wxAuiCreateBitmap(restore_bitmap_data, 16, 16, inactive);
     m_activeRestoreBitmap = wxAuiCreateBitmap(restore_bitmap_data, 16, 16, active);
 
-    m_inactivePinBitmap = wxAuiCreateBitmap(pin_bitmap_data, 16, 16, inactive);
-    m_activePinBitmap = wxAuiCreateBitmap(pin_bitmap_data, 16, 16, active);
+    m_inactivePinBitmap = wxAuiCreatePinButtonBitmap(inactive);
+    m_activePinBitmap = wxAuiCreatePinButtonBitmap(active);
 }
 
 void wxAuiDefaultDockArt::UpdateColoursFromSystem()

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -35,6 +35,7 @@
 #include "wx/osx/private.h"
 #endif
 
+#include "wx/private/aui.h"
 
 // -- GUI helper classes and functions --
 
@@ -67,10 +68,6 @@ private:
 // these functions live in dockart.cpp -- they'll eventually
 // be moved to a new utility cpp file
 
-wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
-                             const wxColour& color);
-
-// This function is defined in dockart.cpp.
 float wxAuiGetColourContrast(const wxColour& c1, const wxColour& c2);
 
 wxString wxAuiChopText(wxDC& dc, const wxString& text, int max_size);
@@ -132,43 +129,43 @@ static void IndentPressedBitmap(const wxSize& offset, wxRect* rect, int button_s
 // TODO: Provide x1.5 and x2.0 versions or migrate to SVG.
 
 #if defined( __WXMAC__ )
- static const unsigned char close_bits[]={
+ static const unsigned char close_bitmap_data[]={
      0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0xFE, 0x03, 0xF8, 0x01, 0xF0, 0x19, 0xF3,
      0xB8, 0xE3, 0xF0, 0xE1, 0xE0, 0xE0, 0xF0, 0xE1, 0xB8, 0xE3, 0x19, 0xF3,
      0x01, 0xF0, 0x03, 0xF8, 0x0F, 0xFE, 0xFF, 0xFF };
 #elif defined( __WXGTK__)
- static const unsigned char close_bits[]={
+ static const unsigned char close_bitmap_data[]={
      0xff, 0xff, 0xff, 0xff, 0x07, 0xf0, 0xfb, 0xef, 0xdb, 0xed, 0x8b, 0xe8,
      0x1b, 0xec, 0x3b, 0xee, 0x1b, 0xec, 0x8b, 0xe8, 0xdb, 0xed, 0xfb, 0xef,
      0x07, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 #else
- static const unsigned char close_bits[]={
+ static const unsigned char close_bitmap_data[]={
      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xe7, 0xf3, 0xcf, 0xf9,
      0x9f, 0xfc, 0x3f, 0xfe, 0x3f, 0xfe, 0x9f, 0xfc, 0xcf, 0xf9, 0xe7, 0xf3,
      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 #endif
 
-static const unsigned char left_bits[] = {
+static const unsigned char left_bitmap_data[] = {
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0x7f, 0xfe, 0x3f, 0xfe,
    0x1f, 0xfe, 0x0f, 0xfe, 0x1f, 0xfe, 0x3f, 0xfe, 0x7f, 0xfe, 0xff, 0xfe,
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-static const unsigned char right_bits[] = {
+static const unsigned char right_bitmap_data[] = {
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xdf, 0xff, 0x9f, 0xff, 0x1f, 0xff,
    0x1f, 0xfe, 0x1f, 0xfc, 0x1f, 0xfe, 0x1f, 0xff, 0x9f, 0xff, 0xdf, 0xff,
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-static const unsigned char list_bits[] = {
+static const unsigned char list_bitmap_data[] = {
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
    0x0f, 0xf8, 0xff, 0xff, 0x0f, 0xf8, 0x1f, 0xfc, 0x3f, 0xfe, 0x7f, 0xff,
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-static const unsigned char pin_bits[] = {
+static const unsigned char pin_bitmap_data[] = {
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xbf, 0xff, 0x3f, 0xe0,
    0xbf, 0xef, 0x87, 0xef, 0x3f, 0xe0, 0x3f, 0xe0, 0xbf, 0xff, 0xff, 0xff,
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-static const unsigned char unpin_bits[]={
+static const unsigned char unpin_bitmap_data[]={
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0xfc, 0xdf, 0xfc, 0xdf, 0xfc,
    0xdf, 0xfc, 0xdf, 0xfc, 0xdf, 0xfc, 0x0f, 0xf8, 0x7f, 0xff, 0x7f, 0xff,
    0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -320,18 +317,18 @@ void wxAuiGenericTabArt::UpdateColoursFromSystem()
 
     const int disabledLightness = wxSystemSettings::GetAppearance().IsUsingDarkBackground() ? 130 : 70;
 
-    m_activeCloseBmp = wxAuiBitmapFromBits(close_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledCloseBmp = wxAuiBitmapFromBits(close_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT).ChangeLightness(disabledLightness));
-    m_activeLeftBmp = wxAuiBitmapFromBits(left_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledLeftBmp = wxAuiBitmapFromBits(left_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
-    m_activeRightBmp = wxAuiBitmapFromBits(right_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledRightBmp = wxAuiBitmapFromBits(right_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
-    m_activeWindowListBmp = wxAuiBitmapFromBits(list_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledWindowListBmp = wxAuiBitmapFromBits(list_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
-    m_activePinBmp = wxAuiBitmapFromBits(pin_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledPinBmp = wxAuiBitmapFromBits(pin_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
-    m_activeUnpinBmp = wxAuiBitmapFromBits(unpin_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledUnpinBmp = wxAuiBitmapFromBits(unpin_bits, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    m_activeCloseBmp = wxAuiCreateBitmap(close_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledCloseBmp = wxAuiCreateBitmap(close_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT).ChangeLightness(disabledLightness));
+    m_activeLeftBmp = wxAuiCreateBitmap(left_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledLeftBmp = wxAuiCreateBitmap(left_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    m_activeRightBmp = wxAuiCreateBitmap(right_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledRightBmp = wxAuiCreateBitmap(right_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    m_activeWindowListBmp = wxAuiCreateBitmap(list_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledWindowListBmp = wxAuiCreateBitmap(list_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    m_activePinBmp = wxAuiCreateBitmap(pin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledPinBmp = wxAuiCreateBitmap(pin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    m_activeUnpinBmp = wxAuiCreateBitmap(unpin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledUnpinBmp = wxAuiCreateBitmap(unpin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
 }
 
 wxAuiTabArt* wxAuiGenericTabArt::Clone()
@@ -1093,14 +1090,14 @@ wxFont wxAuiGenericTabArt::GetSelectedFont() const
 wxAuiSimpleTabArt::wxAuiSimpleTabArt()
     : m_normalFont(*wxNORMAL_FONT)
     , m_selectedFont(m_normalFont)
-    , m_activeCloseBmp(wxAuiBitmapFromBits(close_bits, 16, 16, *wxBLACK))
-    , m_disabledCloseBmp(wxAuiBitmapFromBits(close_bits, 16, 16, wxColour(128,128,128)))
-    , m_activeLeftBmp(wxAuiBitmapFromBits(left_bits, 16, 16, *wxBLACK))
-    , m_disabledLeftBmp(wxAuiBitmapFromBits(left_bits, 16, 16, wxColour(128,128,128)))
-    , m_activeRightBmp(wxAuiBitmapFromBits(right_bits, 16, 16, *wxBLACK))
-    , m_disabledRightBmp(wxAuiBitmapFromBits(right_bits, 16, 16, wxColour(128,128,128)))
-    , m_activeWindowListBmp(wxAuiBitmapFromBits(list_bits, 16, 16, *wxBLACK))
-    , m_disabledWindowListBmp(wxAuiBitmapFromBits(list_bits, 16, 16, wxColour(128,128,128)))
+    , m_activeCloseBmp(wxAuiCreateBitmap(close_bitmap_data, 16, 16, *wxBLACK))
+    , m_disabledCloseBmp(wxAuiCreateBitmap(close_bitmap_data, 16, 16, wxColour(128,128,128)))
+    , m_activeLeftBmp(wxAuiCreateBitmap(left_bitmap_data, 16, 16, *wxBLACK))
+    , m_disabledLeftBmp(wxAuiCreateBitmap(left_bitmap_data, 16, 16, wxColour(128,128,128)))
+    , m_activeRightBmp(wxAuiCreateBitmap(right_bitmap_data, 16, 16, *wxBLACK))
+    , m_disabledRightBmp(wxAuiCreateBitmap(right_bitmap_data, 16, 16, wxColour(128,128,128)))
+    , m_activeWindowListBmp(wxAuiCreateBitmap(list_bitmap_data, 16, 16, *wxBLACK))
+    , m_disabledWindowListBmp(wxAuiCreateBitmap(list_bitmap_data, 16, 16, wxColour(128,128,128)))
 {
     m_selectedFont.SetWeight(wxFONTWEIGHT_BOLD);
     m_measuringFont = m_selectedFont;

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -127,6 +127,32 @@ static void IndentPressedBitmap(const wxSize& offset, wxRect* rect, int button_s
 
 // -- bitmaps --
 
+#ifdef wxHAS_SVG
+    static const char* const left_bitmap_data = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+    <polygon points="3, 8 9, 3 9, 13" stroke="currentColor" fill="currentColor" stroke-width="0"/>
+</svg>
+)svg";
+
+    static const char* const right_bitmap_data = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+    <polygon points="13, 8 7, 3 7, 13" stroke="currentColor" fill="currentColor" stroke-width="0"/>
+</svg>
+)svg";
+
+    static const char* const list_bitmap_data = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+    <rect x="4.5" y="7" width="7" height="1" stroke="currentColor" fill="currentColor" stroke-width="0"/>
+    <polygon points="4.5, 9 11.5 9 8, 13" stroke="currentColor" fill="currentColor" stroke-width="0"/>
+</svg>
+)svg";
+
+    static const char* const unpin_bitmap_data = R"svg(
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+    <path d="M 7 5 v 6 v -1 h 6 v -1 h -6 h 6 v -3 h -6 v 2 h -4" stroke="currentColor" fill="none" stroke-width="1"/>
+</svg>
+)svg";
+#else // !wxHAS_SVG
 static const unsigned char left_bitmap_data[] = {
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0x7f, 0xfe, 0x3f, 0xfe,
    0x1f, 0xfe, 0x0f, 0xfe, 0x1f, 0xfe, 0x3f, 0xfe, 0x7f, 0xfe, 0xff, 0xfe,
@@ -146,6 +172,7 @@ static const unsigned char unpin_bitmap_data[] = {
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xbf, 0xff, 0x3f, 0xe0,
    0xbf, 0xef, 0x87, 0xef, 0x3f, 0xe0, 0x3f, 0xe0, 0xbf, 0xff, 0xff, 0xff,
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+#endif // wxHAS_SVG/!wxHAS_SVG
 
 // wxAuiTabArt implementation
 

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -126,24 +126,6 @@ static void IndentPressedBitmap(const wxSize& offset, wxRect* rect, int button_s
 }
 
 // -- bitmaps --
-// TODO: Provide x1.5 and x2.0 versions or migrate to SVG.
-
-#if defined( __WXMAC__ )
- static const unsigned char close_bitmap_data[]={
-     0xFF, 0xFF, 0xFF, 0xFF, 0x0F, 0xFE, 0x03, 0xF8, 0x01, 0xF0, 0x19, 0xF3,
-     0xB8, 0xE3, 0xF0, 0xE1, 0xE0, 0xE0, 0xF0, 0xE1, 0xB8, 0xE3, 0x19, 0xF3,
-     0x01, 0xF0, 0x03, 0xF8, 0x0F, 0xFE, 0xFF, 0xFF };
-#elif defined( __WXGTK__)
- static const unsigned char close_bitmap_data[]={
-     0xff, 0xff, 0xff, 0xff, 0x07, 0xf0, 0xfb, 0xef, 0xdb, 0xed, 0x8b, 0xe8,
-     0x1b, 0xec, 0x3b, 0xee, 0x1b, 0xec, 0x8b, 0xe8, 0xdb, 0xed, 0xfb, 0xef,
-     0x07, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
-#else
- static const unsigned char close_bitmap_data[]={
-     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xe7, 0xf3, 0xcf, 0xf9,
-     0x9f, 0xfc, 0x3f, 0xfe, 0x3f, 0xfe, 0x9f, 0xfc, 0xcf, 0xf9, 0xe7, 0xf3,
-     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-#endif
 
 static const unsigned char left_bitmap_data[] = {
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0x7f, 0xfe, 0x3f, 0xfe,
@@ -160,16 +142,10 @@ static const unsigned char list_bitmap_data[] = {
    0x0f, 0xf8, 0xff, 0xff, 0x0f, 0xf8, 0x1f, 0xfc, 0x3f, 0xfe, 0x7f, 0xff,
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-static const unsigned char pin_bitmap_data[] = {
+static const unsigned char unpin_bitmap_data[] = {
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xbf, 0xff, 0x3f, 0xe0,
    0xbf, 0xef, 0x87, 0xef, 0x3f, 0xe0, 0x3f, 0xe0, 0xbf, 0xff, 0xff, 0xff,
    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-
-static const unsigned char unpin_bitmap_data[]={
-   0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1f, 0xfc, 0xdf, 0xfc, 0xdf, 0xfc,
-   0xdf, 0xfc, 0xdf, 0xfc, 0xdf, 0xfc, 0x0f, 0xf8, 0x7f, 0xff, 0x7f, 0xff,
-   0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-
 
 // wxAuiTabArt implementation
 
@@ -317,18 +293,23 @@ void wxAuiGenericTabArt::UpdateColoursFromSystem()
 
     const int disabledLightness = wxSystemSettings::GetAppearance().IsUsingDarkBackground() ? 130 : 70;
 
-    m_activeCloseBmp = wxAuiCreateBitmap(close_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledCloseBmp = wxAuiCreateBitmap(close_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT).ChangeLightness(disabledLightness));
+    m_activeCloseBmp = wxAuiCreateCloseButtonBitmap(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledCloseBmp = wxAuiCreateCloseButtonBitmap(wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT).ChangeLightness(disabledLightness));
+
     m_activeLeftBmp = wxAuiCreateBitmap(left_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
     m_disabledLeftBmp = wxAuiCreateBitmap(left_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
     m_activeRightBmp = wxAuiCreateBitmap(right_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
     m_disabledRightBmp = wxAuiCreateBitmap(right_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
     m_activeWindowListBmp = wxAuiCreateBitmap(list_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
     m_disabledWindowListBmp = wxAuiCreateBitmap(list_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
-    m_activePinBmp = wxAuiCreateBitmap(pin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledPinBmp = wxAuiCreateBitmap(pin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
-    m_activeUnpinBmp = wxAuiCreateBitmap(unpin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
-    m_disabledUnpinBmp = wxAuiCreateBitmap(unpin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+
+    // This is a bit confusing, but we use "pin" bitmap to indicate that the
+    // tab is currently pinned, i.e. for the "unpin" button, and vice versa.
+    m_activePinBmp = wxAuiCreateBitmap(unpin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledPinBmp = wxAuiCreateBitmap(unpin_bitmap_data, 16, 16, wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+
+    m_activeUnpinBmp = wxAuiCreatePinButtonBitmap(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
+    m_disabledUnpinBmp = wxAuiCreatePinButtonBitmap(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
 }
 
 wxAuiTabArt* wxAuiGenericTabArt::Clone()
@@ -1090,8 +1071,8 @@ wxFont wxAuiGenericTabArt::GetSelectedFont() const
 wxAuiSimpleTabArt::wxAuiSimpleTabArt()
     : m_normalFont(*wxNORMAL_FONT)
     , m_selectedFont(m_normalFont)
-    , m_activeCloseBmp(wxAuiCreateBitmap(close_bitmap_data, 16, 16, *wxBLACK))
-    , m_disabledCloseBmp(wxAuiCreateBitmap(close_bitmap_data, 16, 16, wxColour(128,128,128)))
+    , m_activeCloseBmp(wxAuiCreateCloseButtonBitmap(*wxBLACK))
+    , m_disabledCloseBmp(wxAuiCreateCloseButtonBitmap(wxColour(128,128,128)))
     , m_activeLeftBmp(wxAuiCreateBitmap(left_bitmap_data, 16, 16, *wxBLACK))
     , m_disabledLeftBmp(wxAuiCreateBitmap(left_bitmap_data, 16, 16, wxColour(128,128,128)))
     , m_activeRightBmp(wxAuiCreateBitmap(right_bitmap_data, 16, 16, *wxBLACK))


### PR DESCRIPTION
This improves their appearance in high DPI.

I've kept the same icons for now (except for not using platform-specific close icons because there really doesn't seem to be any good reason for this), but this should also make it simpler to update them in the future.