### PR TITLE
Add wxVector(std::initializer_list<U> list) ctor (3.2)

### DIFF
--- a/include/wx/vector.h
+++ b/include/wx/vector.h
@@ -19,6 +19,10 @@
 #include <vector>
 #include <algorithm>
 
+#ifdef wxHAVE_INITIALIZER_LIST
+    #include <initializer_list>
+#endif
+
 #define wxVector std::vector
 template<typename T>
 inline void wxVectorSort(wxVector<T>& v)
@@ -344,6 +348,11 @@ public:
     {
         assign(first, last);
     }
+
+#ifdef wxHAVE_INITIALIZER_LIST
+    template<typename U>
+    wxVector(std::initializer_list<U> list) : wxVector(list.begin(), list.end()) {}
+#endif
 
     ~wxVector()
     {


### PR DESCRIPTION
(This is 3.2-only as this code is gone on master. I *think* it doesn't have ABI implications and so is safe to add to 3.2, and that it is worth having, because Linux distros ship w/o `wxUSE_STD_CONTAINERS`, but I realize your mileage may vary, so feel free to reject it.)

This is analogous to code present for `wxArray` and makes using `wxVector` easier. As a motivating example, adding data to `wxDataViewListCtrl` is a bit of a PITA w/o it:

```cxx
wxVector<wxVariant> data;
data.push_back("foo");
data.push_back("bar");
data.push_back("zar");
list->AppendItem(data);
```

vs.

```cxx
list->AppendItem({"foo", "bar", "zar"});
```