### PR TITLE
Fixes for wxGTK on macOS – 3 (cfstring)

### DIFF
--- a/include/wx/osx/core/cfstring.h
+++ b/include/wx/osx/core/cfstring.h
@@ -64,7 +64,7 @@ public:
 
     static wxString AsString( CFStringRef ref ) ;
     static wxString AsStringWithNormalizationFormC( CFStringRef ref ) ;
-#ifdef __WXMAC__
+#if defined(__WXMAC__) || defined(__OBJC__)
     static wxString AsString( WX_NSString ref ) ;
     static wxString AsStringWithNormalizationFormC( WX_NSString ref ) ;
 #endif
@@ -85,7 +85,7 @@ inline wxCFStringRef wxCFStringRefFromGet(CFStringRef p)
     return wxCFStringRef(wxCFRetain(p));
 }
 
-#ifdef __WXMAC__
+#if defined(__WXMAC__) || defined(__OBJC__)
 /*! @function   wxCFStringRefFromGet
     @abstract   Factory function to create wxCFStringRefRef from a NSString* obtained from a Get-rule function
     @param  p           The NSString pointer to retain and create a wxCFStringRefRef from.  May be null.

--- a/include/wx/osx/core/cfstring.h
+++ b/include/wx/osx/core/cfstring.h
@@ -64,10 +64,8 @@ public:
 
     static wxString AsString( CFStringRef ref ) ;
     static wxString AsStringWithNormalizationFormC( CFStringRef ref ) ;
-#if defined(__WXMAC__) || defined(__OBJC__)
     static wxString AsString( WX_NSString ref ) ;
     static wxString AsStringWithNormalizationFormC( WX_NSString ref ) ;
-#endif
 #ifdef __OBJC__
     WX_NSString AsNSString() const { return (WX_OSX_BRIDGE WX_NSString)(CFStringRef) *this; }
 #endif
@@ -85,7 +83,6 @@ inline wxCFStringRef wxCFStringRefFromGet(CFStringRef p)
     return wxCFStringRef(wxCFRetain(p));
 }
 
-#if defined(__WXMAC__) || defined(__OBJC__)
 /*! @function   wxCFStringRefFromGet
     @abstract   Factory function to create wxCFStringRefRef from a NSString* obtained from a Get-rule function
     @param  p           The NSString pointer to retain and create a wxCFStringRefRef from.  May be null.
@@ -96,6 +93,5 @@ inline wxCFStringRef wxCFStringRefFromGet(NSString *p)
 {
     return wxCFStringRefFromGet((WX_OSX_BRIDGE CFStringRef)p);
 }
-#endif
 
 #endif //__WXCFSTRINGHOLDER_H__

--- a/src/osx/core/cfstring.cpp
+++ b/src/osx/core/cfstring.cpp
@@ -674,7 +674,7 @@ wxString wxCFStringRef::AsString() const
     return AsString( get() );
 }
 
-#ifdef __WXMAC__
+#if defined(__WXMAC__) || defined(__OBJC__)
 
 wxString wxCFStringRef::AsString( NSString* ref )
 {

--- a/src/osx/core/cfstring.cpp
+++ b/src/osx/core/cfstring.cpp
@@ -674,8 +674,6 @@ wxString wxCFStringRef::AsString() const
     return AsString( get() );
 }
 
-#if defined(__WXMAC__) || defined(__OBJC__)
-
 wxString wxCFStringRef::AsString( NSString* ref )
 {
     return AsString( (CFStringRef) ref );
@@ -685,5 +683,3 @@ wxString wxCFStringRef::AsStringWithNormalizationFormC( NSString* ref )
 {
     return AsStringWithNormalizationFormC( (CFStringRef) ref );
 }
-
-#endif


### PR DESCRIPTION
@vadz This is an empirically derived fix :) I do not know if it is correct, but apparently it works.

Can `__WXMAC__` be defined _without_ `__OBJC__` being defined along? I assumed that no. If yes, then macros are to be adjusted.