### PR TITLE
Fixes for wxGTK on macOS – 2 (fix condition for X11)

### DIFF
--- a/build/cmake/toolkit.cmake
+++ b/build/cmake/toolkit.cmake
@@ -119,7 +119,7 @@ endif()
 # support, but not for Wayland-only GTK (necessarily 3 or later), which is why
 # we have to do this after find_package(GTKx) above, as this is what sets
 # wxHAVE_GDK_X11.
-if(UNIX AND NOT APPLE AND NOT WIN32 AND (WXX11 OR WXGTK2 OR (WXGTK AND wxHAVE_GDK_X11)))
+if(UNIX AND NOT WIN32 AND (WXX11 OR WXGTK2 OR (WXGTK AND wxHAVE_GDK_X11)))
     find_package(X11 REQUIRED)
     list(APPEND wxTOOLKIT_INCLUDE_DIRS ${X11_INCLUDE_DIR})
     list(APPEND wxTOOLKIT_LIBRARIES ${X11_LIBRARIES})


### PR DESCRIPTION
Cocoa builds are already excluded by GTK requirement in the macro, but for GTK builds on Apple we need X11.