### PR TITLE
fix some event macro arguments in interface declarations

### DIFF
--- a/interface/wx/mediactrl.h
+++ b/interface/wx/mediactrl.h
@@ -48,10 +48,10 @@ enum wxMediaCtrlPlayerControls
     Event wxMediaCtrl uses.
 
     @beginEventTable{wxMediaEvent}
-    @event{EVT_MEDIA_LOADED(id\, func)}
+    @event{EVT_MEDIA_LOADED(id, func)}
            Sent when a media has loaded enough data that it can start playing.
            Processes a @c wxEVT_MEDIA_LOADED event type.
-    @event{EVT_MEDIA_STOP(id\, func)}
+    @event{EVT_MEDIA_STOP(id, func)}
            Sent when a media has switched to the @c wxMEDIASTATE_STOPPED state.
            You may be able to Veto this event to prevent it from stopping,
            causing it to continue playing - even if it has reached that end of
@@ -59,16 +59,16 @@ enum wxMediaCtrlPlayerControls
            want to loop the media, for example, catch the @c EVT_MEDIA_FINISHED
            and play there instead).
            Processes a @c wxEVT_MEDIA_STOP event type.
-    @event{EVT_MEDIA_FINISHED(id\, func)}
+    @event{EVT_MEDIA_FINISHED(id, func)}
            Sent when a media has finished playing in a wxMediaCtrl.
            Processes a @c wxEVT_MEDIA_FINISHED event type.
-    @event{EVT_MEDIA_STATECHANGED(id\, func)}
+    @event{EVT_MEDIA_STATECHANGED(id, func)}
            Sent when a media has switched its state (from any media state).
            Processes a @c wxEVT_MEDIA_STATECHANGED event type.
-    @event{EVT_MEDIA_PLAY(id\, func)}
+    @event{EVT_MEDIA_PLAY(id, func)}
            Sent when a media has switched to the @c wxMEDIASTATE_PLAYING state.
            Processes a @c wxEVT_MEDIA_PLAY event type.
-    @event{EVT_MEDIA_PAUSE(id\, func)}
+    @event{EVT_MEDIA_PAUSE(id, func)}
            Sent when a media has switched to the @c wxMEDIASTATE_PAUSED state.
            Processes a @c wxEVT_MEDIA_PAUSE event type.
     @endEventTable

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -60,7 +60,7 @@ enum
     internal top level window list.
 
     @beginEventEmissionTable
-    @event{EVT_MAXIMIZE(id, func)}
+    @event{EVT_MAXIMIZE(func)}
         Process a @c wxEVT_MAXIMIZE event. See wxMaximizeEvent.
     @event{EVT_MOVE(func)}
         Process a @c wxEVT_MOVE event, which is generated when a window is moved.
@@ -75,7 +75,7 @@ enum
         See wxMoveEvent.
     @event{EVT_SHOW(func)}
         Process a @c wxEVT_SHOW event. See wxShowEvent.
-    @event{EVT_FULLSCREEN(id, func)}
+    @event{EVT_FULLSCREEN(func)}
         Process a @c wxEVT_FULLSCREEN event. See wxFullScreenEvent.
     @endEventTable
 

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -289,7 +289,7 @@ enum wxWindowVariant
     @endExtraStyleTable
 
     @beginEventEmissionTable
-    @event{EVT_ACTIVATE(id, func)}
+    @event{EVT_ACTIVATE(func)}
         Process a @c wxEVT_ACTIVATE event. See wxActivateEvent.
     @event{EVT_CHILD_FOCUS(func)}
         Process a @c wxEVT_CHILD_FOCUS event. See wxChildFocusEvent.


### PR DESCRIPTION
For these event macros there are mismatches in the argument list:
```
EVT_MAXIMIZE(func)
EVT_ACTIVATE(func)
EVT_FULLSCREEN(func)
```
They are correct in `event.h`, but have an additional `id` argument in `interface/toplevel.h` and `interface/window.h`.

(Two samples are using e.g. `EVT_ACTIVATE(MyChild::OnActivate)`, so I assume that `event.h` is correct. I did not actually build them, as I'm just parsing the interface files for the event informations.)

This PR fixes the mismatch and also removes trailing backslashes from the argument list in `interface/mediactrl.h`, e.g. `@event{EVT_MEDIA_LOADED(id\, func)}`.