### PR TITLE
3.0: Restore support for years > 3000 in wxDateTime with MSVC CRT

### DIFF
--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -1232,7 +1232,14 @@ wxDateTime& wxDateTime::Set(wxDateTime_t day,
 
     // test only the year instead of testing for the exact end of the Unix
     // time_t range - it doesn't bring anything to do more precise checks
-    if ( year >= yearMinInRange && (sizeof(time_t) > 4 || year <= yearMaxInRange) )
+    if ( year >= yearMinInRange &&
+            ((sizeof(time_t) > 4
+#if defined(__VISUALC__) || defined(__MINGW64__)
+              // MSVC CRT (also used by MinGW) is documented not to support
+              // years > 3000, even when using 64-bit time_t.
+              && year <= 3000
+#endif // Using MSVC CRT
+             ) || year <= yearMaxInRange) )
     {
         // use the standard library version if the date is in range - this is
         // probably more efficient than our code

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1238,6 +1238,12 @@ void DateTimeTestCase::TestDateTimeParse()
         },
 
         {
+            "4242-04-02 4:20",
+            {  2, wxDateTime::Apr, 4242, 4, 20,  0 },
+            true
+        },
+
+        {
             "2010-01-04 14:30",
             {  4, wxDateTime::Jan, 2010, 14, 30,  0 },
             true


### PR DESCRIPTION
Backport to WX_3_0_BRANCH.

(cherry picked from commit 181b20b5b869c6ce4e0b7dba196a330ab71f652b)