### PR TITLE
wxMSW: Try to fix wxTextCtrl::AppendText() for plain EDIT controls

### DIFF
--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -349,6 +349,17 @@ private:
 
 namespace
 {
+struct InsertTextData
+{
+    // VS14.0 refuses to compile code that uses initializer list to create objects
+    // of this struct: InsertTextData{_somevalue_}; // VS14.0 rejects this
+    explicit InsertTextData(unsigned long len) : lenOfInsertedText(len)
+    {
+    }
+
+    unsigned long lenOfInsertedText = 0;
+    unsigned long oldMaximumLength = 0;
+};
 
 // This stack stores the length of the text being currently inserted into the
 // current control.
@@ -358,7 +369,7 @@ namespace
 // time (but possibly more than into one, if wxEVT_TEXT event handler does
 // something that results in another text control update), and we don't want to
 // waste space in every wxTextCtrl object for this field unnecessarily.
-wxStack<int> gs_lenOfInsertedText;
+wxStack<InsertTextData> gs_insertTextData;
 
 } // anonymous namespace
 
@@ -1291,17 +1302,19 @@ void wxTextCtrl::DoWriteText(const wxString& value, int flags)
 
     // Remember the length of the text we're inserting so that
     // AdjustSpaceLimit() could adjust the limit to be big enough for it:
-    // and also signal us whether it did it by resetting it to 0.
-    gs_lenOfInsertedText.push(valueDos.length());
+    // and also signal us whether it did it by setting the oldMaximumLength field.
+    // Notice that the cast is needed because length() returns unsigned long long
+    // under x64 systems.
+    gs_insertTextData.push(InsertTextData(static_cast<unsigned long>(valueDos.length())));
 
     ::SendMessage(GetHwnd(), selectionOnly ? EM_REPLACESEL : WM_SETTEXT,
                   // EM_REPLACESEL takes 1 to indicate the operation should be redoable
                   selectionOnly ? 1 : 0, wxMSW_CONV_LPARAM(valueDos));
 
-    const int lenActuallyInserted = gs_lenOfInsertedText.top();
-    gs_lenOfInsertedText.pop();
+    const auto oldMaxLength = gs_insertTextData.top().oldMaximumLength;
+    gs_insertTextData.pop();
 
-    if ( lenActuallyInserted < 0 )
+    if ( oldMaxLength > 0 )
     {
         // Text size limit has been hit and added text has been truncated.
         // But the max length has been increased by the EN_MAXTEXT message
@@ -1313,7 +1326,7 @@ void wxTextCtrl::DoWriteText(const wxString& value, int flags)
         ::SendMessage(GetHwnd(), selectionOnly ? EM_REPLACESEL : WM_SETTEXT,
                       selectionOnly ? 1 : 0, wxMSW_CONV_LPARAM(valueDos));
 
-        SetMaxLength(~lenActuallyInserted); // Restore the old max length
+        SetMaxLength(oldMaxLength); // Restore the old max length
     }
 
     if ( !ucf.GotUpdate() && (flags & SetValue_SendEvent) )
@@ -2572,7 +2585,7 @@ bool wxTextCtrl::HasSpaceLimit(unsigned int *len) const
 bool wxTextCtrl::AdjustSpaceLimit()
 {
     unsigned int limit;
-    if ( HasSpaceLimit(&limit) && gs_lenOfInsertedText.empty() )
+    if ( HasSpaceLimit(&limit) && gs_insertTextData.empty() )
     {
         // Do nothing if the text is entered interactively.
         return false;
@@ -2587,13 +2600,13 @@ bool wxTextCtrl::AdjustSpaceLimit()
         // it too many times make sure that we make it at least big enough to
         // fit all the text we are currently inserting into the control, if
         // we're inserting any, i.e. if we're called from DoWriteText().
-        if ( !gs_lenOfInsertedText.empty() )
+        if ( !gs_insertTextData.empty() )
         {
-            increaseBy = gs_lenOfInsertedText.top();
+            auto& data = gs_insertTextData.top();
+            increaseBy = data.lenOfInsertedText;
 
             // Save the old max length (will be restored in DoWriteText())
-            // to Indicate to the caller that we increased the limit.
-            gs_lenOfInsertedText.top() = ~limit;
+            data.oldMaximumLength = limit;
         }
         else // Not inserting text, must be text actually typed by user.
         {

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -16,6 +16,8 @@
 #include "wx/qt/private/winevent.h"
 #include "wx/qt/private/utils.h"
 
+#include <QtGui/QClipboard>
+#include <QtWidgets/QApplication>
 #include <QtWidgets/QLineEdit>
 #include <QtWidgets/QTextEdit>
 
@@ -118,6 +120,8 @@ private:
 #endif
 };
 
+class wxQtTextLimitFilter;
+
 class wxQtTextEdit : public wxQtEventSignalHandler< QTextEdit, wxTextCtrl >
 {
 public:
@@ -131,11 +135,108 @@ public:
     bool IsUndoAvailable() const { return m_undoAvailable; }
     bool IsRedoAvailable() const { return m_redoAvailable; }
 
+    void SetMaxLength(unsigned long len);
+    int  GetMaxLength() const { return m_maxLength; }
+
+    // wxQtTextLimitFilter calls this function to try to enter
+    // as much text as possible into the control, before emitting
+    // the wxEVT_TEXT_MAXLEN event.
+    bool TryEnterText(const QString& str)
+    {
+        if ( !str.isEmpty() )
+        {
+            long from, to;
+            GetHandler()->GetSelection(&from, &to);
+            const int lenSel = to - from;
+            const int nChars = document()->characterCount() - 1;
+
+            if ( nChars + str.length() - lenSel > m_maxLength )
+            {
+                if ( lenSel || nChars < m_maxLength )
+                {
+                    QString content = toPlainText();
+                    QString text = str;
+
+                    text.truncate(m_maxLength - nChars + lenSel);
+
+                    if ( lenSel )
+                        content.replace(from, lenSel, text);
+                    else
+                        content.insert(from, text);
+
+                    wxQtEnsureSignalsBlocked blocker(this);
+                    setPlainText(content);
+
+                    moveCursor(QTextCursor::End);
+                    ensureCursorVisible();
+                }
+
+                wxCommandEvent event(wxEVT_TEXT_MAXLEN, GetHandler()->GetId());
+                event.SetString(GetHandler()->GetValue());
+                EmitEvent(event);
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
 private:
     void textChanged();
 
     bool m_undoAvailable = false,
          m_redoAvailable = false;
+
+    long m_maxLength = 0;
+    wxQtTextLimitFilter* m_textLimiter = nullptr;
+};
+
+class wxQtTextLimitFilter : public QObject
+{
+public:
+    explicit wxQtTextLimitFilter(wxQtTextEdit* textEdit)
+        : m_textEdit(textEdit)
+    {}
+
+private:
+    virtual bool eventFilter(QObject* obj, QEvent* event) override
+    {
+        if ( event->type() == QEvent::KeyPress )
+        {
+            auto keyEvent = static_cast<QKeyEvent*>(event);
+
+            if ( keyEvent->key() != Qt::Key_Backspace &&
+                 keyEvent->key() != Qt::Key_Delete )
+            {
+                QString text;
+
+                if ( keyEvent->matches(QKeySequence::Cut) )
+                {
+                    // Always let default handling of Ctrl+X event to take place.
+                }
+                else if ( keyEvent->matches(QKeySequence::Paste) )
+                {
+                    const QClipboard* clipboard = QApplication::clipboard();
+
+                    text = clipboard->text();
+                }
+                else
+                {
+                    text = keyEvent->text();
+                }
+
+                if ( !m_textEdit->TryEnterText(text) )
+                {
+                    return true; // Block the event
+                }
+            }
+        }
+
+        return QObject::eventFilter(obj, event);
+    }
+
+    wxQtTextEdit* const m_textEdit;
 };
 
 class wxQtMultiLineEdit : public wxQtEdit
@@ -157,7 +258,19 @@ public:
 
     virtual void Copy() override { m_edit->copy(); }
     virtual void Cut() override  { m_edit->cut(); }
-    virtual void Paste() override  { m_edit->paste(); }
+    virtual void Paste() override
+    {
+        auto qtEdit = static_cast<wxQtTextEdit*>(m_edit);
+        if ( qtEdit->GetMaxLength() > 0 )
+        {
+            QKeyEvent event(QEvent::KeyPress, Qt::Key_V, Qt::ControlModifier);
+            QApplication::sendEvent(qtEdit, &event);
+        }
+        else
+        {
+            m_edit->paste();
+        }
+    }
 
     virtual void Undo() override  { m_edit->undo(); }
     virtual void Redo() override  { m_edit->redo(); }
@@ -287,9 +400,9 @@ public:
         m_edit->ensureCursorVisible();
     }
 
-    virtual void SetMaxLength(unsigned long WXUNUSED(len)) override
+    virtual void SetMaxLength(unsigned long len) override
     {
-        wxMISSING_IMPLEMENTATION("not implemented for multiline control");
+        static_cast<wxQtTextEdit*>(m_edit)->SetMaxLength(len);
     }
 
     virtual wxTextSearchResult SearchText(const wxTextSearch& search) const override
@@ -663,6 +776,34 @@ wxQtTextEdit::wxQtTextEdit( wxWindow *parent, wxTextCtrl *handler )
     connect(this, &QTextEdit::redoAvailable, [this](bool available) {
                 m_redoAvailable = available;
             });
+}
+
+void wxQtTextEdit::SetMaxLength(unsigned long len)
+{
+    const unsigned long maxlen = std::numeric_limits<int>::max();
+    if ( len == 0 || len > maxlen )
+    {
+        len = maxlen;
+    }
+
+    m_maxLength = len;
+
+    if ( m_maxLength > 0 )
+    {
+        if ( !m_textLimiter )
+        {
+            m_textLimiter = new wxQtTextLimitFilter(this);
+            installEventFilter(m_textLimiter);
+        }
+    }
+    else
+    {
+        if ( m_textLimiter )
+        {
+            removeEventFilter(m_textLimiter);
+            wxDELETE(m_textLimiter);
+        }
+    }
 }
 
 void wxQtTextEdit::textChanged()

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -277,7 +277,7 @@ void TextCtrlTestCase::MaxLength()
 
     if ( ms_style == wxTE_MULTILINE )
     {
-#if defined(__WXMSW__) || defined(__WXGTK3__)
+#if defined(__WXMSW__) || defined(__WXGTK3__) || defined(__WXQT__)
         delete m_text;
         CreateText(wxTE_DONTWRAP);
         EventCounter maxlen(m_text, wxEVT_TEXT_MAXLEN);
@@ -351,7 +351,7 @@ void TextCtrlTestCase::MaxLength()
         m_text->AppendText(wxString::Format("\n%s", linePattern));
         CPPUNIT_ASSERT_EQUAL(4, m_text->GetNumberOfLines());
         CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
-#endif // __WXMSW__ || __WXGTK3__
+#endif // __WXMSW__ || __WXGTK3__ || __WXQT__
     }
     else // !wxTE_MULTILINE
     {

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -678,9 +678,6 @@ void TextCtrlTestCase::LogTextCtrl()
 
 void TextCtrlTestCase::LongText()
 {
-    // In the other ports SetMaxLength() can't be used with multi line text
-    // controls.
-#if defined(__WXMSW__) || defined(__WXGTK__)
     delete m_text;
     CreateText(wxTE_MULTILINE|wxTE_DONTWRAP);
 
@@ -690,12 +687,14 @@ void TextCtrlTestCase::LongText()
     // Pattern for the line.
     const wxString linePattern = MakeLinePattern();
 
-    // Fill the control.
-    m_text->SetMaxLength(15000);
+    wxString content;
     for (i = 0; i < numLines; i++)
     {
-        m_text->AppendText(wxString::Format(wxT("[%3d] %s\n"), i, linePattern));
+        content << wxString::Format(wxT("[%3d] %s\n"), i, linePattern);
     }
+
+    // Fill the control.
+    m_text->AppendText(content);
 
     // Check the content.
     for (i = 0; i < numLines; i++)
@@ -704,7 +703,6 @@ void TextCtrlTestCase::LongText()
         wxString line = m_text->GetLineText(i);
         CPPUNIT_ASSERT_EQUAL( line, pattern );
     }
-#endif // __WXMSW__
 }
 
 void TextCtrlTestCase::PositionToCoords()

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -42,6 +42,7 @@
 #include "testableframe.h"
 #include "asserthelper.h"
 
+#include <algorithm>
 #include <memory>
 
 static const int TEXT_HEIGHT = 200;
@@ -157,6 +158,9 @@ private:
     // (or not) already contain wxTE_MULTILINE.
     void CreateText(long extraStyles);
 
+    // Return a string pattern of length _len_ used as text lines in multi-line control
+    static wxString MakeLinePattern(int len = 100);
+
     wxTextCtrl *m_text;
 
     static long ms_style;
@@ -185,6 +189,16 @@ void TextCtrlTestCase::CreateText(long extraStyles)
     m_text = new wxTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY, "",
                             wxDefaultPosition, wxSize(400, h),
                             style);
+}
+
+wxString TextCtrlTestCase::MakeLinePattern(int len)
+{
+    wxString pattern;
+    pattern.reserve(len);
+    for ( int i = 0; i < len; i++ )
+        pattern += '0' + i % 10;
+
+    return pattern;
 }
 
 void TextCtrlTestCase::setUp()
@@ -671,16 +685,10 @@ void TextCtrlTestCase::LongText()
     CreateText(wxTE_MULTILINE|wxTE_DONTWRAP);
 
     const int numLines = 1000;
-    const int lenPattern = 100;
     int i;
 
     // Pattern for the line.
-    wxChar linePattern[lenPattern+1];
-    for (i = 0; i < lenPattern - 1; i++)
-    {
-        linePattern[i] = wxChar('0' + i % 10);
-    }
-    linePattern[WXSIZEOF(linePattern) - 1] = wxChar('\0');
+    const wxString linePattern = MakeLinePattern();
 
     // Fill the control.
     m_text->SetMaxLength(15000);

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -28,9 +28,7 @@
     #include "wx/dataobj.h"
 #endif // wxUSE_CLIPBOARD
 
-#if defined(__WXGTK__) || defined(__WXQT__)
-    #include "waitfor.h"
-#endif
+#include "waitfor.h"
 
 #ifdef __WXQT__
 #include <QtGlobal>
@@ -89,6 +87,7 @@ private:
         // Rerun the text entry tests not specific to single line controls for
         // multiline ones now.
         wxTEXT_ENTRY_TESTS();
+        WXUISIM_TEST( MaxLength );
         SINGLE_AND_MULTI_TESTS();
 
 
@@ -274,6 +273,88 @@ void TextCtrlTestCase::ReadOnly()
 void TextCtrlTestCase::MaxLength()
 {
 #if wxUSE_UIACTIONSIMULATOR
+    wxUIActionSimulator sim;
+
+    if ( ms_style == wxTE_MULTILINE )
+    {
+#if defined(__WXMSW__) || defined(__WXGTK3__)
+        delete m_text;
+        CreateText(wxTE_DONTWRAP);
+        EventCounter maxlen(m_text, wxEVT_TEXT_MAXLEN);
+
+        m_text->SetMaxLength(250);
+        m_text->SetFocus();
+        wxYield();
+
+        const wxString linePattern = MakeLinePattern();
+
+        m_text->AppendText(linePattern);
+        m_text->SelectAll();
+        m_text->Copy();
+
+        m_text->SetInsertionPointEnd();
+
+        sim.Char(WXK_RETURN);
+        sim.Char('v', wxMOD_CONTROL); // Paste copied line.
+        wxYield();
+
+        CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
+
+        m_text->SetInsertionPointEnd();
+
+        sim.Char(WXK_RETURN);
+        wxYield();
+
+        sim.Char('v', wxMOD_CONTROL); // Paste copied line (2nd time).
+        WaitFor("wxTextCtrl update", [&]() { return maxlen.GetCount() != 0; });
+
+        CPPUNIT_ASSERT_EQUAL(1, maxlen.GetCount()); // Maximum length reached.
+        maxlen.Clear();
+
+        sim.Text("7"); // Should be rejected.
+        WaitFor("wxTextCtrl update", [&]() { return maxlen.GetCount() != 0; });
+
+        CPPUNIT_ASSERT_EQUAL(1, maxlen.GetCount());
+        maxlen.Clear();
+
+        // Depending on the underlying system, the new line (NL) could be
+        // LF, CR or CRLF, and as a consequence the length of the last line
+        // should be 50 - 2*NL.
+
+        CPPUNIT_ASSERT_EQUAL(3, m_text->GetNumberOfLines());
+
+        int lineLength = m_text->GetLineText(0).length(); // 1st line
+        CPPUNIT_ASSERT_EQUAL(100, lineLength);
+
+        lineLength = m_text->GetLineText(1).length(); // 2nd line
+        CPPUNIT_ASSERT_EQUAL(100, lineLength);
+
+        lineLength = m_text->GetLineText(2).length(); // 3rd line
+        CPPUNIT_ASSERT( (lineLength == 46 || lineLength == 48) );
+
+        // Try to paste a long string into a shorter selection:
+
+        m_text->SetSelection(0, 20);  // selection is: 01234567890123456789
+        m_text->Copy();
+        m_text->SetSelection(15, 21); // selection is: 567890
+        m_text->Paste(); // Only the first six characters can actually be pasted.
+        WaitFor("wxTextCtrl update", [&]() { return maxlen.GetCount() != 0; });
+        const auto line = m_text->GetLineText(0);
+        CPPUNIT_ASSERT( (line[15].GetValue() == '0' &&
+                         line[20].GetValue() == '5' &&
+                         line[21].GetValue() == '1') );
+        CPPUNIT_ASSERT_EQUAL(1, maxlen.GetCount());
+        maxlen.Clear();
+
+        // Now, despite the maximum length of 250 set above, adding additional
+        // content to the control programmatically is still possible/allowed:
+        m_text->AppendText(wxString::Format("\n%s", linePattern));
+        CPPUNIT_ASSERT_EQUAL(4, m_text->GetNumberOfLines());
+        CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
+#endif // __WXMSW__ || __WXGTK3__
+    }
+    else // !wxTE_MULTILINE
+    {
 #ifdef __WXQT__
     #if (QT_VERSION < QT_VERSION_CHECK(5, 12, 0))
         WARN("wxEVT_TEXT_MAXLEN event is only generated if Qt version is 5.12 or greater");
@@ -281,44 +362,44 @@ void TextCtrlTestCase::MaxLength()
     #endif
 #endif
 
-    EventCounter updated(m_text, wxEVT_TEXT);
-    EventCounter maxlen(m_text, wxEVT_TEXT_MAXLEN);
+        EventCounter updated(m_text, wxEVT_TEXT);
+        EventCounter maxlen(m_text, wxEVT_TEXT_MAXLEN);
 
-    m_text->SetFocus();
-    wxYield();
-    m_text->SetMaxLength(10);
+        m_text->SetMaxLength(10);
+        m_text->SetFocus();
+        wxYield();
 
-    wxUIActionSimulator sim;
-    sim.Text("abcdef");
-    wxYield();
+        sim.Text("abcdef");
+        wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
+        CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
 
-    sim.Text("ghij");
-    wxYield();
+        sim.Text("ghij");
+        wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
-    CPPUNIT_ASSERT_EQUAL(10, updated.GetCount());
+        CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
+        CPPUNIT_ASSERT_EQUAL(10, updated.GetCount());
 
-    maxlen.Clear();
-    updated.Clear();
+        maxlen.Clear();
+        updated.Clear();
 
-    sim.Text("k");
-    wxYield();
+        sim.Text("k");
+        wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, maxlen.GetCount());
-    CPPUNIT_ASSERT_EQUAL(0, updated.GetCount());
+        CPPUNIT_ASSERT_EQUAL(1, maxlen.GetCount());
+        CPPUNIT_ASSERT_EQUAL(0, updated.GetCount());
 
-    maxlen.Clear();
-    updated.Clear();
+        maxlen.Clear();
+        updated.Clear();
 
-    m_text->SetMaxLength(0);
+        m_text->SetMaxLength(0);
 
-    sim.Text("k");
-    wxYield();
+        sim.Text("k");
+        wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
-    CPPUNIT_ASSERT_EQUAL(1, updated.GetCount());
+        CPPUNIT_ASSERT_EQUAL(0, maxlen.GetCount());
+        CPPUNIT_ASSERT_EQUAL(1, updated.GetCount());
+    }
 #endif
 }
 


### PR DESCRIPTION
See #25164

For RICHEDIT controls the maxlimit is updated after each `AppendText()` calls and don't know how to fix it?
maybe we should just document this limitation and live with it as is ?