### PR TITLE
Fix wxDataViewCtrl scrollbar overlapping last item

### DIFF
--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -4686,6 +4686,9 @@ bool wxDataViewCtrl::Create(wxWindow *parent,
     gtk_tree_view_set_rules_hint( GTK_TREE_VIEW(m_treeview), (style & wxDV_ROW_LINES) != 0 );
     wxGCC_WARNING_RESTORE()
 #endif
+#ifdef __WXGTK3__
+    gtk_scrolled_window_set_overlay_scrolling(GTK_SCROLLED_WINDOW(m_widget), FALSE);
+#endif
 
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (m_widget),
         GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);


### PR DESCRIPTION
## Problem Description
In wxGTK3 applications using `wxDataViewCtrl`, the overlay scrollbar (a GTK3 feature where scrollbars appear as floating bars) overlaps the last row of content, making it partially obscured and hard to interact with.

### Affected Versions
- wxWidgets 3.2.x
- GTK3 environments (all major Linux distributions)

## Visual Demonstration

### Before Fix
![image_2025-03-26_16-43-04](https://github.com/user-attachments/assets/f7aec982-0c15-4e1f-90f0-a7435f2c0d82)
*Scrollbar covers bottom row content*

### After Fix
![image_2025-03-26_16-41-24](https://github.com/user-attachments/assets/152ad830-8510-4b8e-a03c-6d0dd945082a)
*Scrollbar properly reserves space, leaving content fully visible*

## Root Cause Analysis
The issue occurs because:
1. GTK3 enables overlay scrollbars by default
2. These scrollbars render on top of content rather than reducing client area
3. wxDataViewCtrl's implementation doesn't account for this behavior

## Solution Implementation
The fix involves disabling GTK3's overlay scrolling feature for wxDataViewCtrl.
