### PR TITLE
Don't define wxListCtrl as wxGenericListCtrl in wxQt

### DIFF
--- a/include/wx/generic/listctrl.h
+++ b/include/wx/generic/listctrl.h
@@ -245,7 +245,7 @@ private:
     wxDECLARE_DYNAMIC_CLASS(wxGenericListCtrl);
 };
 
-#if (!defined(__WXMSW__) || defined(__WXUNIVERSAL__)) && (!(defined(__WXMAC__) && wxOSX_USE_CARBON) || defined(__WXUNIVERSAL__ ))
+#if !(defined(__WXMSW__) || defined(__WXQT__)) || defined(__WXUNIVERSAL__ )
 /*
  * wxListCtrl has to be a real class or we have problems with
  * the run-time information.


### PR DESCRIPTION
Make it possible to include wx/generic/listctrl.h in wxQt without getting compilation errors due to wxListCtrl redefinition.

Also remove the outdated test for __WXMAC__ which doesn't provide its own wxListCtrl implementation.