### PR TITLE
Print fixes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -141,6 +141,10 @@ Changes in behaviour not resulting in compilation errors
 - wxAUI_MGR_HINT_FADE is not included in default wxAuiManager style any longer,
   please add it explicitly if you really want to use it.
 
+- Behaviour of wxPrintDialogData::SetAllPages() and SetSelection() has
+  changed when called with "false" argument, please review the documentation
+  and update your code if you called them with "false" (which is rarely done).
+
 Changes in behaviour which may result in build errors
 -----------------------------------------------------
 

--- a/include/wx/cmndata.h
+++ b/include/wx/cmndata.h
@@ -194,11 +194,10 @@ public:
     int GetMinPage() const { return m_printMinPage; }
     int GetMaxPage() const { return m_printMaxPage; }
     int GetNoCopies() const { return m_printNoCopies; }
-    bool GetAllPages() const { return m_printAllPages; }
-    bool GetSelection() const { return m_printSelection; }
-    bool GetCurrentPage() const { return m_printCurrentPage; }
-    bool GetSpecifiedPages() const
-        { return !(m_printAllPages || m_printSelection || m_printCurrentPage); }
+    bool GetAllPages() const { return m_printWhat == Print::AllPages; }
+    bool GetSelection() const { return m_printWhat == Print::Selection; }
+    bool GetCurrentPage() const { return m_printWhat == Print::CurrentPage; }
+    bool GetSpecifiedPages() const { return m_printWhat == Print::SpecifiedPages; }
     bool GetCollate() const { return m_printCollate; }
     bool GetPrintToFile() const { return m_printToFile; }
 
@@ -212,9 +211,13 @@ public:
     void SetMinPage(int v) { m_printMinPage = v; }
     void SetMaxPage(int v) { m_printMaxPage = v; }
     void SetNoCopies(int v) { m_printNoCopies = v; }
-    void SetAllPages(bool flag) { m_printAllPages = flag; }
-    void SetSelection(bool flag) { m_printSelection = flag; }
-    void SetCurrentPage(bool flag) { m_printCurrentPage = flag; }
+
+    // Avoid calling these functions with flag == false as it's not really
+    // obvious what they do in this case.
+    void SetAllPages(bool flag = true) { DoSetWhat(Print::AllPages, flag); }
+    void SetSelection(bool flag = true) { DoSetWhat(Print::Selection, flag); }
+    void SetCurrentPage(bool flag = true) { DoSetWhat(Print::CurrentPage, flag); }
+
     void SetCollate(bool flag) { m_printCollate = flag; }
     void SetPrintToFile(bool flag) { m_printToFile = flag; }
 
@@ -247,14 +250,24 @@ public:
     void operator=(const wxPrintData& data); // Sets internal m_printData member
 
 private:
+    enum class Print
+    {
+        SpecifiedPages, // Default used if none of the other flags are selected.
+        AllPages,
+        Selection,
+        CurrentPage
+    };
+
+    void DoSetWhat(Print what, bool flag);
+
+    Print           m_printWhat = Print::AllPages;
+
     int             m_printMinPage = 0;
     int             m_printMaxPage = 0;
     int             m_printNoCopies = 1;
-    bool            m_printAllPages = false;
+
     bool            m_printCollate = false;
     bool            m_printToFile = false;
-    bool            m_printSelection = false;
-    bool            m_printCurrentPage = false;
     bool            m_printEnableSelection = false;
     bool            m_printEnableCurrentPage = false;
     bool            m_printEnablePageNumbers = true;

--- a/include/wx/cmndata.h
+++ b/include/wx/cmndata.h
@@ -197,6 +197,8 @@ public:
     bool GetAllPages() const { return m_printAllPages; }
     bool GetSelection() const { return m_printSelection; }
     bool GetCurrentPage() const { return m_printCurrentPage; }
+    bool GetSpecifiedPages() const
+        { return !(m_printAllPages || m_printSelection || m_printCurrentPage); }
     bool GetCollate() const { return m_printCollate; }
     bool GetPrintToFile() const { return m_printToFile; }
 

--- a/interface/wx/cmndata.h
+++ b/interface/wx/cmndata.h
@@ -607,6 +607,15 @@ public:
     bool GetCurrentPage() const;
 
     /**
+        Returns @true if the user requested printing only the specified pages.
+
+        The pages to print can be retrieved using GetPageRanges().
+
+        @since 3.3.0
+    */
+    bool GetSpecifiedPages() const;
+
+    /**
         Returns the @e "print to" page number, as entered by the user.
 
         This function can't be used if multiple page ranges were specified, use

--- a/interface/wx/cmndata.h
+++ b/interface/wx/cmndata.h
@@ -631,6 +631,18 @@ public:
     bool IsOk() const;
 
     /**
+        Selects the "All pages" radio button.
+
+        When called with @true value, enables printing all pages. This is the
+        default behaviour.
+
+        If @a flag is @false, this function doesn't do anything unless it had
+        been called with @true value before and in this case it switches to
+        printing the selected pages only (see GetSpecifiedPages()).
+    */
+    void SetAllPages(bool flag = true);
+
+    /**
         Sets the "Collate" checkbox to @true or @false.
     */
     void SetCollate(bool flag);
@@ -674,11 +686,19 @@ public:
     void SetPrintToFile(bool flag);
 
     /**
-        Selects the "Selection" radio button. The effect of printing the
-        selection depends on how the application implements this command, if at
-        all.
+        Selects the "Selection" radio button.
+
+        The effect of printing the selection depends on how the application
+        implements this command, if at all.
+
+        This function should only be called when EnableSelection() is used as
+        well.
+
+        If @a flag is @false, this function doesn't do anything unless it had
+        been called with @true value before and in this case it switches to
+        printing the selected pages only (see GetSpecifiedPages()).
     */
-    void SetSelection(bool flag);
+    void SetSelection(bool flag = true);
 
     /**
         Selects the "Current Page" radio button when the dialog is initially
@@ -687,11 +707,15 @@ public:
         This function can only be called when EnableCurrentPage() is used as
         well.
 
+        If @a flag is @false, this function doesn't do anything unless it had
+        been called with @true value before and in this case it switches to
+        printing the selected pages only (see GetSpecifiedPages()).
+
         @see GetCurrentPage()
 
         @since 3.3.0
     */
-    void SetCurrentPage(bool flag);
+    void SetCurrentPage(bool flag = true);
 
     /**
         @deprecated This function has been deprecated since version 2.5.4.

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -710,23 +710,21 @@ public:
     void GetPPIScreen(int* w, int* h) const;
 
     /**
-        Called by the framework to obtain information from the application about minimum
-        and maximum page values that the user can select, and the required page range to
-        be printed.
+        Called by the framework to obtain information from the application
+        about minimum and maximum page numbers to print.
 
-        @note This function is only called if GetPagesInfo() is not overridden.
+        @note This function is only called if GetPagesInfo() is not overridden
+        and new code should override that function instead of this one.
 
-        If the user chose to print the current page, then @a pageFrom and
-        @a pageTo should be both set to the current page number.
+        The values returned in @a pageFrom and @a pageTo are ignored, and the
+        page ranges selected by user in the print dialog are always used
+        instead. Override GetPagesInfo() if you need to customize the page
+        ranges to be printed.
 
-        By default this returns (1, 32000) for the page minimum and maximum values, and
-        (1, 1) for the required page range.
+        By default returns (1, 32000) for the page minimum and maximum values.
 
         @a minPage must be greater than zero and @a maxPage must be greater
-        than @a minPage.
-
-        This function allows to indicate only a single range of pages to print,
-        consider overriding GetPagesInfo() to allow specifying multiple ranges.
+        than @a minPage, otherwise printing is aborted.
     */
     virtual void GetPageInfo(int* minPage, int* maxPage, int* pageFrom,
                              int* pageTo);
@@ -736,14 +734,24 @@ public:
         about the entire range of pages and sub-ranges to be printed.
 
         The implementation of this function in the derived class should return
-        the total range of pages and fill in the provided @a ranges parameter
-        with the ranges of pages that should be printed if necessary (if @a
-        ranges remains empty, all pages are printed).
+        the total range of pages and may also return one or more ranges of
+        pages to print.
 
-        To print a single page, add a single range with both @c fromPage and @c
-        toPage set to the page index, in @a ranges.
+        Note that @a ranges vector is filled with the values selected by the
+        user in the print dialog on entry to this function, so in many cases it
+        shouldn't be changed to respect the user's choice. However, you may
+        override it if desired and you should set the range if the associated
+        wxPrintDialogData indicates that only the current or only the selected
+        pages should be printed, e.g. when printing the current page you need
+        to clear @a ranges vector and add a single range with both @c fromPage
+        and @c toPage set to the current page index to it.
 
-        The default implementation forwards to GetPageInfo().
+        As a special case, if @a ranges is empty on return from this function,
+        all pages are printed.
+
+        The default implementation forwards to GetPageInfo() for compatibility
+        but it is recommended to override this function in the new code, and
+        this is required to support printing the current page or selection.
 
         @since 3.3.0.
     */

--- a/src/common/cmndata.cpp
+++ b/src/common/cmndata.cpp
@@ -107,10 +107,6 @@ wxPrintDialogData::wxPrintDialogData(const wxPrintData& printData)
 {
     m_printMinPage = 1;
     m_printMaxPage = 9999;
-    // On Mac the Print dialog always defaults to "All Pages"
-#ifdef __WXMAC__
-    m_printAllPages = true;
-#endif
 }
 
 wxPrintDialogData::~wxPrintDialogData()
@@ -120,6 +116,15 @@ wxPrintDialogData::~wxPrintDialogData()
 void wxPrintDialogData::operator=(const wxPrintData& data)
 {
     m_printData = data;
+}
+
+void wxPrintDialogData::DoSetWhat(Print what, bool flag)
+{
+    if ( flag )
+        m_printWhat = what;
+    else if ( m_printWhat == what )
+        m_printWhat = Print::SpecifiedPages;
+    //else: the current value is not the one we're clearing, don't do anything
 }
 
 void wxPrintDialogData::SetFromPage(int v)

--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -627,9 +627,6 @@ void wxPrintout::GetPageInfo(int *minPage, int *maxPage, int *fromPage, int *toP
 
 wxPrintPageRange wxPrintout::GetPagesInfo(wxPrintPageRanges& ranges)
 {
-    // We always override the provided range in the default implementation.
-    ranges.clear();
-
     int minPage = 0;
     int maxPage = 0;
     int fromPage = 0;
@@ -637,8 +634,14 @@ wxPrintPageRange wxPrintout::GetPagesInfo(wxPrintPageRanges& ranges)
 
     GetPageInfo(&minPage, &maxPage, &fromPage, &toPage);
 
-    if ( fromPage > 0 && toPage >= fromPage )
-        ranges.push_back({fromPage, toPage});
+    // We intentionally ignore fromPage and toPage here as we want to keep
+    // using the page ranges as they were set by the user in the print dialog
+    // but existing code dating from before support for multiple print ranges
+    // always returns something from its GetPageInfo() -- which is incompatible
+    // with multiple pages ranges selection (in fact, it's not even compatible
+    // with a single range selection because the values returned in these
+    // parameters used to be ignored in at least wxMSW anyhow).
+    wxUnusedVar(ranges);
 
     return { minPage, maxPage };
 }

--- a/src/msw/dcprint.cpp
+++ b/src/msw/dcprint.cpp
@@ -60,6 +60,9 @@
 #define XLOG2DEV(x) ((x) + (m_deviceOriginX / m_scaleX))
 #define YLOG2DEV(y) ((y) + (m_deviceOriginY / m_scaleY))
 
+// This variable is used in src/msw/printwin.cpp.
+bool wxPrinterOperationCancelled = false;
+
 // ----------------------------------------------------------------------------
 // wxWin macros
 // ----------------------------------------------------------------------------
@@ -136,7 +139,19 @@ bool wxPrinterDCImpl::StartDoc(const wxString& message)
 
     if ( ::StartDoc(GetHdc(), &docinfo) <= 0 )
     {
-        wxLogLastError(wxT("StartDoc"));
+        if ( ::GetLastError() == ERROR_CANCELLED )
+        {
+            // No need to log anything, this is not an unexpected error.
+            //
+            // Also indicate this to wxWindowsPrinter::Print() by setting this
+            // variable.
+            wxPrinterOperationCancelled = true;
+        }
+        else
+        {
+            wxLogLastError(wxT("StartDoc"));
+        }
+
         return false;
     }
 

--- a/src/msw/dcprint.cpp
+++ b/src/msw/dcprint.cpp
@@ -117,6 +117,9 @@ void wxPrinterDCImpl::Init()
 
 bool wxPrinterDCImpl::StartDoc(const wxString& message)
 {
+    if (!m_hDC)
+        return false;
+
     DOCINFO docinfo;
     docinfo.cbSize = sizeof(DOCINFO);
     docinfo.lpszDocName = message.t_str();
@@ -130,9 +133,6 @@ bool wxPrinterDCImpl::StartDoc(const wxString& message)
 
     docinfo.lpszDatatype = nullptr;
     docinfo.fwType = 0;
-
-    if (!m_hDC)
-        return false;
 
     if ( ::StartDoc(GetHdc(), &docinfo) <= 0 )
     {

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -904,7 +904,6 @@ bool wxWindowsPrintDialog::ConvertToNative( wxPrintDialogData &data )
     pd->nCopies = (DWORD)data.GetNoCopies();
 
     // Required only if PD_NOPAGENUMS flag is not set.
-    // Currently only one page range is supported.
     if ( data.GetEnablePageNumbers() )
     {
         pd->nMaxPageRanges = (DWORD)data.GetMaxPageRanges();
@@ -929,6 +928,14 @@ bool wxWindowsPrintDialog::ConvertToNative( wxPrintDialogData &data )
         const wxVector<wxPrintPageRange>& ranges = data.GetPageRanges();
         if ( ranges.empty() )
         {
+            // Use values for from/to page here to define a single range (which
+            // will usually be just "1") for compatibility: it would arguably
+            // make more sense to not define any ranges at all by setting
+            // nPageRanges to 0 (which is allowed, only lpPageRanges must be
+            // non-null), but this would change the behaviour of the existing
+            // code without any real gain, so don't do it, even if this means
+            // that there is currently no way to not show anything at all in
+            // the "Pages" text box of the print dialog.
             pd->nPageRanges = 1;
             pd->lpPageRanges = new PRINTPAGERANGE[pd->nMaxPageRanges];
 

--- a/src/msw/printwin.cpp
+++ b/src/msw/printwin.cpp
@@ -155,12 +155,8 @@ bool wxWindowsPrinter::Print(wxWindow *parent, wxPrintout *printout, bool prompt
     // Initialize page ranges with the value from the dialog, but then allow
     // the printout to customize them.
     std::vector<wxPrintPageRange> pageRanges;
-    if ( !(m_printDialogData.GetAllPages() ||
-            m_printDialogData.GetSelection() ||
-                m_printDialogData.GetCurrentPage()) )
-    {
+    if ( m_printDialogData.GetSpecifiedPages() )
         pageRanges = m_printDialogData.GetPageRanges();
-    }
     const wxPrintPageRange allPages = printout->GetPagesInfo(pageRanges);
 
     if (!allPages.IsValid())

--- a/src/msw/printwin.cpp
+++ b/src/msw/printwin.cpp
@@ -154,8 +154,13 @@ bool wxWindowsPrinter::Print(wxWindow *parent, wxPrintout *printout, bool prompt
 
     // Initialize page ranges with the value from the dialog, but then allow
     // the printout to customize them.
-    std::vector<wxPrintPageRange>
+    std::vector<wxPrintPageRange> pageRanges;
+    if ( !(m_printDialogData.GetAllPages() ||
+            m_printDialogData.GetSelection() ||
+                m_printDialogData.GetCurrentPage()) )
+    {
         pageRanges = m_printDialogData.GetPageRanges();
+    }
     const wxPrintPageRange allPages = printout->GetPagesInfo(pageRanges);
 
     if (!allPages.IsValid())

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -126,6 +126,11 @@
 // global variables
 // ---------------------------------------------------------------------------
 
+#ifndef __WXUNIVERSAL__
+// This variable is defined in src/msw/printdlg.cpp.
+extern bool wxPrinterDialogShown;
+#endif // !__WXUNIVERSAL__
+
 #if wxUSE_MENUS_NATIVE
 extern wxMenu *wxCurrentPopupMenu;
 #endif
@@ -4405,6 +4410,15 @@ bool wxWindowMSW::HandleActivate(int state,
         // (still existent) hidden parent, see #18970.
         return false;
     }
+
+#ifndef __WXUNIVERSAL__
+    if ( wxPrinterDialogShown )
+    {
+        // Finally, there is a weird case of WM_ACTIVATE synthesized by the
+        // native print dialog, see the code in src/msw/printdlg.cpp.
+        return false;
+    }
+#endif // !__WXUNIVERSAL__
 
     wxActivateEvent event(wxEVT_ACTIVATE,
                           (state == WA_ACTIVE) || (state == WA_CLICKACTIVE),

--- a/src/osx/core/printmac.cpp
+++ b/src/osx/core/printmac.cpp
@@ -502,7 +502,6 @@ void wxOSXPrintData::TransferTo( wxPrintDialogData* data )
 
 void wxOSXPrintData::TransferFrom( const wxPrintDialogData* data )
 {
-    // Respect the value of m_printAllPages
     if ( data->GetAllPages() )
         PMSetPageRange( m_macPrintSettings , data->GetMinPage() , (UInt32) kPMPrintAllPages ) ;
     else


### PR DESCRIPTION
Restore compatibility with the existing code overriding `GetPageInfo()` by ignoring values returned by it (sic).

Also a couple of minor wxMSW-specific printing-related bug fixes/improvements.