### PR TITLE
Fix wxTreeCtrl indent regression

### DIFF
--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -357,8 +357,6 @@ protected:
     virtual wxSize DoGetBestSize() const override;
 
 private:
-    void OnDPIChanged(wxDPIChangedEvent& event);
-
     void OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
     {
         InitVisualAttributes();

--- a/include/wx/msw/treectrl.h
+++ b/include/wx/msw/treectrl.h
@@ -289,6 +289,9 @@ private:
 
     void DeleteTextCtrl();
 
+    unsigned int DoGetIndent() const;
+    void DoSetIndent();
+
     // return true if the item is the hidden root one (i.e. it's the root item
     // and the tree has wxTR_HIDE_ROOT style)
     bool IsHiddenRoot(const wxTreeItemId& item) const;
@@ -347,6 +350,9 @@ private:
 
     friend class wxTreeItemIndirectData;
     friend class wxTreeSortHelper;
+
+    // indentation in DIP
+    unsigned int m_indent;
 
     wxDECLARE_DYNAMIC_CLASS(wxTreeCtrl);
     wxDECLARE_NO_COPY_CLASS(wxTreeCtrl);

--- a/interface/wx/treectrl.h
+++ b/interface/wx/treectrl.h
@@ -517,13 +517,15 @@ public:
     virtual void SetFocusedItem(const wxTreeItemId& item);
 
     /**
-        Returns the current tree control indentation.
+        Returns the current tree control indentation in DPI independent
+        pixels.
     */
     virtual unsigned int GetIndent() const;
 
     /**
         Returns the current tree control spacing.  This is the number of
-        horizontal pixels between the buttons and the state images.
+        horizontal DIPs (DPI independent pixels) between the buttons and the
+        state images.
     */
     unsigned int GetSpacing() const;
 
@@ -884,13 +886,15 @@ public:
     void SetButtonsImageList(wxImageList* imageList);
 
     /**
-        Sets the indentation for the tree control.
+        Sets the indentation for the tree control, in DIP (DPI independent
+        pixels).
     */
     virtual void SetIndent(unsigned int indent);
 
     /**
         Sets the spacing for the tree control. Spacing is the number of
-        horizontal pixels between the buttons and the state images.
+        horizontal DIPs (DPI independent pixels) between the buttons and the
+        state images.
         This has no effect under wxMSW.
     */
     void SetSpacing(unsigned int spacing);

--- a/samples/widgets/activityindicator.cpp
+++ b/samples/widgets/activityindicator.cpp
@@ -55,7 +55,7 @@ enum
 class ActivityIndicatorWidgetsPage : public WidgetsPage
 {
 public:
-    ActivityIndicatorWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist)
+    ActivityIndicatorWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist)
         : WidgetsPage(book, imaglist, activityindicator_xpm)
     {
         m_indicator = nullptr;

--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -98,7 +98,7 @@ enum
 class BitmapComboBoxWidgetsPage : public ItemContainerWidgetsPage
 {
 public:
-    BitmapComboBoxWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    BitmapComboBoxWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_combobox; }
     virtual wxItemContainer* GetContainer() const override { return m_combobox; }
@@ -247,7 +247,7 @@ IMPLEMENT_WIDGETS_PAGE(BitmapComboBoxWidgetsPage, "BitmapCombobox",
 
 
 BitmapComboBoxWidgetsPage::BitmapComboBoxWidgetsPage(WidgetsBookCtrl *book,
-                                             wxImageList *imaglist)
+                                             wxVector<wxBitmapBundle>& imaglist)
                   : ItemContainerWidgetsPage(book, imaglist, bmpcombobox_xpm)
 {
     // init everything

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -87,7 +87,7 @@ enum
 class ButtonWidgetsPage : public WidgetsPage
 {
 public:
-    ButtonWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    ButtonWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_button; }
     virtual void RecreateWidget() override { CreateButton(); }
@@ -206,7 +206,7 @@ wxEND_EVENT_TABLE()
 IMPLEMENT_WIDGETS_PAGE(ButtonWidgetsPage, "Button", FAMILY_CTRLS );
 
 ButtonWidgetsPage::ButtonWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, button_xpm)
 {
     // init everything

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -69,7 +69,7 @@ enum
 class CheckBoxWidgetsPage : public WidgetsPage
 {
 public:
-    CheckBoxWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    CheckBoxWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_checkbox; }
     virtual void RecreateWidget() override { CreateCheckbox(); }
@@ -155,7 +155,7 @@ wxEND_EVENT_TABLE()
 IMPLEMENT_WIDGETS_PAGE(CheckBoxWidgetsPage, "CheckBox", FAMILY_CTRLS );
 
 CheckBoxWidgetsPage::CheckBoxWidgetsPage(WidgetsBookCtrl *book,
-                                         wxImageList *imaglist)
+                                         wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, checkbox_xpm)
 {
 }

--- a/samples/widgets/choice.cpp
+++ b/samples/widgets/choice.cpp
@@ -72,7 +72,7 @@ enum
 class ChoiceWidgetsPage : public ItemContainerWidgetsPage
 {
 public:
-    ChoiceWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    ChoiceWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_choice; }
     virtual wxItemContainer* GetContainer() const override { return m_choice; }
@@ -180,7 +180,7 @@ IMPLEMENT_WIDGETS_PAGE(ChoiceWidgetsPage, "Choice",
                        );
 
 ChoiceWidgetsPage::ChoiceWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : ItemContainerWidgetsPage(book, imaglist, choice_xpm)
 {
     // init everything

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -60,7 +60,7 @@ enum
 class ColourPickerWidgetsPage : public WidgetsPage
 {
 public:
-    ColourPickerWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    ColourPickerWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_clrPicker; }
     virtual void RecreateWidget() override { RecreatePicker(); }
@@ -132,7 +132,7 @@ IMPLEMENT_WIDGETS_PAGE(ColourPickerWidgetsPage, "ColourPicker",
                        PICKER_CTRLS | FAMILY_CTRLS);
 
 ColourPickerWidgetsPage::ColourPickerWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, clrpicker_xpm)
 {
 }

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -90,7 +90,7 @@ enum
 class ComboboxWidgetsPage : public ItemContainerWidgetsPage
 {
 public:
-    ComboboxWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    ComboboxWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_combobox; }
     virtual wxTextEntryBase *GetTextEntry() const override { return m_combobox; }
@@ -236,7 +236,7 @@ IMPLEMENT_WIDGETS_PAGE(ComboboxWidgetsPage, "Combobox",
                        );
 
 ComboboxWidgetsPage::ComboboxWidgetsPage(WidgetsBookCtrl *book,
-                                         wxImageList *imaglist)
+                                         wxVector<wxBitmapBundle>& imaglist)
                   : ItemContainerWidgetsPage(book, imaglist, combobox_xpm)
 {
     // init everything

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -65,7 +65,7 @@ enum
 class DatePickerWidgetsPage : public WidgetsPage
 {
 public:
-    DatePickerWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    DatePickerWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_datePicker; }
     virtual void RecreateWidget() override { CreateDatePicker(); }
@@ -140,7 +140,7 @@ IMPLEMENT_WIDGETS_PAGE(DatePickerWidgetsPage, "DatePicker",
                        );
 
 DatePickerWidgetsPage::DatePickerWidgetsPage(WidgetsBookCtrl *book,
-                                         wxImageList *imaglist)
+                                         wxVector<wxBitmapBundle>& imaglist)
                       :WidgetsPage(book, imaglist, datepick_xpm)
 {
 }

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -92,7 +92,7 @@ enum
 class DirCtrlWidgetsPage : public WidgetsPage
 {
 public:
-    DirCtrlWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    DirCtrlWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
     virtual ~DirCtrlWidgetsPage() {}
 
     virtual wxWindow *GetWidget() const override { return m_dirCtrl; }
@@ -166,7 +166,7 @@ IMPLEMENT_WIDGETS_PAGE(DirCtrlWidgetsPage, "DirCtrl",
                        );
 
 DirCtrlWidgetsPage::DirCtrlWidgetsPage(WidgetsBookCtrl *book,
-                                       wxImageList *imaglist)
+                                       wxVector<wxBitmapBundle>& imaglist)
                    :WidgetsPage(book, imaglist, dirctrl_xpm)
 {
     m_dirCtrl = nullptr;

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -63,7 +63,7 @@ enum
 class DirPickerWidgetsPage : public WidgetsPage
 {
 public:
-    DirPickerWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    DirPickerWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_dirPicker; }
     virtual void RecreateWidget() override { RecreatePicker(); }
@@ -136,7 +136,7 @@ IMPLEMENT_WIDGETS_PAGE(DirPickerWidgetsPage, "DirPicker",
                        PICKER_CTRLS | FAMILY_CTRLS);
 
 DirPickerWidgetsPage::DirPickerWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, dirpicker_xpm)
 {
 }

--- a/samples/widgets/editlbox.cpp
+++ b/samples/widgets/editlbox.cpp
@@ -64,7 +64,7 @@ enum
 class EditableListboxWidgetsPage : public WidgetsPage
 {
 public:
-    EditableListboxWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    EditableListboxWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_lbox->GetListCtrl(); }
     virtual void RecreateWidget() override { CreateLbox(); }
@@ -115,7 +115,7 @@ wxEND_EVENT_TABLE()
 IMPLEMENT_WIDGETS_PAGE(EditableListboxWidgetsPage, "EditableListbox", GENERIC_CTRLS);
 
 EditableListboxWidgetsPage::EditableListboxWidgetsPage(WidgetsBookCtrl *book,
-                                                       wxImageList *imaglist)
+                                                       wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, listbox_xpm)
 {
 

--- a/samples/widgets/filectrl.cpp
+++ b/samples/widgets/filectrl.cpp
@@ -64,7 +64,7 @@ enum
 class FileCtrlWidgetsPage : public WidgetsPage
 {
 public:
-    FileCtrlWidgetsPage( WidgetsBookCtrl *book, wxImageList *imaglist );
+    FileCtrlWidgetsPage( WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist );
     virtual ~FileCtrlWidgetsPage() {}
 
     virtual wxWindow *GetWidget() const override { return m_fileCtrl; }
@@ -146,7 +146,7 @@ IMPLEMENT_WIDGETS_PAGE( FileCtrlWidgetsPage, "FileCtrl",
                         FAMILY_CTRLS );
 
 FileCtrlWidgetsPage::FileCtrlWidgetsPage( WidgetsBookCtrl *book,
-        wxImageList *imaglist )
+        wxVector<wxBitmapBundle>& imaglist )
         : WidgetsPage( book, imaglist, dirctrl_xpm )
 {
 }

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -70,7 +70,7 @@ enum
 class FilePickerWidgetsPage : public WidgetsPage
 {
 public:
-    FilePickerWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    FilePickerWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_filePicker; }
     virtual void RecreateWidget() override { RecreatePicker(); }
@@ -153,7 +153,7 @@ IMPLEMENT_WIDGETS_PAGE(FilePickerWidgetsPage, "FilePicker",
                        PICKER_CTRLS | FAMILY_CTRLS);
 
 FilePickerWidgetsPage::FilePickerWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, filepicker_xpm)
 {
 }

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -60,7 +60,7 @@ enum
 class FontPickerWidgetsPage : public WidgetsPage
 {
 public:
-    FontPickerWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    FontPickerWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_fontPicker; }
     virtual void RecreateWidget() override { RecreatePicker(); }
@@ -127,7 +127,7 @@ IMPLEMENT_WIDGETS_PAGE(FontPickerWidgetsPage, "FontPicker",
                        PICKER_CTRLS | FAMILY_CTRLS);
 
 FontPickerWidgetsPage::FontPickerWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, fontpicker_xpm)
 {
 }

--- a/samples/widgets/gauge.cpp
+++ b/samples/widgets/gauge.cpp
@@ -69,7 +69,7 @@ enum
 class GaugeWidgetsPage : public WidgetsPage
 {
 public:
-    GaugeWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    GaugeWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
     virtual ~GaugeWidgetsPage();
 
     virtual wxWindow *GetWidget() const override { return m_gauge; }
@@ -175,7 +175,7 @@ wxEND_EVENT_TABLE()
 IMPLEMENT_WIDGETS_PAGE(GaugeWidgetsPage, "Gauge", FAMILY_CTRLS );
 
 GaugeWidgetsPage::GaugeWidgetsPage(WidgetsBookCtrl *book,
-                                   wxImageList *imaglist)
+                                   wxVector<wxBitmapBundle>& imaglist)
                  :WidgetsPage(book, imaglist, gauge_xpm)
 {
     // init everything

--- a/samples/widgets/headerctrl.cpp
+++ b/samples/widgets/headerctrl.cpp
@@ -50,7 +50,7 @@
 class HeaderCtrlWidgetsPage : public WidgetsPage
 {
 public:
-    HeaderCtrlWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist)
+    HeaderCtrlWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist)
         : WidgetsPage(book, imaglist, header_xpm)
     {
         m_header = nullptr;

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -73,7 +73,7 @@ enum
 class HyperlinkWidgetsPage : public WidgetsPage
 {
 public:
-    HyperlinkWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    HyperlinkWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
     virtual ~HyperlinkWidgetsPage() {}
 
     virtual wxWindow *GetWidget() const override { return m_hyperlink; }
@@ -144,7 +144,7 @@ IMPLEMENT_WIDGETS_PAGE(HyperlinkWidgetsPage, "Hyperlink",
                        );
 
 HyperlinkWidgetsPage::HyperlinkWidgetsPage(WidgetsBookCtrl *book,
-                                           wxImageList *imaglist)
+                                           wxVector<wxBitmapBundle>& imaglist)
                      :WidgetsPage(book, imaglist, hyperlnk_xpm)
 {
 }

--- a/samples/widgets/itemcontainer.cpp
+++ b/samples/widgets/itemcontainer.cpp
@@ -63,9 +63,9 @@ private:
 // ============================================================================
 
 ItemContainerWidgetsPage::ItemContainerWidgetsPage(WidgetsBookCtrl *book,
-                                                   wxImageList *image_list,
+                                                   wxVector<wxBitmapBundle>& imaglist,
                                                    const char *const icon[])
-: WidgetsPage(book, image_list, icon)
+: WidgetsPage(book, imaglist, icon)
 #if defined(__WXMSW__) || defined(__WXGTK__)
 // Reference data needs to be sorted in a dictionary order
 // since control's items are sorted in this order too.

--- a/samples/widgets/itemcontainer.h
+++ b/samples/widgets/itemcontainer.h
@@ -15,7 +15,7 @@ class ItemContainerWidgetsPage : public WidgetsPage
 {
 public:
     ItemContainerWidgetsPage(WidgetsBookCtrl *book,
-                             wxImageList *image_list,
+                             wxVector<wxBitmapBundle>& imaglist,
                              const char *const icon[]);
     virtual ~ItemContainerWidgetsPage();
 

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -81,7 +81,7 @@ enum
 class ListboxWidgetsPage : public ItemContainerWidgetsPage
 {
 public:
-    ListboxWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    ListboxWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_lbox; }
     virtual wxItemContainer* GetContainer() const override { return m_lbox; }
@@ -246,7 +246,7 @@ IMPLEMENT_WIDGETS_PAGE(ListboxWidgetsPage, "Listbox",
                        );
 
 ListboxWidgetsPage::ListboxWidgetsPage(WidgetsBookCtrl *book,
-                                       wxImageList *imaglist)
+                                       wxVector<wxBitmapBundle>& imaglist)
                   : ItemContainerWidgetsPage(book, imaglist, listbox_xpm)
 {
     // init everything

--- a/samples/widgets/native.cpp
+++ b/samples/widgets/native.cpp
@@ -250,7 +250,7 @@ public:
 class NativeWidgetsPage : public WidgetsPage
 {
 public:
-    NativeWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    NativeWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_nativeWindow; }
     virtual void RecreateWidget() override;
@@ -275,7 +275,7 @@ private:
 
 IMPLEMENT_WIDGETS_PAGE(NativeWidgetsPage, "Native", NATIVE_CTRLS);
 
-NativeWidgetsPage::NativeWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist)
+NativeWidgetsPage::NativeWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist)
                  : WidgetsPage(book, imaglist, native_xpm)
 {
     m_nativeWindow = nullptr;

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -80,7 +80,7 @@ enum Orient
 class BookWidgetsPage : public WidgetsPage
 {
 public:
-    BookWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist, const char *const icon[]);
+    BookWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist, const char *const icon[]);
     virtual ~BookWidgetsPage();
 
     virtual wxWindow *GetWidget() const override { return m_book; }
@@ -182,7 +182,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-BookWidgetsPage::BookWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist, const char *const icon[])
+BookWidgetsPage::BookWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist, const char *const icon[])
                 :WidgetsPage(book, imaglist, icon)
 {
     // init everything
@@ -531,7 +531,7 @@ void BookWidgetsPage::OnCheckOrRadioBox(wxCommandEvent& WXUNUSED(event))
 class NotebookWidgetsPage : public BookWidgetsPage
 {
 public:
-    NotebookWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist)
+    NotebookWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist)
         : BookWidgetsPage(book, imaglist, notebook_xpm)
     {
         RecreateBook();
@@ -610,7 +610,7 @@ void NotebookWidgetsPage::OnPageChanged(wxNotebookEvent& event)
 class ListbookWidgetsPage : public BookWidgetsPage
 {
 public:
-    ListbookWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist)
+    ListbookWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist)
         : BookWidgetsPage(book, imaglist, listbook_xpm)
     {
         RecreateBook();
@@ -683,7 +683,7 @@ void ListbookWidgetsPage::OnPageChanged(wxListbookEvent& event)
 class ChoicebookWidgetsPage : public BookWidgetsPage
 {
 public:
-    ChoicebookWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist)
+    ChoicebookWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist)
         : BookWidgetsPage(book, imaglist, choicebk_xpm)
     {
         RecreateBook();

--- a/samples/widgets/odcombobox.cpp
+++ b/samples/widgets/odcombobox.cpp
@@ -85,7 +85,7 @@ enum
 class ODComboboxWidgetsPage : public ItemContainerWidgetsPage
 {
 public:
-    ODComboboxWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    ODComboboxWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_combobox; }
     virtual wxTextEntryBase *GetTextEntry() const override
@@ -301,7 +301,7 @@ IMPLEMENT_WIDGETS_PAGE(ODComboboxWidgetsPage, "OwnerDrawnCombobox",
                        );
 
 ODComboboxWidgetsPage::ODComboboxWidgetsPage(WidgetsBookCtrl *book,
-                                             wxImageList *imaglist)
+                                             wxVector<wxBitmapBundle>& imaglist)
                   : ItemContainerWidgetsPage(book, imaglist, odcombobox_xpm)
 {
     // init everything

--- a/samples/widgets/radiobox.cpp
+++ b/samples/widgets/radiobox.cpp
@@ -71,7 +71,7 @@ static const int TEST_BUTTON = 1;
 class RadioWidgetsPage : public WidgetsPage
 {
 public:
-    RadioWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    RadioWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_radio; }
     virtual void RecreateWidget() override { CreateRadio(); }
@@ -174,7 +174,7 @@ IMPLEMENT_WIDGETS_PAGE(RadioWidgetsPage, "Radio",
                        );
 
 RadioWidgetsPage::RadioWidgetsPage(WidgetsBookCtrl *book,
-                                   wxImageList *imaglist)
+                                   wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, radio_xpm)
 {
     // init everything

--- a/samples/widgets/searchctrl.cpp
+++ b/samples/widgets/searchctrl.cpp
@@ -65,7 +65,7 @@ enum
 class SearchCtrlWidgetsPage : public WidgetsPage
 {
 public:
-    SearchCtrlWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    SearchCtrlWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_srchCtrl; }
     virtual wxTextEntryBase *GetTextEntry() const override { return m_srchCtrl; }
@@ -137,7 +137,7 @@ IMPLEMENT_WIDGETS_PAGE(SearchCtrlWidgetsPage, "SearchCtrl",
                        FAMILY_CTRLS | EDITABLE_CTRLS | ALL_CTRLS);
 
 SearchCtrlWidgetsPage::SearchCtrlWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, text_xpm)
 {
 }

--- a/samples/widgets/slider.cpp
+++ b/samples/widgets/slider.cpp
@@ -94,7 +94,7 @@ enum
 class SliderWidgetsPage : public WidgetsPage
 {
 public:
-    SliderWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    SliderWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_slider; }
     virtual void RecreateWidget() override { CreateSlider(); }
@@ -251,7 +251,7 @@ wxEND_EVENT_TABLE()
 IMPLEMENT_WIDGETS_PAGE(SliderWidgetsPage, "Slider", FAMILY_CTRLS );
 
 SliderWidgetsPage::SliderWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, slider_xpm)
 {
     // init everything

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -82,7 +82,7 @@ enum
 class SpinBtnWidgetsPage : public WidgetsPage
 {
 public:
-    SpinBtnWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    SpinBtnWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_spinbtn; }
     virtual Widgets GetWidgets() const override
@@ -220,7 +220,7 @@ IMPLEMENT_WIDGETS_PAGE(SpinBtnWidgetsPage, "Spin",
                        );
 
 SpinBtnWidgetsPage::SpinBtnWidgetsPage(WidgetsBookCtrl *book,
-                                       wxImageList *imaglist)
+                                       wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, spinbtn_xpm)
 {
     m_chkVert = nullptr;

--- a/samples/widgets/statbmp.cpp
+++ b/samples/widgets/statbmp.cpp
@@ -46,7 +46,7 @@
 class StatBmpWidgetsPage : public WidgetsPage
 {
 public:
-    StatBmpWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist)
+    StatBmpWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist)
         : WidgetsPage(book, imaglist, statbmp_xpm) {}
 
     virtual void CreateContent() override;

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -78,7 +78,7 @@ enum
 class StaticWidgetsPage : public WidgetsPage
 {
 public:
-    StaticWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    StaticWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_statText; }
     virtual Widgets GetWidgets() const override
@@ -181,7 +181,7 @@ IMPLEMENT_WIDGETS_PAGE(StaticWidgetsPage, "Static",
                        );
 
 StaticWidgetsPage::StaticWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                   : WidgetsPage(book, imaglist, statbox_xpm)
 {
     // init everything

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -147,7 +147,7 @@ class TextWidgetsPage : public WidgetsPage
 {
 public:
     // ctor(s) and dtor
-    TextWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    TextWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_text; }
     virtual wxTextEntryBase *GetTextEntry() const override { return m_text; }
@@ -372,7 +372,7 @@ IMPLEMENT_WIDGETS_PAGE(TextWidgetsPage, "Text",
 // TextWidgetsPage creation
 // ----------------------------------------------------------------------------
 
-TextWidgetsPage::TextWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist)
+TextWidgetsPage::TextWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist)
                : WidgetsPage(book, imaglist, text_xpm)
 {
     // init everything

--- a/samples/widgets/timepick.cpp
+++ b/samples/widgets/timepick.cpp
@@ -60,7 +60,7 @@ enum
 class TimePickerWidgetsPage : public WidgetsPage
 {
 public:
-    TimePickerWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    TimePickerWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_timePicker; }
     virtual void RecreateWidget() override { CreateTimePicker(); }
@@ -121,7 +121,7 @@ IMPLEMENT_WIDGETS_PAGE(TimePickerWidgetsPage, "TimePicker",
                        );
 
 TimePickerWidgetsPage::TimePickerWidgetsPage(WidgetsBookCtrl *book,
-                                         wxImageList *imaglist)
+                                         wxVector<wxBitmapBundle>& imaglist)
                      : WidgetsPage(book, imaglist, timepick_xpm)
 {
 }

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -84,7 +84,7 @@ enum
 class ToggleWidgetsPage : public WidgetsPage
 {
 public:
-    ToggleWidgetsPage(WidgetsBookCtrl *book, wxImageList *imaglist);
+    ToggleWidgetsPage(WidgetsBookCtrl *book, wxVector<wxBitmapBundle>& imaglist);
 
     virtual wxWindow *GetWidget() const override { return m_toggle; }
     virtual void RecreateWidget() override { CreateToggle(); }
@@ -184,7 +184,7 @@ IMPLEMENT_WIDGETS_PAGE(ToggleWidgetsPage, "ToggleButton",
                        );
 
 ToggleWidgetsPage::ToggleWidgetsPage(WidgetsBookCtrl *book,
-                                     wxImageList *imaglist)
+                                     wxVector<wxBitmapBundle>& imaglist)
                       :WidgetsPage(book, imaglist, toggle_xpm)
 {
     m_chkFit =

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -35,8 +35,6 @@
     #define USE_LOG 0
 #endif
 
-#define ICON_SIZE         16
-
 class WXDLLIMPEXP_FWD_CORE wxCheckBox;
 class WXDLLIMPEXP_FWD_CORE wxSizer;
 class WXDLLIMPEXP_FWD_CORE wxImageList;
@@ -123,7 +121,7 @@ class WidgetsPage : public wxScrolledWindow
 {
 public:
     WidgetsPage(WidgetsBookCtrl *book,
-                wxImageList *imaglist,
+                wxVector<wxBitmapBundle>& imaglist,
                 const char *const icon[]);
 
     // return the control shown by this page
@@ -165,6 +163,8 @@ public:
     // return true if we're showing logs in the log window (always the case
     // except during startup and shutdown)
     static bool IsUsingLogWindow();
+
+    static wxBitmapBundle CreateBitmapBundle(const char* const icon[]);
 
 protected:
     // several helper functions for page creation
@@ -211,7 +211,7 @@ class WidgetsPageInfo
 {
 public:
     typedef WidgetsPage *(*Constructor)(WidgetsBookCtrl *book,
-                                        wxImageList *imaglist);
+                                        wxVector<wxBitmapBundle>& imaglist);
 
     // our ctor
     WidgetsPageInfo(Constructor ctor, const wxString& label, int categories);
@@ -249,7 +249,7 @@ private:
 // and this one must be inserted somewhere in the source file
 #define IMPLEMENT_WIDGETS_PAGE(classname, label, categories)                \
     WidgetsPage *wxCtorFor##classname(WidgetsBookCtrl *book,                \
-                                      wxImageList *imaglist)                \
+                                      wxVector<wxBitmapBundle>& imaglist)   \
         { return new classname(book, imaglist); }                           \
     WidgetsPageInfo classname::                                             \
         ms_info##classname(wxCtorFor##classname, label, ALL_CTRLS | categories)

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2447,6 +2447,8 @@ void wxGenericTreeCtrl::OnImagesChanged()
     // of ensuring that we can always get the size to use for the images.
     GetUpdatedImageListFor(this);
 
+    m_imagesState.GetUpdatedImageListFor(this);
+
     UpdateAfterImageListChange();
 }
 

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -720,7 +720,7 @@ wxGenericTreeItem *wxGenericTreeItem::HitTest(const wxPoint& point,
             else
                 flags |= wxTREE_HITTEST_ONITEMLOWERPART;
 
-            int xCross = m_x - theCtrl->GetSpacing();
+            int xCross = m_x - theCtrl->FromDIP(theCtrl->GetSpacing());
 #ifdef __WXMAC__
             // according to the drawing code the triangels are drawn
             // at -4 , -4  from the position up to +10/+10 max
@@ -947,7 +947,6 @@ wxBEGIN_EVENT_TABLE(wxGenericTreeCtrl, wxTreeCtrlBase)
     EVT_KILL_FOCUS     (wxGenericTreeCtrl::OnKillFocus)
     EVT_TREE_ITEM_GETTOOLTIP(wxID_ANY, wxGenericTreeCtrl::OnGetToolTip)
     EVT_SYS_COLOUR_CHANGED(wxGenericTreeCtrl::OnSysColourChanged)
-    EVT_DPI_CHANGED(wxGenericTreeCtrl::OnDPIChanged)
 wxEND_EVENT_TABLE()
 
 // -----------------------------------------------------------------------------
@@ -1064,8 +1063,8 @@ void wxGenericTreeCtrl::InitVisualAttributes()
 #endif
     m_boldFont = m_normalFont.Bold();
 
-    m_indent = FromDIP(10);
-    m_spacing = FromDIP(10);
+    m_indent = 10;
+    m_spacing = 10;
 }
 
 // -----------------------------------------------------------------------------
@@ -2744,10 +2743,13 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
                               int level,
                               int &y)
 {
-    int x = level*m_indent;
+    int indent = FromDIP(m_indent);
+    int spacing = FromDIP(m_spacing);
+
+    int x = level*indent;
     if (!HasFlag(wxTR_HIDE_ROOT))
     {
-        x += m_indent;
+        x += indent;
     }
     else if (level == 0)
     {
@@ -2775,7 +2777,7 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
         return;
     }
 
-    item->SetX(x+m_spacing);
+    item->SetX(x+spacing);
     item->SetY(y);
 
     int h = GetLineHeight(item);
@@ -2840,11 +2842,11 @@ wxGenericTreeCtrl::PaintLevel(wxGenericTreeItem *item,
         {
             // draw the horizontal line here
             int x_start = x;
-            if (x > (int)m_indent)
-                x_start -= m_indent;
+            if (x > (int)indent)
+                x_start -= indent;
             else if (HasFlag(wxTR_LINES_AT_ROOT))
                 x_start = 3;
-            dc.DrawLine(x_start, y_mid, x + m_spacing, y_mid);
+            dc.DrawLine(x_start, y_mid, x + spacing, y_mid);
         }
 
         // should the item show a button?
@@ -3985,10 +3987,13 @@ wxGenericTreeCtrl::CalculateLevel(wxGenericTreeItem *item,
                                   int level,
                                   int &y )
 {
-    int x = level*m_indent;
+    int indent = FromDIP(m_indent);
+    int spacing = FromDIP(m_spacing);
+
+    int x = level*indent;
     if (!HasFlag(wxTR_HIDE_ROOT))
     {
-        x += m_indent;
+        x += indent;
     }
     else if (level == 0)
     {
@@ -4000,7 +4005,7 @@ wxGenericTreeCtrl::CalculateLevel(wxGenericTreeItem *item,
     item->CalculateSize(this, dc);
 
     // set its position
-    item->SetX( x+m_spacing );
+    item->SetX( x+spacing );
     item->SetY( y );
     y += GetLineHeight(item);
 
@@ -4216,18 +4221,6 @@ wxSize wxGenericTreeCtrl::DoGetBestSize() const
         size.y += PIXELS_PER_UNIT - dy;
 
     return size;
-}
-
-void wxGenericTreeCtrl::OnDPIChanged(wxDPIChangedEvent& event)
-{
-    // For the platforms using DPI-dependent pixels we need to adjust various
-    // metrics after the DPI change.
-#ifndef wxHAS_DPI_INDEPENDENT_PIXELS
-    m_indent = event.ScaleX(m_indent);
-    m_spacing = event.ScaleX(m_spacing);
-#endif // !wxHAS_DPI_INDEPENDENT_PIXELS
-
-    event.Skip();
 }
 
 #endif // wxUSE_TREECTRL

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -815,11 +815,8 @@ bool wxTreeCtrl::Create(wxWindow *parent,
         EnableSystemThemeByDefault();
     }
 
-    // When using non-standard DPI, we need to scale the default indent with
-    // the DPI scaling factor as Windows doesn't do it and the "+" buttons
-    // would be displayed too small if the tree is used without images.
-    if ( GetDPIScaleFactor() > 1.0 )
-        SetIndent(FromDIP(GetIndent()));
+    m_indent = DoGetIndent();
+    DoSetIndent();
 
     // And ensure we adjust it again if the DPI changes in the future.
     Bind(wxEVT_DPI_CHANGED, &wxTreeCtrl::OnDPIChanged, this);
@@ -933,11 +930,26 @@ unsigned int wxTreeCtrl::GetCount() const
 
 unsigned int wxTreeCtrl::GetIndent() const
 {
+    return m_indent;
+}
+
+unsigned int wxTreeCtrl::DoGetIndent() const
+{
     return TreeView_GetIndent(GetHwnd());
 }
 
 void wxTreeCtrl::SetIndent(unsigned int indent)
 {
+    m_indent = indent;
+    DoSetIndent();
+}
+
+void wxTreeCtrl::DoSetIndent()
+{
+    // When using non-standard DPI, we need to scale the default indent with
+    // the DPI scaling factor as Windows doesn't do it and the "+" buttons
+    // would be displayed too small if the tree is used without images.
+    int indent = FromDIP(m_indent);
     (void)TreeView_SetIndent(GetHwnd(), indent);
 }
 
@@ -2322,7 +2334,7 @@ void wxTreeCtrl::MSWUpdateFontOnDPIChange(const wxSize& newDPI)
 void wxTreeCtrl::OnDPIChanged(wxDPIChangedEvent& event)
 {
     // Adjust the indent to the new DPI scaling factor as Windows doesn't do it.
-    SetIndent(event.ScaleX(GetIndent()));
+    DoSetIndent();
 
     event.Skip();
 }

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -950,6 +950,19 @@ void wxTreeCtrl::DoSetIndent()
     // the DPI scaling factor as Windows doesn't do it and the "+" buttons
     // would be displayed too small if the tree is used without images.
     int indent = FromDIP(m_indent);
+
+    // When the images in the imageList are smaller than FromDIP(16),
+    // the scaled indent has to be reduced to the width of the images.
+    // Otherwise the hitbox of the collapse/expand button will be shifted
+    // too much to the right.
+    wxImageList* imgList = GetImageList();
+    if (imgList != nullptr)
+    {
+        int diff = imgList->GetSize().GetWidth() - FromDIP(16);
+        if (diff < 0)
+            indent += diff;
+    }
+
     (void)TreeView_SetIndent(GetHwnd(), indent);
 }
 
@@ -959,6 +972,7 @@ void wxTreeCtrl::SetAnyImageList(wxImageList *imageList, int which)
     (void) TreeView_SetImageList(GetHwnd(),
                                  imageList ? imageList->GetHIMAGELIST() : 0,
                                  which);
+    DoSetIndent();
 }
 
 void wxTreeCtrl::SetImageList(wxImageList *imageList)


### PR DESCRIPTION
The changes from https://github.com/wxWidgets/wxWidgets/issues/24640 don't seem to work when the size of the images in the image list is too small.
The win32 control seems to expect an image size of at least `FromDIP(16)`px. When the images are smaller, for example just `16`px, the extra indent causes the expand/collapse hitbox to be shifted to the right and not overlap with the twist (or plus-min) button.
Fix this by reducing the indent when the images are too small.

Note: this also happens when manually applying a large `SetIndent`, can't do anything about that.

In red I marked where the hitbox is approximately (at 150% DPI):
<img width="300" alt="before" src="https://github.com/user-attachments/assets/ee58e8a7-f843-47d5-a0c2-7d385393de9d" /> <img width="300" alt="after" src="https://github.com/user-attachments/assets/1415d815-9ee9-47ff-8e3e-01735f731e41" />

I also updated the widgets sample to use a `wxBitmapBundle` for the images, instead of using hardcoded 16x16px.
<img width="300" alt="after2" src="https://github.com/user-attachments/assets/a6331e70-740b-43a6-92c0-a56438f5ff74" />

-----

I made the indent and spacing DPI independent, so get/set return the same values no matter the DPI. Is this desired or should it be possible to keep pixel-perfect control?

-----

3.2 has this problem too, but this fix cannot easily be backported, because adding functions and variables breaks ABI.  One way would be to fix the indent when setting the image list, taking into account corrections for any previous image lists. I can create a PR with this, but maybe someone has a better idea. (Like documenting the image list should have at least size `FromDIP(16)`.)
```diff
diff --git "a/src/msw/treectrl.cpp" "b/src/msw/treectrl.cpp"
index 8baabda684..7f9f16b13b 100644
--- "a/src/msw/treectrl.cpp"
+++ "b/src/msw/treectrl.cpp"
@@ -922,10 +922,33 @@ void wxTreeCtrl::SetIndent(unsigned int indent)
 
 void wxTreeCtrl::SetAnyImageList(wxImageList *imageList, int which)
 {
+    int indent = GetIndent();
+
+    HIMAGELIST oldImgList = TreeView_GetImageList(GetHwnd(), which);
+    if (oldImgList != nullptr)
+    {
+        int oldWidth = 0, oldHeight = 0;
+        if (ImageList_GetIconSize(oldImgList, &oldWidth, &oldHeight))
+        {
+            int diff = oldWidth - FromDIP(16);
+            if (diff < 0)
+                indent -= diff;
+        }
+    }
+
     // no error return
     (void) TreeView_SetImageList(GetHwnd(),
                                  imageList ? imageList->GetHIMAGELIST() : 0,
                                  which);
+
+    wxImageList* newImgList = GetImageList();
+    if (newImgList != nullptr)
+    {
+        int diff = newImgList->GetSize().GetWidth() - FromDIP(16);
+        if (diff < 0)
+            indent += diff;
+    }
+    SetIndent(indent);
 }
 
 void wxTreeCtrl::SetImageList(wxImageList *imageList)
```