### PR TITLE
Fix gtk3 font scaling on Windows

### DIFF
--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -554,7 +554,7 @@ protected:
         );
     }
 
-#ifdef __WXGTK3__
+#if defined(__WXGTK3__) && !defined(__WIN32__)
     // This factor must be applied to the font before actually using it, for
     // consistency with the text drawn by GTK itself.
     float m_fontScalingFactor;
@@ -2540,7 +2540,7 @@ wxCairoContext::~wxCairoContext()
 
 void wxCairoContext::Init(cairo_t *context, bool storeInitClip)
 {
-#ifdef __WXGTK3__
+#if defined(__WXGTK3__) && !defined(__WIN32__)
     // Attempt to find the system font scaling parameter (e.g. "Fonts->Scaling
     // Factor" in Gnome Tweaks, "Force font DPI" in KDE System Settings or
     // GDK_DPI_SCALE environment variable).


### PR DESCRIPTION
Scaling issues seem to never end. When using gtk3 on Windows with a high-dpi screen, all controls that are custom drawn (treectrl, statusbar, dc) have the wrong font size.
Fix by not applying an additional `fontScalingFactor`, the font has already the correct size for the DPI of the display.

<img width="300" alt="before" src="https://github.com/user-attachments/assets/23fb2e43-fe5c-46d1-9576-e71fc9f34a70" /><img width="300" alt="after" src="https://github.com/user-attachments/assets/ea67a571-f267-4d95-9d65-33a88a7f00a0" />

<img width="300" alt="before2" src="https://github.com/user-attachments/assets/5a79a418-c7a3-4ded-aa60-40582d0f5c40" /><img width="300" alt="after2" src="https://github.com/user-attachments/assets/58119e63-a519-4444-9440-7392145d2545" />
