### PR TITLE
Use hues of blue for highlight colours in MSW dark mode

### DIFF
--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -322,7 +322,7 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
             return wxColour(0xe0e0e0);
 
         case wxSYS_COLOUR_HOTLIGHT:
-            return wxColour(0x474747);
+            return wxColour(0xe48435);
 
         case wxSYS_COLOUR_SCROLLBAR:
             return wxColour(0x4d4d4d);
@@ -337,11 +337,11 @@ wxColour wxDarkModeSettings::GetColour(wxSystemColour index)
         case wxSYS_COLOUR_MENUBAR:
             return wxColour(0x626262);
 
+        case wxSYS_COLOUR_HIGHLIGHT:
         case wxSYS_COLOUR_MENUHILIGHT:
-            return wxColour(0x353535);
+            return wxColour(0x9e5315);
 
         case wxSYS_COLOUR_BTNHIGHLIGHT:
-        case wxSYS_COLOUR_HIGHLIGHT:
             return wxColour(0x777777);
 
         case wxSYS_COLOUR_INACTIVECAPTIONTEXT:


### PR DESCRIPTION
Using grey colours meant that we didn't have almost any non-grey system colours in the dark mode, unlike in the light one, in which all the high/hot light colours were bluish.

Change these colours to (different) hues of blue in dark mode as well to make them more appropriate for actually highlighting something.

----

I'd like to merge this if nobody has any objections because otherwise we just have no nice highlight colours in dark mode under MSW.