### PR TITLE
wxQt: Fix passing command line arguments to QApplication and to wxWidgets

### DIFF
--- a/include/wx/qt/app.h
+++ b/include/wx/qt/app.h
@@ -9,8 +9,6 @@
 #ifndef _WX_QT_APP_H_
 #define _WX_QT_APP_H_
 
-#include <wx/scopedarray.h>
-
 #include <memory>
 
 class QApplication;
@@ -24,8 +22,6 @@ public:
 
 private:
     std::unique_ptr<QApplication> m_qtApplication;
-    int m_qtArgc;
-    wxScopedArray<char*> m_qtArgv;
 
     wxDECLARE_DYNAMIC_CLASS_NO_COPY( wxApp );
 };


### PR DESCRIPTION

For example: "`./minimal -style fusion`" or "`./minimal -stylesheet myStylesheet`" didn't work before, but it work now with this commit.

Explanation:
------------
The old code was not correct: it just crashes when trying to delete "`argv_`" and if it doesn't, it tries to recreate it with the already consumed args which doesn't make sense to wxWidgets.

Additionally, it makes unnecessary memory allocations for the arguments, which simply results in memory leaks.

-----------------------
FYI: http://bugreports.qt.nokia.com/browse/QTBUG-7551 no longer available and I don't know what the problem was with the reported bug?