### PR TITLE
Fix leak of wxInitData::argv in wxMSW

### DIFF
--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -264,13 +264,15 @@ void wxInitData::Free()
         // If argvMSW is non-null, argv must be the same value, so reset it too.
         argv = argvMSW = nullptr;
     }
-#else
-    for ( int i = 0; i < argc; i++ )
-    {
-        free(argv[i]);
-    }
-    wxDELETEA(argv);
+    else
 #endif // __WINDOWS__
+    {
+        for ( int i = 0; i < argc; i++ )
+        {
+            free(argv[i]);
+        }
+        wxDELETEA(argv);
+    }
 
     if ( argc )
     {


### PR DESCRIPTION
When not using MSWInitialize(), e.g. in console MSW applications, we need to free argv elements ourselves as they're not the same as argvMSW and so are not freed when freeing it.

This is different from the leak fixed in #24694 but is in the same code.

----

cc @MaartenBent just in case I'm missing something here